### PR TITLE
tools: update Visual Studio reference to 2022 in install script

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -39,7 +39,7 @@ echo license terms or not. Read and understand the license terms of the packages
 echo being installed and their dependencies prior to installation:
 echo - https://chocolatey.org/packages/chocolatey
 echo - https://chocolatey.org/packages/python
-echo - https://chocolatey.org/packages/visualstudio2019-workload-vctools
+echo - https://chocolatey.org/packages/visualstudio2022-workload-vctools
 echo.
 echo This script is provided AS-IS without any warranties of any kind
 echo ----------------------------------------------------------------


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60733

## Summary
The `install_tools.bat` script displayed an outdated URL reference to `visualstudio2019-workload-vctools` in the license information section, while the actual installation command correctly uses `visualstudio2022-workload-vctools`.

## Changes
- Updated line 42 of `tools/msvs/install_tools/install_tools.bat` to reference the correct Visual Studio 2022 package URL that matches what is actually being installed

This ensures users see accurate information about what packages will be installed when they review the license terms.