### PR TITLE
child_process: add getMemoryUsage() method to ChildProcess

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -1624,6 +1624,32 @@ running if `.unref()` has been called before.
 
 #### `subprocess.channel.unref()`
 
+#### `subprocess.getMemoryUsage()`
+
+<!-- YAML
+added: v25.2.1
+-->
+
+* Returns: {Promise} fulfilled with an object containing:
+  * `rss`
+  * `heapTotal`
+  * `heapUsed`
+  * `external`
+  * `arrayBuffers`
+
+Retrieves memory statistics for the child via an IPC round-trip. The promise rejects with
+`ERR_CHILD_PROCESS_NOT_RUNNING` if the child has already exited or with `ERR_IPC_CHANNEL_CLOSED` when no IPC
+channel is available. The child must have been spawned with an IPC channel (e.g., `'ipc'` in `stdio` or
+`child_process.fork()`).
+
+```mjs
+import { fork } from 'node:child_process';
+
+const child = fork('./worker.js');
+const usage = await child.getMemoryUsage();
+console.log(usage.heapUsed);
+```
+
 <!-- YAML
 added: v7.1.0
 -->

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -774,6 +774,23 @@ A child process was closed before the parent received a reply.
 
 Used when a child process is being forked without specifying an IPC channel.
 
+<a id="ERR_CHILD_PROCESS_MEMORY_USAGE_FAILED"></a>
+
+### `ERR_CHILD_PROCESS_MEMORY_USAGE_FAILED`
+
+Thrown from `ChildProcess.prototype.getMemoryUsage()` when a memory usage
+request fails inside the child. The error's `cause` contains the serialized
+error information reported by the child process, when available.
+
+<a id="ERR_CHILD_PROCESS_NOT_RUNNING"></a>
+
+### `ERR_CHILD_PROCESS_NOT_RUNNING`
+
+Raised when an operation expects an active child process but the process has
+already exited or has not been started yet. For example,
+`ChildProcess.prototype.getMemoryUsage()` rejects with this error after the
+child terminates.
+
 <a id="ERR_CHILD_PROCESS_STDIO_MAXBUFFER"></a>
 
 ### `ERR_CHILD_PROCESS_STDIO_MAXBUFFER`

