### PR TITLE
worker: add worker.getMemoryUsage() API

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1828,6 +1828,33 @@ This method returns a `Promise` that will resolve to an object identical to [`v8
 or reject with an [`ERR_WORKER_NOT_RUNNING`][] error if the worker is no longer running.
 This methods allows the statistics to be observed from outside the actual thread.
 
+### `worker.getMemoryUsage()`
+
+<!-- YAML
+added:
+changes:
+  - version: v25.2.0
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Added `worker.getMemoryUsage()`.
+-->
+
+* Returns: {Promise}
+
+Returns an object mirroring [`process.memoryUsage()`][] but scoped to the
+worker's isolate:
+
+* `rss` {integer} Resident Set Size. This value represents the RSS reported by
+  the worker thread and may still include memory shared across threads.
+* `heapTotal` {integer} Total size of the V8 heap for the worker.
+* `heapUsed` {integer} Heap space used by the worker.
+* `external` {integer} Memory used by C++ objects bound to JavaScript objects in
+  the worker.
+* `arrayBuffers` {integer} Memory allocated for `ArrayBuffer` and
+  `SharedArrayBuffer` instances within the worker.
+
+The returned `Promise` rejects with [`ERR_WORKER_NOT_RUNNING`][] if called after
+the worker has stopped.
+
 ### `worker.performance`
 
 <!-- YAML

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -537,6 +537,20 @@ class Worker extends EventEmitter {
     });
   }
 
+  getMemoryUsage() {
+    const taker = this[kHandle]?.getMemoryUsage();
+
+    return new Promise((resolve, reject) => {
+      if (!taker) return reject(new ERR_WORKER_NOT_RUNNING());
+      taker.ondone = (err, usage) => {
+        if (err) {
+          return reject(err);
+        }
+        resolve(usage);
+      };
+    });
+  }
+
   cpuUsage(prev) {
     if (prev) {
       validateObject(prev, 'prev');

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -84,6 +84,7 @@ namespace node {
   V(WORKERHEAPPROFILE)                                                         \
   V(WORKERHEAPSNAPSHOT)                                                        \
   V(WORKERHEAPSTATISTICS)                                                      \
+  V(WORKERMEMORYUSAGE)                                                         \
   V(WRITEWRAP)                                                                 \
   V(ZLIB)
 

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -406,6 +406,7 @@
   V(free_list_statistics_template, v8::DictionaryTemplate)                     \
   V(fsreqpromise_constructor_template, v8::ObjectTemplate)                     \
   V(handle_wrap_ctor_template, v8::FunctionTemplate)                           \
+  V(memory_usage_template, v8::DictionaryTemplate)                          \
   V(heap_statistics_template, v8::DictionaryTemplate)                          \
   V(v8_heap_statistics_template, v8::DictionaryTemplate)                       \
   V(histogram_ctor_template, v8::FunctionTemplate)                             \
@@ -449,6 +450,7 @@
   V(write_wrap_template, v8::ObjectTemplate)                                   \
   V(worker_cpu_profile_taker_template, v8::ObjectTemplate)                     \
   V(worker_cpu_usage_taker_template, v8::ObjectTemplate)                       \
+  V(worker_memory_usage_taker_template, v8::ObjectTemplate)                    \
   V(worker_heap_profile_taker_template, v8::ObjectTemplate)                    \
   V(worker_heap_snapshot_taker_template, v8::ObjectTemplate)                   \
   V(worker_heap_statistics_taker_template, v8::ObjectTemplate)                 \

--- a/src/node_worker.h
+++ b/src/node_worker.h
@@ -84,6 +84,7 @@ class Worker : public AsyncWrap {
   static void StopCpuProfile(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StartHeapProfile(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void StopHeapProfile(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void GetMemoryUsage(const v8::FunctionCallbackInfo<v8::Value>& args);
 
  private:
   bool CreateEnvMessagePort(Environment* env);

--- a/test/parallel/test-worker-get-memory-usage.js
+++ b/test/parallel/test-worker-get-memory-usage.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Worker, isMainThread } = require('worker_threads');
+
+if (!isMainThread) {
+  common.skip('This test only works on the main thread');
+}
+
+const worker = new Worker(`
+  const { parentPort } = require('worker_threads');
+  parentPort.once('message', () => process.exit(0));
+  parentPort.postMessage('ready');
+`, { eval: true });
+
+worker.once('message', common.mustCall(async () => {
+  const usage = await worker.getMemoryUsage();
+  const keys = [
+    'rss',
+    'heapTotal',
+    'heapUsed',
+    'external',
+    'arrayBuffers',
+  ].sort();
+
+  assert.deepStrictEqual(Object.keys(usage).sort(), keys);
+
+  for (const key of keys) {
+    assert.strictEqual(typeof usage[key], 'number', `Expected ${key} to be a number`);
+    assert.ok(usage[key] >= 0, `Expected ${key} to be >= 0`);
+  }
+
+  assert.ok(usage.heapUsed <= usage.heapTotal,
+            'heapUsed should not exceed heapTotal');
+
+  worker.postMessage('exit');
+}));
+
+worker.once('exit', common.mustCall(async (code) => {
+  assert.strictEqual(code, 0);
+  await assert.rejects(worker.getMemoryUsage(), {
+    code: 'ERR_WORKER_NOT_RUNNING'
+  });
+}));


### PR DESCRIPTION
## Summary
- Add `worker.getMemoryUsage()` so worker threads can report RSS, heap usage, external memory, and ArrayBuffer statistics.
- Introduce the native `WorkerMemoryUsageTaker` plus the per-isolate templates/bindings to expose this data.
- Add a regression test (`test/parallel/test-worker-get-memory-usage.js`) and document the API in `doc/api/worker_threads.md`.

## Testing
- `python3 tools/test.py parallel/test-worker-get-memory-usage`
- `ninja -C out/Debug node`
