### PR TITLE
[v25.x] deps: V8: cherry-pick 72b0e27bd936

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.14',
+    'v8_embedder_string': '-node.15',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/regexp/regexp-nodes.h
+++ b/deps/v8/src/regexp/regexp-nodes.h
@@ -709,10 +709,10 @@ class ChoiceNode : public RegExpNode {
                              AlternativeGenerationList* alt_gens,
                              PreloadState* preloads,
                              FixedLengthLoopState* fixed_length_loop_state,
-                             int text_length);
+                             int text_length, RegExpFlags flags);
   void EmitChoices(RegExpCompiler* compiler,
                    AlternativeGenerationList* alt_gens, int first_choice,
-                   Trace* trace, PreloadState* preloads);
+                   Trace* trace, PreloadState* preloads, RegExpFlags flags);
 
   // If true, this node is never checked at the start of the input.
   // Allows a new trace to start with at_start() set to false.

--- a/deps/v8/test/mjsunit/regexp-modifiers.js
+++ b/deps/v8/test/mjsunit/regexp-modifiers.js
@@ -51,6 +51,11 @@ test(/F(?i:oo(?-i:b)a)r/, ['Foobar', 'FoObAr'], ['FooBar', 'FoobaR']);
 test(/F(?i:oo(?i:b)a)r/, ['Foobar', 'FoObAr', 'FOOBAr'], ['FoobaR']);
 test(/^[a-z](?-i:[a-z])$/i, ['ab', 'Ab'], ['aB']);
 test(/^(?i:[a-z])[a-z]$/, ['ab', 'Ab'], ['aB']);
+test(/(?i:foo|bar)/, ['FOO', 'FOo', 'Foo', 'fOO', 'BAR', 'BAr', 'Bar', 'bAR']);
+test(/(?i:foo|bar|baz)/, [
+  'FOO', 'FOo', 'Foo', 'fOO', 'BAR', 'BAr', 'Bar', 'bAR', 'BAZ', 'BAz', 'Baz',
+  'bAZ'
+]);
 test(
     /Foo(?i:B[\q{ĀĂĄ|AaA}--\q{āăą}])r/v, ['FooBaaar', 'FoobAAAr'],
     ['FooBĀĂĄr', 'FooBaaaR']);


### PR DESCRIPTION
Original commit message:

    [regexp] Fix modifiers for ChoiceNodes

    Each alternative might modify flags when their sub-graph is emitted.
    We need to restore flags to the value at the beginning of a ChoiceNode
    for each alternative.

    Drive-by: Move regexp-modifiers test out of harmony/

    Fixed: 447583670
    Change-Id: I9f41e51f34df7659461da0a4fcd28b7e157f52e1
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6995181
    Reviewed-by: Jakob Linke <jgruber@chromium.org>
    Commit-Queue: Patrick Thier <pthier@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#102838}

Refs: https://github.com/v8/v8/commit/72b0e27bd936432d4998e4d1762e7a8fe6d347f5
Refs: https://github.com/nodejs/node/issues/60030

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
