### PR TITLE
test: replace deprecated regex test assertions in http trailers test

### DIFF
--- a/test/parallel/test-http-set-trailers.js
+++ b/test/parallel/test-http-set-trailers.js
@@ -43,8 +43,9 @@ function testHttp10(port, callback) {
 
   c.on('end', common.mustCall(() => {
     c.end();
-    assert.ok(
-      !/x-foo/.test(res_buffer),
+    assert.doesNotMatch(
+      res_buffer,
+      /x-foo/,
       `No trailer in HTTP/1.0 response. Response buffer: ${res_buffer}`
     );
     callback();
@@ -68,8 +69,9 @@ function testHttp11(port, callback) {
     res_buffer += chunk;
     if (/0\r\n/.test(res_buffer)) { // got the end.
       clearTimeout(tid);
-      assert.ok(
-        /0\r\nx-foo: bar\r\n\r\n$/.test(res_buffer),
+      assert.match(
+        res_buffer,
+        /0\r\nx-foo: bar\r\n\r\n$/,
         `No trailer in HTTP/1.1 response. Response buffer: ${res_buffer}`
       );
       callback();


### PR DESCRIPTION
This PR updates `test/parallel/test-http-set-trailers.js` to align with the recent test modernization work happening across the Node.js codebase. Maintainers have been gradually replacing older `assert.ok(/regex/.test(...))` patterns with clearer, more explicit helpers such as `assert.match()` and `assert.doesNotMatch()`.  
This PR applies that same modernization to this test file.

## What was changed
### HTTP/1.0 test
Previously:
```js
assert.ok(!/x-foo/.test(res_buffer));
```

Updated to:
```js
assert.doesNotMatch(res_buffer, /x-foo/);
```

### HTTP/1.1 test
Previously:
```js
assert.ok(/0\r\nx-foo: bar\r\n\r\n$/.test(res_buffer));
```

Updated to:
```js
assert.match(res_buffer, /0\r\nx-foo: bar\r\n\r\n$/);
```

## Why this change

- Improves readability by using purpose-built assertion helpers.
- Aligns the test with modern Node.js testing conventions.
- No functional or behavioral changes to the test . Only assertion style updates.

## Additional notes

- All tests continue to pass.
- No logic or behavior was altered; only assertions were updated.
