### PR TITLE
module: mark module compile cache as stable

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3387,9 +3387,11 @@ Any other value will result in colorized output being disabled.
 
 <!-- YAML
 added: v22.1.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60971
+    description: This feature is no longer experimental.
 -->
-
-> Stability: 1.1 - Active Development
 
 Enable the [module compile cache][] for the Node.js instance. See the documentation of
 [module compile cache][] for details.

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -410,6 +410,11 @@ to disk when the Node.js instance is about to exit. This is subject to change. T
 is flushed to disk in case the application wants to spawn other Node.js instances
 and let them share the cache long before the parent exits.
 
+The compile cache layout on disk is an implementation detail and should not be
+relied upon. The compile cache generated is typically only reusable in the same
+version of Node.js, and should be not assumed to be compatible across different
+versions of Node.js.
+
 ### Portability of the compile cache
 
 By default, caches are invalidated when the absolute paths of the modules being
@@ -449,9 +454,11 @@ separately if the same base directory is used to persist the cache, so they can 
 
 <!-- YAML
 added: v22.8.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60971
+    description: This feature is no longer experimental.
 -->
-
-> Stability: 1.1 - Active Development
 
 The following constants are returned as the `status` field in the object returned by
 [`module.enableCompileCache()`][] to indicate the result of the attempt to enable the
@@ -503,6 +510,9 @@ The following constants are returned as the `status` field in the object returne
 <!-- YAML
 added: v22.8.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60971
+    description: This feature is no longer experimental.
   - version: v25.0.0
     pr-url: https://github.com/nodejs/node/pull/58797
     description: Add `portable` option to enable portable compile cache.
@@ -510,8 +520,6 @@ changes:
     pr-url: https://github.com/nodejs/node/pull/59931
     description: Rename the unreleased `path` option to `directory` to maintain consistency.
 -->
-
-> Stability: 1.1 - Active Development
 
 * `options` {string|Object} Optional. If a string is passed, it is considered to be `options.directory`.
   * `directory` {string} Optional. Directory to store the compile cache. If not specified,
@@ -557,9 +565,11 @@ be inherited into the child workers. The directory can be obtained either from t
 added:
  - v23.0.0
  - v22.10.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60971
+    description: This feature is no longer experimental.
 -->
-
-> Stability: 1.1 - Active Development
 
 Flush the [module compile cache][] accumulated from modules already loaded
 in the current Node.js instance to disk. This returns after all the flushing
@@ -571,9 +581,11 @@ interfere with the actual operation of the application.
 
 <!-- YAML
 added: v22.8.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/60971
+    description: This feature is no longer experimental.
 -->
-
-> Stability: 1.1 - Active Development
 
 * Returns: {string|undefined} Path to the [module compile cache][] directory if it is enabled,
   or `undefined` otherwise.


### PR DESCRIPTION
The feature set has been stable without any breaking changes in the past year, and it's been depended enough in the wild by popular packages that we'll likely need to treat any breakages as semver-major in the future anyway. The future TODOs are likely all non-breaking. Potential subtle breakages in implementation details that should not be relied upon (such as the cache layout) are explicitly excluded from the contract.

We'll investigate whether it can be enabled by default as a different topic, which can be potentially semver-major.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
