### PR TITLE
tools: run tests `--without-amaro` on test-shared macOS

### DIFF
--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -164,7 +164,7 @@ jobs:
             --arg ccache '(import <nixpkgs> {}).sccache' \
             --arg devTools '[]' \
             --arg benchmarkTools '[]' \
-            ${{ endsWith(matrix.system, '-darwin') && '--arg extraConfigFlags ''["--without-inspector"]'' \' || '\' }}
+            ${{ endsWith(matrix.system, '-darwin') && '--arg extraConfigFlags ''["--without-amaro" "--without-inspector"]'' \' || '\' }}
             --run '
                 make -C "$TAR_DIR" run-ci -j4 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9 --skip-tests=$CI_SKIP_TESTS"
             '


### PR DESCRIPTION
We currently have no CI that run the tests with those options. Rather than introducing an additional job, we can reuse that job which is already kinda redundant anyway (we already test with macOS, and we already test with shared-libs on Linux).
I did not include `--without-intl` and `--without-ssl` because we already have Jenkins CI jobs dedicated to those.

EDIT: because each of the options were broken on its own right, I'm splitting this in separate PRs. This one only enables `--without-amaro` as the fix for its tests has already landed.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
