### PR TITLE
tools: ignore more paths in GHA CI

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -25,7 +25,7 @@ on:
       - tools/eslint/**
       - tools/lint-md/**
       - typings/**
-      - vcbuild.bat 
+      - vcbuild.bat
       - .**
       - '!.github/workflows/build-tarball.yml'
   push:
@@ -55,7 +55,7 @@ on:
       - tools/eslint/**
       - tools/lint-md/**
       - typings/**
-      - vcbuild.bat 
+      - vcbuild.bat
       - .**
       - '!.github/workflows/build-tarball.yml'
 

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -25,7 +25,7 @@ on:
       - tools/eslint/**
       - tools/lint-md/**
       - typings/**
-      - vcbuild.bat 
+      - vcbuild.bat
       - .**
       - '!.github/workflows/test-macos.yml'
   push:
@@ -56,7 +56,7 @@ on:
       - tools/eslint/**
       - tools/lint-md/**
       - typings/**
-      - vcbuild.bat 
+      - vcbuild.bat
       - .**
       - '!.github/workflows/test-macos.yml'
 

--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -40,7 +40,7 @@ on:
       - '!tools/v8/**'
       - '!tools/v8_gypfiles/**'
       - typings/**
-      - vcbuild.bat 
+      - vcbuild.bat
       - .**
       - '!.github/workflows/test-shared.yml'
     types: [opened, synchronize, reopened, ready_for_review]
@@ -86,7 +86,7 @@ on:
       - '!tools/v8/**'
       - '!tools/v8_gypfiles/**'
       - typings/**
-      - vcbuild.bat 
+      - vcbuild.bat
       - .**
       - '!.github/workflows/test-shared.yml'
 


### PR DESCRIPTION
We don't need to build `node` 8 times in PRs such as https://github.com/nodejs/node/pull/60908. I noticed we were still listing the `AUTHORS` file despite getting rid of it ages ago.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
