### PR TITLE
test: deflake test-perf-hooks-timerify-histogram-sync

### DIFF
--- a/test/common/index.js
+++ b/test/common/index.js
@@ -931,6 +931,12 @@ function expectRequiredTLAError(err) {
   }
 }
 
+function sleepSync(ms) {
+  const sab = new SharedArrayBuffer(4);
+  const i32 = new Int32Array(sab);
+  Atomics.wait(i32, 0, 0, ms);
+}
+
 const common = {
   allowGlobals,
   buildType,
@@ -982,6 +988,7 @@ const common = {
   skipIfInspectorDisabled,
   skipIfSQLiteMissing,
   spawnPromisified,
+  sleepSync,
 
   get enoughTestMem() {
     return require('os').totalmem() > 0x70000000; /* 1.75 Gb */

--- a/test/common/index.mjs
+++ b/test/common/index.mjs
@@ -50,6 +50,7 @@ const {
   skipIfInspectorDisabled,
   skipIfSQLiteMissing,
   spawnPromisified,
+  sleepSync,
 } = common;
 
 const getPort = () => common.PORT;
@@ -103,4 +104,5 @@ export {
   skipIfInspectorDisabled,
   skipIfSQLiteMissing,
   spawnPromisified,
+  sleepSync,
 };

--- a/test/parallel/test-perf-hooks-timerify-histogram-sync.mjs
+++ b/test/parallel/test-perf-hooks-timerify-histogram-sync.mjs
@@ -1,22 +1,19 @@
 // Test that timerify works with histogram option for synchronous functions.
 
-import '../common/index.mjs';
+import { sleepSync } from '../common/index.mjs';
 import assert from 'assert';
 import { createHistogram, timerify } from 'perf_hooks';
-import { setTimeout as sleep } from 'timers/promises';
-
-let _deadCode;
 
 const histogram = createHistogram();
-const m = (a, b = 1) => {
-  for (let i = 0; i < 1e3; i++)
-    _deadCode = i;
+
+const m = () => {
+  // Deterministic blocking delay (~1 millisecond). The histogram operates on
+  // nanosecond precision, so this should be sufficient to prevent zero timings.
+  sleepSync(1);
 };
 const n = timerify(m, { histogram });
 assert.strictEqual(histogram.max, 0);
 for (let i = 0; i < 10; i++) {
   n();
-  await sleep(10);
 }
-assert(_deadCode >= 0);
 assert.notStrictEqual(histogram.max, 0);


### PR DESCRIPTION
The previous busy loop wasn't robust enough in making sure that the function runs for more than 1 nanosecond - and when it runs faster than that on a fast machine, it measures to 0 for nanosecond precision and throws a RangeErorr as histogram.record() only takes positive values. Update it to use Atomics.wait() to make sure that the function being measured runs for at least 1 millisecond so that the histogram always records a positive value.

Fixes: https://github.com/nodejs/node/issues/60638
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
