### PR TITLE
docs: Add docs on NodeEventTarget

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -2482,6 +2482,9 @@ added: v14.5.0
 The `NodeEventTarget` is a Node.js-specific extension to `EventTarget`
 that emulates a subset of the `EventEmitter` API.
 
+`NodeEventTarget` is not part of the Node.js public API itself but is implemented
+by some Node.js classes.
+
 #### `nodeEventTarget.addListener(type, listener)`
 
 <!-- YAML


### PR DESCRIPTION
While researching EventEmitter versus Node.js's EventTarget versus DOM EventTarget, I found these docs on NodeEventTarget and was confused when I couldn't find NodeEventTarget itself.

As far as I can tell, NodeEventTarget is used exactly once - by MessagePort. This makes me wonder if NodeEventTarget should be deprecated and/or become undocumented - but these docs are a minimal, hopefully helpful step if that isn't desirable.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
