### PR TITLE
to avoid crash because of null pointer

### DIFF
--- a/src/stream_base.cc
+++ b/src/stream_base.cc
@@ -754,6 +754,7 @@ void CustomBufferJSListener::OnStreamRead(ssize_t nread, const uv_buf_t& buf) {
 
 void ReportWritesToJSStreamListener::OnStreamAfterReqFinished(
     StreamReq* req_wrap, int status) {
+  if(!req_wrap) return;
   StreamBase* stream = static_cast<StreamBase*>(stream_);
   Environment* env = stream->stream_env();
   if (!env->can_call_into_js()) return;


### PR DESCRIPTION
null might be expected along the call stack, but here, null is not expected, so just return, and crash could be avoided.

when it crashes, req_wrap is null.  For more information, please refer to https://github.com/nodejs/node/issues/59465
