### PR TITLE
doc: improve dual package hazard section with node/default pattern

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -939,6 +939,26 @@ $ node other.js
 
 ## Dual CommonJS/ES module packages
 
+Dual packages provide both CommonJS and ES module entry points. A common
+approach is to use the `"require"` and `"import"` conditions in `"exports"`
+to serve different files depending on whether the package is loaded through
+`require()` or `import`. However, this can still lead to the *dual package
+hazard*: different parts of an application may end up evaluating separate
+copies of the package, one from each module system.
+
+A more robust pattern is to use the `"node"` and `"default"` conditions
+instead:
+
+```json
+{
+  "name": "example",
+  "exports": {
+    "node": "./index.cjs",
+    "default": "./index.mjs"
+  }
+}
+```
+
 See [the package examples repository][] for details.
 
 ## Node.js `package.json` field definitions


### PR DESCRIPTION
Fixes: #52174

### What

Expands the "Dual CommonJS/ES module packages" section in `doc/api/packages.md`
to describe the dual package hazard and recommend using `"node"` / `"default"`
conditions for dual packages, with a small `package.json` example.

### Why

The existing section only linked to the package examples repository without
describing the recommended pattern. Using `"node"` / `"default"` conditions
helps avoid the dual package hazard in Node.js while still allowing other
environments (such as bundlers) to consume an ES module build.

### How

- Described the dual package hazard in more detail.
- Documented the `"node"` / `"default"` export conditions pattern.
- Added an example `package.json` snippet.

### Testing

- [x] `python tools/test.py doctool`
