### PR TITLE
deps: V8: increase RISC-V trampoline pool gap

### DIFF
--- a/deps/v8/src/codegen/riscv/assembler-riscv.h
+++ b/deps/v8/src/codegen/riscv/assembler-riscv.h
@@ -481,7 +481,7 @@ class V8_EXPORT_PRIVATE Assembler : public AssemblerBase,
    public:
     // We leave space for a number of trampoline pool slots, so we do not
     // have to pass in an explicit margin for all scopes.
-    static constexpr int kGap = kTrampolineSlotsSize * 16;
+    static constexpr int kGap = kTrampolineSlotsSize * 32;
 
     explicit BlockPoolsScope(Assembler* assem, int margin = 0)
         : BlockPoolsScope(assem, ConstantPoolEmission::kCheck, margin) {}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60895

The error `(trampoline_pos - fixup_pos) <= kMaxBranchOffset` on RISC-V
indicates that the trampoline pool is being emitted too late, causing
branch targets to be out of range.

This commit increases `BlockPoolsScope::kGap` in `assembler-riscv.h`
from 16 slots to 32 slots. This increases the safety margin, ensuring
that the trampoline pool is checked and emitted earlier, preventing
the branch offset overflow.