### PR TITLE
test: add missing test for empty string in path.posix.normalize()

### DIFF
--- a/test/parallel/test-path-normalize.js
+++ b/test/parallel/test-path-normalize.js
@@ -98,3 +98,6 @@ assert.strictEqual(
   '../../../../baz'
 );
 assert.strictEqual(path.posix.normalize('foo/bar\\baz'), 'foo/bar\\baz');
+
+// Missing test for empty string 
+assert.strictEqual(path.posix.normalize(''), '.');


### PR DESCRIPTION
Refs: #60822


## Problem
The implementation of `path.posix.normalize()` explicitly handles the empty string case:

```js
if (path.length === 0)
  return '.';
```

However, the test suite (`test/parallel/test-path-normalize.js`) did not include a test for this behavior, leaving this branch untested.

## Fix
This PR adds the following assertion to ensure the empty path case is properly covered:

```js
assert.strictEqual(path.posix.normalize(''), '.');
```

- Improves test coverage for the path subsystem
- Ensures edge-case behavior is tested and protected
- Helps prevent regressions during future refactors

## Tests
- ✔ Added new test case
- ✔ All existing tests pass
