### PR TITLE
lib,src: isInsideNodeModules should test on the first non-internal frame

### DIFF
--- a/benchmark/internal/util_isinsidenodemodules.js
+++ b/benchmark/internal/util_isinsidenodemodules.js
@@ -1,0 +1,52 @@
+'use strict';
+const common = require('../common.js');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  n: [1e6],
+  stackLimit: [100],
+  stackCount: [99, 101],
+  method: ['isInsideNodeModules', 'noop'],
+}, {
+  flags: ['--expose-internals', '--disable-warning=internal/test/binding'],
+});
+
+function main({ n, stackLimit, stackCount, method }) {
+  const { internalBinding } = require('internal/test/binding');
+  const { isInsideNodeModules } = internalBinding('util');
+
+  const testFunction = method === 'noop' ?
+    () => {
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        noop();
+      }
+      bench.end(n);
+    } :
+    () => {
+      Error.stackTraceLimit = Infinity;
+      const existingStackFrameCount = new Error().stack.split('\n').length - 1;
+      assert.strictEqual(existingStackFrameCount, stackCount);
+
+      bench.start();
+      for (let i = 0; i < n; i++) {
+        isInsideNodeModules(stackLimit, true);
+      }
+      bench.end(n);
+    };
+
+  // Excluding the message line.
+  const existingStackFrameCount = new Error().stack.split('\n').length - 1;
+  // Excluding the test function itself.
+  nestCallStack(stackCount - existingStackFrameCount - 1, testFunction);
+}
+
+function nestCallStack(depth, callback) {
+  // nestCallStack(1) already adds a stack frame, so we stop at 1.
+  if (depth === 1) {
+    return callback();
+  }
+  return nestCallStack(depth - 1, callback);
+}
+
+function noop() {}

--- a/benchmark/internal/util_isinsidenodemodules.js
+++ b/benchmark/internal/util_isinsidenodemodules.js
@@ -4,14 +4,13 @@ const assert = require('assert');
 
 const bench = common.createBenchmark(main, {
   n: [1e6],
-  stackLimit: [100],
   stackCount: [99, 101],
   method: ['isInsideNodeModules', 'noop'],
 }, {
   flags: ['--expose-internals', '--disable-warning=internal/test/binding'],
 });
 
-function main({ n, stackLimit, stackCount, method }) {
+function main({ n, stackCount, method }) {
   const { internalBinding } = require('internal/test/binding');
   const { isInsideNodeModules } = internalBinding('util');
 
@@ -30,7 +29,7 @@ function main({ n, stackLimit, stackCount, method }) {
 
       bench.start();
       for (let i = 0; i < n; i++) {
-        isInsideNodeModules(stackLimit, true);
+        isInsideNodeModules();
       }
       bench.end(n);
     };

--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -178,15 +178,14 @@ function showFlaggedDeprecation() {
   if (bufferWarningAlreadyEmitted ||
       ++nodeModulesCheckCounter > 10000 ||
       (!require('internal/options').getOptionValue('--pending-deprecation') &&
-       isInsideNodeModules(100, true))) {
+       isInsideNodeModules(3))) {
     // We don't emit a warning, because we either:
     // - Already did so, or
     // - Already checked too many times whether a call is coming
     //   from node_modules and want to stop slowing down things, or
     // - We aren't running with `--pending-deprecation` enabled,
     //   and the code is inside `node_modules`.
-    // - We found node_modules in up to the topmost 100 frames, or
-    //   there are more than 100 frames and we don't want to search anymore.
+    // - If the topmost non-internal frame is not inside `node_modules`.
     return;
   }
 

--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1537,9 +1537,8 @@ function loadESMFromCJS(mod, filename, format, source) {
         } else if (mod[kIsCachedByESMLoader]) {
           // It comes from the require() built for `import cjs` and doesn't have a parent recorded
           // in the CJS module instance. Inspect the stack trace to see if the require()
-          // comes from node_modules and reduce the noise. If there are more than 100 frames,
-          // just give up and assume it is under node_modules.
-          shouldEmitWarning = !isInsideNodeModules(100, true);
+          // comes from node_modules as a direct call and reduce the noise.
+          shouldEmitWarning = !isInsideNodeModules();
         }
       } else {
         shouldEmitWarning = true;

--- a/lib/punycode.js
+++ b/lib/punycode.js
@@ -3,7 +3,7 @@ const {
   isInsideNodeModules,
 } = internalBinding('util');
 
-if (!isInsideNodeModules(100, true)) {
+if (!isInsideNodeModules()) {
 	process.emitWarning(
 		'The `punycode` module is deprecated. Please use a userland ' +
 		'alternative instead.',

--- a/lib/url.js
+++ b/lib/url.js
@@ -132,7 +132,7 @@ const {
 let urlParseWarned = false;
 
 function urlParse(url, parseQueryString, slashesDenoteHost) {
-  if (!urlParseWarned && !isInsideNodeModules(100, true)) {
+  if (!urlParseWarned && !isInsideNodeModules(2)) {
     urlParseWarned = true;
     process.emitWarning(
       '`url.parse()` behavior is not standardized and prone to ' +

--- a/test/parallel/test-internal-util-isinsidenodemodules.js
+++ b/test/parallel/test-internal-util-isinsidenodemodules.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// Flags: --expose-internals
+
+const common = require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const { internalBinding } = require('internal/test/binding');
+const { isInsideNodeModules } = internalBinding('util');
+
+const script = new vm.Script(`
+  const runInsideNodeModules = (cb) => {
+    return cb();
+  };
+
+  runInsideNodeModules;
+`, {
+  filename: '/workspace/node_modules/test.js',
+});
+const runInsideNodeModules = script.runInThisContext();
+
+// Test when called directly inside node_modules
+assert.strictEqual(runInsideNodeModules(isInsideNodeModules), true);
+
+// Test when called inside a user callback from node_modules
+runInsideNodeModules(common.mustCall(() => {
+  function nonNodeModulesFunction() {
+    assert.strictEqual(isInsideNodeModules(), false);
+  }
+
+  nonNodeModulesFunction();
+}));
+
+// Test when called outside node_modules
+assert.strictEqual(isInsideNodeModules(), false);

--- a/typings/internalBinding/util.d.ts
+++ b/typings/internalBinding/util.d.ts
@@ -45,7 +45,7 @@ export interface UtilBinding {
   guessHandleType(fd: number): 'TCP' | 'TTY' | 'UDP' | 'FILE' | 'PIPE' | 'UNKNOWN';
   parseEnv(content: string): Record<string, string>;
   styleText(format: Array<string> | string, text: string): string;
-  isInsideNodeModules(frameLimit: number, defaultValue: unknown): boolean;
+  isInsideNodeModules(frameLimit?: number): boolean;
   constructSharedArrayBuffer(length?: number): SharedArrayBuffer;
 
   constants: {


### PR DESCRIPTION
Avoid checking up to 100 frames every time on functions like `require('node:url').parse`, when the user application never invokes them with `--disable-deprecation=DEP0169` is present (so `urlParseWarned` will never be true).

Before https://github.com/nodejs/node/pull/55286, `isInsideNodeModules` only checks the topmost non-internal frame. This restores the original behavior.

https://github.com/nodejs/node/blob/6e474c024c85d9a93db40020dacd20a768c62369/lib/url.js#L135