### PR TITLE
benchmark: fix incorrect base64 input in byteLength benchmark

### DIFF
--- a/benchmark/buffers/buffer-bytelength-string.js
+++ b/benchmark/buffers/buffer-bytelength-string.js
@@ -22,7 +22,7 @@ const chars = {
 function getInput(type, repeat, encoding) {
   const original = (repeat === 1) ? chars[type] : chars[type].repeat(repeat);
   if (encoding === 'base64') {
-    Buffer.from(original, 'utf8').toString('base64');
+    return Buffer.from(original, 'utf8').toString('base64');
   }
   return original;
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
The benchmark for `Buffer.byteLength` with `encoding === 'base64'` does not
return a Base64-encoded string. `getInput()` discards the encoded value and
returns the original UTF-8 string, causing the benchmark to run against
non-base64 input.

This patch ensures that when `encoding === 'base64'`, the function returns the
actual Base64-encoded string.

This brings the benchmark in line with its expected behavior and makes the
results meaningful.

This fixes the benchmark issue reported in #60836.

Fixes: https://github.com/nodejs/node/issues/60836

