### PR TITLE
doc: mark module.register as active development

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -193,7 +193,7 @@ changes:
     description: Add support for WHATWG URL instances.
 -->
 
-> Stability: 1.2 - Release candidate
+> Stability: 1.1 - Active development
 
 * `specifier` {string|URL} Customization hooks to be registered; this should be
   the same string that would be passed to `import()`, except that if it is


### PR DESCRIPTION
The async module customization hooks were moved to active development in #60302. This API should also be marked as active development.

Refs: https://github.com/nodejs/node/pull/60302