### PR TITLE
tools: dump config.gypi as json

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2437,8 +2437,9 @@ if make_global_settings:
 
 print_verbose(output)
 
+# Dump as JSON to allow js2c.cc read it as a simple json file.
 write('config.gypi', do_not_edit +
-      pprint.pformat(output, indent=2, width=128) + '\n')
+      json.dumps(output, indent=2) + '\n')
 
 write('config.status', '#!/bin/sh\nset -x\nexec ./configure ' +
       ' '.join([shlex.quote(arg) for arg in original_argv]) + '\n')

--- a/test/parallel/test-process-config.js
+++ b/test/parallel/test-process-config.js
@@ -49,8 +49,7 @@ let config = fs.readFileSync(configPath, 'utf8');
 
 // Clean up comment at the first line.
 config = config.split('\n').slice(1).join('\n');
-config = config.replace(/"/g, '\\"');
-config = config.replace(/'/g, '"');
+// Turn pseudo-booleans strings into booleans.
 config = JSON.parse(config, (key, value) => {
   if (value === 'true') return true;
   if (value === 'false') return false;

--- a/tools/js2c.cc
+++ b/tools/js2c.cc
@@ -796,21 +796,11 @@ std::vector<char> JSONify(const std::vector<char>& code) {
   // 1. Remove string comments
   std::vector<char> stripped = StripComments(code);
 
-  // 2. join multiline strings
-  std::vector<char> joined = JoinMultilineString(stripped);
+  // 2. turn pseudo-booleans strings into Booleans
+  std::vector<char> result1 = ReplaceAll(stripped, R"("true")", "true");
+  std::vector<char> result2 = ReplaceAll(result1, R"("false")", "false");
 
-  // 3. normalize string literals from ' into "
-  for (size_t i = 0; i < joined.size(); ++i) {
-    if (joined[i] == '\'') {
-      joined[i] = '"';
-    }
-  }
-
-  // 4. turn pseudo-booleans strings into Booleans
-  std::vector<char> result3 = ReplaceAll(joined, R"("true")", "true");
-  std::vector<char> result4 = ReplaceAll(result3, R"("false")", "false");
-
-  return result4;
+  return result2;
 }
 
 int AddGypi(const std::string& var,


### PR DESCRIPTION
This helps js2c processing the node.gypi correctly when a string contains a quote.

Refs: https://github.com/nodejs/node/pull/60703