### PR TITLE
module: read from stdin when input is a pipe

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1135,6 +1135,11 @@ function defaultLoadImpl(filename, format) {
     case 'module-typescript':
     case 'commonjs-typescript':
     case 'typescript': {
+      const isPipePath = ['/dev/stdin', '/dev/fd/0'].includes(filename) ||
+                         (filename.startsWith('/proc/') && filename.includes('/fd/pipe:'));
+      if (isPipePath) {
+        return fs.readFileSync(0, 'utf8');
+      }
       return fs.readFileSync(filename, 'utf8');
     }
     case 'builtin':

--- a/test/parallel/test-typescript-stdin-pipe.js
+++ b/test/parallel/test-typescript-stdin-pipe.js
@@ -1,0 +1,21 @@
+'use strict';
+const common = require('../common');
+
+if (common.isWindows || common.isAIX || common.isIBMi)
+  common.skip(`No /dev/stdin on ${process.platform}.`);
+
+const assert = require('assert');
+const { exec } = require('child_process');
+
+const tsCode = `
+const message = "JavaScript from pipe";
+console.log(message);
+`;
+
+
+const [cmd, opts] = common.escapePOSIXShell`echo ${tsCode} | ${process.execPath} /dev/stdin`;
+
+exec(cmd, opts, common.mustSucceed((stdout, stderr) => {
+  assert.strictEqual(stdout.trim(), 'JavaScript from pipe');
+  assert.strictEqual(stderr, '');
+}));

--- a/test/parallel/test-typescript-stdin-pipe.js
+++ b/test/parallel/test-typescript-stdin-pipe.js
@@ -13,7 +13,7 @@ console.log(message);
 `;
 
 
-const [cmd, opts] = common.escapePOSIXShell`echo ${tsCode} | ${process.execPath} /dev/stdin`;
+const [cmd, opts] = common.escapePOSIXShell`printf "${tsCode}" | ${process.execPath} /dev/stdin`;
 
 exec(cmd, opts, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout.trim(), 'JavaScript from pipe');


### PR DESCRIPTION
Update the CommonJS module loader to detect when the input filename is /dev/stdin and stdin is a pipe. In such cases, read directly from file descriptor 0 instead of attempting to open the /proc/<pid>/fd/pipe:[...] path, which can result in ENOENT errors.

This change ensures that running Node with piped input like:
  printf 'console.log(1)' | node /dev/stdin
works reliably on Linux systems.

Fixes: https://github.com/nodejs/node/issues/54200

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
