### PR TITLE
doc: correct concurrency wording in test() documentation

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1619,7 +1619,7 @@ changes:
 * `options` {Object} Configuration options for the test. The following
   properties are supported:
   * `concurrency` {number|boolean} If a number is provided,
-    then that many tests would run concurrently within the test process.
+    then that many tests would run asynchronously (they are still managed by the single-threaded event loop).
     If `true`, all scheduled asynchronous tests run concurrently within the
     thread. If `false`, only one test runs at a time.
     If unspecified, subtests inherit this value from their parent.
@@ -3882,7 +3882,7 @@ changes:
 * `options` {Object} Configuration options for the subtest. The following
   properties are supported:
   * `concurrency` {number|boolean|null} If a number is provided,
-    then that many tests would run concurrently within the test process.
+    then that many tests would run asynchronously (they are still managed by the single-threaded event loop).
     If `true`, it would run all subtests in parallel.
     If `false`, it would only run one test at a time.
     If unspecified, subtests inherit this value from their parent.


### PR DESCRIPTION
This PR updates the test runner documentation for the `concurrency` option.

- Replaces “application thread” with “test process”
- Clarifies that concurrency is achieved using child processes, not threads
- Changes “parallel” to “concurrent” for accuracy

As discussed in #60721.

Requesting reviews from @Ethan-Arrowood and @cjihrig.