### PR TITLE
[v24.x backport] src: use CP_UTF8 for wide file names on win32

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3175,42 +3175,6 @@ static void GetFormatOfExtensionlessFile(
   return args.GetReturnValue().Set(EXTENSIONLESS_FORMAT_JAVASCRIPT);
 }
 
-#ifdef _WIN32
-#define BufferValueToPath(str)                                                 \
-  std::filesystem::path(ConvertToWideString(str.ToString(), CP_UTF8))
-
-std::string ConvertWideToUTF8(const std::wstring& wstr) {
-  if (wstr.empty()) return std::string();
-
-  int size_needed = WideCharToMultiByte(CP_UTF8,
-                                        0,
-                                        &wstr[0],
-                                        static_cast<int>(wstr.size()),
-                                        nullptr,
-                                        0,
-                                        nullptr,
-                                        nullptr);
-  std::string strTo(size_needed, 0);
-  WideCharToMultiByte(CP_UTF8,
-                      0,
-                      &wstr[0],
-                      static_cast<int>(wstr.size()),
-                      &strTo[0],
-                      size_needed,
-                      nullptr,
-                      nullptr);
-  return strTo;
-}
-
-#define PathToString(path) ConvertWideToUTF8(path.wstring());
-
-#else  // _WIN32
-
-#define BufferValueToPath(str) std::filesystem::path(str.ToStringView());
-#define PathToString(path) path.native();
-
-#endif  // _WIN32
-
 static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
@@ -3223,7 +3187,7 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemRead, src.ToStringView());
 
-  auto src_path = BufferValueToPath(src);
+  auto src_path = src.ToPath();
 
   BufferValue dest(isolate, args[1]);
   CHECK_NOT_NULL(*dest);
@@ -3231,7 +3195,7 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemWrite, dest.ToStringView());
 
-  auto dest_path = BufferValueToPath(dest);
+  auto dest_path = dest.ToPath();
   bool dereference = args[2]->IsTrue();
   bool recursive = args[3]->IsTrue();
 
