### PR TITLE
http: add Server.drainTimeout for gracefully closing idle connections

### DIFF
--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -560,9 +560,13 @@ function setupConnectionsTracking() {
     setInterval(checkConnections.bind(this), this.connectionsCheckingInterval).unref();
 }
 
-function httpServerPreClose(server) {
-  server.closeIdleConnections();
-  clearInterval(server[kConnectionsCheckingInterval]);
+function httpServerPreClose(server, callback) {
+  server.closeIdleConnections(() => {
+    clearInterval(server[kConnectionsCheckingInterval]);
+    if (typeof callback === 'function') {
+      callback();
+    }
+  });
 }
 
 function Server(options, requestListener) {
@@ -592,8 +596,26 @@ function Server(options, requestListener) {
       keepAliveInitialDelay: options.keepAliveInitialDelay,
       highWaterMark: options.highWaterMark });
 
+  this.drainStarted = false;
+  this.drainTimeout = options.drainTimeout || 0;
+
   if (requestListener) {
-    this.on('request', requestListener);
+    // Do we want to gracefully drain existing keep-alive connections
+    // using 'Connection: close' once server.close() was called?
+    if (this.drainTimeout > 0) {
+      // Yes, we do, so wrap the requestListener using a listener
+      // that sets the 'Connection: close' header.
+      const gracefulHandler = (req, res) => {
+        if (this.drainStarted) {
+          res.setHeader('Connection', 'close');
+        }
+        return requestListener.bind(this)(req, res);
+      };
+      this.on('request', gracefulHandler);
+    } else {
+      // Default behaviour: No graceful listener.
+      this.on('request', requestListener);
+    }
   }
 
   // Similar option to this. Too lazy to write my own docs.
@@ -614,8 +636,9 @@ ObjectSetPrototypeOf(Server.prototype, net.Server.prototype);
 ObjectSetPrototypeOf(Server, net.Server);
 
 Server.prototype.close = function close() {
-  httpServerPreClose(this);
-  ReflectApply(net.Server.prototype.close, this, arguments);
+  httpServerPreClose(this, () => {
+    ReflectApply(net.Server.prototype.close, this, arguments);
+  })
   return this;
 };
 
@@ -635,19 +658,27 @@ Server.prototype.closeAllConnections = function closeAllConnections() {
   }
 };
 
-Server.prototype.closeIdleConnections = function closeIdleConnections() {
+Server.prototype.closeIdleConnections = function closeIdleConnections(callback) {
   if (!this[kConnections]) {
     return;
   }
-
-  const connections = this[kConnections].idle();
-
-  for (let i = 0, l = connections.length; i < l; i++) {
-    if (connections[i].socket._httpMessage && !connections[i].socket._httpMessage.finished) {
-      continue;
+  const fn = () => {
+    const connections = this[kConnections].idle();
+    for (let i = 0, l = connections.length; i < l; i++) {
+      if (connections[i].socket._httpMessage && !connections[i].socket._httpMessage.finished) {
+        continue;
+      }
+      connections[i].socket.destroy();
     }
-
-    connections[i].socket.destroy();
+    if (typeof callback === 'function') {
+      callback();
+    }
+  };
+  this.drainStarted = true;
+  if (this.drainTimeout > 0) {
+    setTimeout(() => { fn() }, this.drainTimeout);
+  } else {
+    fn();
   }
 };
 
@@ -1390,3 +1421,4 @@ module.exports = {
   httpServerPreClose,
   kConnectionsCheckingInterval,
 };
+

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -598,6 +598,7 @@ function Server(options, requestListener) {
 
   this.drainStarted = false;
   this.drainTimeout = options.drainTimeout || 0;
+  this.drainConnectionsPollInterval = options.drainConnectionsPollInterval || 500;
 
   if (requestListener) {
     // Do we want to gracefully drain existing keep-alive connections
@@ -662,7 +663,9 @@ Server.prototype.closeIdleConnections = function closeIdleConnections(callback) 
   if (!this[kConnections]) {
     return;
   }
+
   const fn = () => {
+    // Destroy all still remaining idle connections.
     const connections = this[kConnections].idle();
     for (let i = 0, l = connections.length; i < l; i++) {
       if (connections[i].socket._httpMessage && !connections[i].socket._httpMessage.finished) {
@@ -673,10 +676,27 @@ Server.prototype.closeIdleConnections = function closeIdleConnections(callback) 
     if (typeof callback === 'function') {
       callback();
     }
+  }
+
+  // For graceful draining, if drainTimeout > 0 (see below)
+  let startTime = Date.now()
+  let timer = null;
+  const checkFn = () => {
+    const connections = this[kConnections].all();
+    if (Date.now() - startTime > this.drainTimeout || connections.length === 0) {
+      // Either drain period has ended, or we have no open connections anymore.
+      // We can close now.
+      clearInterval(timer);
+      timer = null;
+      fn();
+    }
   };
-  this.drainStarted = true;
-  if (this.drainTimeout > 0) {
-    setTimeout(() => { fn() }, this.drainTimeout);
+
+  if (this.drainTimeout > 0 && !this.drainStarted) {
+    this.drainStarted = true;
+    // Start polling for idle connections.
+    // If all connections are gone or drain period ends, we call the callback.
+    timer = setInterval(checkFn, this.drainConnectionsPollInterval);
   } else {
     fn();
   }


### PR DESCRIPTION
This is an initial draft implementation for https://github.com/nodejs/node/issues/60617 .
Please see that issue for a detailed discussion of the proposed enhancement.

The implemented behaviour is:
- upon http.Server.close() or http.Server.closeIdleConnections() we set a new variable `drainStarted` to `true`
- then, via a wrapper for the provided `requestListener` in the `Server` constructor, for any then received requests, we set the `Connection: close` response header, leading to the client to close the connection itself (avoiding the race condition mentioned in https://github.com/nodejs/node/issues/60617 )
- then, in http.Server.closeIdleConnections() we wait (via setTimeout) for the configured `drainTimeout` before doing anything with idle connections
- after the timeout callback fires, we proceed normally with what closeIdleConnections() would have done earlier (actually closing any remaining idle connections)

The default behaviour of immediately closing idle connections on "graceful" server shutdown is preserved with the default of `dranTimeout` == 0.

I am aware of the fact that currently, missing are (as per committer guidelines):
- documentation changes
- tests when drainTimeout > 0

But I'd like to first gauge the possibility of this feature actually making it through, eventually.

Currently, all existing tests (via `make test`) pass successfully and using the patched node executable, the following results in the expected behaviour of the server still accepting requests on idle connections for 5s and responding to them with `Connection: close` before finally shutting down:
```javascript
var http = require('http');
var server = http.createServer({drainTimeout: 5000}, function (req, res) {
  res.writeHead(200, {'Content-Type': 'text/plain'});
  res.end('');
}).listen(3000);
function gracefulShutdown(sig) {
  console.log(`${sig} signal received. Draining connections...`);
  server.close(() => {
    console.log('Closed remaining connections');
  })
}
process.on('SIGTERM', () => {
  gracefulShutdown('SIGTERM')
});
process.on('SIGINT', () => {
  gracefulShutdown('SIGINT')
});
```

**What's next**

- Awaiting general acceptance/rejection of such a feature enhancement
- Improving the drain process (as also mentioned in https://github.com/nodejs/node/issues/60617 ) by being more "reactive" to the client actively closing off connections (either because of its own idle timeout expiring or because of a request which the server now responds to with `Connection: close`) until the number of open connections reaches zero; instead of waiting the full `drainTimeout` (**EDIT: actually, I added that now**)