### PR TITLE
doc: update debuglog examples to use 'foo-bar' instead of 'foo'

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -135,14 +135,14 @@ The `section` supports wildcard also:
 
 ```mjs
 import { debuglog } from 'node:util';
-const log = debuglog('foo');
+const log = debuglog('foo-bar');
 
 log('hi there, it\'s foo-bar [%d]', 2333);
 ```
 
 ```cjs
 const { debuglog } = require('node:util');
-const log = debuglog('foo');
+const log = debuglog('foo-bar');
 
 log('hi there, it\'s foo-bar [%d]', 2333);
 ```


### PR DESCRIPTION
This is an example of a code error in a document，the `log` result is `FOO-BAR 3257: hi there, it's foo-bar [2333]`, so the `debuglog` string identifying is `foo-bar`.