### PR TITLE
doc: show the use of string expressions in the SQLTagStore example

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -550,8 +550,8 @@ sql.run`INSERT INTO users VALUES (1, 'Alice')`;
 sql.run`INSERT INTO users VALUES (2, 'Bob')`;
 
 // Using the 'get' method to retrieve a single row.
-const id = 1;
-const user = sql.get`SELECT * FROM users WHERE id = ${id}`;
+const name = 'Alice';
+const user = sql.get`SELECT * FROM users WHERE name = ${name}`;
 console.log(user); // { id: 1, name: 'Alice' }
 
 // Using the 'all' method to retrieve all rows.
@@ -577,8 +577,8 @@ sql.run`INSERT INTO users VALUES (1, 'Alice')`;
 sql.run`INSERT INTO users VALUES (2, 'Bob')`;
 
 // Using the 'get' method to retrieve a single row.
-const id = 1;
-const user = sql.get`SELECT * FROM users WHERE id = ${id}`;
+const name = 'Alice';
+const user = sql.get`SELECT * FROM users WHERE name = ${name}`;
 console.log(user); // { id: 1, name: 'Alice' }
 
 // Using the 'all' method to retrieve all rows.


### PR DESCRIPTION
Slight edit to the example shown for the `database.createTagStore` API. Showing the get query with a string instead of a number to demonstrate correct usage of the template literals in combination with string expressions.

### Reason for this change:

Because strings in SQL queries are usually enclosed in quotation marks:

```"SELECT * FROM users WHERE name = 'Alice'"```

Users may be tempted to enclose them in quotation marks in the template literals used for the SQLTagStore API:

```const user = sql.get`SELECT * FROM users WHERE name = '${name}'`;```

This would lead to a incorrect SQL query (which might actually fail quietly). The correct form is to leave the quotation marks out:

```const user = sql.get`SELECT * FROM users WHERE name = ${name}`;```