### PR TITLE
module: preserve URL in the parent created by createRequire()

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -135,7 +135,7 @@ const { BuiltinModule } = require('internal/bootstrap/realm');
 const {
   maybeCacheSourceMap,
 } = require('internal/source_map/source_map_cache');
-const { pathToFileURL, fileURLToPath, isURL } = require('internal/url');
+const { pathToFileURL, fileURLToPath, isURL, URL } = require('internal/url');
 const {
   pendingDeprecate,
   emitExperimentalWarning,
@@ -1923,7 +1923,7 @@ Module._extensions['.node'] = function(module, filename) {
  * @param {string} filename The path to the module
  * @returns {any}
  */
-function createRequireFromPath(filename) {
+function createRequireFromPath(filename, fileURL) {
   // Allow a directory to be passed as the filename
   const trailingSlash =
     StringPrototypeEndsWith(filename, '/') ||
@@ -1935,6 +1935,10 @@ function createRequireFromPath(filename) {
 
   const m = new Module(proxyPath);
   m.filename = proxyPath;
+  if (fileURL !== undefined) {
+    // Save the URL if createRequire() was given a URL, to preserve search params, if any.
+    m[kURL] = fileURL.href;
+  }
 
   m.paths = Module._nodeModulePaths(m.path);
   return makeRequireFunction(m, null);
@@ -1945,28 +1949,32 @@ const createRequireError = 'must be a file URL object, file URL string, or ' +
 
 /**
  * Creates a new `require` function that can be used to load modules.
- * @param {string | URL} filename The path or URL to the module context for this `require`
+ * @param {string | URL} filenameOrURL The path or URL to the module context for this `require`
  * @throws {ERR_INVALID_ARG_VALUE} If `filename` is not a string or URL, or if it is a relative path that cannot be
  * resolved to an absolute path.
  * @returns {object}
  */
-function createRequire(filename) {
-  let filepath;
+function createRequire(filenameOrURL) {
+  let filepath, fileURL;
 
-  if (isURL(filename) ||
-      (typeof filename === 'string' && !path.isAbsolute(filename))) {
+  if (isURL(filenameOrURL) ||
+      (typeof filenameOrURL === 'string' && !path.isAbsolute(filenameOrURL))) {
     try {
-      filepath = fileURLToPath(filename);
+      // It might be an URL, try to convert it.
+      // If it's a relative path, it would not parse and would be considered invalid per
+      // the documented contract.
+      fileURL = new URL(filenameOrURL);
+      filepath = fileURLToPath(fileURL);
     } catch {
-      throw new ERR_INVALID_ARG_VALUE('filename', filename,
+      throw new ERR_INVALID_ARG_VALUE('filename', filenameOrURL,
                                       createRequireError);
     }
-  } else if (typeof filename !== 'string') {
-    throw new ERR_INVALID_ARG_VALUE('filename', filename, createRequireError);
+  } else if (typeof filenameOrURL !== 'string') {
+    throw new ERR_INVALID_ARG_VALUE('filename', filenameOrURL, createRequireError);
   } else {
-    filepath = filename;
+    filepath = filenameOrURL;
   }
-  return createRequireFromPath(filepath);
+  return createRequireFromPath(filepath, fileURL);
 }
 
 /**

--- a/test/fixtures/module-hooks/create-require-with-url.mjs
+++ b/test/fixtures/module-hooks/create-require-with-url.mjs
@@ -1,0 +1,3 @@
+import { createRequire } from 'node:module'
+const require = createRequire(import.meta.url);
+require('./empty.mjs');

--- a/test/module-hooks/test-module-hooks-create-require-with-url.mjs
+++ b/test/module-hooks/test-module-hooks-create-require-with-url.mjs
@@ -1,0 +1,26 @@
+// Verify that if URL is used to createRequire, that URL is passed to the resolve hook
+// as parentURL.
+import * as common from '../common/index.mjs';
+import assert from 'node:assert';
+import { registerHooks } from 'node:module';
+import * as fixtures from '../common/fixtures.mjs';
+
+const fixtureURL = fixtures.fileURL('module-hooks/create-require-with-url.mjs').href + '?test=1';
+registerHooks({
+  resolve: common.mustCall((specifier, context, defaultResolve) => {
+    const resolved = defaultResolve(specifier, context, defaultResolve);
+    if (specifier.startsWith('node:')) {
+      return resolved;
+    }
+
+    if (specifier === fixtureURL) {
+      assert.strictEqual(context.parentURL, import.meta.url);
+    } else {  // From the createRequire call.
+      assert.strictEqual(specifier, './empty.mjs');
+      assert.strictEqual(context.parentURL, fixtureURL);
+    }
+    return resolved;
+  }, 3),
+});
+
+await import(fixtureURL);


### PR DESCRIPTION
Previously, createRequire() does not preserve the URL it gets passed in the mock parent module created, which can be observable if it's used together with module.registerHooks(). This patch adds preservation of the URL if createRequire() is invoked with one.

Fixes: https://github.com/nodejs/node/issues/60973

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
