### PR TITLE
watch: re-expose watch flags via execArgv

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -7,6 +7,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypePushApply,
   ArrayPrototypeSlice,
+  JSONStringify,
   StringPrototypeStartsWith,
 } = primordials;
 
@@ -44,17 +45,22 @@ const kCommand = ArrayPrototypeSlice(process.argv, 1);
 const kCommandStr = inspect(ArrayPrototypeJoin(kCommand, ' '));
 
 const argsWithoutWatchOptions = [];
-for (let i = 0; i < process.execArgv.length; i++) {
-  const arg = process.execArgv[i];
+const removedWatchFlags = [];
+const args = process.execArgv;
+for (let i = 0; i < args.length; i++) {
+  const arg = args[i];
   if (StringPrototypeStartsWith(arg, '--watch=')) {
+    ArrayPrototypePush(removedWatchFlags, arg);
     continue;
   }
   if (arg === '--watch') {
-    const nextArg = process.execArgv[i + 1];
+    ArrayPrototypePush(removedWatchFlags, arg);
+    const nextArg = args[i + 1];
     if (nextArg && nextArg[0] !== '-') {
       // If `--watch` doesn't include `=` and the next
       // argument is not a flag then it is interpreted as
       // the watch argument, so we need to skip that as well
+      ArrayPrototypePush(removedWatchFlags, nextArg);
       i++;
     }
     continue;
@@ -65,7 +71,14 @@ for (let i = 0; i < process.execArgv.length; i++) {
       // if --watch-path doesn't include `=` it means
       // that the next arg is the target path, so we
       // need to skip that as well
-      i++;
+      ArrayPrototypePush(removedWatchFlags, arg);
+      const nextArg = args[i + 1];
+      if (nextArg) {
+        ArrayPrototypePush(removedWatchFlags, nextArg);
+        i++;
+      }
+    } else {
+      ArrayPrototypePush(removedWatchFlags, arg);
     }
     continue;
   }
@@ -94,12 +107,16 @@ let exited;
 function start() {
   exited = false;
   const stdio = kShouldFilterModules ? ['inherit', 'inherit', 'inherit', 'ipc'] : 'inherit';
+  const env = {
+    ...process.env,
+    WATCH_REPORT_DEPENDENCIES: '1',
+  };
+  if (removedWatchFlags.length > 0) {
+    env.NODE_WATCH_ARGS = JSONStringify(removedWatchFlags);
+  }
   child = spawn(process.execPath, argsWithoutWatchOptions, {
     stdio,
-    env: {
-      ...process.env,
-      WATCH_REPORT_DEPENDENCIES: '1',
-    },
+    env,
   });
   watcher.watchChildProcessModules(child);
   if (kEnvFiles.length > 0) {

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const {
+  ArrayIsArray,
   ArrayPrototypeForEach,
+  ArrayPrototypeUnshiftApply,
   Date,
   DatePrototypeGetDate,
   DatePrototypeGetFullYear,
@@ -9,6 +11,7 @@ const {
   DatePrototypeGetMinutes,
   DatePrototypeGetMonth,
   DatePrototypeGetSeconds,
+  JSONParse,
   NumberParseInt,
   ObjectDefineProperty,
   ObjectFreeze,
@@ -269,6 +272,19 @@ function patchProcessObject(expandArgv1) {
   process.exitCode = undefined;
   process._exiting = false;
   process.argv[0] = process.execPath;
+
+  const watchArgsFromLauncher = process.env.NODE_WATCH_ARGS;
+  if (watchArgsFromLauncher !== undefined) {
+    delete process.env.NODE_WATCH_ARGS;
+    try {
+      const parsed = JSONParse(watchArgsFromLauncher);
+      if (ArrayIsArray(parsed) && parsed.length > 0) {
+        ArrayPrototypeUnshiftApply(process.execArgv, parsed);
+      }
+    } catch {
+      // Ignore malformed payloads.
+    }
+  }
 
   /** @type {string} */
   let mainEntry;


### PR DESCRIPTION
Fixes:  #60594
  ## Summary
  - Make the watch launcher capture the stripped `--watch*` flags and pass them to the child through `NODE_WATCH_ARGS`.
  - During bootstrap, parse `NODE_WATCH_ARGS`, prepend the recovered flags to `process.execArgv`, and delete the env var.
  - Extend `test/sequential/test-watch-mode-watch-flags.mjs` to assert that watch flags show up at the beginning of `process.execArgv`, accepting both `--watch-path
  value` and `--watch-path=value` forms.

  ## Testing
  - python3 tools/test.py sequential/test-watch-mode-watch-flags
  
  
<img width="797" height="120" alt="image" src="https://github.com/user-attachments/assets/7e5cd9c3-8baa-4a91-ba8e-84b5d3f452cd" />