### PR TITLE
test: fix debug test crashes caused by sea tests

### DIFF
--- a/test/sea/testcfg.py
+++ b/test/sea/testcfg.py
@@ -5,7 +5,15 @@ import testpy
 def GetConfiguration(context, root):
   # We don't use arch-specific out folder in Node.js; use none/none to auto
   # detect release mode from GetVm and get the path to the executable.
-  vm = context.GetVm('none', 'none')
+  try:
+    vm = context.GetVm('none', 'none')
+  except ValueError:
+    # In debug only builds, we are getting an exception because none/none
+    # results in taking the release flavor that is missing in that case. Try to
+    # recover by using the first mode passed explicitly to the test.py.
+    preferred_mode = getattr(context, 'default_mode', 'none') or 'none'
+    vm = context.GetVm('none', preferred_mode)
+
   if not os.path.isfile(vm):
     return testpy.SimpleTestConfiguration(context, root, 'sea')
 

--- a/tools/test.py
+++ b/tools/test.py
@@ -1697,6 +1697,14 @@ def Main():
                     options.store_unexpected_output,
                     options.repeat,
                     options.abort_on_timeout)
+  # Remember the primary mode requested on the CLI so suites can reuse it when
+  # they need to probe for a binary outside of the normal test runner flow.
+  for requested_mode in options.mode:
+    if requested_mode:
+      context.default_mode = requested_mode
+      break
+  else:
+    context.default_mode = 'none'
 
   if options.error_reporter:
     context.use_error_reporter = True


### PR DESCRIPTION
When we compile for debug on Windows we have the tests crashing with the error log shown below.
The root cause of the issue is that when the SEA tests are probing for parallel execution they call `context.GetVm('none', 'none')`.
This call results with trying to use `Release\node.exe` that is not created for debug-only builds.

In this PR we record the first `--mode` passed to `tools\test.py` and then we use it as a fallback when the `context.GetVm('none', 'none')` raises an exception.

Since I do not know the full background why we use none/none and why `GetVm` unconditionally returns the Release path in that case, this is the best solution that I could come with. Feel free to propose a better version.

This PR and and PR #60806 finally unblock the test runs on Windows while working on the code.

The error log being addressed by this PR:
```
Node.js v26.0.0-pre
running 'python tools\test.py --mode=debug  js-native-api'
Traceback (most recent call last):
  File "E:\GitHub\nodejs\node\tools\test.py", line 1854, in <module>
    sys.exit(Main())
             ^^^^^^
  File "E:\GitHub\nodejs\node\tools\test.py", line 1707, in Main
    root.GetTestStatus(context, sections, defs)
  File "E:\GitHub\nodejs\node\tools\test.py", line 942, in GetTestStatus
    tests_repos.GetTestStatus(context, sections, defs)
  File "E:\GitHub\nodejs\node\tools\test.py", line 909, in GetTestStatus
    self.GetConfiguration(context).GetTestStatus(sections, defs)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\GitHub\nodejs\node\tools\test.py", line 891, in GetConfiguration
    self.config = module.GetConfiguration(context, self.path)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\GitHub\nodejs\node\test\sea\testcfg.py", line 8, in GetConfiguration
    vm = context.GetVm('none', 'none')
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "E:\GitHub\nodejs\node\tools\test.py", line 991, in GetVm
    raise ValueError('Could not find executable. Should be ' + name)
ValueError: Could not find executable. Should be E:\GitHub\nodejs\node\Release\node.exe
```
