### PR TITLE
fix: prevent V8 tool scripts from being loaded as builtin modules

### DIFF
--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -115,16 +115,25 @@ function getCjsConditionsArray() {
  * @returns {object|undefined}
  */
 function loadBuiltinModule(id) {
+  if (id.startsWith('internal/deps/v8/tools/')) {
+    return;
+  }
+
   if (!BuiltinModule.canBeRequiredByUsers(id)) {
     return;
   }
-  /** @type {import('internal/bootstrap/realm.js').BuiltinModule} */
+
   const mod = BuiltinModule.map.get(id);
+
+  if (!mod) {
+    return;
+  }
+
   debug('load built-in module %s', id);
-  // compileForPublicLoader() throws if canBeRequiredByUsers is false:
   mod.compileForPublicLoader();
   return mod;
 }
+
 
 /** @type {Module} */
 let $Module = null;
@@ -220,8 +229,8 @@ function addBuiltinLibsToObject(object, dummyModuleName) {
     // Neither add underscored modules, nor ones that contain slashes (e.g.,
     // 'fs/promises') or ones that are already defined.
     if (name[0] === '_' ||
-        StringPrototypeIncludes(name, '/') ||
-        ObjectPrototypeHasOwnProperty(object, name)) {
+      StringPrototypeIncludes(name, '/') ||
+      ObjectPrototypeHasOwnProperty(object, name)) {
       return;
     }
     // Goals of this mechanism are:
@@ -284,7 +293,7 @@ function normalizeReferrerURL(referrerName) {
     }
 
     if (StringPrototypeStartsWith(referrerName, 'file://') ||
-    URLCanParse(referrerName)) {
+      URLCanParse(referrerName)) {
       return referrerName;
     }
 


### PR DESCRIPTION
This patch prevents Node.js from attempting to load V8 tool scripts under
`internal/deps/v8/tools/` as builtin modules.

These files are part of V8’s internal tooling and are not valid Node.js
builtins. When required or imported with `--expose-internals`, the loader
attempts to treat them as builtin CJS modules, which results in either:

- SyntaxError: Unexpected token 'export'  
  (because the V8 tool scripts contain ESM syntax), or  
- AssertionError in BuiltinLoader::LookupAndCompileFunction  
  (`data->IsValue()`), aborting the process.

This change adds a guard in `loadBuiltinModule()` to skip any module whose
path starts with `internal/deps/v8/tools/`, and also adds a defensive check
to avoid calling `compileForPublicLoader()` when no builtin module entry
exists.

This aligns the behavior with expectations and avoids a crash when users
attempt to load these paths with `--expose-internals`.

Fixes: #60865
