### PR TITLE
test_runner: propagate V8 options to child process

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -154,6 +154,22 @@ function getRunArgs(path, { forceExit,
                             cwd }) {
   const processNodeOptions = getOptionsAsFlagsFromBinding();
   const runArgs = ArrayPrototypeFilter(processNodeOptions, filterExecArgv);
+
+  /**
+   * Node supports V8 options passed via cli.
+   * These options are being consumed by V8 and are not stored in nodeOptions.
+   *
+   * We need to propagate these options to the child processes manually.
+   *
+   * An example of such option are --allow-natives-syntax and --expose-gc
+   */
+  const nodeOptionsSet = new SafeSet(processNodeOptions);
+  const unknownProcessExecArgv = ArrayPrototypeFilter(
+    process.execArgv,
+    (arg) => !nodeOptionsSet.has(arg),
+  );
+  ArrayPrototypePushApply(runArgs, unknownProcessExecArgv);
+
   if (forceExit === true) {
     ArrayPrototypePush(runArgs, '--test-force-exit');
   }

--- a/test/fixtures/test-runner/flag-propagation/issue-60986.mjs
+++ b/test/fixtures/test-runner/flag-propagation/issue-60986.mjs
@@ -1,0 +1,7 @@
+import { describe, it } from "node:test";
+
+describe("test", () => {
+  it("calls gc", () => {
+    globalThis.gc();
+  });
+});

--- a/test/parallel/test-runner-flag-propagation.js
+++ b/test/parallel/test-runner-flag-propagation.js
@@ -125,4 +125,28 @@ describe('test runner flag propagation', () => {
       });
     }
   });
+
+  describe('V8 specific flags', () => {
+    const v8FlagTestFixture = path.join(fixtureDir, 'issue-60986.mjs');
+    it('should propagate V8 only flags to child tests', () => {
+
+      const child = spawnSync(
+        process.execPath,
+        [
+          '--allow-natives-syntax',
+          '--expose-gc',
+          '--test',
+          v8FlagTestFixture,
+        ],
+        {
+          cwd: fixtureDir,
+        },
+      );
+
+      assert.strictEqual(child.status, 0, `V8 flag propagation test failed.`);
+      const stdout = child.stdout.toString();
+      assert.match(stdout, /tests 1/, `Test should execute for V8 flag propagation`);
+      assert.match(stdout, /pass 1/, `Test should pass for V8 flag propagation check`);
+    });
+  });
 });


### PR DESCRIPTION
This PR should address #60986!

At the moment, this solution doesn't take into account `NODE_OPTIONS` nor the config file.
In order to support both of them, at least for V8 options defined as `kV8Option`, changes to `GetOptionsAsFlags` are required.

They will follow in a follow-up PR.
