### PR TITLE
doc: add section describing differences between Node.js fetch and WHATWG Fetch Standard

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -588,19 +588,13 @@ Node.js implements the [WHATWG Fetch Standard][] with intentional differences to
 ##### Async iterable request bodies
 
 Node.js supports async iterables as request bodies—a behavior not included in the Fetch Standard.
-```js
+```mjs
 const data = {
   async *[Symbol.asyncIterator]() {
     yield 'hello';
     yield 'world';
-  }
+  },
 };
-
-await fetch('https://example.com', {
-  method: 'POST',
-  body: data,
-  duplex: 'half'
-});
 ```
 
 When using an async iterable or a `ReadableStream` as the request body, the `duplex` option must be set to `'half'`.
@@ -608,7 +602,7 @@ When using an async iterable or a `ReadableStream` as the request body, the `dup
 ##### FormData with stream-backed Blob objects
 
 `FormData` entries may include stream-backed `Blob` objects created from the filesystem, enabling efficient uploads of large files without buffering them in memory.
-```js
+```mjs
 import { openAsBlob } from 'node:fs';
 
 const file = await openAsBlob('./large-file.csv');
@@ -623,7 +617,7 @@ await fetch('https://example.com', { method: 'POST', body: form });
 ##### Async iterable response bodies
 
 The `Response` constructor accepts async iterables, allowing flexible construction of streaming responses in server environments.
-```js
+```mjs
 const res = new Response(asyncIterable);
 ```
 
@@ -646,7 +640,7 @@ When using `redirect: 'manual'`, Node.js returns the actual redirect response ra
 In Node.js, unconsumed response bodies may delay the release of underlying network resources. This can reduce connection reuse or cause stalls under load.
 
 Always consume or cancel the response body:
-```js
+```mjs
 const res = await fetch(url);
 for await (const chunk of res.body) {
   // process chunk
@@ -654,7 +648,7 @@ for await (const chunk of res.body) {
 ```
 
 For header-only requests, prefer `HEAD` to avoid creating a body:
-```js
+```mjs
 const headers = (await fetch(url, { method: 'HEAD' })).headers;
 ```
 
@@ -667,7 +661,9 @@ The `Expect` request header is not supported. Request bodies are sent immediatel
 #### Implementation Notes
 
 Node.js uses the [undici][] HTTP client internally to implement `fetch()`. The bundled version can be inspected with:
-```js
+```mjs
+import process from 'node:process';
+
 console.log(process.versions.undici);
 ```
 


### PR DESCRIPTION
## Description

This PR adds documentation for the intentional differences between Node.js's `fetch()` implementation and the WHATWG Fetch Standard. These behavioral differences are frequently encountered by developers using server-side fetch, but the information has been scattered across tests, release notes, and undici documentation.

## Changes

Adds a new section **"Differences from the WHATWG Fetch Standard"** under `doc/api/globals.md` that documents:

### Request Body Extensions
- Support for async iterable request bodies
- Requirement for `duplex: 'half'` when using streaming request bodies
- FormData streaming via filesystem-backed Blob objects

### Response Body Extensions
- Async iterable response bodies

### Server-Side Behavioral Differences
- Absence of browser CORS enforcement in Node.js
- Removal of browser-forbidden header restrictions
- Server-appropriate redirect handling (`redirect: 'manual'`)
- Resource management considerations (garbage collection and socket reuse)

### Unsupported Features
- `Expect: 100-continue` header behavior

### Implementation Details
- Information about bundled undici version and when to install separately

## Motivation

Developers frequently encounter confusion when porting fetch code from browsers to Node.js due to these behavioral differences. This PR:

- Consolidates previously scattered information into one discoverable location
- Reduces repeated questions in issues and discussions  
- Makes fetch behavior predictable and well-documented
- Aligns Node.js docs with the level of detail given for other Web API deviations

Fixes #52163