--- a/lib/internal/child_process.js
+++ b/lib/internal/child_process.js
@@ -8,7 +8,11 @@ const {
   FunctionPrototype,
   FunctionPrototypeCall,
   ObjectSetPrototypeOf,
+  Promise,
+  PromiseReject,
   ReflectApply,
+  SafeMap,
+  String,
   StringPrototypeSlice,
   Symbol,
   SymbolDispose,
@@ -18,6 +22,8 @@ const {
 const {
   ErrnoException,
   codes: {
+    ERR_CHILD_PROCESS_MEMORY_USAGE_FAILED,
+    ERR_CHILD_PROCESS_NOT_RUNNING,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_HANDLE_TYPE,
@@ -84,6 +90,8 @@ const MAX_HANDLE_RETRANSMISSIONS = 3;
 const kChannelHandle = Symbol('kChannelHandle');
 const kIsUsedAsStdio = Symbol('kIsUsedAsStdio');
 const kPendingMessages = Symbol('kPendingMessages');
+const kMemoryUsageRequests = Symbol('kMemoryUsageRequests');
+const kNextMemoryUsageRequestId = Symbol('kNextMemoryUsageRequestId');
 
 // This object contain function to convert TCP objects to native handle objects
 // and back again.
@@ -265,6 +273,21 @@ function ChildProcess() {
 
   this._handle = new Process();
   this._handle[owner_symbol] = this;
+
+  this[kMemoryUsageRequests] = new SafeMap();
+  this[kNextMemoryUsageRequestId] = 0;
+
+  this.once('exit', () => {
+    rejectAllMemoryUsageRequests(
+      this,
+      new ERR_CHILD_PROCESS_NOT_RUNNING());
+  });
+
+  this.once('disconnect', () => {
+    rejectAllMemoryUsageRequests(
+      this,
+      new ERR_IPC_CHANNEL_CLOSED());
+  });
 
   this._handle.onexit = (exitCode, signalCode) => {
     if (signalCode) {
@@ -488,6 +511,70 @@ function onSpawnNT(self) {
   self.emit('spawn');
 }
 
+function resolveMemoryUsageRequest(target, requestId, usage) {
+  const requests = target[kMemoryUsageRequests];
+  if (!requests) return;
+  const pending = requests.get(requestId);
+  if (!pending) return;
+  requests.delete(requestId);
+  pending.resolve(usage);
+}
+
+function rejectMemoryUsageRequest(target, requestId, error) {
+  const requests = target[kMemoryUsageRequests];
+  if (!requests) return;
+  const pending = requests.get(requestId);
+  if (!pending) return;
+  requests.delete(requestId);
+  pending.reject(error);
+}
+
+function rejectAllMemoryUsageRequests(target, error) {
+  const requests = target[kMemoryUsageRequests];
+  if (!requests || requests.size === 0) return;
+  for (const pending of requests.values()) {
+    pending.reject(error);
+  }
+  requests.clear();
+}
+
+function respondWithMemoryUsage(target, requestId) {
+  try {
+    const usage = process.memoryUsage();
+    target._send({
+      cmd: 'NODE_MEMORY_USAGE_RESULT',
+      requestId,
+      usage,
+    }, null, true);
+  } catch (err) {
+    target._send({
+      cmd: 'NODE_MEMORY_USAGE_ERROR',
+      requestId,
+      error: serializeMemoryUsageError(err),
+    }, null, true);
+  }
+}
+
+function serializeMemoryUsageError(err) {
+  if (err == null || typeof err !== 'object') {
+    return { message: String(err) };
+  }
+  return {
+    message: err.message,
+    code: err.code,
+    name: err.name,
+  };
+}
+
+function createMemoryUsageError(serialized) {
+  if (!serialized) {
+    return new ERR_CHILD_PROCESS_MEMORY_USAGE_FAILED();
+  }
+  const error = new ERR_CHILD_PROCESS_MEMORY_USAGE_FAILED(serialized);
+  error.cause = serialized;
+  return error;
+}
+
 
 ChildProcess.prototype.kill = function kill(sig) {
 
@@ -530,6 +617,34 @@ ChildProcess.prototype.ref = function ref() {
 
 ChildProcess.prototype.unref = function unref() {
   if (this._handle) this._handle.unref();
+};
+
+ChildProcess.prototype.getMemoryUsage = function getMemoryUsage() {
+  if (this._handle === null) {
+    return PromiseReject(new ERR_CHILD_PROCESS_NOT_RUNNING());
+  }
+
+  if (!this.channel || !this.connected) {
+    return PromiseReject(new ERR_IPC_CHANNEL_CLOSED());
+  }
+
+  const requestId = ++this[kNextMemoryUsageRequestId];
+  return new Promise((resolve, reject) => {
+    const requests = this[kMemoryUsageRequests];
+    requests.set(requestId, { resolve, reject });
+
+    this._send(
+      { cmd: 'NODE_MEMORY_USAGE', requestId },
+      null,
+      true,
+      (err) => {
+        if (err === null || err === undefined) return;
+        const pending = requests.get(requestId);
+        if (!pending) return;
+        requests.delete(requestId);
+        pending.reject(err);
+      });
+  });
 };
 
 class Control extends EventEmitter {
@@ -632,8 +747,28 @@ function setupChannel(target, channel, serializationMode) {
   // Object where socket lists will live
   channel.sockets = { got: {}, send: {} };
 
+  const isProcessTarget = target === process;
+
   // Handlers will go through this
   target.on('internalMessage', function(message, handle) {
+    if (message && message.cmd === 'NODE_MEMORY_USAGE') {
+      if (isProcessTarget) {
+        respondWithMemoryUsage(target, message.requestId);
+      }
+      return;
+    }
+
+    if (message && message.cmd === 'NODE_MEMORY_USAGE_RESULT') {
+      resolveMemoryUsageRequest(target, message.requestId, message.usage);
+      return;
+    }
+
+    if (message && message.cmd === 'NODE_MEMORY_USAGE_ERROR') {
+      const error = createMemoryUsageError(message.error);
+      rejectMemoryUsageRequest(target, message.requestId, error);
+      return;
+    }
+
     // Once acknowledged - continue sending handles.
     if (message.cmd === 'NODE_HANDLE_ACK' ||
         message.cmd === 'NODE_HANDLE_NACK') {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1159,6 +1159,10 @@ E('ERR_CHILD_CLOSED_BEFORE_REPLY',
 E('ERR_CHILD_PROCESS_IPC_REQUIRED',
   "Forked processes must have an IPC channel, missing value 'ipc' in %s",
   Error);
+E('ERR_CHILD_PROCESS_MEMORY_USAGE_FAILED',
+  'Child process memory usage request failed', Error);
+E('ERR_CHILD_PROCESS_NOT_RUNNING',
+  'Child process is not running', Error);
 E('ERR_CHILD_PROCESS_STDIO_MAXBUFFER', '%s maxBuffer length exceeded',
   RangeError);
 E('ERR_CONSOLE_WRITABLE_STREAM',

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -394,6 +394,7 @@
   V(contextify_global_template, v8::ObjectTemplate)                            \
   V(contextify_wrapper_template, v8::ObjectTemplate)                           \
   V(cpu_usage_template, v8::DictionaryTemplate)                                \
+  V(memory_usage_template, v8::DictionaryTemplate)                             \
   V(crypto_key_object_handle_constructor, v8::FunctionTemplate)                \
   V(env_proxy_template, v8::ObjectTemplate)                                    \
   V(env_proxy_ctor_template, v8::FunctionTemplate)                             \

--- a/test/fixtures/child-process-get-memory-usage-child.js
+++ b/test/fixtures/child-process-get-memory-usage-child.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const keepAlive = setInterval(() => {}, 1000);
+
+process.on('message', (msg) => {
+  if (msg === 'exit') {
+    clearInterval(keepAlive);
+    process.exit(0);
+  }
+});
+
+if (typeof process.send === 'function') {
+  process.send('ready');
+}

--- a/test/parallel/test-child-process-get-memory-usage.js
+++ b/test/parallel/test-child-process-get-memory-usage.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const common = require('../common');
+const fixtures = require('../common/fixtures');
+const assert = require('assert');
+const { fork } = require('child_process');
+const { once } = require('events');
+
+const childScript = fixtures.path('child-process-get-memory-usage-child.js');
+
+async function spawnChild(stdio = ['ignore', 'ignore', 'ignore', 'ipc']) {
+  const child = fork(childScript, [], { stdio });
+  await once(child, 'message'); // wait for "ready"
+  return child;
+}
+
+async function testSuccessfulMemoryUsageRetrieval() {
+  const child = await spawnChild();
+  const usage = await child.getMemoryUsage();
+
+  assert.strictEqual(typeof usage, 'object');
+  for (const key of ['rss', 'heapTotal', 'heapUsed', 'external', 'arrayBuffers']) {
+    assert.strictEqual(typeof usage[key], 'number');
+  }
+
+  child.send('exit');
+  await once(child, 'exit');
+}
+
+async function testRejectsWhenNotRunning() {
+  const child = await spawnChild();
+  child.kill();
+  await once(child, 'exit');
+
+  await assert.rejects(child.getMemoryUsage(), {
+    code: 'ERR_CHILD_PROCESS_NOT_RUNNING',
+  });
+}
+
+async function testRejectsWhenChannelClosed() {
+  const child = await spawnChild();
+  child.disconnect();
+
+  await assert.rejects(child.getMemoryUsage(), {
+    code: 'ERR_IPC_CHANNEL_CLOSED',
+  });
+
+  child.kill();
+  await once(child, 'exit');
+}
+
+async function main() {
+  await testSuccessfulMemoryUsageRetrieval();
+  await testRejectsWhenNotRunning();
+  await testRejectsWhenChannelClosed();
+}
+
+main().then(common.mustCall());


### PR DESCRIPTION
## Summary

- Expose `ChildProcess.prototype.getMemoryUsage()` via IPC, including request tracking, error propagation, and serialization.  
- Add regression tests plus a fixture exercising the happy path and failure cases (child stopped, IPC closed).  
- Document the new API and error codes (`ERR_CHILD_PROCESS_MEMORY_USAGE_FAILED`, `ERR_CHILD_PROCESS_NOT_RUNNING`) in  
  - `doc/api/child_process.md`  
  - `doc/api/errors.md`

## Testing

```bash
python ./tools/test.py parallel/test-child-process-get-memory-usage
make lint-js
```