### PR TITLE
test: apply a delay to watch-mode-kill-sginal tests

### DIFF
--- a/test/fixtures/kill-signal-for-watch.js
+++ b/test/fixtures/kill-signal-for-watch.js
@@ -7,4 +7,7 @@ process.on('SIGINT', () => {
   process.exit();
 });
 process.send(`script ready ${process.pid}`);
-setTimeout(() => {}, 100_000);
+const timeout = 100_000;
+setTimeout(() => {
+  process._rawDebug(`[CHILD] Timeout ${timeout} fired`);
+}, timeout);

--- a/test/parallel/test-watch-mode-kill-signal-default.mjs
+++ b/test/parallel/test-watch-mode-kill-signal-default.mjs
@@ -51,7 +51,12 @@ child.on('message', (msg) => {
     const match = msg.match(/script ready (\d+)/);
     if (match) {
       firstGrandchildPid = match[1];  // This is the first grandchild
-      writeFileSync(indexPath, indexContents);
+      const writeDelay = 1000;  // Delay to reduce the chance of fs events coalescing
+      console.log(`[PARENT] writing to restart ${firstGrandchildPid} after ${writeDelay}ms`);
+      setTimeout(() => {
+        console.log(`[PARENT] writing to ${indexPath} to restart ${firstGrandchildPid}`);
+        writeFileSync(indexPath, indexContents);
+      }, writeDelay);
     }
   }
 });

--- a/test/parallel/test-watch-mode-kill-signal-override.mjs
+++ b/test/parallel/test-watch-mode-kill-signal-override.mjs
@@ -52,7 +52,12 @@ child.on('message', (msg) => {
     const match = msg.match(/script ready (\d+)/);
     if (match) {
       firstGrandchildPid = match[1];  // This is the first grandchild
-      writeFileSync(indexPath, indexContents);
+      const writeDelay = 1000;  // Delay to reduce the chance of fs events coalescing
+      console.log(`[PARENT] writing to restart ${firstGrandchildPid} after ${writeDelay}ms`);
+      setTimeout(() => {
+        console.log(`[PARENT] writing to ${indexPath} to restart ${firstGrandchildPid}`);
+        writeFileSync(indexPath, indexContents);
+      }, writeDelay);
     }
   }
 });


### PR DESCRIPTION
The test is still flaking on macOS. This might be caused by fs event coalescing. Apply a delay to reduce the chance of it. Also, add a bit more logs to show more information.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2025-11-07.md

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
