### PR TITLE
test: deflake `test-repl-paste-big-data`

### DIFF
--- a/test/pummel/test-repl-paste-big-data.js
+++ b/test/pummel/test-repl-paste-big-data.js
@@ -14,10 +14,10 @@ replServer.input.emit('keypress', '', { name: 'left' });
 replServer.input.emit('data', 'node');
 assert.strictEqual(replServer.line, '{node}');
 
-replServer.input.emit('data', 'a'.repeat(2e4) + '\n');
+replServer.input.emit('data', 'a'.repeat(4e4) + '\n');
 replServer.input.emit('data', '.exit\n');
 
 replServer.once('exit', common.mustCall(() => {
   const diff = process.cpuUsage(cpuUsage);
-  assert.ok(diff.user < 1e6);
+  assert.ok(diff.user < 4e6);
 }));


### PR DESCRIPTION
This test seems to be stable on CI but occasionally fails locally.

Running it alone in a loop gives me `user` times between `800_000` and `900_000` (which is dangerously close to `1e6`):
<details><summary>

`for i in $(seq 100); do ./node test/parallel/test-repl-paste-big-data.js; done`

</summary>

```c
{ user: 866917, system: 185463 }
{ user: 871151, system: 175040 }
{ user: 917807, system: 184395 }
{ user: 899495, system: 187478 }
{ user: 827521, system: 181481 }
{ user: 879701, system: 162936 }
{ user: 860628, system: 172119 }
{ user: 855606, system: 186596 }
{ user: 845470, system: 182765 }
{ user: 881573, system: 172722 }
{ user: 901690, system: 167722 }
{ user: 863722, system: 172600 }
{ user: 904432, system: 159686 }
{ user: 846925, system: 158277 }
{ user: 844934, system: 170959 }
{ user: 835534, system: 160854 }
{ user: 861123, system: 162197 }
{ user: 775973, system: 172439 }
{ user: 881403, system: 153497 }
{ user: 848071, system: 155870 }
{ user: 818715, system: 159727 }
{ user: 834763, system: 178185 }
{ user: 815032, system: 176720 }
{ user: 824114, system: 166100 }
{ user: 864152, system: 160930 }
{ user: 834135, system: 155224 }
{ user: 880504, system: 135156 }
{ user: 841057, system: 169898 }
{ user: 891765, system: 123271 }
{ user: 819927, system: 175587 }
{ user: 821648, system: 150704 }
{ user: 849378, system: 156177 }
{ user: 780979, system: 152167 }
{ user: 913720, system: 182885 }
{ user: 903088, system: 177283 }
{ user: 911141, system: 173317 }
{ user: 880055, system: 178612 }
{ user: 862311, system: 160692 }
{ user: 883291, system: 154022 }
{ user: 902093, system: 156052 }
{ user: 835725, system: 175758 }
{ user: 851204, system: 167661 }
{ user: 875535, system: 175626 }
{ user: 839345, system: 160710 }
{ user: 841029, system: 169111 }
{ user: 916314, system: 191540 }
{ user: 857462, system: 180964 }
{ user: 846694, system: 170697 }
{ user: 902190, system: 160728 }
{ user: 838361, system: 176076 }
{ user: 846143, system: 162471 }
{ user: 805115, system: 162637 }
{ user: 824717, system: 161895 }
{ user: 806976, system: 184627 }
{ user: 869270, system: 163822 }
{ user: 834470, system: 151972 }
{ user: 857789, system: 146842 }
{ user: 814851, system: 172712 }
{ user: 859234, system: 140349 }
{ user: 889904, system: 161638 }
{ user: 804484, system: 153310 }
{ user: 774811, system: 197145 }
{ user: 875437, system: 157809 }
{ user: 799620, system: 161211 }
{ user: 829113, system: 155879 }
{ user: 839526, system: 154259 }
{ user: 868271, system: 150702 }
{ user: 871397, system: 143097 }
{ user: 792251, system: 154913 }
{ user: 791352, system: 182302 }
{ user: 813169, system: 149632 }
{ user: 823347, system: 188265 }
{ user: 855458, system: 171391 }
{ user: 838603, system: 185043 }
{ user: 855971, system: 181007 }
{ user: 904407, system: 148245 }
{ user: 876195, system: 158055 }
{ user: 843357, system: 179377 }
{ user: 851711, system: 177553 }
{ user: 913416, system: 161630 }
{ user: 854593, system: 178993 }
{ user: 902497, system: 191730 }
{ user: 881237, system: 155912 }
{ user: 859059, system: 163697 }
{ user: 891354, system: 162877 }
{ user: 835626, system: 170757 }
{ user: 905143, system: 146084 }
{ user: 826497, system: 179106 }
{ user: 870887, system: 170199 }
{ user: 866499, system: 191698 }
{ user: 874927, system: 179912 }
{ user: 864727, system: 161580 }
{ user: 803581, system: 160939 }
{ user: 825055, system: 168606 }
{ user: 808614, system: 169138 }
{ user: 822435, system: 170344 }
{ user: 809879, system: 159137 }
{ user: 826755, system: 144516 }
{ user: 878608, system: 131937 }
{ user: 828102, system: 164212 }
```

</details>

And when ran in parallel with other tests, it fails frequently.

This PR increases data length to lower fluctuations (x2 length takes about x3 cpu time here), increases the threshold, and moves the test to `pummel`.