### PR TITLE
http,https: fix double ERR_PROXY_TUNNEL emission

### DIFF
--- a/lib/_http_agent.js
+++ b/lib/_http_agent.js
@@ -284,9 +284,8 @@ function handleSocketAfterProxy(err, req) {
   if (err.code === 'ERR_PROXY_TUNNEL') {
     if (err.proxyTunnelTimeout) {
       req.emit('timeout');  // Propagate the timeout from the tunnel to the request.
-    } else {
-      req.emit('error', err);
     }
+    req.emit('error', err);
   }
 }
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -958,7 +958,8 @@ function onSocketNT(req, socket, err) {
       if (!req.aborted && !err) {
         err = new ConnResetException('socket hang up');
       }
-      if (err) {
+      // ERR_PROXY_TUNNEL is handled by the proxying logic
+      if (err && err.code !== 'ERR_PROXY_TUNNEL') {
         emitErrorEvent(req, err);
       }
       req._closed = true;

--- a/test/client-proxy/test-https-proxy-request-malformed-response.mjs
+++ b/test/client-proxy/test-https-proxy-request-malformed-response.mjs
@@ -43,7 +43,7 @@ const { code, signal, stderr, stdout } = await runProxiedRequest({
 });
 
 // The proxy client should get an error from failure in establishing the tunnel.
-assert.match(stderr, /ERR_PROXY_TUNNEL.*Failed to establish tunnel to .* NOT-HTTP MALFORMED RESPONSE/);
+assert.strictEqual(stderr.match(/ERR_PROXY_TUNNEL.*Failed to establish tunnel to .* NOT-HTTP MALFORMED RESPONSE*/g).length, 1);
 assert.strictEqual(stdout.trim(), '');
 assert.strictEqual(code, 0);
 assert.strictEqual(signal, null);

--- a/test/client-proxy/test-https-proxy-request-proxy-failure-404.mjs
+++ b/test/client-proxy/test-https-proxy-request-proxy-failure-404.mjs
@@ -43,7 +43,7 @@ const { code, signal, stderr, stdout } = await runProxiedRequest({
 });
 
 // The proxy client should get an error from failure in establishing the tunnel.
-assert.match(stderr, /ERR_PROXY_TUNNEL.*Failed to establish tunnel to .* HTTP\/1\.1 404 Not Found/);
+assert.strictEqual(stderr.match(/ERR_PROXY_TUNNEL.*Failed to establish tunnel to .* HTTP\/1\.1 404 Not Found/g).length, 1);
 assert.strictEqual(stdout.trim(), '');
 assert.strictEqual(code, 0);
 assert.strictEqual(signal, null);

--- a/test/client-proxy/test-https-proxy-request-proxy-failure-500.mjs
+++ b/test/client-proxy/test-https-proxy-request-proxy-failure-500.mjs
@@ -44,7 +44,7 @@ const { code, signal, stderr, stdout } = await runProxiedRequest({
 });
 
 // The proxy client should get an error from failure in establishing the tunnel.
-assert.match(stderr, /ERR_PROXY_TUNNEL.*Failed to establish tunnel to .* HTTP\/1\.1 500 Connection Error/);
+assert.strictEqual(stderr.match(/ERR_PROXY_TUNNEL.*Failed to establish tunnel to .* HTTP\/1\.1 500 Connection Error/g).length, 1);
 assert.strictEqual(stdout.trim(), '');
 assert.strictEqual(code, 0);
 assert.strictEqual(signal, null);

--- a/test/client-proxy/test-https-proxy-request-proxy-failure-502.mjs
+++ b/test/client-proxy/test-https-proxy-request-proxy-failure-502.mjs
@@ -42,7 +42,7 @@ const { code, signal, stderr, stdout } = await runProxiedRequest({
 });
 
 // The proxy client should get an error from failure in establishing the tunnel.
-assert.match(stderr, /ERR_PROXY_TUNNEL.*Failed to establish tunnel to .* HTTP\/1\.1 502 Bad Gateway/);
+assert.strictEqual(stderr.match(/ERR_PROXY_TUNNEL.*Failed to establish tunnel to .* HTTP\/1\.1 502 Bad Gateway/g).length, 1);
 assert.strictEqual(stdout.trim(), '');
 assert.strictEqual(code, 0);
 assert.strictEqual(signal, null);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60697

Like the issue reporter, I think proxy-related errors should be handled only by the proxy logic.
Otherwise, the same root cause can lead to duplicate errors.

However, there may be cases where an error should also be emitted from within onSocket that I might be overlooking.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
