### PR TITLE
doc: add detailed explanation of suites and their behavior in the test runner

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -125,6 +125,95 @@ Any subtests that are still outstanding when their parent finishes
 are cancelled and treated as failures. Any subtest failures cause the parent
 test to fail.
 
+## Suites
+
+Suites provide a way to group related tests under a common name. A suite
+is created with the `suite()` function (or its alias `describe()`). The
+callback passed to `suite()` is executed synchronously and is used only
+to register nested tests or nested suites.
+
+A suite reports a result, but its status is fully determined by the
+tests and suites inside it --- suites cannot fail independently.
+
+A suite always waits for all of its nested tests and nested suites to
+finish before completing.
+
+*Example*
+
+``` js
+import { suite, test } from 'node:test';
+import assert from 'node:assert';
+
+suite('math operations', () => {
+  test('addition', () => {
+    assert.strictEqual(1 + 1, 2);
+  });
+
+  test('multiplication', () => {
+    assert.strictEqual(2 * 2, 4);
+  });
+});
+```
+
+*Nested suites*
+
+``` js
+suite('user features', () => {
+  suite('profile', () => {
+    test('updates display name', () => {
+      assert.ok(true);
+    });
+  });
+
+  suite('settings', () => {
+    test('enables notifications', () => {
+      assert.ok(true);
+    });
+  });
+});
+```
+
+**Suites vs. Subtests**
+
+Both suites and subtests structure test hierarchies, but they behave
+differently in important ways.
+
+*Execution behavior*
+| Feature                                    | Suite (`suite()`)   | Subtest (`t.test()`) |
+|--------------------------------------------|----------------------|------------------------|
+| Parent waits for children                  | Always               | Only if awaited        |
+| Pending children canceled if parent ends   | Never                | Yes                    |
+| Callback may be async                      | No (ignored)         | Yes                    |
+| Callback controls execution order          | No                   | Yes (via `await`)      |
+
+*Suite example*
+
+``` js
+suite('group', () => {
+  test('test 1', () => assert.ok(true));
+  test('test 2', () => assert.ok(true));
+});
+```
+
+The suite finishes only after both tests complete.
+
+*Subtest example*
+
+``` js
+test('parent test', async (t) => {
+  await t.test('subtest 1', () => assert.ok(true));
+  await t.test('subtest 2', () => assert.ok(true));
+});
+```
+
+If the `await` keywords were omitted, the parent test would complete
+early and the test runner would cancel the unfinished subtests.
+
+**`describe()` Alias**
+
+`describe()` is a direct alias of `suite()` and behaves identically. See
+the "describe() and it() aliases" section for more details.
+
 ## Skipping tests
 
 Individual tests can be skipped by passing the `skip` option to the test, or by

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -135,27 +135,22 @@ to register nested tests or nested suites.
 A suite reports a result, but its status is fully determined by the
 tests and suites inside it --- suites cannot fail independently.
 
-A suite always waits for all of its nested tests and nested suites to
-finish before completing.
-
-*Example*
+A suite always waits for all of its nested tests and nested suites to 
+finish before completing. The following example demonstrates a 
+suite with nested tests and other suites.
 
 ``` js
 import { suite, test } from 'node:test';
 import assert from 'node:assert';
-
 suite('math operations', () => {
   test('addition', () => {
     assert.strictEqual(1 + 1, 2);
   });
-
   test('multiplication', () => {
     assert.strictEqual(2 * 2, 4);
   });
 });
 ```
