### PR TITLE
doc: improve fs.watch documentation for rapid file operations

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -4842,6 +4842,29 @@ implemented by monitoring changes in a directory versus specific files. This
 allows substitution of a file and fs reporting changes on the new file
 with the same filename.
 
+##### Event Reliability with Rapid Operations
+
+<!--type=misc-->
+
+When files are created, modified, or deleted in rapid succession, `fs.watch`
+may miss events or coalesce multiple events into one. This is due to the
+underlying operating system file watching mechanisms (such as `inotify` on
+Linux, `FSEvents` on macOS, and `ReadDirectoryChangesW` on Windows) which
+may debounce or batch events to reduce system overhead.
+
+For applications requiring reliable detection of all file system events,
+especially during rapid operations, consider using:
+
+* **Third-party libraries** like [`chokidar`][] which provide more robust
+  event handling and cross-platform consistency.
+* **`fs.watchFile()`** for individual files where guaranteed event detection
+  is critical, though this uses polling and is less efficient.
+* **Debouncing logic** in your event handlers to handle potential duplicate
+  or coalesced events.
+
+[`chokidar`]: https://github.com/paulmillr/chokidar
+
+
 ##### Availability
 
 <!--type=misc-->


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/60859

## Description

This PR improves the `fs.watch` documentation by adding a new section explaining the behavior of file watching during rapid file operations.

## Changes

Added a new "Event Reliability with Rapid Operations" section to the `fs.watch` caveats that:

- Explains that rapid file create/modify/delete operations may cause missed or coalesced events
- Clarifies this is due to underlying OS file watching mechanisms (inotify, FSEvents, ReadDirectoryChangesW)
- Provides recommendations for applications requiring reliable event detection:
  - Use third-party libraries like `chokidar`
  - Use `fs.watchFile()` for critical individual files
  - Implement debouncing logic in event handlers

## Motivation

Issue #60859 reported that `fs.watch` misses events during rapid file operations. This is expected behavior due to OS-level limitations, not a Node.js bug. This documentation improvement helps users understand this limitation and provides alternative solutions.