### PR TITLE
util: fix Windows-1252 decoder for bytes 0x80-0x9F

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -29,6 +29,7 @@ const kDecoder = Symbol('decoder');
 const kFatal = Symbol('kFatal');
 const kUTF8FastPath = Symbol('kUTF8FastPath');
 const kLatin1FastPath = Symbol('kLatin1FastPath');
+const kWindows1252FastPath = Symbol('kWindows1252FastPath');
 const kIgnoreBOM = Symbol('kIgnoreBOM');
 
 const {
@@ -56,6 +57,7 @@ const {
   encodeUtf8String,
   decodeUTF8,
   decodeLatin1,
+  decodeWindows1252,
 } = binding;
 
 const { Buffer } = require('buffer');
@@ -418,12 +420,12 @@ function makeTextDecoderICU() {
       this[kEncoding] = enc;
       this[kIgnoreBOM] = Boolean(options?.ignoreBOM);
       this[kFatal] = Boolean(options?.fatal);
-      // Only support fast path for UTF-8.
+      // Only support fast path for UTF-8 and Windows-1252.
       this[kUTF8FastPath] = enc === 'utf-8';
-      this[kLatin1FastPath] = enc === 'windows-1252';
+      this[kWindows1252FastPath] = enc === 'windows-1252';
       this[kHandle] = undefined;
 
-      if (!this[kUTF8FastPath] && !this[kLatin1FastPath]) {
+      if (!this[kUTF8FastPath] && !this[kWindows1252FastPath]) {
         this.#prepareConverter();
       }
     }
@@ -440,14 +442,14 @@ function makeTextDecoderICU() {
       validateDecoder(this);
 
       this[kUTF8FastPath] &&= !(options?.stream);
-      this[kLatin1FastPath] &&= !(options?.stream);
+      this[kWindows1252FastPath] &&= !(options?.stream);
 
       if (this[kUTF8FastPath]) {
         return decodeUTF8(input, this[kIgnoreBOM], this[kFatal]);
       }
 
-      if (this[kLatin1FastPath]) {
-        return decodeLatin1(input, this[kIgnoreBOM], this[kFatal]);
+      if (this[kWindows1252FastPath]) {
+        return decodeWindows1252(input, this[kIgnoreBOM], this[kFatal]);
       }
 
       this.#prepareConverter();

--- a/src/encoding_binding.h
+++ b/src/encoding_binding.h
@@ -32,6 +32,7 @@ class BindingData : public SnapshotableObject {
   static void EncodeUtf8String(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void DecodeUTF8(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void DecodeLatin1(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void DecodeWindows1252(const v8::FunctionCallbackInfo<v8::Value>& args);
 
   static void ToASCII(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void ToUnicode(const v8::FunctionCallbackInfo<v8::Value>& args);

--- a/test/parallel/test-util-text-decoder.js
+++ b/test/parallel/test-util-text-decoder.js
@@ -15,3 +15,88 @@ test('TextDecoder correctly decodes windows-1252 encoded data', { skip: !common.
 
   assert.strictEqual(decodedString, expectedString);
 });
+
+test('TextDecoder correctly decodes windows-1252 special characters (0x80-0x9F)', { skip: !common.hasIntl }, () => {
+  const decoder = new TextDecoder('windows-1252');
+  
+  // Test byte 0x92 (right single quotation mark) - the main bug from issue #56542
+  assert.strictEqual(decoder.decode(new Uint8Array([0x92])), '\u2019');
+  assert.strictEqual(decoder.decode(new Uint8Array([0x92])).charCodeAt(0), 0x2019);
+  
+  // Test all special Windows-1252 characters (0x80-0x9F)
+  // Excluding undefined bytes: 0x81, 0x8D, 0x8F, 0x90, 0x9D
+  const testCases = [
+    { byte: 0x80, expected: '\u20AC', name: 'Euro sign' },
+    { byte: 0x82, expected: '\u201A', name: 'Single low-9 quotation mark' },
+    { byte: 0x83, expected: '\u0192', name: 'Latin small letter f with hook' },
+    { byte: 0x84, expected: '\u201E', name: 'Double low-9 quotation mark' },
+    { byte: 0x85, expected: '\u2026', name: 'Horizontal ellipsis' },
+    { byte: 0x86, expected: '\u2020', name: 'Dagger' },
+    { byte: 0x87, expected: '\u2021', name: 'Double dagger' },
+    { byte: 0x88, expected: '\u02C6', name: 'Modifier letter circumflex accent' },
+    { byte: 0x89, expected: '\u2030', name: 'Per mille sign' },
+    { byte: 0x8A, expected: '\u0160', name: 'Latin capital letter S with caron' },
+    { byte: 0x8B, expected: '\u2039', name: 'Single left-pointing angle quotation mark' },
+    { byte: 0x8C, expected: '\u0152', name: 'Latin capital ligature OE' },
+    { byte: 0x8E, expected: '\u017D', name: 'Latin capital letter Z with caron' },
+    { byte: 0x91, expected: '\u2018', name: 'Left single quotation mark' },
+    { byte: 0x92, expected: '\u2019', name: 'Right single quotation mark' },
+    { byte: 0x93, expected: '\u201C', name: 'Left double quotation mark' },
+    { byte: 0x94, expected: '\u201D', name: 'Right double quotation mark' },
+    { byte: 0x95, expected: '\u2022', name: 'Bullet' },
+    { byte: 0x96, expected: '\u2013', name: 'En dash' },
+    { byte: 0x97, expected: '\u2014', name: 'Em dash' },
+    { byte: 0x98, expected: '\u02DC', name: 'Small tilde' },
+    { byte: 0x99, expected: '\u2122', name: 'Trade mark sign' },
+    { byte: 0x9A, expected: '\u0161', name: 'Latin small letter s with caron' },
+    { byte: 0x9B, expected: '\u203A', name: 'Single right-pointing angle quotation mark' },
+    { byte: 0x9C, expected: '\u0153', name: 'Latin small ligature oe' },
+    { byte: 0x9E, expected: '\u017E', name: 'Latin small letter z with caron' },
+    { byte: 0x9F, expected: '\u0178', name: 'Latin capital letter Y with diaeresis' },
+  ];
+
+  for (const { byte, expected, name } of testCases) {
+    const result = decoder.decode(new Uint8Array([byte]));
+    assert.strictEqual(result, expected, `Failed for ${name} (0x${byte.toString(16)})`);
+  }
+});
+
+test('TextDecoder windows-1252 handles undefined bytes correctly', { skip: !common.hasIntl }, () => {
+  const decoder = new TextDecoder('windows-1252');
+  
+  // Bytes 0x81, 0x8D, 0x8F, 0x90, 0x9D are undefined in Windows-1252
+  // They should be passed through as their Unicode equivalents
+  const undefinedBytes = [0x81, 0x8D, 0x8F, 0x90, 0x9D];
+  
+  for (const byte of undefinedBytes) {
+    const result = decoder.decode(new Uint8Array([byte]));
+    assert.strictEqual(result.charCodeAt(0), byte, 
+      `Undefined byte 0x${byte.toString(16)} should map to U+00${byte.toString(16).toUpperCase()}`);
+  }
+});
+
+test('TextDecoder windows-1252 handles ASCII range correctly', { skip: !common.hasIntl }, () => {
+  const decoder = new TextDecoder('windows-1252');
+  
+  // Test ASCII range (0x00-0x7F) - should be identical to UTF-8
+  const asciiBytes = new Uint8Array([0x48, 0x65, 0x6C, 0x6C, 0x6F]); // "Hello"
+  assert.strictEqual(decoder.decode(asciiBytes), 'Hello');
+});
+
+test('TextDecoder windows-1252 handles Latin-1 range correctly', { skip: !common.hasIntl }, () => {
+  const decoder = new TextDecoder('windows-1252');
+  
+  // Test Latin-1 range (0xA0-0xFF) - should be identical to ISO-8859-1
+  const latin1Bytes = new Uint8Array([0xA0, 0xC0, 0xE0, 0xFF]);
+  const expected = '\u00A0\u00C0\u00E0\u00FF';
+  assert.strictEqual(decoder.decode(latin1Bytes), expected);
+});
+
+test('TextDecoder windows-1252 handles mixed content', { skip: !common.hasIntl }, () => {
+  const decoder = new TextDecoder('windows-1252');
+  
+  // Mix of ASCII, Windows-1252 special chars, and Latin-1
+  // "It's €100" where 's is 0x92 (right single quote) and € is 0x80
+  const mixedBytes = new Uint8Array([0x49, 0x74, 0x92, 0x73, 0x20, 0x80, 0x31, 0x30, 0x30]);
+  assert.strictEqual(decoder.decode(mixedBytes), 'It\u2019s \u20AC100');
+});


### PR DESCRIPTION
## Description

TextDecoder was incorrectly using the Latin-1 decoder for Windows-1252 encoding, which caused bytes in the range 0x80-0x9F to be decoded incorrectly.

### Problem
- Bytes 0x80-0x9F have specific character mappings in Windows-1252 (e.g., 0x92 → U+2019 ')
- These bytes are undefined in ISO-8859-1 (Latin-1)
- The previous implementation used `decodeLatin1` for Windows-1252, causing incorrect decoding

### Solution
- Added a proper Windows-1252 decoder with a character mapping table for the 32 special characters (0x80-0x9F)
- Created `DecodeWindows1252` function in `src/encoding_binding.cc`
- Updated JavaScript bindings in `lib/internal/encoding.js` to use the correct decoder
- Follows the WHATWG Encoding Standard

### Changes
- **src/encoding_binding.h**: Added `DecodeWindows1252` declaration
- **src/encoding_binding.cc**: Implemented Windows-1252 decoder with character mapping table
- **lib/internal/encoding.js**: Updated to use `decodeWindows1252` instead of `decodeLatin1`
- **test/parallel/test-util-text-decoder.js**: Added comprehensive tests for all Windows-1252 special characters

## Fixes
Fixes: #56542

## Checklist
- [x] Tests included
- [x] Documentation not needed (internal fix)
- [x] Commit message follows guidelines