### PR TITLE
test_runner: simplify code and make it more consistent

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -13,7 +13,6 @@ const {
   MathMax,
   Number,
   NumberPrototypeToFixed,
-  ObjectDefineProperty,
   ObjectSeal,
   Promise,
   PromisePrototypeThen,
@@ -55,6 +54,7 @@ const {
 const {
   kEmptyObject,
   once: runOnce,
+  setOwnProperty,
 } = require('internal/util');
 const { isPromise } = require('internal/util/types');
 const {
@@ -133,20 +133,14 @@ function stopTest(timeout, signal) {
   if (timeout === kDefaultTimeout) {
     disposeFunction = abortListener[SymbolDispose];
   } else {
-    timer = setTimeout(() => deferred.resolve(), timeout);
+    timer = setTimeout(deferred.resolve, timeout);
     timer.unref();
-
-    ObjectDefineProperty(deferred, 'promise', {
-      __proto__: null,
-      configurable: true,
-      writable: true,
-      value: PromisePrototypeThen(deferred.promise, () => {
-        throw new ERR_TEST_FAILURE(
-          `test timed out after ${timeout}ms`,
-          kTestTimeoutFailure,
-        );
-      }),
-    });
+    setOwnProperty(deferred, 'promise', PromisePrototypeThen(deferred.promise, () => {
+      throw new ERR_TEST_FAILURE(
+        `test timed out after ${timeout}ms`,
+        kTestTimeoutFailure,
+      );
+    }));
 
     disposeFunction = () => {
       abortListener[SymbolDispose]();
@@ -154,12 +148,7 @@ function stopTest(timeout, signal) {
     };
   }
 
-  ObjectDefineProperty(deferred.promise, SymbolDispose, {
-    __proto__: null,
-    configurable: true,
-    writable: true,
-    value: disposeFunction,
-  });
+  setOwnProperty(deferred.promise, SymbolDispose, disposeFunction);
   return deferred.promise;
 }
 
@@ -994,7 +983,7 @@ class Test extends AsyncResource {
     if (this.root.harness.buildPromise || !this.parent.hasConcurrency()) {
       const deferred = PromiseWithResolvers();
 
-      deferred.test = this;
+      setOwnProperty(deferred, 'test', this);
       this.parent.addPendingSubtest(deferred);
       return deferred.promise;
     }


### PR DESCRIPTION
We can reuse the `setOwnProperty` helper; also I realized that `deferred.resolve` is sometimes used directly as a callback, or sometimes wrapped in an arrow function.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
