### PR TITLE
test: fix test-buffer-zero-fill-cli to be effective

### DIFF
--- a/test/parallel/test-buffer-zero-fill-cli.js
+++ b/test/parallel/test-buffer-zero-fill-cli.js
@@ -14,6 +14,13 @@ function isZeroFilled(buf) {
   return true;
 }
 
+// We have to consume the data from the pool as otherwise
+// we would be testing what's in snapshot, which is zero-filled
+// regardless of the flag presence, and we want to test the flag
+for (let i = 0; i < 8; i++) {
+  assert(isZeroFilled(Buffer.allocUnsafe(1024)));
+}
+
 // This can be somewhat unreliable because the
 // allocated memory might just already happen to
 // contain all zeroes. The test is run multiple
@@ -22,7 +29,8 @@ for (let i = 0; i < 50; i++) {
   const bufs = [
     Buffer.alloc(20),
     Buffer.allocUnsafe(20),
-    Buffer.allocUnsafeSlow(20),
+    Buffer.allocUnsafeSlow(20), // Heap
+    Buffer.allocUnsafeSlow(128), // Alloc
     Buffer(20),
   ];
   for (const buf of bufs) {


### PR DESCRIPTION
The test was useless for testing `--zero-fill-buffers` flag, which is what it was supposed to test.

1. `Buffer.allocUnsafeSlow(20)` is zero-filled regardless of the flag because it's from heap (<=64), not an alloc

2. 50 first calls to `Buffer.allocUnsafe(20)` were zero-filled regardless of the flag because they all come from the pool which was in the snapshot, and no real runtime alloc was made.

This PR fixes the test, so it now fails without the flag (as expected).