### PR TITLE
[v24.x] deps: V8: cherry-pick 06bf293610ef, 146962dda8d2 and e0fb10b5148c

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.30',
+    'v8_embedder_string': '-node.31',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/builtins/base.tq
+++ b/deps/v8/src/builtins/base.tq
@@ -58,9 +58,6 @@ type Zero extends PositiveSmi;
 // A tagged value represented by an all-zero bitpattern.
 type TaggedZeroPattern extends TaggedIndex;
 
-// A value with the size of Tagged which may contain arbitrary data.
-type Uninitialized extends Tagged;
-
 type BuiltinsName extends int31 constexpr 'Builtin';
 
 type UseCounterFeature extends int31

--- a/deps/v8/src/compiler/access-builder.cc
+++ b/deps/v8/src/compiler/access-builder.cc
@@ -892,15 +892,6 @@ FieldAccess AccessBuilder::ForNameRawHashField() {
 }
 
 // static
-FieldAccess AccessBuilder::ForFreeSpaceSize() {
-  FieldAccess access = {kTaggedBase,         FreeSpace::kSizeOffset,
-                        MaybeHandle<Name>(), OptionalMapRef(),
-                        Type::SignedSmall(), MachineType::TaggedSigned(),
-                        kNoWriteBarrier};
-  return access;
-}
-
-// static
 FieldAccess AccessBuilder::ForStringLength() {
   FieldAccess access = {kTaggedBase,
                         offsetof(String, length_),

--- a/deps/v8/src/compiler/access-builder.h
+++ b/deps/v8/src/compiler/access-builder.h
@@ -266,9 +266,6 @@ class V8_EXPORT_PRIVATE AccessBuilder final
   // Provides access to Name::raw_hash_field() field.
   static FieldAccess ForNameRawHashField();
 
-  // Provides access to FreeSpace::size() field
-  static FieldAccess ForFreeSpaceSize();
-
   // Provides access to String::length() field.
   static FieldAccess ForStringLength();
 

--- a/deps/v8/src/diagnostics/objects-debug.cc
+++ b/deps/v8/src/diagnostics/objects-debug.cc
@@ -330,6 +330,10 @@ void HeapObject::HeapObjectVerify(Isolate* isolate) {
       Cast<BigIntBase>(*this)->BigIntBaseVerify(isolate);
       break;
 
+    case FREE_SPACE_TYPE:
+      Cast<FreeSpace>(*this)->FreeSpaceVerify(isolate);
+      break;
+
     case JS_CLASS_CONSTRUCTOR_TYPE:
     case JS_PROMISE_CONSTRUCTOR_TYPE:
     case JS_REG_EXP_CONSTRUCTOR_TYPE:
@@ -360,6 +364,14 @@ void HeapObject::VerifyCodePointer(Isolate* isolate, Tagged<Object> p) {
   CHECK(IsValidCodeObject(isolate->heap(), Cast<HeapObject>(p)));
   PtrComprCageBase cage_base(isolate);
   CHECK(IsInstructionStream(Cast<HeapObject>(p), cage_base));
+}
+
+void FreeSpace::FreeSpaceVerify(Isolate* isolate) {
+  CHECK(IsFreeSpace(this));
+  {
+    Tagged<Object> size_in_tagged = size_in_tagged_.Relaxed_Load();
+    CHECK(IsSmi(size_in_tagged));
+  }
 }
 
 void Name::NameVerify(Isolate* isolate) {

--- a/deps/v8/src/diagnostics/objects-printer.cc
+++ b/deps/v8/src/diagnostics/objects-printer.cc
@@ -357,6 +357,9 @@ void HeapObject::HeapObjectPrint(std::ostream& os) {
     case BIG_INT_BASE_TYPE:
       Cast<BigIntBase>(*this)->BigIntBasePrint(os);
       break;
+    case FREE_SPACE_TYPE:
+      Cast<FreeSpace>(*this)->FreeSpacePrint(os);
+      break;
     case JS_CLASS_CONSTRUCTOR_TYPE:
     case JS_PROMISE_CONSTRUCTOR_TYPE:
     case JS_REG_EXP_CONSTRUCTOR_TYPE:

--- a/deps/v8/src/heap/free-list.cc
+++ b/deps/v8/src/heap/free-list.cc
@@ -28,7 +28,7 @@ void FreeListCategory::Unlink(FreeList* owner) {
 
 void FreeListCategory::Reset(FreeList* owner) {
   Unlink(owner);
-  set_top(FreeSpace());
+  set_top(Tagged<FreeSpace>());
   available_ = 0;
 }
 
@@ -39,7 +39,7 @@ Tagged<FreeSpace> FreeListCategory::PickNodeFromList(size_t minimum_size,
   DCHECK(MemoryChunk::FromHeapObject(node)->CanAllocate());
   if (static_cast<size_t>(node->Size()) < minimum_size) {
     *node_size = 0;
-    return FreeSpace();
+    return Tagged<FreeSpace>();
   }
   set_top(node->next());
   *node_size = node->Size();
@@ -80,7 +80,7 @@ Tagged<FreeSpace> FreeListCategory::SearchForNodeInList(size_t minimum_size,
 
     prev_non_evac_node = cur_node;
   }
-  return FreeSpace();
+  return Tagged<FreeSpace>();
 }
 
 void FreeListCategory::Free(const WritableFreeSpace& writable_free_space,
@@ -140,7 +140,7 @@ Tagged<FreeSpace> FreeList::TryFindNodeIn(FreeListCategoryType type,
                                           size_t minimum_size,
                                           size_t* node_size) {
   FreeListCategory* category = categories_[type];
-  if (category == nullptr) return FreeSpace();
+  if (category == nullptr) return Tagged<FreeSpace>();
   Tagged<FreeSpace> node = category->PickNodeFromList(minimum_size, node_size);
   if (!node.is_null()) {
     DecreaseAvailableBytes(*node_size);

--- a/deps/v8/src/heap/heap.cc
+++ b/deps/v8/src/heap/heap.cc
@@ -6247,13 +6247,14 @@ void Heap::TearDown() {
 }
 
 // static
-bool Heap::IsFreeSpaceValid(FreeSpace object) {
+bool Heap::IsFreeSpaceValid(const FreeSpace* object) {
   Heap* heap = HeapUtils::GetOwnerHeap(object);
   Tagged<Object> free_space_map =
       heap->isolate()->root(RootIndex::kFreeSpaceMap);
   CHECK(!heap->deserialization_complete() ||
-        object.map_slot().contains_map_value(free_space_map.ptr()));
-  CHECK_LE(FreeSpace::kNextOffset + kTaggedSize, object.size(kRelaxedLoad));
+        object->map_slot().contains_map_value(free_space_map.ptr()));
+  CHECK_LE(offsetof(FreeSpace, next_) + kTaggedSize,
+           object->size(kRelaxedLoad));
   return true;
 }
 

--- a/deps/v8/src/heap/heap.h
+++ b/deps/v8/src/heap/heap.h
@@ -352,7 +352,7 @@ class Heap final {
            collector == GarbageCollector::MINOR_MARK_SWEEPER;
   }
 
-  V8_EXPORT_PRIVATE static bool IsFreeSpaceValid(FreeSpace object);
+  V8_EXPORT_PRIVATE static bool IsFreeSpaceValid(const FreeSpace* object);
 
   static inline GarbageCollector YoungGenerationCollector() {
     return (v8_flags.minor_ms) ? GarbageCollector::MINOR_MARK_SWEEPER

--- a/deps/v8/src/heap/sweeper.cc
+++ b/deps/v8/src/heap/sweeper.cc
@@ -947,11 +947,11 @@ std::optional<base::AddressRegion> Sweeper::ComputeDiscardMemoryArea(
 
 void Sweeper::ZeroOrDiscardUnusedMemory(PageMetadata* page, Address addr,
                                         size_t size) {
-  if (size < FreeSpace::kSize) {
+  if (size < sizeof(FreeSpace)) {
     return;
   }
 
-  const Address unused_start = addr + FreeSpace::kSize;
+  const Address unused_start = addr + sizeof(FreeSpace);
   DCHECK(page->ContainsLimit(unused_start));
   const Address unused_end = addr + size;
   DCHECK(page->ContainsLimit(unused_end));

--- a/deps/v8/src/objects/free-space-inl.h
+++ b/deps/v8/src/objects/free-space-inl.h
@@ -19,17 +19,19 @@
 namespace v8 {
 namespace internal {
 
-#include "torque-generated/src/objects/free-space-tq-inl.inc"
-
-TQ_OBJECT_CONSTRUCTORS_IMPL(FreeSpace)
-
-RELAXED_SMI_ACCESSORS(FreeSpace, size, kSizeOffset)
+int FreeSpace::size(RelaxedLoadTag) const {
+  return size_in_tagged_.Relaxed_Load().value() * kTaggedSize;
+}
 
 // static
 inline void FreeSpace::SetSize(const WritableFreeSpace& writable_free_space,
                                int size, RelaxedStoreTag tag) {
-  writable_free_space.WriteHeaderSlot<Smi, kSizeOffset>(Smi::FromInt(size),
-                                                        tag);
+  // For size <= 2 * kTaggedSize, we expect to use one/two pointer filler maps.
+  DCHECK_GT(size, 2 * kTaggedSize);
+  DCHECK_EQ(size % kTaggedSize, 0);
+  writable_free_space
+      .WriteHeaderSlot<Smi, offsetof(FreeSpace, size_in_tagged_)>(
+          Smi::FromInt(size / kTaggedSize), tag);
 }
 
 int FreeSpace::Size() { return size(kRelaxedLoad); }
@@ -37,16 +39,14 @@ int FreeSpace::Size() { return size(kRelaxedLoad); }
 Tagged<FreeSpace> FreeSpace::next() const {
   DCHECK(IsValid());
 #ifdef V8_EXTERNAL_CODE_SPACE
-  intptr_t diff_to_next =
-      static_cast<intptr_t>(TaggedField<Smi, kNextOffset>::load(*this).value());
+  intptr_t diff_to_next{next_.Relaxed_Load().value()};
   if (diff_to_next == 0) {
-    return FreeSpace();
+    return {};
   }
   Address next_ptr = ptr() + diff_to_next * kObjectAlignment;
   return UncheckedCast<FreeSpace>(Tagged<Object>(next_ptr));
 #else
-  return UncheckedCast<FreeSpace>(
-      TaggedField<Object, kNextOffset>::load(*this));
+  return next_.Relaxed_Load();
 #endif  // V8_EXTERNAL_CODE_SPACE
 }
 
@@ -56,20 +56,21 @@ void FreeSpace::SetNext(const WritableFreeSpace& writable_free_space,
 
 #ifdef V8_EXTERNAL_CODE_SPACE
   if (next.is_null()) {
-    writable_free_space.WriteHeaderSlot<Smi, kNextOffset>(Smi::zero(),
-                                                          kRelaxedStore);
+    writable_free_space.WriteHeaderSlot<Smi, offsetof(FreeSpace, next_)>(
+        Smi::zero(), kRelaxedStore);
     return;
   }
   intptr_t diff_to_next = next.ptr() - ptr();
   DCHECK(IsAligned(diff_to_next, kObjectAlignment));
-  writable_free_space.WriteHeaderSlot<Smi, kNextOffset>(
+  writable_free_space.WriteHeaderSlot<Smi, offsetof(FreeSpace, next_)>(
       Smi::FromIntptr(diff_to_next / kObjectAlignment), kRelaxedStore);
 #else
-  writable_free_space.WriteHeaderSlot<Object, kNextOffset>(next, kRelaxedStore);
+  writable_free_space.WriteHeaderSlot<Object, offsetof(FreeSpace, next_)>(
+      next, kRelaxedStore);
 #endif  // V8_EXTERNAL_CODE_SPACE
 }
 
-bool FreeSpace::IsValid() const { return Heap::IsFreeSpaceValid(*this); }
+bool FreeSpace::IsValid() const { return Heap::IsFreeSpaceValid(this); }
 
 }  // namespace internal
 }  // namespace v8

--- a/deps/v8/src/objects/free-space.tq
+++ b/deps/v8/src/objects/free-space.tq
@@ -2,7 +2,4 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-extern class FreeSpace extends HeapObject {
-  size: Smi;
-  next: FreeSpace|Smi|Uninitialized;
-}
+extern class FreeSpace extends HeapObject;

--- a/deps/v8/src/objects/heap-object.h
+++ b/deps/v8/src/objects/heap-object.h
@@ -48,6 +48,8 @@ V8_OBJECT class HeapObjectLayout {
   inline void set_map_safe_transition(IsolateT* isolate, Tagged<Map> value,
                                       ReleaseStoreTag);
 
+  inline ObjectSlot map_slot() const;
+
   inline void set_map_safe_transition_no_write_barrier(
       Isolate* isolate, Tagged<Map> value, RelaxedStoreTag = kRelaxedStore);
 

--- a/deps/v8/src/objects/objects-inl.h
+++ b/deps/v8/src/objects/objects-inl.h
@@ -1496,6 +1496,10 @@ DEF_ACQUIRE_GETTER(HeapObject, map, Tagged<Map>) {
   return map_word(cage_base, kAcquireLoad).ToMap();
 }
 
+ObjectSlot HeapObjectLayout::map_slot() const {
+  return Tagged<HeapObject>(this)->map_slot();
+}
+
 ObjectSlot HeapObject::map_slot() const {
   return ObjectSlot(MapField::address(*this));
 }

--- a/deps/v8/src/snapshot/read-only-serializer.cc
+++ b/deps/v8/src/snapshot/read-only-serializer.cc
@@ -421,7 +421,7 @@ std::vector<ReadOnlyHeapImageSerializer::MemoryRegion> GetUnmappedRegions(
   Tagged<HeapObject> wasm_null_padding = ro_roots.wasm_null_padding();
   CHECK(IsFreeSpace(wasm_null_padding));
   Address wasm_null_padding_start =
-      wasm_null_padding.address() + FreeSpace::kHeaderSize;
+      wasm_null_padding.address() + sizeof(FreeSpace);
   std::vector<ReadOnlyHeapImageSerializer::MemoryRegion> unmapped;
   if (wasm_null.address() > wasm_null_padding_start) {
     unmapped.push_back({wasm_null_padding_start,

--- a/deps/v8/src/torque/constants.h
+++ b/deps/v8/src/torque/constants.h
@@ -37,7 +37,6 @@ static const char* const JSOBJECT_TYPE_STRING = "JSObject";
 static const char* const SMI_TYPE_STRING = "Smi";
 static const char* const TAGGED_TYPE_STRING = "Tagged";
 static const char* const STRONG_TAGGED_TYPE_STRING = "StrongTagged";
-static const char* const UNINITIALIZED_TYPE_STRING = "Uninitialized";
 static const char* const UNINITIALIZED_HEAP_OBJECT_TYPE_STRING =
     "UninitializedHeapObject";
 static const char* const RAWPTR_TYPE_STRING = "RawPtr";

--- a/deps/v8/src/torque/implementation-visitor.cc
+++ b/deps/v8/src/torque/implementation-visitor.cc
@@ -5307,8 +5307,6 @@ void GenerateClassFieldVerifier(const std::string& class_name,
   // Protected pointer fields cannot be read or verified from torque yet.
   if (field_type->IsSubtypeOf(TypeOracle::GetProtectedPointerType())) return;
   if (field_type == TypeOracle::GetFloat64OrUndefinedOrHoleType()) return;
-  // Do not verify if the field may be uninitialized.
-  if (TypeOracle::GetUninitializedType()->IsSubtypeOf(field_type)) return;
 
   std::string field_start_offset;
   if (f.index) {

--- a/deps/v8/src/torque/type-oracle.h
+++ b/deps/v8/src/torque/type-oracle.h
@@ -249,10 +249,6 @@ class TypeOracle : public base::ContextualClass<TypeOracle> {
     return Get().GetBuiltinType(STRONG_TAGGED_TYPE_STRING);
   }
 
-  static const Type* GetUninitializedType() {
-    return Get().GetBuiltinType(UNINITIALIZED_TYPE_STRING);
-  }
-
   static const Type* GetUninitializedHeapObjectType() {
     return Get().GetBuiltinType(
         QualifiedName({TORQUE_INTERNAL_NAMESPACE_STRING},

--- a/deps/v8/test/mjsunit/regress/regress-crbug-1057653.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-1057653.js
@@ -3,6 +3,6 @@
 // found in the LICENSE file.
 
 Object.prototype.length = 3642395160;
-const array = new Float32Array(2**27);
+const array = new Float32Array(2**28);
 
 assertThrows(() => {for (const key in array) {}}, RangeError);

--- a/deps/v8/test/unittests/torque/torque-unittest.cc
+++ b/deps/v8/test/unittests/torque/torque-unittest.cc
@@ -48,7 +48,6 @@ type StrongTagged extends Tagged
 type Smi extends StrongTagged generates 'TNode<Smi>' constexpr 'Smi';
 type WeakHeapObject extends Tagged;
 type Weak<T : type extends HeapObject> extends WeakHeapObject;
-type Uninitialized extends Tagged;
 type TaggedIndex extends StrongTagged;
 type TaggedZeroPattern extends TaggedIndex;
 


### PR DESCRIPTION
Cherry-pick 06bf293610ef.
Original commit message:

    [tagged] Make FreeSpace a HeapObjectLayout

    Bug: 42202654
    Change-Id: I2c5d1a69d9bf0272b631e3fa7964026f3ccded11
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6596552
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Auto-Submit: Leszek Swirski <leszeks@chromium.org>
    Commit-Queue: Michael Lippautz <mlippautz@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#100564}

Refs: https://github.com/v8/v8/commit/06bf293610ef8cae7cf1d02f285ead7383d7786f

Cherry-pick 146962dda8d2.
Original commit message:

    [heap] Store FreeSpace size in multiples of tagged words

    Since FreeSpace has to be aligned to Tagged words, we can support larger
    free spaces by storing the size in words rather than bytes.

    Bug: 417413670
    Change-Id: I19ef4921e00a5ec23d39ff4aa5b379b36fc86e0a
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6596680
    Commit-Queue: Leszek Swirski <leszeks@chromium.org>
    Reviewed-by: Michael Lippautz <mlippautz@chromium.org>
    Auto-Submit: Leszek Swirski <leszeks@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#100590}

Refs: https://github.com/v8/v8/commit/146962dda8d25d8a917a589dc8d0aa9ae973e3f2

Cherry-pick e0fb10b5148c.
Original commit message:

    [array] Increase the maximum size of FixedArrays

    Use the newly increased maximum FreeSpace size to allow a larger upper
    bound for FixedArray/FixedDoubleArray size.

    Bug: 417413670
    Change-Id: I655c98bb68dfe033ae62f2b16441c62bc4403058
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6597277
    Commit-Queue: Leszek Swirski <leszeks@chromium.org>
    Reviewed-by: Igor Sheludko <ishell@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#100593}

Refs: https://github.com/v8/v8/commit/e0fb10b5148ceaf3cea8e7af612c257d593ac94b