-
-*Nested suites*
 
 ``` js
 suite('user features', () => {
@@ -164,7 +159,6 @@ suite('user features', () => {
       assert.ok(true);
     });
   });
-
   suite('settings', () => {
     test('enables notifications', () => {
       assert.ok(true);
@@ -179,12 +173,13 @@ Both suites and subtests structure test hierarchies, but they behave
 differently in important ways.
 
 *Execution behavior*
-| Feature                                    | Suite (`suite()`)   | Subtest (`t.test()`) |
-|--------------------------------------------|----------------------|------------------------|
-| Parent waits for children                  | Always               | Only if awaited        |
-| Pending children canceled if parent ends   | Never                | Yes                    |
-| Callback may be async                      | No (ignored)         | Yes                    |
-| Callback controls execution order          | No                   | Yes (via `await`)      |
+| Feature                                   | Suite (`suite()`)                                                                           | Subtest (`t.test()`)                         |
+|-------------------------------------------|---------------------------------------------------------------------------------------------|----------------------------------------------|
+| Parent waits for children                 | Always                                                                                      | Only if awaited                              |
+| Pending children canceled if parent ends  | No, unless the suite is canceled via `AbortSignal`                                          | Yes                                          |
+| Callback may be async                     | Suite callbacks run synchronously; returning a Promise does not affect execution            | Yes (async functions are allowed)            |
+| Callback controls execution order         | No — tests execute strictly in declaration order; the suite callback cannot pause execution | Yes — execution order controlled via `await` |
+
 
 *Suite example*
 
@@ -208,11 +203,6 @@ test('parent test', async (t) => {
 
 If the `await` keywords were omitted, the parent test would complete
 early and the test runner would cancel the unfinished subtests.
-
-**`describe()` Alias**
-
-`describe()` is a direct alias of `suite()` and behaves identically. See
-the "describe() and it() aliases" section for more details.
 
 ## Skipping tests
 

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -130,7 +130,7 @@ test to fail.
 Suites provide a way to group related tests under a common name. A suite
 is created with the `suite()` function (or its alias `describe()`). The
 callback passed to `suite()` is executed synchronously and is used only
-to register nested tests or nested suites.
+to register lifecycle methods (such as `before()` and `after()`), nested tests, or nested suites.
 
 A suite reports a result, but its status is fully determined by the
 tests and suites inside it --- suites cannot fail independently.

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -139,29 +139,22 @@ A suite always waits for all of its nested tests and nested suites to
 finish before completing. The following example demonstrates a 
 suite with nested tests and other suites.
 
-``` js
+```js
 import { suite, test } from 'node:test';
 import assert from 'node:assert';
+
 suite('math operations', () => {
   test('addition', () => {
     assert.strictEqual(1 + 1, 2);
   });
-  test('multiplication', () => {
-    assert.strictEqual(2 * 2, 4);
-  });
-});
-```
 
-``` js
-suite('user features', () => {
-  suite('profile', () => {
-    test('updates display name', () => {
-      assert.ok(true);
+  suite('multiplication', () => {
+    test('negative one', () => {
+      assert.strictEqual(2 * -1, -2);
     });
-  });
-  suite('settings', () => {
-    test('enables notifications', () => {
-      assert.ok(true);
+
+    test('zero', () => {
+      assert.strictEqual(2 * 0, 0);
     });
   });
 });

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -167,7 +167,7 @@ suite('user features', () => {
 });
 ```
 
-**Suites vs. Subtests**
+### Suites vs. Subtests
 
 Both suites and subtests structure test hierarchies, but they behave
 differently in important ways.


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->



### Summary

This PR adds a dedicated **Suites** section to the `node:test` documentation.  
The existing docs reference suites (for example, in the Subtests section) without explaining what they are or how they differ from tests with subtests. This addition fills that gap and clarifies suite behavior.

### What This PR Adds

- A new “Suites” section covering:
  - What a suite is and how it works
  - Synchronous callback behavior when registering tests
  - How suites wait for all nested tests/suites
  - How suite results depend entirely on their children
- Examples of suites and nested suites
- A comparison table between suites (`suite()` / `describe()`) and subtests (`t.test()`)
- Clarification that `describe()` is an alias of `suite()`

### Why This Is Needed

- The documentation references suites without defining them.
- Developers transitioning from Mocha/Jest often assume different semantics.
- Suites and subtests look similar but behave differently in important ways (async behavior, execution order, cancellation).
- This makes the test runner easier to understand and reduces confusion.

### Related Issue
Fixes: #60758
