### PR TITLE
http2,zlib: prefer `call()` over `apply()` if argument list is not array

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -7,7 +7,6 @@ const {
   ObjectHasOwn,
   ObjectKeys,
   Proxy,
-  ReflectApply,
   ReflectGetPrototypeOf,
   Symbol,
 } = primordials;
@@ -846,7 +845,7 @@ class Http2ServerResponse extends Stream {
       this.writeHead(this[kState].statusCode);
 
     if (this[kState].closed || stream.destroyed)
-      ReflectApply(onStreamCloseResponse, stream, []);
+      onStreamCloseResponse.call(stream);
     else
       stream.end();
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -1960,7 +1960,7 @@ function shutdownWritable(callback) {
   req.handle = handle;
   const err = handle.shutdown(req);
   if (err === 1)  // synchronous finish
-    return ReflectApply(afterShutdown, req, [0]);
+    return afterShutdown.call(req, 0);
 }
 
 function finishSendTrailers(stream, headersList) {
@@ -2327,7 +2327,7 @@ class Http2Stream extends Duplex {
       return;
     }
     debugStreamObj(this, 'shutting down writable on _final');
-    ReflectApply(shutdownWritable, this, [cb]);
+    shutdownWritable.call(this, cb);
 
     if (this.session[kType] === NGHTTP2_SESSION_CLIENT && onClientStreamBodySentChannel.hasSubscribers) {
       onClientStreamBodySentChannel.publish({ stream: this });
@@ -2741,8 +2741,7 @@ function doSendFD(session, options, fd, headers, streamOptions, err, stat) {
   // response is canceled. The user code may also send a separate type
   // of response so check again for the HEADERS_SENT flag
   if ((typeof options.statCheck === 'function' &&
-       ReflectApply(options.statCheck, this,
-                    [stat, headers, statOptions]) === false) ||
+       options.statCheck.call(this, stat, headers, statOptions) === false) ||
        (this[kState].flags & STREAM_FLAGS_HEADERS_SENT)) {
     return;
   }
@@ -2801,7 +2800,7 @@ function doSendFileFD(session, options, fd, headers, streamOptions, err, stat) {
   // response is canceled. The user code may also send a separate type
   // of response so check again for the HEADERS_SENT flag
   if ((typeof options.statCheck === 'function' &&
-       ReflectApply(options.statCheck, this, [stat, headers]) === false) ||
+       options.statCheck.call(this, stat, headers) === false) ||
        (this[kState].flags & STREAM_FLAGS_HEADERS_SENT)) {
     tryClose(fd);
     return;
@@ -3633,9 +3632,9 @@ function getUnpackedSettings(buf, options = kEmptyObject) {
   const settings = {};
   let offset = 0;
   while (offset < buf.length) {
-    const id = ReflectApply(readUInt16BE, buf, [offset]);
+    const id = readUInt16BE.call(buf, offset);
     offset += 2;
-    const value = ReflectApply(readUInt32BE, buf, [offset]);
+    const value = readUInt32BE.call(buf, offset);
     switch (id) {
       case NGHTTP2_SETTINGS_HEADER_TABLE_SIZE:
         settings.headerTableSize = value;

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -31,7 +31,6 @@ const {
   ObjectFreeze,
   ObjectKeys,
   ObjectSetPrototypeOf,
-  ReflectApply,
   Symbol,
   Uint32Array,
 } = primordials;
@@ -255,7 +254,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
     }
   }
 
-  ReflectApply(Transform, this, [{ autoDestroy: true, ...opts }]);
+  Transform.call(this, { autoDestroy: true, ...opts });
   this[kError] = null;
   this.bytesWritten = 0;
   this._handle = handle;
@@ -681,7 +680,7 @@ function Zlib(opts, mode) {
               processCallback,
               dictionary);
 
-  ReflectApply(ZlibBase, this, [opts, mode, handle, zlibDefaultOpts]);
+  ZlibBase.call(this, opts, mode, handle, zlibDefaultOpts);
 
   this._level = level;
   this._strategy = strategy;
@@ -724,7 +723,7 @@ function Deflate(opts) {
   if (!(this instanceof Deflate)) {
     return deprecateInstantiation(Deflate, 'DEP0184', opts);
   }
-  ReflectApply(Zlib, this, [opts, DEFLATE]);
+  Zlib.call(this, opts, DEFLATE);
 }
 ObjectSetPrototypeOf(Deflate.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Deflate, Zlib);
@@ -733,7 +732,7 @@ function Inflate(opts) {
   if (!(this instanceof Inflate)) {
     return deprecateInstantiation(Inflate, 'DEP0184', opts);
   }
-  ReflectApply(Zlib, this, [opts, INFLATE]);
+  Zlib.call(this, opts, INFLATE);
 }
 ObjectSetPrototypeOf(Inflate.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Inflate, Zlib);
@@ -742,7 +741,7 @@ function Gzip(opts) {
   if (!(this instanceof Gzip)) {
     return deprecateInstantiation(Gzip, 'DEP0184', opts);
   }
-  ReflectApply(Zlib, this, [opts, GZIP]);
+  Zlib.call(this, opts, GZIP);
 }
 ObjectSetPrototypeOf(Gzip.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Gzip, Zlib);
@@ -751,7 +750,7 @@ function Gunzip(opts) {
   if (!(this instanceof Gunzip)) {
     return deprecateInstantiation(Gunzip, 'DEP0184', opts);
   }
-  ReflectApply(Zlib, this, [opts, GUNZIP]);
+  Zlib.call(this, opts, GUNZIP);
 }
 ObjectSetPrototypeOf(Gunzip.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Gunzip, Zlib);
@@ -761,7 +760,7 @@ function DeflateRaw(opts) {
   if (!(this instanceof DeflateRaw)) {
     return deprecateInstantiation(DeflateRaw, 'DEP0184', opts);
   }
-  ReflectApply(Zlib, this, [opts, DEFLATERAW]);
+  Zlib.call(this, opts, DEFLATERAW);
 }
 ObjectSetPrototypeOf(DeflateRaw.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(DeflateRaw, Zlib);
@@ -770,7 +769,7 @@ function InflateRaw(opts) {
   if (!(this instanceof InflateRaw)) {
     return deprecateInstantiation(InflateRaw, 'DEP0184', opts);
   }
-  ReflectApply(Zlib, this, [opts, INFLATERAW]);
+  Zlib.call(this, opts, INFLATERAW);
 }
 ObjectSetPrototypeOf(InflateRaw.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(InflateRaw, Zlib);
@@ -779,7 +778,7 @@ function Unzip(opts) {
   if (!(this instanceof Unzip)) {
     return deprecateInstantiation(Unzip, 'DEP0184', opts);
   }
-  ReflectApply(Zlib, this, [opts, UNZIP]);
+  Zlib.call(this, opts, UNZIP);
 }
 ObjectSetPrototypeOf(Unzip.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Unzip, Zlib);
@@ -837,7 +836,7 @@ function Brotli(opts, mode) {
   this._writeState = new Uint32Array(2);
   handle.init(brotliInitParamsArray, this._writeState, processCallback);
 
-  ReflectApply(ZlibBase, this, [opts, mode, handle, brotliDefaultOpts]);
+  ZlibBase.call(this, opts, mode, handle, brotliDefaultOpts);
 }
 ObjectSetPrototypeOf(Brotli.prototype, Zlib.prototype);
 ObjectSetPrototypeOf(Brotli, Zlib);
@@ -846,7 +845,7 @@ function BrotliCompress(opts) {
   if (!(this instanceof BrotliCompress)) {
     return deprecateInstantiation(BrotliCompress, 'DEP0184', opts);
   }
-  ReflectApply(Brotli, this, [opts, BROTLI_ENCODE]);
+  Brotli.call(this, opts, BROTLI_ENCODE);
 }
 ObjectSetPrototypeOf(BrotliCompress.prototype, Brotli.prototype);
 ObjectSetPrototypeOf(BrotliCompress, Brotli);
@@ -855,7 +854,7 @@ function BrotliDecompress(opts) {
   if (!(this instanceof BrotliDecompress)) {
     return deprecateInstantiation(BrotliDecompress, 'DEP0184', opts);
   }
-  ReflectApply(Brotli, this, [opts, BROTLI_DECODE]);
+  Brotli.call(this, opts, BROTLI_DECODE);
 }
 ObjectSetPrototypeOf(BrotliDecompress.prototype, Brotli.prototype);
 ObjectSetPrototypeOf(BrotliDecompress, Brotli);


### PR DESCRIPTION
Follow-up from https://github.com/nodejs/node/pull/60796

In `http2` and `zlib`, `fn.call(...)` is preferable over `FunctionPrototypeCall(fn, ...)` according to:

https://github.com/nodejs/node/blob/8dc2bddbd5d0a3a25147c824d81074ace8e4fb1b/doc/contributing/primordials.md#L7-L13

<details>

<summary>

Local benchmark shows about +5% performance in `zlib/creation` and about +3-4% in `deflateSync` and `inflateSync`

</summary>

```r
                                                                                                        confidence improvement accuracy (*)    (**)   (***)
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=100                      *     -2.59 %       ±2.41%  ±3.20%  ±4.18%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=1000                           -0.12 %       ±2.07%  ±2.76%  ±3.59%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=5000                           -0.11 %       ±2.04%  ±2.71%  ±3.53%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=100                            0.58 %       ±2.59%  ±3.45%  ±4.50%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=1000                          -2.23 %       ±2.47%  ±3.29%  ±4.28%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=5000                          -1.42 %       ±2.57%  ±3.42%  ±4.46%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=100                           0.49 %       ±1.92%  ±2.56%  ±3.34%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=1000                          1.07 %       ±2.23%  ±2.96%  ±3.86%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=5000                          1.31 %       ±2.33%  ±3.10%  ±4.04%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=100                            0.63 %       ±2.15%  ±2.86%  ±3.73%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=1000                           0.36 %       ±2.16%  ±2.88%  ±3.75%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=5000                           0.71 %       ±2.27%  ±3.02%  ±3.94%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=100                           0.65 %       ±2.48%  ±3.30%  ±4.30%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=1000                          0.69 %       ±2.72%  ±3.63%  ±4.72%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=5000                          0.71 %       ±2.05%  ±2.73%  ±3.55%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=100                            2.05 %       ±2.10%  ±2.79%  ±3.64%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=1000                          -1.53 %       ±2.24%  ±2.98%  ±3.89%
http2/compat.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=5000                           1.05 %       ±2.20%  ±2.93%  ±3.82%
http2/headers.js nheaders=0 n=1000                                                                               *      1.24 %       ±1.03%  ±1.36%  ±1.78%
http2/headers.js nheaders=10 n=1000                                                                                     0.08 %       ±1.02%  ±1.36%  ±1.77%
http2/headers.js nheaders=100 n=1000                                                                                    0.39 %       ±0.87%  ±1.16%  ±1.51%
http2/headers.js nheaders=1000 n=1000                                                                                   0.54 %       ±0.80%  ±1.07%  ±1.40%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=100            **      5.16 %       ±3.53%  ±4.70%  ±6.12%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=1000                  -1.27 %       ±4.34%  ±5.78%  ±7.52%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=5000                   2.88 %       ±4.02%  ±5.35%  ±6.97%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=100                  -0.13 %       ±3.78%  ±5.04%  ±6.56%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=1000                  1.86 %       ±3.81%  ±5.08%  ±6.62%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=5000                 -1.39 %       ±3.64%  ±4.84%  ±6.30%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=100                  1.74 %       ±3.83%  ±5.10%  ±6.64%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=1000                -1.61 %       ±4.33%  ±5.76%  ±7.50%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=5000                 0.63 %       ±4.14%  ±5.51%  ±7.18%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=100                   0.29 %       ±3.71%  ±4.94%  ±6.43%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=1000                 -0.70 %       ±4.28%  ±5.70%  ±7.43%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=5000                 -1.56 %       ±3.89%  ±5.18%  ±6.74%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=100                  0.07 %       ±4.05%  ±5.39%  ±7.02%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=1000                -1.21 %       ±3.62%  ±4.82%  ±6.30%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=5000                -2.92 %       ±3.62%  ±4.82%  ±6.29%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=100                   1.37 %       ±4.08%  ±5.43%  ±7.07%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=1000                  3.15 %       ±3.55%  ±4.72%  ±6.15%
http2/respond-with-fd.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=5000                  1.35 %       ±3.86%  ±5.13%  ±6.68%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=100                            -2.66 %       ±2.78%  ±3.69%  ±4.81%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=1000                           -0.44 %       ±3.69%  ±4.91%  ±6.39%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=1 requests=5000                            0.66 %       ±2.68%  ±3.57%  ±4.65%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=100                            1.45 %       ±2.68%  ±3.57%  ±4.65%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=1000                          -1.87 %       ±2.41%  ±3.21%  ±4.18%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=10 requests=5000                          -0.36 %       ±2.77%  ±3.68%  ±4.80%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=100                           0.66 %       ±3.39%  ±4.51%  ±5.87%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=1000                         -0.99 %       ±2.70%  ±3.59%  ±4.67%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=100 requests=5000                          0.98 %       ±2.62%  ±3.49%  ±4.54%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=100                            0.01 %       ±2.93%  ±3.90%  ±5.08%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=1000                           1.33 %       ±2.98%  ±3.97%  ±5.16%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=20 requests=5000                           0.20 %       ±2.63%  ±3.50%  ±4.55%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=100                           1.07 %       ±2.71%  ±3.60%  ±4.69%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=1000                         -0.00 %       ±3.01%  ±4.01%  ±5.23%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=200 requests=5000                          0.88 %       ±2.68%  ±3.56%  ±4.64%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=100                            1.44 %       ±3.08%  ±4.11%  ±5.36%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=1000                          -2.14 %       ±2.46%  ±3.27%  ±4.26%
http2/simple.js duration=5 benchmarker='test-double-http2' clients=2 streams=40 requests=5000                           1.06 %       ±3.07%  ±4.09%  ±5.35%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=1048576 streams=100                       -0.21 %       ±1.41%  ±1.87%  ±2.44%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=1048576 streams=1000                       0.37 %       ±1.39%  ±1.84%  ±2.40%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=1048576 streams=200                       -0.34 %       ±1.18%  ±1.56%  ±2.04%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=131072 streams=100                         0.48 %       ±2.07%  ±2.76%  ±3.60%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=131072 streams=1000                        0.94 %       ±3.20%  ±4.25%  ±5.54%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=131072 streams=200                         1.02 %       ±2.81%  ±3.74%  ±4.87%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=262144 streams=100                         0.24 %       ±1.60%  ±2.13%  ±2.78%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=262144 streams=1000                       -0.62 %       ±1.44%  ±1.91%  ±2.49%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=262144 streams=200                         0.61 %       ±1.68%  ±2.24%  ±2.93%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=65536 streams=100                          0.34 %       ±0.82%  ±1.10%  ±1.44%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=65536 streams=1000                        -0.18 %       ±0.93%  ±1.24%  ±1.62%
http2/write.js duration=5 benchmarker='test-double-http2' size=100000 length=65536 streams=200                          0.82 %       ±1.20%  ±1.60%  ±2.08%
zlib/crc32.js n=4000000 len=256 type='buffer'                                                                           0.47 %       ±0.83%  ±1.10%  ±1.43%
zlib/crc32.js n=4000000 len=256 type='string'                                                                           0.13 %       ±0.58%  ±0.77%  ±1.00%
zlib/crc32.js n=4000000 len=32 type='buffer'                                                                           -0.22 %       ±0.75%  ±0.99%  ±1.29%
zlib/crc32.js n=4000000 len=32 type='string'                                                                           -0.05 %       ±0.66%  ±0.88%  ±1.14%
zlib/crc32.js n=4000000 len=4096 type='buffer'                                                                         -0.56 %       ±0.80%  ±1.07%  ±1.40%
zlib/crc32.js n=4000000 len=4096 type='string'                                                                         -0.31 %       ±0.67%  ±0.89%  ±1.15%
zlib/crc32.js n=4000000 len=65536 type='buffer'                                                                        -0.72 %       ±0.73%  ±0.97%  ±1.27%
zlib/crc32.js n=4000000 len=65536 type='string'                                                                         0.19 %       ±0.80%  ±1.07%  ±1.39%
zlib/createInflate.js n=100 chunkLen=1024 inputLen=16777216                                                            -3.20 %       ±4.95%  ±6.59%  ±8.59%
zlib/creation.js n=500000 options='false' type='BrotliCompress'                                                ***      4.30 %       ±2.29%  ±3.05%  ±3.97%
zlib/creation.js n=500000 options='false' type='BrotliDecompress'                                              ***      5.34 %       ±2.11%  ±2.81%  ±3.67%
zlib/creation.js n=500000 options='false' type='Deflate'                                                        **      4.83 %       ±2.82%  ±3.76%  ±4.89%
zlib/creation.js n=500000 options='false' type='DeflateRaw'                                                    ***      6.19 %       ±2.73%  ±3.64%  ±4.74%
zlib/creation.js n=500000 options='false' type='Gunzip'                                                         **      3.70 %       ±2.59%  ±3.45%  ±4.49%
zlib/creation.js n=500000 options='false' type='Gzip'                                                          ***      6.44 %       ±3.37%  ±4.49%  ±5.86%
zlib/creation.js n=500000 options='false' type='Inflate'                                                       ***      5.87 %       ±2.49%  ±3.31%  ±4.31%
zlib/creation.js n=500000 options='false' type='InflateRaw'                                                    ***      4.81 %       ±2.47%  ±3.30%  ±4.30%
zlib/creation.js n=500000 options='false' type='Unzip'                                                         ***      7.42 %       ±2.83%  ±3.77%  ±4.90%
zlib/creation.js n=500000 options='false' type='ZstdCompress'                                                          -0.21 %       ±1.83%  ±2.44%  ±3.18%
zlib/creation.js n=500000 options='false' type='ZstdDecompress'                                                        -1.24 %       ±2.83%  ±3.77%  ±4.90%
zlib/creation.js n=500000 options='true' type='BrotliCompress'                                                 ***      4.90 %       ±2.27%  ±3.02%  ±3.93%
zlib/creation.js n=500000 options='true' type='BrotliDecompress'                                               ***      5.66 %       ±2.27%  ±3.02%  ±3.93%
zlib/creation.js n=500000 options='true' type='Deflate'                                                        ***      5.32 %       ±2.47%  ±3.28%  ±4.28%
zlib/creation.js n=500000 options='true' type='DeflateRaw'                                                     ***      5.71 %       ±2.51%  ±3.36%  ±4.40%
zlib/creation.js n=500000 options='true' type='Gunzip'                                                         ***      6.08 %       ±2.81%  ±3.74%  ±4.88%
zlib/creation.js n=500000 options='true' type='Gzip'                                                           ***      4.87 %       ±2.63%  ±3.50%  ±4.56%
zlib/creation.js n=500000 options='true' type='Inflate'                                                        ***      4.49 %       ±2.44%  ±3.26%  ±4.26%
zlib/creation.js n=500000 options='true' type='InflateRaw'                                                     ***      7.47 %       ±2.29%  ±3.05%  ±3.97%
zlib/creation.js n=500000 options='true' type='Unzip'                                                           **      3.97 %       ±2.59%  ±3.45%  ±4.49%
zlib/creation.js n=500000 options='true' type='ZstdCompress'                                                           -0.51 %       ±1.95%  ±2.59%  ±3.37%
zlib/creation.js n=500000 options='true' type='ZstdDecompress'                                                          1.30 %       ±2.66%  ±3.54%  ±4.61%
zlib/deflate.js n=400000 inputLen=1024 method='createDeflate'                                                         -10.55 %      ±12.56% ±16.79% ±22.00%
zlib/deflate.js n=400000 inputLen=1024 method='deflate'                                                                 2.23 %       ±3.61%  ±4.80%  ±6.26%
zlib/deflate.js n=400000 inputLen=1024 method='deflateSync'                                                    ***      3.21 %       ±0.72%  ±0.96%  ±1.25%
zlib/inflate.js n=400000 inputLen=1024 method='inflate'                                                                 6.46 %      ±17.81% ±23.71% ±30.89%
zlib/inflate.js n=400000 inputLen=1024 method='inflateSync'                                                    ***      4.22 %       ±1.64%  ±2.18%  ±2.84%
zlib/pipe.js algorithm='brotli' type='buffer' duration=5 inputLen=1024                                                  2.69 %       ±8.00% ±10.65% ±13.88%
zlib/pipe.js algorithm='brotli' type='string' duration=5 inputLen=1024                                                  4.14 %       ±7.30%  ±9.71% ±12.64%
zlib/pipe.js algorithm='gzip' type='buffer' duration=5 inputLen=1024                                                    1.27 %       ±1.99%  ±2.64%  ±3.44%
zlib/pipe.js algorithm='gzip' type='string' duration=5 inputLen=1024                                                    0.21 %       ±1.92%  ±2.56%  ±3.33%
zlib/pipe.js algorithm='zstd' type='buffer' duration=5 inputLen=1024                                                   -1.33 %       ±3.24%  ±4.32%  ±5.62%
zlib/pipe.js algorithm='zstd' type='string' duration=5 inputLen=1024                                                   -1.04 %       ±1.64%  ±2.19%  ±2.85%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 112 comparisons, you can thus expect the following amount of false-positive results:
  5.60 false positives, when considering a   5% risk acceptance (*, **, ***),
  1.12 false positives, when considering a   1% risk acceptance (**, ***),
  0.11 false positives, when considering a 0.1% risk acceptance (***)
```

</details>