### PR TITLE
tools: use open instead of codecs.open in cpplint

### DIFF
--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -6179,7 +6179,7 @@ def UpdateIncludeState(filename, include_dict, io=codecs):
   """
   headerfile = None
   try:
-    with io.open(filename, 'r', 'utf8', 'replace') as headerfile:
+    with open(filename, encoding='utf-8', errors='replace') as headerfile:
       linenum = 0
       for line in headerfile:
         linenum += 1
@@ -6706,7 +6706,7 @@ def ProcessConfigOverrides(filename):
       continue
 
     try:
-      with codecs.open(cfg_file, 'r', 'utf8', 'replace') as file_handle:
+      with open(cfg_file, encoding='utf-8', errors='replace') as file_handle:
         for line in file_handle:
           line, _, _ = line.partition('#')  # Remove comments.
           if not line.strip():
@@ -6809,7 +6809,7 @@ def ProcessFile(filename, vlevel, extra_check_functions=None):
                                         codecs.getwriter('utf8'),
                                         'replace').read().split('\n')
     else:
-      with codecs.open(filename, 'r', 'utf8', 'replace') as target_file:
+      with open(filename, encoding='utf-8', errors='replace') as target_file:
         lines = target_file.read().split('\n')
 
     # Remove trailing '\r'.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60771

The following error is observed with Python 3.14. The reason is that `codecs.open()` is deprecated, and we want to use `open()` instead.

``` bash
Running C++ linter...
/Users/mzasso/git/nodejs/node/tools/cpplint.py:6709: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
  with codecs.open(cfg_file, 'r', 'utf8', 'replace') as file_handle:
/Users/mzasso/git/nodejs/node/tools/cpplint.py:6812: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
  with codecs.open(filename, 'r', 'utf8', 'replace') as target_file:
/Users/mzasso/git/nodejs/node/tools/cpplint.py:6182: DeprecationWarning: codecs.open() is deprecated. Use open() instead.
  with io.open(filename, 'r', 'utf8', 'replace') as headerfile:
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
