### PR TITLE
[v24.x][riscv] V8 backport to resolve compile failure

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.37',
+    'v8_embedder_string': '-node.38',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -334,3 +334,4 @@ Kotaro Ohsugi <dec4m4rk@gmail.com>
 Jing Peiyang <jingpeiyang@eswincomputing.com>
 magic-akari <akari.ccino@gmail.com>
 Ryuhei Shima <shimaryuhei@gmail.com>
+Domagoj Stolfa <domagoj.stolfa@gmail.com>

--- a/deps/v8/src/codegen/riscv/assembler-riscv-inl.h
+++ b/deps/v8/src/codegen/riscv/assembler-riscv-inl.h
@@ -115,8 +115,9 @@ void Assembler::set_target_compressed_address_at(
     Address pc, Address constant_pool, Tagged_t target,
     WritableJitAllocation* jit_allocation, ICacheFlushMode icache_flush_mode) {
   if (COMPRESS_POINTERS_BOOL) {
-    Assembler::set_uint32_constant_at(pc, constant_pool, target, jit_allocation,
-                                      icache_flush_mode);
+    Assembler::set_uint32_constant_at(pc, constant_pool,
+                                      static_cast<uint32_t>(target),
+                                      jit_allocation, icache_flush_mode);
   } else {
     UNREACHABLE();
   }

--- a/deps/v8/src/execution/riscv/simulator-riscv.h
+++ b/deps/v8/src/execution/riscv/simulator-riscv.h
@@ -538,6 +538,7 @@ class Simulator : public SimulatorBase {
   // Return central stack view, without additional safety margins.
   // Users, for example wasm::StackMemory, can add their own.
   base::Vector<uint8_t> GetCentralStackView() const;
+  static constexpr int JSStackLimitMargin() { return kAdditionalStackMargin; }
 
   void IterateRegistersAndStack(::heap::base::StackVisitor* visitor);
 


### PR DESCRIPTION
Failure referenced in https://github.com/nodejs/build/issues/4099#issuecomment-3617069521 - the single line fix to 
`deps/v8/src/execution/riscv/simulator-riscv.h` is enough to allow the cross-compiled build to pass but it seems cleaner to to pull the full commit across. If any reviewers disagree then I'm happy to cut this down to just the single line.

This will allow us to enable v24.x in the unofficial-builds repository.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
