### PR TITLE
test: fix flaky keepalive timeout test on slow platforms

### DIFF
--- a/test/sequential/test-http-server-keep-alive-timeout-slow-client-headers.js
+++ b/test/sequential/test-http-server-keep-alive-timeout-slow-client-headers.js
@@ -5,11 +5,12 @@ const assert = require('assert');
 const http = require('http');
 const net = require('net');
 
-const server = http.createServer(common.mustCall((req, res) => {
+const server = http.createServer({
+  keepAliveTimeout: common.platformTimeout(100),
+  keepAliveTimeoutBuffer: common.platformTimeout(1000),
+}, common.mustCall((req, res) => {
   res.end();
 }, 2));
-
-server.keepAliveTimeout = common.platformTimeout(100);
 
 server.listen(0, common.mustCall(() => {
   const port = server.address().port;


### PR DESCRIPTION
Fixes: #60656

The test was setting keepAliveTimeout with platformTimeout() but
keepAliveTimeoutBuffer remained at the hardcoded default of 1000ms.
This caused timing issues on slow CI platforms where platformTimeout
scales up timeout values but the buffer did not scale accordingly.

Now both keepAliveTimeout and keepAliveTimeoutBuffer are set using
platformTimeout() to ensure consistent behavior across all platforms

<img width="696" height="96" alt="image" src="https://github.com/user-attachments/assets/c0ba9bc9-fdde-4004-9351-d9358467b120" />