@@ -3260,8 +3224,8 @@ static void CpSyncCheckPaths(const FunctionCallbackInfo<Value>& args) {
       (src_status.type() == std::filesystem::file_type::directory) ||
       (dereference && src_status.type() == std::filesystem::file_type::symlink);
 
-  auto src_path_str = PathToString(src_path);
-  auto dest_path_str = PathToString(dest_path);
+  auto src_path_str = ConvertPathToUTF8(src_path);
+  auto dest_path_str = ConvertPathToUTF8(dest_path);
 
   if (!error_code) {
     // Check if src and dest are identical.
@@ -3356,7 +3320,7 @@ static bool CopyUtimes(const std::filesystem::path& src,
   uv_fs_t req;
   auto cleanup = OnScopeLeave([&req]() { uv_fs_req_cleanup(&req); });
 
-  auto src_path_str = PathToString(src);
+  auto src_path_str = ConvertPathToUTF8(src);
   int result = uv_fs_stat(nullptr, &req, src_path_str.c_str(), nullptr);
   if (is_uv_error(result)) {
     env->ThrowUVException(result, "stat", nullptr, src_path_str.c_str());
@@ -3367,7 +3331,7 @@ static bool CopyUtimes(const std::filesystem::path& src,
   const double source_atime = s->st_atim.tv_sec + s->st_atim.tv_nsec / 1e9;
   const double source_mtime = s->st_mtim.tv_sec + s->st_mtim.tv_nsec / 1e9;
 
-  auto dest_file_path_str = PathToString(dest);
+  auto dest_file_path_str = ConvertPathToUTF8(dest);
   int utime_result = uv_fs_utime(nullptr,
                                  &req,
                                  dest_file_path_str.c_str(),
@@ -3502,7 +3466,7 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
     std::error_code error;
     for (auto dir_entry : std::filesystem::directory_iterator(src)) {
       auto dest_file_path = dest / dir_entry.path().filename();
-      auto dest_str = PathToString(dest);
+      auto dest_str = ConvertPathToUTF8(dest);
 
       if (dir_entry.is_symlink()) {
         if (verbatim_symlinks) {
@@ -3561,7 +3525,7 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
               }
             } else if (std::filesystem::is_regular_file(dest_file_path)) {
               if (!dereference || (!force && error_on_exist)) {
-                auto dest_file_path_str = PathToString(dest_file_path);
+                auto dest_file_path_str = ConvertPathToUTF8(dest_file_path);
                 env->ThrowStdErrException(
                     std::make_error_code(std::errc::file_exists),
                     "cp",

--- a/src/node_modules.cc
+++ b/src/node_modules.cc
@@ -296,22 +296,24 @@ const BindingData::PackageConfig* BindingData::TraverseParent(
 
     // Stop the search when the process doesn't have permissions
     // to walk upwards
-    if (is_permissions_enabled &&
-        !env->permission()->is_granted(
-            env,
-            permission::PermissionScope::kFileSystemRead,
-            current_path.generic_string())) [[unlikely]] {
-      return nullptr;
+    if (is_permissions_enabled) {
+      if (!env->permission()->is_granted(
+              env,
+              permission::PermissionScope::kFileSystemRead,
+              ConvertGenericPathToUTF8(current_path))) [[unlikely]] {
+        return nullptr;
+      }
     }
 
     // Check if the path ends with `/node_modules`
-    if (current_path.generic_string().ends_with("/node_modules")) {
+    if (current_path.filename() == "node_modules") {
       return nullptr;
     }
 
     auto package_json_path = current_path / "package.json";
+
     auto package_json =
-        GetPackageJSON(realm, package_json_path.string(), nullptr);
+        GetPackageJSON(realm, ConvertPathToUTF8(package_json_path), nullptr);
     if (package_json != nullptr) {
       return package_json;
     }
@@ -333,19 +335,11 @@ void BindingData::GetNearestParentPackageJSONType(
 
   ToNamespacedPath(realm->env(), &path_value);
 
-  std::string path_value_str = path_value.ToString();
+  auto path = path_value.ToPath();
+
   if (slashCheck) {
-    path_value_str.push_back(kPathSeparator);
+    path /= "";
   }
-
-  std::filesystem::path path;
-
-#ifdef _WIN32
-  std::wstring wide_path = ConvertToWideString(path_value_str, GetACP());
-  path = std::filesystem::path(wide_path);
-#else
-  path = std::filesystem::path(path_value_str);
-#endif
 
   auto package_json = TraverseParent(realm, path);
 

--- a/src/util.h
+++ b/src/util.h
@@ -507,6 +507,8 @@ class MaybeStackBuffer {
   inline std::basic_string_view<T> ToStringView() const {
     return {out(), length()};
   }
+  // This can only be used if the buffer contains path data in UTF8
+  inline std::filesystem::path ToPath() const;
 
  private:
   size_t length_;
@@ -1038,8 +1040,14 @@ class JSONOutputStream final : public v8::OutputStream {
 // Returns true if OS==Windows and filename ends in .bat or .cmd,
 // case insensitive.
 inline bool IsWindowsBatchFile(const char* filename);
-inline std::wstring ConvertToWideString(const std::string& str, UINT code_page);
+inline std::wstring ConvertUTF8ToWideString(const std::string& str);
+inline std::string ConvertWideStringToUTF8(const std::wstring& wstr);
+
 #endif  // _WIN32
+
+inline std::filesystem::path ConvertUTF8ToPath(const std::string& str);
+inline std::string ConvertPathToUTF8(const std::filesystem::path& path);
+inline std::string ConvertGenericPathToUTF8(const std::filesystem::path& path);
 
 // A helper to create a new instance of the dictionary template.
 // Unlike v8::DictionaryTemplate::NewInstance, this method will


### PR DESCRIPTION
`src/node_modules.cc` needs to be consistent with `src/node_file.cc` in how it translates the utf8 strings to `std::wstring` otherwise we might end up in situation where we can read the source code of imported package from disk, but fail to recognize that it is an ESM (or CJS) and cause runtime errors. This type of error is possible on Windows when the path contains unicode characters and "Language for non-Unicode programs" is set to "Chinese (Traditional, Taiwan)".

See: #58768
PR-URL: https://github.com/nodejs/node/pull/60575
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Darshan Sen <raisinten@gmail.com>
Reviewed-By: Stefan Stojanovic <stefan.stojanovic@janeasystems.com>
Reviewed-By: Juan José Arboleda <soyjuanarbol@gmail.com>
Reviewed-By: Joyee Cheung <joyeec9h3@gmail.com>
Reviewed-By: Rafael Gonzaga <rafael.nunu@hotmail.com>

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
