### PR TITLE
 Render “About this documentation” on the docs landing page

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -871,6 +871,16 @@ out/doc/api/all.json: $(apidocs_json) tools/doc/alljson.mjs | out/doc/api
 		$(call available-node, tools/doc/alljson.mjs) \
 	fi
 
+# Ensure the documentation landing page mirrors About this documentation.
+out/doc/api/documentation.html out/doc/api/documentation.json: \
+		doc/api/index.md
+
+out/doc/api/index.html: out/doc/api/documentation.html doc/api/index.md
+	cp $< $@
+
+out/doc/api/index.json: out/doc/api/documentation.json doc/api/index.md
+	cp $< $@
+
 .PHONY: out/doc/api/stability
 out/doc/api/stability: out/doc/api/all.json tools/doc/stability.mjs | out/doc/api
 	@if [ "$(shell $(node_use_icu))" != "true" ]; then \

--- a/tools/doc/alljson.mjs
+++ b/tools/doc/alljson.mjs
@@ -28,7 +28,9 @@ const seen = new Set(['all.json', 'index.json']);
 // Extract (and concatenate) the selected data from each document.
 // Expand hrefs found in json to include source HTML file.
 for (const link of toc.match(/<a.*?>/g)) {
-  const href = /href="(.*?)"/.exec(link)[1];
+  const hrefMatch = /href="(.*?)"/.exec(link);
+  if (!hrefMatch) continue;
+  const href = hrefMatch[1];
   const json = href.replace('.html', '.json');
   if (!jsonFiles.includes(json) || seen.has(json)) continue;
   const data = JSON.parse(


### PR DESCRIPTION
Fixes: #60667
- Copy the documentation.md output to index.html/.json so /docs/latest/api/ immediately shows the
    introduction instead of a duplicated TOC
- Harden tools/doc/allhtml.mjs and tools/doc/alljson.mjs against the new index structure by skipping
    anchor tags without href, replacing the TOC picker markup, and keeping anchor validation intact