### PR TITLE
src: handle indexed properties in `process.env`

### DIFF
--- a/test/parallel/test-process-env.js
+++ b/test/parallel/test-process-env.js
@@ -29,6 +29,7 @@ if (process.argv[2] === 'you-are-the-child') {
   assert.strictEqual('NODE_PROCESS_ENV_DELETED' in process.env, false);
   assert.strictEqual(process.env.NODE_PROCESS_ENV, '42');
   assert.strictEqual(process.env.hasOwnProperty, 'asdf');
+  assert.strictEqual(process.env[42], 'forty-two');
   const has = Object.hasOwn(process.env, 'hasOwnProperty');
   assert.strictEqual(has, true);
   process.exit(0);
@@ -46,6 +47,9 @@ if (process.argv[2] === 'you-are-the-child') {
 
   process.env.NODE_PROCESS_ENV = 42;
   assert.strictEqual(process.env.NODE_PROCESS_ENV, '42');
+
+  process.env[42] = 'forty-two';
+  assert.strictEqual(process.env[42], 'forty-two');
 
   process.env.NODE_PROCESS_ENV_DELETED = 42;
   assert.strictEqual('NODE_PROCESS_ENV_DELETED' in process.env, true);


### PR DESCRIPTION
Closes: https://github.com/nodejs/node/issues/60795

I'm not sure if we should treat this as a breaking change.
Before this change, indexed properties would not be intercepted, so setting them in JS would not coerce the value to a string.