### PR TITLE
test: fix embedtest in debug windows

### DIFF
--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -210,23 +210,23 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
       return 1;
 
     exit_code = node::SpinEventLoop(env).FromMaybe(1);
-  }
 
-  if (!snapshot_blob_path.empty() && is_building_snapshot) {
-    snapshot = setup->CreateSnapshot();
-    assert(snapshot);
+    if (!snapshot_blob_path.empty() && is_building_snapshot) {
+      snapshot = setup->CreateSnapshot();
+      assert(snapshot);
 
-    FILE* fp = fopen(snapshot_blob_path.c_str(), "wb");
-    assert(fp != nullptr);
-    if (snapshot_as_file) {
-      snapshot->ToFile(fp);
-    } else {
-      const std::vector<char> vec = snapshot->ToBlob();
-      size_t written = fwrite(vec.data(), vec.size(), 1, fp);
-      assert(written == 1);
+      FILE* fp = fopen(snapshot_blob_path.c_str(), "wb");
+      assert(fp != nullptr);
+      if (snapshot_as_file) {
+        snapshot->ToFile(fp);
+      } else {
+        const std::vector<char> vec = snapshot->ToBlob();
+        size_t written = fwrite(vec.data(), vec.size(), 1, fp);
+        assert(written == 1);
+      }
+      int ret = fclose(fp);
+      assert(ret == 0);
     }
-    int ret = fclose(fp);
-    assert(ret == 0);
   }
 
   node::Stop(env);


### PR DESCRIPTION
When we run the embedding tests compiled for Windows debug it crashes with the error that you can see below.
The crash happens when the code tries to create a snapshot that causes a GC run.
At that moment the `v8::Isolate` is not locked to our thread and as a result debug-only V8 check causes the crash.

This PR extends the scope for the Isolate-to-thread lock so all snapshot operations have the valid thread association.

I am not 100% sure that this is the best fix here. Feel free to advise on a better approach.
E.g. we can have a separate Isolate lock for the snapshot operations instead of extending the existing scope.

This PR and and PR #60807 finally unblock the test runs on Windows while working on the code.

The error log being addressed by this PR:

```
#
# Fatal error in ..\..\deps\v8\src\heap\cppgc\prefinalizer-handler.cc, line 54
# Debug check failed: CurrentThreadIsCreationThread().
#
#
#
#FailureMessage Object: 00000064F82FE210
----- Native stack trace -----

 1: 00007FF670CF56BB node::DumpNativeBacktrace+107 [E:\GitHub\nodejs\node\src\debug_utils.cc]:L321
 2: 00007FF670CDAEC4 node::NodePlatform::GetStackTracePrinter::<lambda_3>::operator()+52 [E:\GitHub\nodejs\node\src\node_platform.cc]:L766
 3: 00007FF670CDAE7D node::NodePlatform::GetStackTracePrinter::<lambda_3>::__invoke+29 [E:\GitHub\nodejs\node\src\node_platform.cc]:L763
 4: 00007FF6710A40FC V8_Fatal+268 [E:\GitHub\nodejs\node\deps\v8\src\base\logging.cc]:L231
 5: 00007FF6710A39F3 v8::base::`anonymous namespace'::DefaultDcheckHandler+19 [E:\GitHub\nodejs\node\deps\v8\src\base\logging.cc]:L59
 6: 00007FF67257D669 cppgc::internal::PreFinalizerHandler::InvokePreFinalizers+1865 [E:\GitHub\nodejs\node\deps\v8\src\heap\cppgc\prefinalizer-handler.cc]:L54
 7: 00007FF671943F62 cppgc::internal::HeapBase::ExecutePreFinalizers+50 [E:\GitHub\nodejs\node\deps\v8\src\heap\cppgc\heap-base.cc]:L170
 8: 00007FF670C8C697 v8::internal::CppHeap::CompactAndSweep+55 [E:\GitHub\nodejs\node\deps\v8\src\heap\cppgc-js\cpp-heap.cc]:L1031
 9: 00007FF671172306 v8::internal::Heap::PerformGarbageCollection+2086 [E:\GitHub\nodejs\node\deps\v8\src\heap\heap.cc]:L2385
10: 00007FF67119E859 v8::internal::Heap::CollectGarbage::<lambda_11>::operator()+1321 [E:\GitHub\nodejs\node\deps\v8\src\heap\heap.cc]:L1701
11: 00007FF67119E30B heap::base::Stack::SetMarkerAndCallbackImpl<`lambda at ..\..\deps\v8\src\heap\heap.cc:1664:40'>+43 [E:\GitHub\nodejs\node\deps\v8\src\heap\base\stack.h]:L181
12: 00007FF6753F8DDD PushAllRegistersAndIterateStack+109 [E:\GitHub\nodejs\node\deps\v8\src\heap\base\asm\x64\push_registers_masm.asm]:L64
13: 00007FF67116C189 v8::internal::Heap::CollectGarbage+1161 [E:\GitHub\nodejs\node\deps\v8\src\heap\heap.cc]:L1664
14: 00007FF67116D585 v8::internal::Heap::CollectAllAvailableGarbage+325 [E:\GitHub\nodejs\node\deps\v8\src\heap\heap.cc]:L1388
15: 00007FF6711C87B0 v8::internal::SnapshotCreatorImpl::CreateBlob+1232 [E:\GitHub\nodejs\node\deps\v8\src\snapshot\snapshot.cc]:L1086
16: 00007FF670AF93E3 v8::SnapshotCreator::CreateBlob+19 [E:\GitHub\nodejs\node\deps\v8\src\api\api.cc]:L420
17: 00007FF670AA465E node::SnapshotBuilder::CreateSnapshot+2014 [E:\GitHub\nodejs\node\src\node_snapshotable.cc]:L1189
18: 00007FF670A7AD01 node::CommonEnvironmentSetup::CreateSnapshot+209 [E:\GitHub\nodejs\node\src\api\embed_helpers.cc]:L266
19: 00007FF670A6BCBE RunNodeInstance+3086 [E:\GitHub\nodejs\node\test\embedding\embedtest.cc]:L216
20: 00007FF670A6B037 wmain+711 [E:\GitHub\nodejs\node\test\embedding\embedtest.cc]:L62
21: 00007FF67542E849 invoke_main+57 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl]:L91
22: 00007FF67542E982 __scrt_common_main_seh+306 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl]:L288
23: 00007FF67542EA0E __scrt_common_main+14 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl]:L331
24: 00007FF67542EA2E wmainCRTStartup+14 [D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_wmain.cpp]:L17
SymGetLineFromAddr64 returned error : 487
25: 00007FFE930FE8D7 BaseThreadInitThunk+23
SymGetLineFromAddr64 returned error : 487
26: 00007FFE9400C53C RtlUserThreadStart+44

[process 52484]: --- stdout ---

[process 52484]: status = 2147483651, signal = null
E:\GitHub\nodejs\node\test\common\child_process.js:112
    throw error;
    ^

Error: - process terminated with status 2147483651, expected 0
    at Object.<anonymous> (E:\GitHub\nodejs\node\test\embedding\test-embedding.js:113:3)
    at Module._compile (node:internal/modules/cjs/loader:1760:14)
    at Object..js (node:internal/modules/cjs/loader:1892:10)
    at Module.load (node:internal/modules/cjs/loader:1480:32)
    at Module._load (node:internal/modules/cjs/loader:1299:12)
    at TracingChannel.traceSync (node:diagnostics_channel:328:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:245:24)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  options: { cwd: 'E:\\GitHub\\nodejs\\node\\test\\.tmp.0' },
  command: 'E:\\GitHub\\nodejs\\node\\Debug\\embedtest.exe -- eval((require("fs").readFileSync("E:\\\\GitHub\\\\nodejs\\\\node\\\\test\\\\fixtures\\\\snapshot\\\\echo-args.js", "utf8"))) arg1 arg2 --embedder-snapshot-blob E:\\GitHub\\nodejs\\node\\test\\.tmp.0\\embedder-snapshot.blob --embedder-snapshot-create'
}
```