### PR TITLE
[v20.x] deps: V8: cherry-pick a0d0d4fc4f19

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -36,7 +36,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.31',
+    'v8_embedder_string': '-node.32',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/test/test262/testcfg.py
+++ b/deps/v8/test/test262/testcfg.py
@@ -25,15 +25,11 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import imp
-import itertools
-import os
-import re
+import importlib.machinery
 import sys
 
 from testrunner.local import statusfile
 from testrunner.local import testsuite
-from testrunner.local import utils
 from testrunner.objects import testcase
 from testrunner.outproc import base as outproc
 from testrunner.outproc import test262
@@ -141,11 +137,12 @@ class TestSuite(testsuite.TestSuite):
     root = os.path.join(*TEST_262_TOOLS_ABS_PATH)
     f = None
     try:
-      (f, pathname, description) = imp.find_module("parseTestRecord", [root])
-      module = imp.load_module("parseTestRecord", f, pathname, description)
+      loader = importlib.machinery.SourceFileLoader(
+          "parseTestRecord", f"{root}/parseTestRecord.py")
+      module = loader.load_module()
       return module.parseTestRecord
-    except:
-      print('Cannot load parseTestRecord')
+    except Exception as e:
+      print(f'Cannot load parseTestRecord: {e}')
       raise
     finally:
       if f:

--- a/deps/v8/tools/testrunner/local/testsuite.py
+++ b/deps/v8/tools/testrunner/local/testsuite.py
@@ -26,7 +26,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
-import imp
+import importlib.machinery
 import itertools
 import os
 from contextlib import contextmanager
@@ -238,11 +238,12 @@ class TestGenerator(object):
 def _load_testsuite_module(name, root):
   f = None
   try:
-    (f, pathname, description) = imp.find_module("testcfg", [root])
-    yield imp.load_module(name + "_testcfg", f, pathname, description)
+    yield importlib.machinery.SourceFileLoader(
+        name + "_testcfg", f"{root}/testcfg.py").load_module()
   finally:
     if f:
       f.close()
+
 
 class TestSuite(object):
   @staticmethod


### PR DESCRIPTION
Original commit message:

    [py3.12] Optimize some py files

    1. Remove the imp module and use its equivalent instead
    2. Delete unused module imports

    Bug: chromium:1487454
    Change-Id: I06fd342ba8e17f96ee2e55926cca0efded845b2a
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/4983809
    Reviewed-by: Michael Achenbach <machenbach@chromium.org>
    Commit-Queue: Ho Cheung <uioptt24@gmail.com>
    Cr-Commit-Position: refs/heads/main@{#90641}

Refs: https://github.com/v8/v8/commit/a0d0d4fc4f190b192864ba7c0ff0758dd803e6fd

---

cc @nodejs/releasers This fixes Python 3.12 compatibility for the V8 CI with Node.js `v20.x(-staging)`. The change is already present in `v22.x-staging`. It only touches the V8 test runner so has no effect on Node.js itself.

e.g. failure without this cherry-pick:
https://ci.nodejs.org/job/node-test-commit-v8-linux/6855/nodes=rhel8-s390x,v8test=v8test/console
```
12:48:09 export PATH="/home/iojs/build-tools:/opt/rh/gcc-toolset-10/root/usr/bin:/home/iojs/build/workspace/node-test-commit-v8-linux/depot_tools:/home/iojs/venv/bin:/home/iojs/nghttp2/src:/home/iojs/wrk:/usr/lib/ccache:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" && \
12:48:09 	/usr/bin/python3.12 deps/v8/tools/run-tests.py --gn --arch=s390x --progress=dots --timeout=120 intl \
12:48:09 			mjsunit cctest debugger inspector message preparser \
12:48:09 			--json-test-results /home/iojs/build/workspace/node-test-commit-v8-linux/v8-tap.json --slow-tests-cutoff 1000000
12:48:09 Traceback (most recent call last):
12:48:09   File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/run-tests.py", line 11, in <module>
12:48:09     from testrunner import standard_runner
12:48:09   File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/testrunner/standard_runner.py", line 23, in <module>
12:48:09     import testrunner.base_runner as base_runner
12:48:09   File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/testrunner/base_runner.py", line 19, in <module>
12:48:09     from testrunner.local import testsuite
12:48:09   File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/testrunner/local/testsuite.py", line 29, in <module>
12:48:09     import imp
12:48:09 ModuleNotFoundError: No module named 'imp'
12:48:09 make: *** [Makefile:715: test-v8] Error 1
12:48:09 Build step 'Execute shell' marked build as failure
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
