### PR TITLE
util: assert getCallSites does not invoke Error.prepareStackTrace

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -564,6 +564,9 @@ changes:
 Returns an array of call site objects containing the stack of
 the caller function.
 
+Unlike accessing an `error.stack`, the result returned from this API is not
+interfered with `Error.prepareStackTrace`.
+
 ```mjs
 import { getCallSites } from 'node:util';
 

--- a/test/parallel/test-util-getcallsites-preparestacktrace.js
+++ b/test/parallel/test-util-getcallsites-preparestacktrace.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const { getCallSites } = require('node:util');
+
+// Asserts that util.getCallSites() does not invoke
+// Error.prepareStackTrace.
+
+Error.prepareStackTrace = common.mustNotCall();
+
+const sites = getCallSites(1);
+assert.strictEqual(sites.length, 1);
+assert.strictEqual(sites[0].scriptName, __filename);


### PR DESCRIPTION
Assert that `util.getCallSites` does not invoke `Error.prepareStackTrace`.