### PR TITLE
feat: improve error message

### DIFF
--- a/lib/internal/bootstrap/switches/does_own_process_state.js
+++ b/lib/internal/bootstrap/switches/does_own_process_state.js
@@ -138,7 +138,17 @@ function wrappedUmask(mask) {
 }
 
 function wrappedCwd() {
-  if (cachedCwd === '')
-    cachedCwd = rawMethods.cwd();
+  if (cachedCwd === '') {
+    try {
+      cachedCwd = rawMethods.cwd();
+    } catch (err) {
+      // Enhance the error message to make it clearer what failed and why
+      if (err.code === 'ENOENT') {
+        err.message = 'current working directory does not exist: ' +
+                      'process.cwd() failed because the directory was deleted';
+      }
+      throw err;
+    }
+  }
   return cachedCwd;
 }

--- a/test/parallel/test-cwd-enoent-improved-message.js
+++ b/test/parallel/test-cwd-enoent-improved-message.js
@@ -1,0 +1,32 @@
+'use strict';
+const common = require('../common');
+// Fails with EINVAL on SmartOS, EBUSY on Windows, EBUSY on AIX.
+if (common.isSunOS || common.isWindows || common.isAIX || common.isIBMi) {
+  common.skip('cannot rmdir current working directory');
+}
+
+const { isMainThread } = require('worker_threads');
+
+if (!isMainThread) {
+  common.skip('process.chdir is not available in Workers');
+}
+
+const assert = require('assert');
+const fs = require('fs');
+
+const tmpdir = require('../common/tmpdir');
+
+const dirname = `${tmpdir.path}/cwd-does-not-exist-${process.pid}`;
+tmpdir.refresh();
+fs.mkdirSync(dirname);
+process.chdir(dirname);
+fs.rmdirSync(dirname);
+
+// Test that process.cwd() throws with an improved error message
+assert.throws(
+  () => process.cwd(),
+  {
+    code: 'ENOENT',
+    message: /current working directory does not exist.*process\.cwd\(\) failed because the directory was deleted/,
+  }
+);


### PR DESCRIPTION
## Description
Improves the error message when `process.cwd()` fails because the current working directory no longer exists (e.g., was deleted).

## Before
```

Error: ENOENT: no such file or directory, uv_cwd

```

## After
```

Error: current working directory does not exist: process.cwd() failed because the directory was deleted

```

## Changes
- Modified `lib/internal/bootstrap/switches/does_own_process_state.js` to catch and enhance the ENOENT error message in `wrappedCwd()`
- Added `test/parallel/test-cwd-enoent-improved-message.js` to verify the improved error message

## Testing
- ✅ All existing tests pass  
- ✅ New test added and passing  
- ✅ Linter passed  
- ✅ Manual verification successful  
- ✅ Backward compatibility maintained (error code and properties unchanged)

## Fixes
- Fixes: #57045
