### PR TITLE
fs: fix errorOnExist behavior for directory copy in fs.cp

### DIFF
--- a/lib/internal/fs/cp/cp.js
+++ b/lib/internal/fs/cp/cp.js
@@ -300,8 +300,17 @@ async function setDestTimestamps(src, dest) {
   return utimes(dest, updatedSrcStat.atime, updatedSrcStat.mtime);
 }
 
-function onDir(srcStat, destStat, src, dest, opts) {
+async function onDir(srcStat, destStat, src, dest, opts) {
   if (!destStat) return mkDirAndCopy(srcStat.mode, src, dest, opts);
+  if (opts.errorOnExist && !opts.force) {
+    throw new ERR_FS_CP_EEXIST({
+      message: `${dest} already exists`,
+      path: dest,
+      syscall: 'cp',
+      errno: EEXIST,
+      code: 'EEXIST',
+    });
+  }
   return copyDir(src, dest, opts);
 }
 

--- a/test/parallel/test-fs-cp-async-dir-exists-error-on-exist.mjs
+++ b/test/parallel/test-fs-cp-async-dir-exists-error-on-exist.mjs
@@ -1,0 +1,30 @@
+// This tests that cp() returns error if errorOnExist is true, force is false,
+// and the destination directory already exists (even if contents don't conflict).
+
+import { mustCall } from '../common/index.mjs';
+import { nextdir } from '../common/fs.js';
+import assert from 'node:assert';
+import { cp, mkdirSync, writeFileSync } from 'node:fs';
+import tmpdir from '../common/tmpdir.js';
+
+tmpdir.refresh();
+
+const src = nextdir();
+const dest = nextdir();
+
+// Create source directory with a file
+mkdirSync(src);
+writeFileSync(`${src}/file.txt`, 'test');
+
+// Create destination directory with different file
+mkdirSync(dest);
+writeFileSync(`${dest}/other.txt`, 'existing');
+
+// Should fail because dest directory already exists
+cp(src, dest, {
+  recursive: true,
+  errorOnExist: true,
+  force: false,
+}, mustCall((err) => {
+  assert.strictEqual(err.code, 'ERR_FS_CP_EEXIST');
+}));


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/58947. This implements the errorOnExists check for onDir, which we previously had only for onFile.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
