### PR TITLE
docs: add missing CLI options to manpage and cli docs

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -956,6 +956,19 @@ export USERNAME="nodejs" # will result in `nodejs` as the value.
 If you want to load environment variables from a file that may not exist, you
 can use the [`--env-file-if-exists`][] flag instead.
 
+#### `--env-file`
+Loads environment variables from the provided file and applies them to the current process environment.  
+If the file does not exist, Node.js will exit with an error.
+
+#### `--env-file-if-exists`
+Same as `--env-file` but does not error when the file is missing.  
+Useful for optional `.env` setups.
+
+#### `--report-dir`, `--report-directory`
+Specifies the directory where diagnostic reports will be written.  
+If the directory does not exist, Node.js will attempt to create it.
+
+
 ### `-e`, `--eval "script"`
 
 <!-- YAML

--- a/doc/node.1
+++ b/doc/node.1
@@ -927,3 +927,14 @@ Documentation:
 .Pp
 GitHub repository and issue tracker:
 .Sy https://github.com/nodejs/node
+.TP
+.B --env-file
+Load environment variables from the specified file. Node.js exits with an error if the file does not exist.
+
+.TP
+.B --env-file-if-exists
+Load environment variables from the specified file if it exists. No error is thrown when the file is missing.
+
+.TP
+.B --report-dir, --report-directory
+Set the directory where diagnostic reports are written. Node.js may create the directory if it does not exist.


### PR DESCRIPTION
This PR updates the Node.js documentation to include several CLI options that were present in the CLI reference but missing from the `node.1` manpage.

### Added CLI flags
- `--env-file` — load environment variables from a file, error if missing  
- `--env-file-if-exists` — load env file only if it exists  
- `--report-dir`, `--report-directory` — specify the directory for diagnostic reports  

These flags now appear in both:
- `doc/api/cli.md`
- `doc/node.1`

### Notes
- `--expose-gc` is intentionally excluded pending the discussion in #58909.
- This change removes inconsistencies between the manpage and CLI docs.

Fixes: #58895
