### PR TITLE
url: add fast path to getPathFromURL decoder

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -1473,7 +1473,7 @@ function getPathFromURLWin32(url) {
   }
   pathname = SideEffectFreeRegExpPrototypeSymbolReplace(FORWARD_SLASH, pathname, '\\');
   // Fast-path: if there is no percent-encoding, avoid decodeURIComponent.
-  if (StringPrototypeIndexOf(pathname, '%') !== -1) {
+  if (StringPrototypeIncludes(pathname, '%')) {
     pathname = decodeURIComponent(pathname);
   }
   if (hostname !== '') {
@@ -1582,7 +1582,7 @@ function getPathFromURLPosix(url) {
     }
   }
   // Fast-path: if there is no percent-encoding, avoid decodeURIComponent.
-  return StringPrototypeIndexOf(pathname, '%') !== -1 ? decodeURIComponent(pathname) : pathname;
+  return StringPrototypeIncludes(pathname, '%') ? decodeURIComponent(pathname) : pathname;
 }
 
 function getPathBufferFromURLPosix(url) {


### PR DESCRIPTION
branch:

```sh
node % ./node benchmark/run.js --filter whatwg-url-to-and-from-path url
url/whatwg-url-to-and-from-path.js
url/whatwg-url-to-and-from-path.js n=5000000 input="file:///dev/null" method="fileURLToPath": 3,853,044.868707496
url/whatwg-url-to-and-from-path.js n=5000000 input="file:///dev/null?key=param&bool" method="fileURLToPath": 3,490,012.0935340663
url/whatwg-url-to-and-from-path.js n=5000000 input="file:///dev/null?key=param&bool#hash" method="fileURLToPath": 3,167,181.914377771
```

main:

```sh
node % ./node benchmark/run.js --filter whatwg-url-to-and-from-path url
url/whatwg-url-to-and-from-path.js n=5000000 input="file:///dev/null" method="fileURLToPath": 2,034,421.4266934511
url/whatwg-url-to-and-from-path.js n=5000000 input="file:///dev/null?key=param&bool" method="fileURLToPath": 2,062,544.6025270298
url/whatwg-url-to-and-from-path.js n=5000000 input="file:///dev/null?key=param&bool#hash" method="fileURLToPath": 2,022,311.8969784945
```

The majority of file paths won't need decoding, so this PR avoids calling `decodeURIComponent` when the path is pure ASCII with no encodings