### PR TITLE
crypto: fix DOMException name for non-extractable key error

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -676,7 +676,7 @@ async function exportKey(format, key) {
   }
 
   if (!key[kExtractable])
-    throw lazyDOMException('key is not extractable', 'InvalidAccessException');
+    throw lazyDOMException('key is not extractable', 'InvalidAccessError');
 
   let result;
   switch (format) {

--- a/test/parallel/test-webcrypto-export-import-cfrg.js
+++ b/test/parallel/test-webcrypto-export-import-cfrg.js
@@ -134,7 +134,8 @@ async function testImportSpki({ name, publicUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('spki', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -172,7 +173,8 @@ async function testImportPkcs8({ name, privateUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -303,11 +305,13 @@ async function testImportJwk({ name, publicUsages, privateUsages }, extractable)
   } else {
     await assert.rejects(
       subtle.exportKey('jwk', publicKey), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
     await assert.rejects(
       subtle.exportKey('jwk', privateKey), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 

--- a/test/parallel/test-webcrypto-export-import-ec.js
+++ b/test/parallel/test-webcrypto-export-import-ec.js
@@ -123,7 +123,8 @@ async function testImportSpki({ name, publicUsages }, namedCurve, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('spki', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -165,7 +166,8 @@ async function testImportPkcs8(
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -270,11 +272,13 @@ async function testImportJwk(
   } else {
     await assert.rejects(
       subtle.exportKey('jwk', publicKey), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
     await assert.rejects(
       subtle.exportKey('jwk', privateKey), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 

--- a/test/parallel/test-webcrypto-export-import-ml-dsa.js
+++ b/test/parallel/test-webcrypto-export-import-ml-dsa.js
@@ -106,7 +106,8 @@ async function testImportSpki({ name, publicUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('spki', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -144,7 +145,8 @@ async function testImportPkcs8({ name, privateUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -181,7 +183,8 @@ async function testImportPkcs8SeedOnly({ name, privateUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -219,7 +222,8 @@ async function testImportPkcs8PrivOnly({ name, privateUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -299,11 +303,13 @@ async function testImportJwk({ name, publicUsages, privateUsages }, extractable)
   } else {
     await assert.rejects(
       subtle.exportKey('jwk', publicKey), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
     await assert.rejects(
       subtle.exportKey('jwk', privateKey), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 

--- a/test/parallel/test-webcrypto-export-import-ml-kem.js
+++ b/test/parallel/test-webcrypto-export-import-ml-kem.js
@@ -89,7 +89,8 @@ async function testImportSpki({ name, publicUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('spki', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -127,7 +128,8 @@ async function testImportPkcs8({ name, privateUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -164,7 +166,8 @@ async function testImportPkcs8SeedOnly({ name, privateUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -202,7 +205,8 @@ async function testImportPkcs8PrivOnly({ name, privateUsages }, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 

--- a/test/parallel/test-webcrypto-export-import-rsa.js
+++ b/test/parallel/test-webcrypto-export-import-rsa.js
@@ -336,7 +336,8 @@ async function testImportSpki({ name, publicUsages }, size, hash, extractable) {
   } else {
     await assert.rejects(
       subtle.exportKey('spki', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 }
@@ -372,7 +373,8 @@ async function testImportPkcs8(
   } else {
     await assert.rejects(
       subtle.exportKey('pkcs8', key), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 
@@ -479,11 +481,13 @@ async function testImportJwk(
   } else {
     await assert.rejects(
       subtle.exportKey('jwk', publicKey), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
     await assert.rejects(
       subtle.exportKey('jwk', privateKey), {
-        message: /key is not extractable/
+        message: /key is not extractable/,
+        name: 'InvalidAccessError',
       });
   }
 


### PR DESCRIPTION
As per step 7 in https://w3c.github.io/webcrypto/#SubtleCrypto-method-exportKey