### PR TITLE
crypto: ensure documented RSA-PSS saltLength default is used

### DIFF
--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -50,6 +50,8 @@ const {
   isArrayBufferView,
 } = require('internal/util/types');
 
+const constants = internalBinding('constants').crypto;
+
 function Sign(algorithm, options) {
   if (!(this instanceof Sign))
     return new Sign(algorithm, options);
@@ -85,7 +87,11 @@ function getPadding(options) {
 }
 
 function getSaltLength(options) {
-  return getIntOption('saltLength', options);
+  let saltLength = getIntOption('saltLength', options);
+  if (options.padding === constants.RSA_PKCS1_PSS_PADDING && saltLength === undefined) {
+    saltLength = constants.RSA_PSS_SALTLEN_MAX_SIGN;
+  }
+  return saltLength;
 }
 
 function getDSASignatureEncoding(options) {

--- a/test/parallel/test-crypto-rsa-pss-default-salt-length.js
+++ b/test/parallel/test-crypto-rsa-pss-default-salt-length.js
@@ -1,0 +1,37 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+
+const fixtures = require('../common/fixtures');
+
+const privateKey = crypto.createPrivateKey(fixtures.readKey('rsa_private.pem', 'ascii'));
+const publicKey = crypto.createPublicKey(fixtures.readKey('rsa_public.pem', 'ascii'));
+
+const data = crypto.randomBytes(32);
+
+for (const digest of ['sha256', 'sha384', 'sha512']) {
+  const hLen = crypto.hash(digest, data, 'buffer').byteLength;
+  const maxSaltLength =
+      privateKey.asymmetricKeyDetails.modulusLength / 8 - hLen - 2;
+
+  const sig = crypto.sign(digest, data, {
+    key: privateKey,
+    padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+    // No "saltLength" provided, documented default RSA_PSS_SALTLEN_MAX_SIGN expected
+  });
+
+  assert.strictEqual(crypto.verify(
+    digest,
+    data,
+    {
+      key: publicKey,
+      padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+      saltLength: maxSaltLength,
+    },
+    sig
+  ), true);
+}


### PR DESCRIPTION
This PR ensures that the documented RSA-PSS saltLength default is used regardless of the OpenSSL version used by the runtime.