### PR TITLE
tools: don't fetch V8 deps in the source tree

### DIFF
--- a/tools/v8/fetch_deps.py
+++ b/tools/v8/fetch_deps.py
@@ -26,6 +26,14 @@ GCLIENT_SOLUTION = [
     "custom_deps" : {
       # These deps are already part of Node.js.
       "v8/base/trace_event/common"            : None,
+      "v8/third_party/abseil-cpp"             : None,
+      "v8/third_party/dragonbox/src"          : None,
+      "v8/third_party/fp16/src"               : None,
+      "v8/third_party/fast_float/src"         : None,
+      "v8/third_party/highway/src"            : None,
+      "v8/third_party/jinja2"                 : None,
+      "v8/third_party/markupsafe"             : None,
+      "v8/third_party/simdutf"                : None,
       # These deps are unnecessary for building.
       "v8/test/benchmarks/data"               : None,
       "v8/testing/gmock"                      : None,


### PR DESCRIPTION
The Node.js source tree already includes several V8 DEPS under `deps/v8/third_party` that are needed to build Node.js. Exclude these in `tools/v8/fetch_deps.py` to prevent "Conflicting directory" warnings when running the V8 CI.

---

e.g. https://ci.nodejs.org/job/node-test-commit-v8-linux/6886/nodes=benchmark-ubuntu2204-intel-64,v8test=v8test/consoleFull
```
10:35:32 Warnings:
10:35:32 Conflicting directory ./v8/third_party/jinja2 moved to ./_bad_scm/v8/third_party/jinja2ev06og_3.
10:35:32 Conflicting directory ./v8/third_party/fp16/src moved to ./_bad_scm/v8/third_party/fp16/srcofo97bgs.
10:35:32 Conflicting directory ./v8/third_party/fast_float/src moved to ./_bad_scm/v8/third_party/fast_float/src9v1zqv71.
10:35:32 Conflicting directory ./v8/third_party/abseil-cpp moved to ./_bad_scm/v8/third_party/abseil-cppki9can6x.
10:35:32 Conflicting directory ./v8/third_party/markupsafe moved to ./_bad_scm/v8/third_party/markupsafechfk151u.
10:35:32 Conflicting directory ./v8/third_party/googletest/src moved to ./_bad_scm/v8/third_party/googletest/srcnct99h20.
10:35:32 Conflicting directory ./v8/third_party/simdutf moved to ./_bad_scm/v8/third_party/simdutfu_7og22d.
10:35:32 Conflicting directory ./v8/third_party/zlib moved to ./_bad_scm/v8/third_party/zlib7aw3bhfj.
10:35:32 Conflicting directory ./v8/third_party/dragonbox/src moved to ./_bad_scm/v8/third_party/dragonbox/src_awrr_e7.
10:35:32 Conflicting directory ./v8/third_party/highway/src moved to ./_bad_scm/v8/third_party/highway/srcfch45l4t.
10:35:32 git update is recommended.
```

I initially added all of the above to the overrides in `tools/v8/fetch_deps.py` but the V8 CI failed when some of them were skipped which suggests the V8 build requires things that have been removed from/not copied into the Node.js source tree: 

- `v8/third_party/googletest/src` 
<details>

```
iojs@test-hetzner-ubuntu2204-x64-2:~/build/workspace/node-test-commit-v8-linux/deps/v8$ PATH=/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/depot_tools:/home/iojs/build/workspace/node-test-commit-v8-linux/depot_tools:/home/iojs/venv/bin:/home/iojs/nghttp2/src:/home/iojs/wrk:/usr/lib/ccache:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin tools/dev/v8gen.py -vv x64.release
################################################################################
/usr/bin/python3 -u tools/mb/mb.py gen -f infra/mb/mb_config.pyl -m developer_default -b x64.release out.gn/x64.release

  Writing """\
  dcheck_always_on = false
  is_debug = false
  target_cpu = "x64"
  """ to /home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/out.gn/x64.release/args.gn.

  /home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/buildtools/linux64/gn gen out.gn/x64.release --check
    -> returned 1
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock-cardinalities.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock-actions.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock-matchers.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock-function-mocker.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock-more-matchers.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock-more-actions.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock-spec-builders.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/internal/gmock-port.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/internal/gmock-internal-utils.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock-nice-strict.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/gmock.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/src/gmock-cardinalities.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/src/gmock-internal-utils.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/src/gmock.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock_main
  has a source file:
    //third_party/googletest/src/googlemock/src/gmock_main.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/include/gmock/internal/gmock-pp.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/src/gmock-matchers.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-assertion-result.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gmock
  has a source file:
    //third_party/googletest/src/googlemock/src/gmock-spec-builders.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-death-test.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-matchers.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-param-test.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-printers.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-test-part.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-message.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-typed-test.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest-spi.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/internal/gtest-filepath.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/gtest_pred_impl.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/internal/gtest-internal.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/internal/gtest-param-util.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/internal/gtest-port.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/internal/gtest-string.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-death-test.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/internal/gtest-death-test-internal.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/include/gtest/internal/gtest-type-util.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-port.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-matchers.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-printers.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-typed-test.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-internal-inl.h
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-test-part.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-assertion-result.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest_main
  has a source file:
    //third_party/googletest/src/googletest/src/gtest_main.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:558:5: Source file not found.
      target(_target_type, target_name) {
      ^----------------------------------
  The target:
    //third_party/googletest:gtest
  has a source file:
    //third_party/googletest/src/googletest/src/gtest-filepath.cc
  which was not found.
  ___________________
  ERROR at //build/config/BUILDCONFIG.gn:648:5: Source file not found.
      target(_target_type, _target_name) {
      ^-----------------------------------
  The target:
    //third_party/zlib:zlib_bench
  has a source file:
    //third_party/zlib/contrib/bench/zlib_bench.cc
  which was not found.
  GN gen failed: 1
Traceback (most recent call last):
  File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/dev/v8gen.py", line 256, in <module>
    sys.exit(gen.main())
  File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/dev/v8gen.py", line 250, in main
    return self._options.func()
  File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/dev/v8gen.py", line 147, in cmd_gen
    self._call_cmd([
  File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/dev/v8gen.py", line 189, in _call_cmd
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/usr/bin/python3', '-u', 'tools/mb/mb.py', 'gen', '-f', 'infra/mb/mb_config.pyl', '-m', 'developer_default', '-b', 'x64.release', 'out.gn/x64.release']' returned non-zero exit status 1.
iojs@test-hetzner-ubuntu2204-x64-2:~/build/workspace/node-test-commit-v8-linux/deps/v8$
```
</details>

- `v8/third_party/zlib`
<details>

```
iojs@test-hetzner-ubuntu2204-x64-1:~/build/workspace/node-test-commit-v8-linux/deps/v8$ PATH=/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/depot_tools:/home/iojs/build/workspace/node-test-commit-v8-linux/depot_tools:/home/iojs/venv/bin:/home/iojs/nghttp2/src:/home/iojs/wrk:/usr/lib/ccache:/usr/lib64/ccache:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin tools/dev/v8gen.py -vv x64.release
################################################################################
/usr/bin/python3 -u tools/mb/mb.py gen -f infra/mb/mb_config.pyl -m developer_default -b x64.release out.gn/x64.release

  Writing """\
  dcheck_always_on = false
  is_debug = false
  target_cpu = "x64"
  """ to /home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/out.gn/x64.release/args.gn.

  /home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/buildtools/linux64/gn gen out.gn/x64.release --check
    -> returned 1
  ERROR at //build/config/BUILDCONFIG.gn:648:5: Source file not found.
      target(_target_type, _target_name) {
      ^-----------------------------------
  The target:
    //third_party/zlib:zlib_bench
  has a source file:
    //third_party/zlib/contrib/bench/zlib_bench.cc
  which was not found.
  GN gen failed: 1
Traceback (most recent call last):
  File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/dev/v8gen.py", line 256, in <module>
    sys.exit(gen.main())
  File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/dev/v8gen.py", line 250, in main
    return self._options.func()
  File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/dev/v8gen.py", line 147, in cmd_gen
    self._call_cmd([
  File "/home/iojs/build/workspace/node-test-commit-v8-linux/deps/v8/tools/dev/v8gen.py", line 189, in _call_cmd
    output = subprocess.check_output(
  File "/usr/lib/python3.10/subprocess.py", line 421, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "/usr/lib/python3.10/subprocess.py", line 526, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '['/usr/bin/python3', '-u', 'tools/mb/mb.py', 'gen', '-f', 'infra/mb/mb_config.pyl', '-m', 'developer_default', '-b', 'x64.release', 'out.gn/x64.release']' returned non-zero exit status 1.
iojs@test-hetzner-ubuntu2204-x64-1:~/build/workspace/node-test-commit-v8-linux/deps/v8$
```
</details>

so I have left the above two out of this PR (i.e. we'll still get warnings for those).

cc @nodejs/v8-update 

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
