### PR TITLE
doc: fix typos in changelogs

### DIFF
--- a/doc/changelogs/CHANGELOG_V12.md
+++ b/doc/changelogs/CHANGELOG_V12.md
@@ -1883,7 +1883,7 @@ consumption.
 #### Increase of the default server headers timeout
 
 The default value of `server.headersTimeout` for `http` and `https` servers was
-increased from `40000` to `60000` (60 seconds). This to accomodate for systems
+increased from `40000` to `60000` (60 seconds). This to accommodate for systems
 like AWS ELB that have a timeout of 60 seconds.
 
 Contributed by Tim Costa - [#30071](https://github.com/nodejs/node/pull/30071).

--- a/doc/changelogs/CHANGELOG_V13.md
+++ b/doc/changelogs/CHANGELOG_V13.md
@@ -676,7 +676,7 @@ impact on Node.js 13.x users with older versions of macOS.
 
 In Node.js 13.9.0 deps/zlib was switched to the chromium maintained implementation. This change
 had the unforseen consequence of breaking building from the tarballs we release as we were too
-aggressively removing `unneccessary files` from the `deps/zlib` folder. This release includes
+aggressively removing `unnecessary files` from the `deps/zlib` folder. This release includes
 a patch that ensures that individuals will once again be able to build Node.js from source.
 
 ### Commits


### PR DESCRIPTION
I know we can't fix the parts that are commit messages, but I believe the rest of the text is editable. Am I misremembering?

(Full disclosure: I'm actually just opening this to make sure the github-bot updates worked. But we might as well fix the typos anyway.)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
