### PR TITLE
fs: add `Temporal.Instant` support to `Stats` and `BigIntStats`

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2465,6 +2465,17 @@ OpenSSL crypto support.
 An attempt was made to use features that require [ICU][], but Node.js was not
 compiled with ICU support.
 
+<a id="ERR_NO_TEMPORAL"></a>
+
+### `ERR_NO_TEMPORAL`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+An attempt was made to use features that require [`Temporal`][], but Node.js was
+compiled with `Temporal` support disabled.
+
 <a id="ERR_NO_TYPESCRIPT"></a>
 
 ### `ERR_NO_TYPESCRIPT`
@@ -4472,6 +4483,7 @@ An error occurred trying to allocate memory. This should never happen.
 [`QuicError`]: quic.md#class-quicerror
 [`REPL`]: repl.md
 [`ServerResponse`]: http.md#class-httpserverresponse
+[`Temporal`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal
 [`Writable`]: stream.md#class-streamwritable
 [`child_process`]: child_process.md
 [`cipher.getAuthTag()`]: crypto.md#ciphergetauthtag

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -2473,8 +2473,9 @@ compiled with ICU support.
 added: REPLACEME
 -->
 
-An attempt was made to use features that require [`Temporal`][], but Node.js was
-compiled with `Temporal` support disabled.
+An attempt was made to use features that require [`Temporal`][], but Node.js was not
+compiled with `Temporal` support or it has been disabled in the current environment
+(for example, when running with `--no-harmony-temporal`).
 
 <a id="ERR_NO_TYPESCRIPT"></a>
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4799,7 +4799,11 @@ Stats {
   atime: 2019-06-22T03:37:33.072Z,
   mtime: 2019-06-22T03:36:54.583Z,
   ctime: 2019-06-22T03:37:06.624Z,
-  birthtime: 2019-06-22T03:28:46.937Z
+  birthtime: 2019-06-22T03:28:46.937Z,
+  atimeInstant: 2019-06-22T03:37:33.071963Z,
+  mtimeInstant: 2019-06-22T03:36:54.5833518Z,
+  ctimeInstant: 2019-06-22T03:37:06.6235366Z,
+  birthtimeInstant: 2019-06-22T03:28:46.9372893Z
 }
 false
 Stats {
@@ -4820,7 +4824,11 @@ Stats {
   atime: 2019-06-22T03:36:56.619Z,
   mtime: 2019-06-22T03:36:54.584Z,
   ctime: 2019-06-22T03:36:54.584Z,
-  birthtime: 2019-06-22T03:26:47.711Z
+  birthtime: 2019-06-22T03:26:47.711Z,
+  atimeInstant: 2019-06-22T03:36:56.6188555Z,
+  mtimeInstant: 2019-06-22T03:36:54.584Z,
+  ctimeInstant: 2019-06-22T03:36:54.5838145Z,
+  birthtimeInstant: 2019-06-22T03:26:47.7107478Z
 }
 ```
 
@@ -7525,6 +7533,9 @@ i.e. before the `'ready'` event is emitted.
 <!-- YAML
 added: v0.1.21
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60789
+    description: Added `Temporal.Instant` support.
   - version:
     - v22.0.0
     - v20.13.0
@@ -7560,10 +7571,19 @@ Stats {
   mtimeMs: 1318289051000.1,
   ctimeMs: 1318289051000.1,
   birthtimeMs: 1318289051000.1,
+
+  // Instances of Date
   atime: Mon, 10 Oct 2011 23:24:11 GMT,
   mtime: Mon, 10 Oct 2011 23:24:11 GMT,
   ctime: Mon, 10 Oct 2011 23:24:11 GMT,
-  birthtime: Mon, 10 Oct 2011 23:24:11 GMT }
+  birthtime: Mon, 10 Oct 2011 23:24:11 GMT,
+
+  // Instances of Temporal.Instant
+  atimeInstant: 2011-10-10T23:24:11.0001Z,
+  mtimeInstant: 2011-10-10T23:24:11.0001Z,
+  ctimeInstant: 2011-10-10T23:24:11.0001Z,
+  birthtimeInstant: 2011-10-10T23:24:11.0001Z
+}
 ```
 
 `bigint` version:
@@ -7588,10 +7608,19 @@ BigIntStats {
   mtimeNs: 1318289051000000000n,
   ctimeNs: 1318289051000000000n,
   birthtimeNs: 1318289051000000000n,
+
+  // Instances of Date
   atime: Mon, 10 Oct 2011 23:24:11 GMT,
   mtime: Mon, 10 Oct 2011 23:24:11 GMT,
   ctime: Mon, 10 Oct 2011 23:24:11 GMT,
-  birthtime: Mon, 10 Oct 2011 23:24:11 GMT }
+  birthtime: Mon, 10 Oct 2011 23:24:11 GMT,
+
+  // Instances of Temporal.Instant
+  atimeInstant: 2011-10-10T23:24:11Z,
+  mtimeInstant: 2011-10-10T23:24:11Z,
+  ctimeInstant: 2011-10-10T23:24:11Z,
+  birthtimeInstant: 2011-10-10T23:24:11Z
+}
 ```
 
 #### `stats.isBlockDevice()`

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1639,6 +1639,8 @@ E('ERR_NO_CRYPTO',
   'Node.js is not compiled with OpenSSL crypto support', Error);
 E('ERR_NO_ICU',
   '%s is not supported on Node.js compiled without ICU', TypeError);
+E('ERR_NO_TEMPORAL',
+  'Node.js is not compiled with Temporal support', Error);
 E('ERR_NO_TYPESCRIPT',
   'Node.js is not compiled with TypeScript support', Error);
 E('ERR_OPERATION_FAILED', 'Operation failed: %s', Error, TypeError);

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1640,7 +1640,7 @@ E('ERR_NO_CRYPTO',
 E('ERR_NO_ICU',
   '%s is not supported on Node.js compiled without ICU', TypeError);
 E('ERR_NO_TEMPORAL',
-  'Node.js is not compiled with Temporal support', Error);
+  'Temporal is not supported in this environment', Error);
 E('ERR_NO_TYPESCRIPT',
   'Node.js is not compiled with TypeScript support', Error);
 E('ERR_OPERATION_FAILED', 'Operation failed: %s', Error, TypeError);

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -441,7 +441,7 @@ function nsFromTimeSpecBigInt(sec, nsec) {
 let TemporalInstant;
 
 function instantFromNs(nsec) {
-  TemporalInstant ??= globalThis.Temporal.Instant;
+  TemporalInstant ??= globalThis.Temporal?.Instant;
   if (TemporalInstant === undefined) {
     throw new ERR_NO_TEMPORAL();
   }

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -8,6 +8,7 @@ const {
   DatePrototypeGetTime,
   ErrorCaptureStackTrace,
   FunctionPrototypeCall,
+  MathFloor,
   MathMin,
   MathRound,
   Number,
@@ -22,6 +23,7 @@ const {
   Symbol,
   TypedArrayPrototypeAt,
   TypedArrayPrototypeIncludes,
+  globalThis,
 } = primordials;
 
 const { Buffer } = require('buffer');
@@ -32,6 +34,7 @@ const {
     ERR_INCOMPATIBLE_OPTION_PAIR,
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
+    ERR_NO_TEMPORAL,
     ERR_OUT_OF_RANGE,
   },
   hideStackFrames,
@@ -43,10 +46,10 @@ const {
   isUint8Array,
 } = require('internal/util/types');
 const {
-  kEmptyObject,
-  once,
   deprecate,
   isWindows,
+  kEmptyObject,
+  once,
   setOwnProperty,
 } = require('internal/util');
 const { toPathIfFileURL } = require('internal/url');
@@ -62,6 +65,10 @@ const {
 const pathModule = require('path');
 const kType = Symbol('type');
 const kStats = Symbol('stats');
+const kPartialAtimeNs = Symbol('partialAtimeNs');
+const kPartialMtimeNs = Symbol('partialMtimeNs');
+const kPartialCtimeNs = Symbol('partialCtimeNs');
+const kPartialBirthtimeNs = Symbol('kPartialBirthtimeNs');
 const assert = require('internal/assert');
 
 const {
@@ -430,6 +437,25 @@ function nsFromTimeSpecBigInt(sec, nsec) {
   return sec * kNsPerSecBigInt + nsec;
 }
 
+// TODO(LiviaMedeiros): TemporalInstant primordial
+let TemporalInstant;
+
+function instantFromNs(nsec) {
+  TemporalInstant ??= globalThis.Temporal.Instant;
+  if (TemporalInstant === undefined) {
+    throw new ERR_NO_TEMPORAL();
+  }
+  return new TemporalInstant(nsec);
+}
+
+function instantFromTimeSpecMs(msec, nsec) {
+  TemporalInstant ??= globalThis.Temporal.Instant;
+  if (TemporalInstant === undefined) {
+    throw new ERR_NO_TEMPORAL();
+  }
+  return new TemporalInstant(BigInt(MathFloor(msec / kMsPerSec)) * kNsPerSecBigInt + BigInt(nsec));
+}
+
 // The Date constructor performs Math.floor() on the absolute value
 // of the timestamp: https://tc39.es/ecma262/#sec-timeclip
 // Since there may be a precision loss when the timestamp is
@@ -490,6 +516,118 @@ const lazyDateFields = {
   },
 };
 
+const lazyTemporalFields = {
+  __proto__: null,
+  atimeInstant: {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      const value = instantFromTimeSpecMs(this.atimeMs, this[kPartialAtimeNs]);
+      setOwnProperty(this, 'atimeInstant', value);
+      return value;
+    },
+    set(value) {
+      setOwnProperty(this, 'atimeInstant', value);
+    },
+  },
+  mtimeInstant: {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      const value = instantFromTimeSpecMs(this.mtimeMs, this[kPartialMtimeNs]);
+      setOwnProperty(this, 'mtimeInstant', value);
+      return value;
+    },
+    set(value) {
+      setOwnProperty(this, 'mtimeInstant', value);
+    },
+  },
+  ctimeInstant: {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      const value = instantFromTimeSpecMs(this.ctimeMs, this[kPartialCtimeNs]);
+      setOwnProperty(this, 'ctimeInstant', value);
+      return value;
+    },
+    set(value) {
+      setOwnProperty(this, 'ctimeInstant', value);
+    },
+  },
+  birthtimeInstant: {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      const value = instantFromTimeSpecMs(this.birthtimeMs, this[kPartialBirthtimeNs]);
+      setOwnProperty(this, 'birthtimeInstant', value);
+      return value;
+    },
+    set(value) {
+      setOwnProperty(this, 'birthtimeInstant', value);
+    },
+  },
+};
+
+const lazyTemporalBigIntFields = {
+  __proto__: null,
+  atimeInstant: {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      const value = instantFromNs(this.atimeNs);
+      setOwnProperty(this, 'atimeInstant', value);
+      return value;
+    },
+    set(value) {
+      setOwnProperty(this, 'atimeInstant', value);
+    },
+  },
+  mtimeInstant: {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      const value = instantFromNs(this.mtimeNs);
+      setOwnProperty(this, 'mtimeInstant', value);
+      return value;
+    },
+    set(value) {
+      setOwnProperty(this, 'mtimeInstant', value);
+    },
+  },
+  ctimeInstant: {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      const value = instantFromNs(this.ctimeNs);
+      setOwnProperty(this, 'ctimeInstant', value);
+      return value;
+    },
+    set(value) {
+      setOwnProperty(this, 'ctimeInstant', value);
+    },
+  },
+  birthtimeInstant: {
+    __proto__: null,
+    enumerable: true,
+    configurable: true,
+    get() {
+      const value = instantFromNs(this.birthtimeNs);
+      setOwnProperty(this, 'birthtimeInstant', value);
+      return value;
+    },
+    set(value) {
+      setOwnProperty(this, 'birthtimeInstant', value);
+    },
+  },
+};
+
 function BigIntStats(dev, mode, nlink, uid, gid, rdev, blksize,
                      ino, size, blocks,
                      atimeNs, mtimeNs, ctimeNs, birthtimeNs) {
@@ -508,6 +646,7 @@ function BigIntStats(dev, mode, nlink, uid, gid, rdev, blksize,
 ObjectSetPrototypeOf(BigIntStats.prototype, StatsBase.prototype);
 ObjectSetPrototypeOf(BigIntStats, StatsBase);
 ObjectDefineProperties(BigIntStats.prototype, lazyDateFields);
+ObjectDefineProperties(BigIntStats.prototype, lazyTemporalBigIntFields);
 
 BigIntStats.prototype._checkModeProperty = function(property) {
   if (isWindows && (property === S_IFIFO || property === S_IFBLK ||
@@ -519,18 +658,23 @@ BigIntStats.prototype._checkModeProperty = function(property) {
 
 function Stats(dev, mode, nlink, uid, gid, rdev, blksize,
                ino, size, blocks,
-               atimeMs, mtimeMs, ctimeMs, birthtimeMs) {
+               atimeS, atimeNs, mtimeS, mtimeNs, ctimeS, ctimeNs, birthtimeS, birthtimeNs) {
   FunctionPrototypeCall(StatsBase, this, dev, mode, nlink, uid, gid, rdev,
                         blksize, ino, size, blocks);
-  this.atimeMs = atimeMs;
-  this.mtimeMs = mtimeMs;
-  this.ctimeMs = ctimeMs;
-  this.birthtimeMs = birthtimeMs;
+  this.atimeMs = msFromTimeSpec(atimeS, atimeNs);
+  this.mtimeMs = msFromTimeSpec(mtimeS, mtimeNs);
+  this.ctimeMs = msFromTimeSpec(ctimeS, ctimeNs);
+  this.birthtimeMs = msFromTimeSpec(birthtimeS, birthtimeNs);
+  this[kPartialAtimeNs] = atimeNs;
+  this[kPartialMtimeNs] = mtimeNs;
+  this[kPartialCtimeNs] = ctimeNs;
+  this[kPartialBirthtimeNs] = birthtimeNs;
 }
 
 ObjectSetPrototypeOf(Stats.prototype, StatsBase.prototype);
 ObjectSetPrototypeOf(Stats, StatsBase);
 ObjectDefineProperties(Stats.prototype, lazyDateFields);
+ObjectDefineProperties(Stats.prototype, lazyTemporalFields);
 
 Stats.prototype._checkModeProperty = function(property) {
   if (isWindows && (property === S_IFIFO || property === S_IFBLK ||
@@ -563,10 +707,10 @@ function getStatsFromBinding(stats, offset = 0) {
     stats[3 + offset], stats[4 + offset], stats[5 + offset],
     stats[6 + offset], stats[7 + offset], stats[8 + offset],
     stats[9 + offset],
-    msFromTimeSpec(stats[10 + offset], stats[11 + offset]),
-    msFromTimeSpec(stats[12 + offset], stats[13 + offset]),
-    msFromTimeSpec(stats[14 + offset], stats[15 + offset]),
-    msFromTimeSpec(stats[16 + offset], stats[17 + offset]),
+    stats[10 + offset], stats[11 + offset], // atime
+    stats[12 + offset], stats[13 + offset], // mtime
+    stats[14 + offset], stats[15 + offset], // ctime
+    stats[16 + offset], stats[17 + offset], // birthtime
   );
 }
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -523,9 +523,8 @@ const lazyTemporalFields = {
     enumerable: true,
     configurable: true,
     get() {
-      const value = instantFromTimeSpecMs(this.atimeMs, this[kPartialAtimeNs]);
-      setOwnProperty(this, 'atimeInstant', value);
-      return value;
+      return setOwnProperty(this, 'atimeInstant',
+                            instantFromTimeSpecMs(this.atimeMs, this[kPartialAtimeNs]));
     },
     set(value) {
       setOwnProperty(this, 'atimeInstant', value);
@@ -536,9 +535,8 @@ const lazyTemporalFields = {
     enumerable: true,
     configurable: true,
     get() {
-      const value = instantFromTimeSpecMs(this.mtimeMs, this[kPartialMtimeNs]);
-      setOwnProperty(this, 'mtimeInstant', value);
-      return value;
+      return setOwnProperty(this, 'mtimeInstant',
+                            instantFromTimeSpecMs(this.mtimeMs, this[kPartialMtimeNs]));
     },
     set(value) {
       setOwnProperty(this, 'mtimeInstant', value);
@@ -549,9 +547,8 @@ const lazyTemporalFields = {
     enumerable: true,
     configurable: true,
     get() {
-      const value = instantFromTimeSpecMs(this.ctimeMs, this[kPartialCtimeNs]);
-      setOwnProperty(this, 'ctimeInstant', value);
-      return value;
+      return setOwnProperty(this, 'ctimeInstant',
+                            instantFromTimeSpecMs(this.ctimeMs, this[kPartialCtimeNs]));
     },
     set(value) {
       setOwnProperty(this, 'ctimeInstant', value);
@@ -562,9 +559,8 @@ const lazyTemporalFields = {
     enumerable: true,
     configurable: true,
     get() {
-      const value = instantFromTimeSpecMs(this.birthtimeMs, this[kPartialBirthtimeNs]);
-      setOwnProperty(this, 'birthtimeInstant', value);
-      return value;
+      return setOwnProperty(this, 'birthtimeInstant',
+                            instantFromTimeSpecMs(this.birthtimeMs, this[kPartialBirthtimeNs]));
     },
     set(value) {
       setOwnProperty(this, 'birthtimeInstant', value);
@@ -579,9 +575,7 @@ const lazyTemporalBigIntFields = {
     enumerable: true,
     configurable: true,
     get() {
-      const value = instantFromNs(this.atimeNs);
-      setOwnProperty(this, 'atimeInstant', value);
-      return value;
+      return setOwnProperty(this, 'atimeInstant', instantFromNs(this.atimeNs));
     },
     set(value) {
       setOwnProperty(this, 'atimeInstant', value);
@@ -592,9 +586,7 @@ const lazyTemporalBigIntFields = {
     enumerable: true,
     configurable: true,
     get() {
-      const value = instantFromNs(this.mtimeNs);
-      setOwnProperty(this, 'mtimeInstant', value);
-      return value;
+      return setOwnProperty(this, 'mtimeInstant', instantFromNs(this.mtimeNs));
     },
     set(value) {
       setOwnProperty(this, 'mtimeInstant', value);
@@ -605,9 +597,7 @@ const lazyTemporalBigIntFields = {
     enumerable: true,
     configurable: true,
     get() {
-      const value = instantFromNs(this.ctimeNs);
-      setOwnProperty(this, 'ctimeInstant', value);
-      return value;
+      return setOwnProperty(this, 'ctimeInstant', instantFromNs(this.ctimeNs));
     },
     set(value) {
       setOwnProperty(this, 'ctimeInstant', value);
@@ -618,9 +608,7 @@ const lazyTemporalBigIntFields = {
     enumerable: true,
     configurable: true,
     get() {
-      const value = instantFromNs(this.birthtimeNs);
-      setOwnProperty(this, 'birthtimeInstant', value);
-      return value;
+      return setOwnProperty(this, 'birthtimeInstant', instantFromNs(this.birthtimeNs));
     },
     set(value) {
       setOwnProperty(this, 'birthtimeInstant', value);

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -449,7 +449,7 @@ function instantFromNs(nsec) {
 }
 
 function instantFromTimeSpecMs(msec, nsec) {
-  TemporalInstant ??= globalThis.Temporal.Instant;
+  TemporalInstant ??= globalThis.Temporal?.Instant;
   if (TemporalInstant === undefined) {
     throw new ERR_NO_TEMPORAL();
   }

--- a/test/parallel/test-fs-stat-temporal.mjs
+++ b/test/parallel/test-fs-stat-temporal.mjs
@@ -1,0 +1,105 @@
+import * as common from '../common/index.mjs';
+
+// Test `Temporal.Instant`s returned by fsPromises.stat and fs.statSync
+
+import fs from 'node:fs';
+import fsPromises from 'node:fs/promises';
+import assert from 'node:assert';
+import tmpdir from '../common/tmpdir.js';
+
+if (!common.hasTemporal) {
+  common.skip('Temporal support unavailable');
+}
+
+// On some platforms (for example, ppc64) boundaries are tighter
+// than usual. If we catch these errors, skip corresponding test.
+const ignoredErrors = new Set(['EINVAL', 'EOVERFLOW']);
+
+tmpdir.refresh();
+const filepath = tmpdir.resolve('timestamp');
+
+await (await fsPromises.open(filepath, 'w')).close();
+
+// Perform a trivial check to determine if filesystem supports setting
+// and retrieving atime and mtime. If it doesn't, skip the test.
+await fsPromises.utimes(filepath, 2, 2);
+const { atimeMs, mtimeMs } = await fsPromises.stat(filepath);
+if (atimeMs !== 2000 || mtimeMs !== 2000) {
+  common.skip(`Unsupported filesystem (atimeMs=${atimeMs}, mtimeMs=${mtimeMs})`);
+}
+
+// Allow delta due to precision loss or platform-specific nuances
+function closeEnough(actual, expected, margin) {
+  // On ppc64, value is rounded to seconds
+  if (process.arch === 'ppc64') {
+    margin += 1000;
+  }
+
+  // Filesystems without support for timestamps before 1970-01-01, such as NFSv3,
+  // should return 0 for negative numbers. Do not treat it as error.
+  if (actual === 0 && expected < 0) {
+    console.log(`ignored 0 while expecting ${expected}`);
+    return;
+  }
+
+  assert.ok(Math.abs(Number(actual - expected)) < margin,
+            `expected ${expected} ± ${margin}, got ${actual}`);
+}
+
+// Ensure that accessed atime and mtime are enumerable
+function validateEnumerability(stats) {
+  const keys = Object.keys(stats);
+  assert.ok(keys.includes('atimeInstant'));
+  assert.ok(keys.includes('mtimeInstant'));
+}
+
+async function runTest(atimeMs, mtimeMs, margin = 0) {
+  margin += Number.EPSILON;
+
+  // TODO(LiviaMedeiros): use bigint nanoseconds once `utimes()` supports Temporal
+  const atime = atimeMs / 1000;
+  const mtime = mtimeMs / 1000;
+  try {
+    await fsPromises.utimes(filepath, atime, mtime);
+  } catch (e) {
+    if (ignoredErrors.has(e.code)) return;
+    throw e;
+  }
+
+  const stats = await fsPromises.stat(filepath);
+  closeEnough(stats.atimeMs, atimeMs, margin);
+  closeEnough(stats.mtimeMs, mtimeMs, margin);
+  closeEnough(stats.atimeInstant.epochMilliseconds, atimeMs, margin);
+  closeEnough(stats.mtimeInstant.epochMilliseconds, mtimeMs, margin);
+  validateEnumerability(stats);
+
+  const statsBigint = await fsPromises.stat(filepath, { bigint: true });
+  closeEnough(statsBigint.atimeMs, BigInt(atimeMs), margin);
+  closeEnough(statsBigint.mtimeMs, BigInt(mtimeMs), margin);
+  closeEnough(statsBigint.atimeInstant.epochMilliseconds, atimeMs, margin);
+  closeEnough(statsBigint.mtimeInstant.epochMilliseconds, mtimeMs, margin);
+  validateEnumerability(statsBigint);
+
+  const statsSync = fs.statSync(filepath);
+  closeEnough(statsSync.atimeMs, atimeMs, margin);
+  closeEnough(statsSync.mtimeMs, mtimeMs, margin);
+  closeEnough(statsSync.atimeInstant.epochMilliseconds, atimeMs, margin);
+  closeEnough(statsSync.mtimeInstant.epochMilliseconds, mtimeMs, margin);
+  validateEnumerability(statsSync);
+
+  const statsSyncBigint = fs.statSync(filepath, { bigint: true });
+  closeEnough(statsSyncBigint.atimeMs, BigInt(atimeMs), margin);
+  closeEnough(statsSyncBigint.mtimeMs, BigInt(mtimeMs), margin);
+  closeEnough(statsSyncBigint.atimeInstant.epochMilliseconds, atimeMs, margin);
+  closeEnough(statsSyncBigint.mtimeInstant.epochMilliseconds, mtimeMs, margin);
+  validateEnumerability(statsSyncBigint);
+}
+
+// Too high/low numbers produce too different results on different platforms
+{
+  await runTest(0, 0);
+  await runTest(1, 1);
+  await runTest(355, 40691, 1); // Precision loss on 32bit
+  await runTest(40691, 355, 1); // Precision loss on 32bit
+  await runTest(1713037251360, 1713037251360, 1); // Precision loss
+}

--- a/test/parallel/test-fs-watchfile.js
+++ b/test/parallel/test-fs-watchfile.js
@@ -42,10 +42,14 @@ const expectedStatObject = new fs.Stats(
   0,                                        // ino
   0,                                        // size
   0,                                        // blocks
-  Date.UTC(1970, 0, 1, 0, 0, 0),            // atime
-  Date.UTC(1970, 0, 1, 0, 0, 0),            // mtime
-  Date.UTC(1970, 0, 1, 0, 0, 0),            // ctime
-  Date.UTC(1970, 0, 1, 0, 0, 0)             // birthtime
+  0,                                        // atimeS
+  0,                                        // atimeNs
+  0,                                        // mtimeS
+  0,                                        // mtimeNs
+  0,                                        // ctime
+  0,                                        // ctimeNs
+  0,                                        // birthtime
+  0,                                        // birthtimeNs
 );
 
 tmpdir.refresh();


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/57891

This is a very rough draft, and probably shouldn't land until `Temporal` implementation is finalized and/or enabled by default.
Opening early to see if there are any objections, suggestions to naming (the `*Instant` properties are facing userspace and having consistent convention would be nice), or to implementation.