### PR TITLE
tools: enforce trailing commas in `test/es-module`

### DIFF
--- a/test/es-module/test-disable-require-module-with-detection.js
+++ b/test/es-module/test-disable-require-module-with-detection.js
@@ -15,5 +15,5 @@ assert.throws(
   () => require('../fixtures/es-modules/loose.js'),
   {
     name: 'SyntaxError',
-    message: /Unexpected token 'export'/
+    message: /Unexpected token 'export'/,
   });

--- a/test/es-module/test-dynamic-import-script-lifetime.js
+++ b/test/es-module/test-dynamic-import-script-lifetime.js
@@ -28,5 +28,5 @@ vm.runInThisContext(code, {
     await m.link(() => {});
     await m.evaluate();
     return m;
-  }
+  },
 });

--- a/test/es-module/test-esm-cjs-named-error.mjs
+++ b/test/es-module/test-esm-cjs-named-error.mjs
@@ -27,21 +27,21 @@ await assert.rejects(async () => {
   await import(`${fixtureBase}/single-quote.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedRelative
+  message: expectedRelative,
 }, 'should support relative specifiers with single quotes');
 
 await assert.rejects(async () => {
   await import(`${fixtureBase}/double-quote.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedRelative
+  message: expectedRelative,
 }, 'should support relative specifiers with double quotes');
 
 await assert.rejects(async () => {
   await import(`${fixtureBase}/renamed-import.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedRenamed
+  message: expectedRenamed,
 }, 'should correctly format named imports with renames');
 
 await assert.rejects(async () => {
@@ -55,21 +55,21 @@ await assert.rejects(async () => {
   await import(`${fixtureBase}/json-hack.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedPackageHack
+  message: expectedPackageHack,
 }, 'should respect recursive package.json for module type');
 
 await assert.rejects(async () => {
   await import(`${fixtureBase}/bare-import-single.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedBare
+  message: expectedBare,
 }, 'should support bare specifiers with single quotes');
 
 await assert.rejects(async () => {
   await import(`${fixtureBase}/bare-import-double.mjs`);
 }, {
   name: 'SyntaxError',
-  message: expectedBare
+  message: expectedBare,
 }, 'should support bare specifiers with double quotes');
 
 await assert.rejects(async () => {

--- a/test/es-module/test-esm-data-urls.js
+++ b/test/es-module/test-esm-data-urls.js
@@ -76,7 +76,7 @@ function createBase64URL(mime, body) {
       import('data:application/json;foo="test,",0',
         { with: { type: 'json' } }), {
       name: 'SyntaxError',
-      message: /Unterminated string in JSON at position 3/
+      message: /Unterminated string in JSON at position 3/,
     });
   }
   {

--- a/test/es-module/test-esm-dns-promises.mjs
+++ b/test/es-module/test-esm-dns-promises.mjs
@@ -10,5 +10,5 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_VALUE',
   name: 'TypeError',
-  message: `The argument 'address' is invalid. Received '${invalidAddress}'`
+  message: `The argument 'address' is invalid. Received '${invalidAddress}'`,
 });

--- a/test/es-module/test-esm-dynamic-import.js
+++ b/test/es-module/test-esm-dynamic-import.js
@@ -19,7 +19,7 @@ function expectOkNamespace(result) {
     .then(common.mustCall((ns) => {
       const expected = { default: true };
       Object.defineProperty(expected, Symbol.toStringTag, {
-        value: 'Module'
+        value: 'Module',
       });
       Object.setPrototypeOf(expected, Object.getPrototypeOf(ns));
       assert.deepStrictEqual(ns, expected);

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -12,7 +12,7 @@ for (const descriptor of Object.values(descriptors)) {
   assert.deepStrictEqual(descriptor, {
     enumerable: true,
     writable: true,
-    configurable: true
+    configurable: true,
   });
 }
 

--- a/test/es-module/test-esm-loader-invalid-format.mjs
+++ b/test/es-module/test-esm-loader-invalid-format.mjs
@@ -5,6 +5,6 @@ import assert from 'assert';
 import('../fixtures/es-modules/test-esm-ok.mjs')
 .then(assert.fail, expectsError({
   code: 'ERR_UNKNOWN_MODULE_FORMAT',
-  message: /Unknown module format: esm/
+  message: /Unknown module format: esm/,
 }))
 .then(mustCall());

--- a/test/es-module/test-esm-loader-mock.mjs
+++ b/test/es-module/test-esm-loader-mock.mjs
@@ -3,21 +3,21 @@ import assert from 'node:assert/strict';
 import { mock } from '../fixtures/es-module-loaders/mock.mjs';
 
 mock('node:events', {
-  EventEmitter: 'This is mocked!'
+  EventEmitter: 'This is mocked!',
 });
 
 // This resolves to node:events
 // It is intercepted by mock-loader and doesn't return the normal value
 assert.deepStrictEqual(await import('events'), Object.defineProperty({
   __proto__: null,
-  EventEmitter: 'This is mocked!'
+  EventEmitter: 'This is mocked!',
 }, Symbol.toStringTag, {
   enumerable: false,
-  value: 'Module'
+  value: 'Module',
 }));
 
 const mutator = mock('node:events', {
-  EventEmitter: 'This is mocked v2!'
+  EventEmitter: 'This is mocked v2!',
 });
 
 // It is intercepted by mock-loader and doesn't return the normal value.
@@ -26,17 +26,17 @@ const mutator = mock('node:events', {
 const mockedV2 = await import('node:events');
 assert.deepStrictEqual(mockedV2, Object.defineProperty({
   __proto__: null,
-  EventEmitter: 'This is mocked v2!'
+  EventEmitter: 'This is mocked v2!',
 }, Symbol.toStringTag, {
   enumerable: false,
-  value: 'Module'
+  value: 'Module',
 }));
 
 mutator.EventEmitter = 'This is mocked v3!';
 assert.deepStrictEqual(mockedV2, Object.defineProperty({
   __proto__: null,
-  EventEmitter: 'This is mocked v3!'
+  EventEmitter: 'This is mocked v3!',
 }, Symbol.toStringTag, {
   enumerable: false,
-  value: 'Module'
+  value: 'Module',
 }));

--- a/test/es-module/test-esm-loader-modulemap.js
+++ b/test/es-module/test-esm-loader-modulemap.js
@@ -55,7 +55,7 @@ const jsonModuleJob = new ModuleJob(loader, jsonModuleDataUrl,
   const errorObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /^The "url" argument must be of type string/
+    message: /^The "url" argument must be of type string/,
   };
 
   [{}, [], true, 1].forEach((value) => {
@@ -73,7 +73,7 @@ const jsonModuleJob = new ModuleJob(loader, jsonModuleDataUrl,
   const errorObj = {
     code: 'ERR_INVALID_ARG_TYPE',
     name: 'TypeError',
-    message: /^The "type" argument must be of type string/
+    message: /^The "type" argument must be of type string/,
   };
 
   [{}, [], true, 1].forEach((value) => {
@@ -91,7 +91,7 @@ const jsonModuleJob = new ModuleJob(loader, jsonModuleDataUrl,
     assert.throws(() => moduleMap.set('', undefined, value), {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: /^The "job" argument must be an instance of ModuleJob/
+      message: /^The "job" argument must be an instance of ModuleJob/,
     });
   });
 }

--- a/test/es-module/test-esm-loader-search.js
+++ b/test/es-module/test-esm-loader-search.js
@@ -7,7 +7,7 @@ require('../common');
 
 const assert = require('assert');
 const {
-  defaultResolve: resolve
+  defaultResolve: resolve,
 } = require('internal/modules/esm/resolve');
 
 assert.throws(
@@ -15,6 +15,6 @@ assert.throws(
   {
     code: 'ERR_MODULE_NOT_FOUND',
     name: 'Error',
-    message: /Cannot find package 'target'/
+    message: /Cannot find package 'target'/,
   }
 );

--- a/test/es-module/test-esm-resolve-type.mjs
+++ b/test/es-module/test-esm-resolve-type.mjs
@@ -25,7 +25,7 @@ if (!isMainThread) {
 import assert from 'assert';
 import internalResolve from 'node:internal/modules/esm/resolve';
 const {
-  defaultResolve: resolve
+  defaultResolve: resolve,
 } = internalResolve;
 
 const rel = (file) => tmpdir.resolve(file);
@@ -82,7 +82,7 @@ try {
     createDir(subDir);
     const pkgJsonContent = {
       ...(moduleType !== undefined) && { type: moduleType },
-      main: `subdir/mainfile.${moduleExtension}`
+      main: `subdir/mainfile.${moduleExtension}`,
     };
     fs.writeFileSync(pkg, JSON.stringify(pkgJsonContent));
     fs.writeFileSync(script,
@@ -150,13 +150,13 @@ try {
         '.': {
           'require': './lib/index.js',
           'import': './es/index.js',
-          'default': './lib/index.js'
+          'default': './lib/index.js',
         },
         './package.json': './package.json',
-      }
+      },
     };
     const esmPkgJsonContent = {
-      type: 'module'
+      type: 'module',
     };
 
     fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));
@@ -220,13 +220,13 @@ try {
         '.': {
           'require': `./subdir/${mainRequireScript}${mainSuffix}`,
           'import': `./subdir/${mainImportScript}${mainSuffix}`,
-          'default': `./subdir/${mainRequireScript}${mainSuffix}`
+          'default': `./subdir/${mainRequireScript}${mainSuffix}`,
         },
         './package.json': './package.json',
-      }
+      },
     };
     const subdirPkgJsonContent = {
-      type: `${subdirPackageType}`
+      type: `${subdirPackageType}`,
     };
 
     fs.writeFileSync(pkg, JSON.stringify(mainPkgJsonContent));

--- a/test/es-module/test-esm-symlink-type.js
+++ b/test/es-module/test-esm-symlink-type.js
@@ -16,12 +16,12 @@ const symlinks = [
     source: 'extensionless-symlink-to-mjs-file',
     target: fixtures.path('es-modules/mjs-file.mjs'),
     prints: '.mjs file',
-    errorsWithPreserveSymlinksMain: false
+    errorsWithPreserveSymlinksMain: false,
   }, {
     source: 'extensionless-symlink-to-cjs-file',
     target: fixtures.path('es-modules/cjs-file.cjs'),
     prints: '.cjs file',
-    errorsWithPreserveSymlinksMain: false
+    errorsWithPreserveSymlinksMain: false,
   }, {
     source: 'extensionless-symlink-to-file-in-module-scope',
     target: fixtures.path('es-modules/package-type-module/index.js'),
@@ -29,17 +29,17 @@ const symlinks = [
     // The package scope of the symlinks' sources is commonjs, and this
     // symlink's target is a .js file in a module scope, so when the scope
     // is evaluated based on the source (commonjs) this esm file should error
-    errorsWithPreserveSymlinksMain: true
+    errorsWithPreserveSymlinksMain: true,
   }, {
     source: 'extensionless-symlink-to-file-in-explicit-commonjs-scope',
     target: fixtures.path('es-modules/package-type-commonjs/index.js'),
     prints: 'package-type-commonjs',
-    errorsWithPreserveSymlinksMain: false
+    errorsWithPreserveSymlinksMain: false,
   }, {
     source: 'extensionless-symlink-to-file-in-implicit-commonjs-scope',
     target: fixtures.path('es-modules/package-without-type/index.js'),
     prints: 'package-without-type',
-    errorsWithPreserveSymlinksMain: false
+    errorsWithPreserveSymlinksMain: false,
   },
 ];
 
@@ -53,7 +53,7 @@ symlinks.forEach((symlink) => {
   ];
   flags.forEach((nodeOptions) => {
     const opts = {
-      env: Object.assign({}, process.env, { NODE_OPTIONS: nodeOptions })
+      env: Object.assign({}, process.env, { NODE_OPTIONS: nodeOptions }),
     };
     exec(process.execPath, [mainPath], opts, common.mustCall(
       (err, stdout) => {

--- a/test/es-module/test-esm-type-field-errors-2.js
+++ b/test/es-module/test-esm-type-field-errors-2.js
@@ -11,7 +11,7 @@ const { describe, it } = require('node:test');
 describe('Errors related to ESM type field', () => {
   it('Should throw an error when loading CJS from a `type: "module"` package.', () => {
     assert.throws(() => require('../fixtures/es-modules/package-type-module/index.js'), {
-      code: 'ERR_REQUIRE_ESM'
+      code: 'ERR_REQUIRE_ESM',
     });
   });
 });

--- a/test/es-module/test-esm-wasm-module-instances-warning.mjs
+++ b/test/es-module/test-esm-wasm-module-instances-warning.mjs
@@ -12,6 +12,6 @@ spawnSyncAndAssert(
     stderr(output) {
       assert.match(output, /ExperimentalWarning/);
       assert.match(output, /Importing WebAssembly module instances/);
-    }
+    },
   }
 );

--- a/test/es-module/test-esm-wasm-source-phase-not-defined-static.mjs
+++ b/test/es-module/test-esm-wasm-source-phase-not-defined-static.mjs
@@ -14,6 +14,6 @@ spawnSyncAndAssert(
     stderr(output) {
       assert.match(output, /Source phase import object is not defined for module/);
       assert(output.includes(fileUrl));
-    }
+    },
   }
 );

--- a/test/es-module/test-esm-wasm-top-level-execution.mjs
+++ b/test/es-module/test-esm-wasm-top-level-execution.mjs
@@ -9,6 +9,6 @@ spawnSyncAndAssert(
   {
     stdout: '[Object: null prototype] { prop: \'hello world\' }',
     stderr: '',
-    trim: true
+    trim: true,
   }
 );

--- a/test/es-module/test-import-require-tla-twice.js
+++ b/test/es-module/test-import-require-tla-twice.js
@@ -16,6 +16,6 @@ spawnSyncAndAssert(
     stdout(output) {
       const matches = output.matchAll(/e\.code === ERR_REQUIRE_ASYNC_MODULE true/g);
       assert.strictEqual([...matches].length, 2);
-    }
+    },
   }
 );

--- a/test/es-module/test-loaders-hidden-from-users.js
+++ b/test/es-module/test-loaders-hidden-from-users.js
@@ -10,7 +10,7 @@ assert.throws(
     require('internal/bootstrap/realm');
   }, {
     code: 'MODULE_NOT_FOUND',
-    message: /Cannot find module 'internal\/bootstrap\/realm'/
+    message: /Cannot find module 'internal\/bootstrap\/realm'/,
   }
 );
 
@@ -23,6 +23,6 @@ assert.throws(
     require('owo');
   }, {
     code: 'MODULE_NOT_FOUND',
-    message: /Cannot find module 'owo'/
+    message: /Cannot find module 'owo'/,
   }
 );

--- a/test/es-module/test-loaders-unknown-builtin-module.mjs
+++ b/test/es-module/test-loaders-unknown-builtin-module.mjs
@@ -7,6 +7,6 @@ const unknownBuiltinModule = 'node:unknown-builtin-module';
 import(unknownBuiltinModule)
 .then(assert.fail, expectsError({
   code: 'ERR_UNKNOWN_BUILTIN_MODULE',
-  message: `No such built-in module: ${unknownBuiltinModule}`
+  message: `No such built-in module: ${unknownBuiltinModule}`,
 }))
 .then(mustCall());

--- a/test/es-module/test-require-as-esm-interop.mjs
+++ b/test/es-module/test-require-as-esm-interop.mjs
@@ -9,7 +9,7 @@ const tests = {
   'object': { a: 'cjs a', b: 'cjs b' },
   'fauxesmdefault': { default: 'faux esm default' },
   'fauxesmmixed': { default: 'faux esm default', a: 'faux esm a', b: 'faux esm b' },
-  'fauxesmnamed': { a: 'faux esm a', b: 'faux esm b' }
+  'fauxesmnamed': { a: 'faux esm a', b: 'faux esm b' },
 };
 
 // This test demonstrates interop between CJS and CJS represented as ESM

--- a/test/es-module/test-require-esm-from-imported-cjs.js
+++ b/test/es-module/test-require-esm-from-imported-cjs.js
@@ -17,7 +17,7 @@ spawnSyncAndAssert(
   ],
   {
     trim: true,
-    stdout: / default: { hello: 'world' }/
+    stdout: / default: { hello: 'world' }/,
   }
 );
 
@@ -31,6 +31,6 @@ spawnSyncAndAssert(
   ],
   {
     trim: true,
-    stdout: / default: { hello: 'world' }/
+    stdout: / default: { hello: 'world' }/,
   }
 );

--- a/test/es-module/test-require-module-conditional-exports.js
+++ b/test/es-module/test-require-module-conditional-exports.js
@@ -17,7 +17,7 @@ const { isModuleNamespaceObject } = require('util/types');
 assert.throws(() => {
   require('../fixtures/es-modules/exports-import-only/load.cjs');
 }, {
-  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+  code: 'ERR_PACKAGE_PATH_NOT_EXPORTED',
 });
 
 // If both are defined, "require" is used.

--- a/test/es-module/test-require-module-cycle-esm-esm-cjs-esm.js
+++ b/test/es-module/test-require-module-cycle-esm-esm-cjs-esm.js
@@ -21,7 +21,7 @@ const assert = require('assert');
         assert.match(output, /Start c/);
         assert.match(output, /dynamic import b\.mjs failed.*ERR_REQUIRE_CYCLE_MODULE/);
         assert.match(output, /dynamic import d\.mjs failed.*ERR_REQUIRE_CYCLE_MODULE/);
-      }
+      },
     }
   );
 }

--- a/test/es-module/test-require-module-dont-detect-cjs.js
+++ b/test/es-module/test-require-module-dont-detect-cjs.js
@@ -7,5 +7,5 @@ const assert = require('assert');
 assert.throws(() => {
   require('../fixtures/es-modules/es-note-unexpected-export-1.cjs');
 }, {
-  message: /Unexpected token 'export'/
+  message: /Unexpected token 'export'/,
 });

--- a/test/es-module/test-require-module-error-catching.js
+++ b/test/es-module/test-require-module-error-catching.js
@@ -9,7 +9,7 @@ const assert = require('assert');
 assert.throws(() => {
   require('../fixtures/es-modules/runtime-error-esm.js');
 }, {
-  message: 'hello'
+  message: 'hello',
 });
 
 // References errors should be caught too.
@@ -17,5 +17,5 @@ assert.throws(() => {
   require('../fixtures/es-modules/reference-error-esm.js');
 }, {
   name: 'ReferenceError',
-  message: 'exports is not defined in ES module scope'
+  message: 'exports is not defined in ES module scope',
 });

--- a/test/es-module/test-require-module-implicit.js
+++ b/test/es-module/test-require-module-implicit.js
@@ -12,7 +12,7 @@ const assert = require('assert');
   assert.throws(() => {
     require(id);
   }, {
-    code: 'MODULE_NOT_FOUND'
+    code: 'MODULE_NOT_FOUND',
   });
   const mod = require(`${id}.mjs`);
   common.expectRequiredModule(mod, { hello: 'world' });

--- a/test/es-module/test-require-module-preload.js
+++ b/test/es-module/test-require-module-preload.js
@@ -16,7 +16,7 @@ function testPreload(preloadFlag) {
         './printA.js',
       ],
       {
-        cwd: fixturesDir
+        cwd: fixturesDir,
       },
       {
         stdout: 'A',
@@ -36,7 +36,7 @@ function testPreload(preloadFlag) {
         './printA.js',
       ],
       {
-        cwd: fixturesDir
+        cwd: fixturesDir,
       },
       {
         stdout: /^world\s+A$/,
@@ -56,7 +56,7 @@ function testPreload(preloadFlag) {
         './printA.js',
       ],
       {
-        cwd: fixturesDir
+        cwd: fixturesDir,
       },
       {
         stdout: /^ok\s+A$/,
@@ -78,7 +78,7 @@ function testPreload(preloadFlag) {
         './printA.js',
       ],
       {
-        cwd: fixturesDir
+        cwd: fixturesDir,
       },
       {
         stdout: /^world\s+A$/,
@@ -103,7 +103,7 @@ testPreload('--import');
       './printA.js',
     ],
     {
-      cwd: fixturesDir
+      cwd: fixturesDir,
     },
     {
       stdout: /^package-type-module\s+A$/,

--- a/test/es-module/test-require-module-retry-import-errored.js
+++ b/test/es-module/test-require-module-retry-import-errored.js
@@ -9,7 +9,7 @@ const { exportedReject } = require('../fixtures/es-modules/tla/export-promise.mj
 assert.throws(() => {
   require('../fixtures/es-modules/tla/await-export-promise.mjs');
 }, {
-  code: 'ERR_REQUIRE_ASYNC_MODULE'
+  code: 'ERR_REQUIRE_ASYNC_MODULE',
 });
 
 const interval = setInterval(() => {}, 1000);  // Keep the test running, because await alone doesn't.

--- a/test/es-module/test-require-module-retry-import-evaluating.js
+++ b/test/es-module/test-require-module-retry-import-evaluating.js
@@ -9,7 +9,7 @@ const { exportedResolve } = require('../fixtures/es-modules/tla/export-promise.m
 assert.throws(() => {
   require('../fixtures/es-modules/tla/await-export-promise.mjs');
 }, {
-  code: 'ERR_REQUIRE_ASYNC_MODULE'
+  code: 'ERR_REQUIRE_ASYNC_MODULE',
 });
 
 const interval = setInterval(() => {}, 1000);  // Keep the test running, because await alone doesn't.

--- a/test/es-module/test-require-module-tla-execution.js
+++ b/test/es-module/test-require-module-tla-execution.js
@@ -21,6 +21,6 @@ const fixtures = require('../common/fixtures');
       assert.match(output, /Requiring .*execution\.mjs/);
       return true;
     },
-    stdout: ''
+    stdout: '',
   });
 }

--- a/test/es-module/test-require-module-tla-print-execution.js
+++ b/test/es-module/test-require-module-tla-print-execution.js
@@ -24,6 +24,6 @@ const fixtures = require('../common/fixtures');
       assert.match(output, /Requiring .*execution\.mjs/);
       return true;
     },
-    stdout: ''
+    stdout: '',
   });
 }

--- a/test/es-module/test-require-module-tla-retry-import-2.js
+++ b/test/es-module/test-require-module-tla-retry-import-2.js
@@ -18,7 +18,7 @@ async function test() {
   assert.throws(() => {
     require('../fixtures/es-modules/tla/export-async.mjs');
   }, {
-    code: 'ERR_REQUIRE_ASYNC_MODULE'
+    code: 'ERR_REQUIRE_ASYNC_MODULE',
   });
 }
 

--- a/test/es-module/test-require-module-tla-retry-import.js
+++ b/test/es-module/test-require-module-tla-retry-import.js
@@ -9,7 +9,7 @@ async function test() {
   assert.throws(() => {
     require('../fixtures/es-modules/tla/export-async.mjs');
   }, {
-    code: 'ERR_REQUIRE_ASYNC_MODULE'
+    code: 'ERR_REQUIRE_ASYNC_MODULE',
   });
   const newNs = await import('../fixtures/es-modules/tla/export-async.mjs');
   if (ns === undefined) {

--- a/test/es-module/test-require-module-tla-retry-require.js
+++ b/test/es-module/test-require-module-tla-retry-require.js
@@ -7,10 +7,10 @@ const assert = require('assert');
 assert.throws(() => {
   require('../fixtures/es-modules/tla/resolved.mjs');
 }, {
-  code: 'ERR_REQUIRE_ASYNC_MODULE'
+  code: 'ERR_REQUIRE_ASYNC_MODULE',
 });
 assert.throws(() => {
   require('../fixtures/es-modules/tla/resolved.mjs');
 }, {
-  code: 'ERR_REQUIRE_ASYNC_MODULE'
+  code: 'ERR_REQUIRE_ASYNC_MODULE',
 });

--- a/test/es-module/test-require-module-warning.js
+++ b/test/es-module/test-require-module-warning.js
@@ -30,7 +30,7 @@ spawnSyncAndAssert(process.execPath, [
       lines[3],
       /at Object\.<anonymous> \(.*require-module\.js:1:1\)/
     );
-  }
+  },
 });
 
 spawnSyncAndAssert(process.execPath, [
@@ -39,5 +39,5 @@ spawnSyncAndAssert(process.execPath, [
 ], {
   status: 9,
   trim: true,
-  stderr: /invalid value for --trace-require-module/
+  stderr: /invalid value for --trace-require-module/,
 });

--- a/test/es-module/test-require-module.js
+++ b/test/es-module/test-require-module.js
@@ -43,6 +43,6 @@ const assert = require('assert');
   const mod = require('../fixtures/es-modules/data-import.mjs');
   common.expectRequiredModule(mod, {
     data: { hello: 'world' },
-    id: 'data:text/javascript,export default %7B%20hello%3A%20%22world%22%20%7D'
+    id: 'data:text/javascript,export default %7B%20hello%3A%20%22world%22%20%7D',
   });
 }

--- a/test/es-module/test-vm-main-context-default-loader.js
+++ b/test/es-module/test-vm-main-context-default-loader.js
@@ -77,7 +77,7 @@ async function main() {
     const filename = tmpdir.resolve('index.js');
     const options = {
       filename,
-      importModuleDynamically: USE_MAIN_CONTEXT_DEFAULT_LOADER
+      importModuleDynamically: USE_MAIN_CONTEXT_DEFAULT_LOADER,
     };
     await testNotFoundErrors(options);
     await testLoader(options);
@@ -90,7 +90,7 @@ async function main() {
     const filename = url.pathToFileURL(tmpdir.resolve('index.js')).href + '?t=1';
     const options = {
       filename,
-      importModuleDynamically: USE_MAIN_CONTEXT_DEFAULT_LOADER
+      importModuleDynamically: USE_MAIN_CONTEXT_DEFAULT_LOADER,
     };
     await testNotFoundErrors(options);
     await testLoader(options);
@@ -101,11 +101,11 @@ async function main() {
     tmpdir.refresh();
     process.chdir(tmpdir.path);
     const undefinedOptions = {
-      importModuleDynamically: USE_MAIN_CONTEXT_DEFAULT_LOADER
+      importModuleDynamically: USE_MAIN_CONTEXT_DEFAULT_LOADER,
     };
     const nonPathOptions = {
       filename: 'non-path',
-      importModuleDynamically: USE_MAIN_CONTEXT_DEFAULT_LOADER
+      importModuleDynamically: USE_MAIN_CONTEXT_DEFAULT_LOADER,
     };
     // Run the error tests first to avoid caching.
     await testNotFoundErrors(undefinedOptions);

--- a/test/es-module/test-wasm-web-api.js
+++ b/test/es-module/test-wasm-web-api.js
@@ -74,7 +74,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
       return assert.rejects(() => WebAssembly.compileStreaming(arg), {
         name: 'TypeError',
         code: 'ERR_INVALID_ARG_TYPE',
-        message: /^The "source" argument .*$/
+        message: /^The "source" argument .*$/,
       });
     }, 2));
   }
@@ -98,7 +98,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
   await testCompileStreamingSuccess(() => {
     return Promise.resolve(new Response(simpleWasmBytes, {
       status: 200,
-      headers: { 'Content-Type': 'application/wasm' }
+      headers: { 'Content-Type': 'application/wasm' },
     }));
   });
 
@@ -111,7 +111,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
     const stream = handle.readableWebStream({ autoClose: true });
     return Promise.resolve(new Response(stream, {
       status: 200,
-      headers: { 'Content-Type': 'application/wasm' }
+      headers: { 'Content-Type': 'application/wasm' },
     }));
   });
 
@@ -161,7 +161,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
     name: 'TypeError',
     code: 'ERR_WEBASSEMBLY_RESPONSE',
     message: 'WebAssembly response has unsupported MIME type ' +
-             "'application/wasm;'"
+             "'application/wasm;'",
   });
 
   // A valid WebAssembly file with an invalid MIME type.
@@ -172,7 +172,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
     name: 'TypeError',
     code: 'ERR_WEBASSEMBLY_RESPONSE',
     message: 'WebAssembly response has unsupported MIME type ' +
-             "'application/octet-stream'"
+             "'application/octet-stream'",
   });
 
   // HTTP status code indicating an error.
@@ -183,7 +183,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
   }, {
     name: 'TypeError',
     code: 'ERR_WEBASSEMBLY_RESPONSE',
-    message: /^WebAssembly response has status code 418$/
+    message: /^WebAssembly response has status code 418$/,
   });
 
   // HTTP status code indicating an error, but using a Response whose body is
@@ -191,7 +191,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
   await testCompileStreamingSuccess(() => {
     return Promise.resolve(new Response(simpleWasmBytes, {
       status: 200,
-      headers: { 'Content-Type': 'application/wasm' }
+      headers: { 'Content-Type': 'application/wasm' },
     }));
   });
 
@@ -201,7 +201,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
     res.end(Buffer.concat([simpleWasmBytes, Buffer.from('foo')]));
   }, {
     name: 'CompileError',
-    message: /^WebAssembly\.compileStreaming\(\): .*$/
+    message: /^WebAssembly\.compileStreaming\(\): .*$/,
   });
 
   // Missing bytes at the end of the WebAssembly file.
@@ -210,7 +210,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
     res.end(simpleWasmBytes.subarray(0, simpleWasmBytes.length - 3));
   }, {
     name: 'CompileError',
-    message: /^WebAssembly\.compileStreaming\(\): .*$/
+    message: /^WebAssembly\.compileStreaming\(\): .*$/,
   });
 
   // Incomplete HTTP response body. The TypeError might come as a surprise, but
@@ -223,7 +223,7 @@ function testCompileStreamingRejectionUsingFetch(responseCallback, rejection) {
     }));
   }, {
     name: 'TypeError',
-    message: /terminated/
+    message: /terminated/,
   });
 
   // Test "Developer-Facing Display Conventions" described in the WebAssembly

--- a/test/eslint.config_partial.mjs
+++ b/test/eslint.config_partial.mjs
@@ -146,7 +146,6 @@ export default [
   },
   {
     files: [
-      'test/es-module/**/*.{js,mjs}',
       'test/parallel/**/*.{js,mjs}',
     ],
     rules: {
@@ -164,6 +163,7 @@ export default [
   },
   {
     files: [
+      'test/es-module/**/*.{js,mjs}',
       'test/sequential/**/*.{js,mjs}',
     ],
     rules: {


### PR DESCRIPTION
There are only a handful missing, seems like a good time to enable it.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
