### PR TITLE
fix: replace invalid expression in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,10 +10,9 @@ updates:
       semver-major-days: 5
       semver-minor-days: 5
       semver-patch-days: 5
-
     commit-message:
       prefix: meta
-    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
+    open-pull-requests-limit: 10
 
   - package-ecosystem: npm
     directory: /tools/eslint
@@ -25,7 +24,7 @@ updates:
       semver-patch-days: 5
     commit-message:
       prefix: tools
-    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
+    open-pull-requests-limit: 10
     groups:
       eslint:
         applies-to: version-updates
@@ -42,7 +41,7 @@ updates:
       semver-patch-days: 5
     commit-message:
       prefix: tools
-    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
+    open-pull-requests-limit: 10
     groups:
       lint-md:
         applies-to: version-updates
@@ -59,7 +58,7 @@ updates:
       semver-patch-days: 5
     commit-message:
       prefix: tools
-    open-pull-requests-limit: ${{secrets.OPEN_PR_LIMIT}}
+    open-pull-requests-limit: 10
     groups:
       doc:
         applies-to: version-updates


### PR DESCRIPTION
Dependabot was failing to parse `.github/dependabot.yml` because `open-pull-requests-limit` was set using a GitHub Actions expression. Dependabot doesn't evaluate expressions and only accepts an integer, so the config was considered invalid.

This change replaces the expression with a number. The YAML now matches Dependabot’s schema and validates without errors.

Fixes: https://github.com/nodejs/node/issues/60637

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
