### PR TITLE
esm: avoid throw when module specifier is not url

### DIFF
--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -847,7 +847,7 @@ function moduleResolve(specifier, base, conditions, preserveSymlinks) {
   } else if (protocol === 'file:' && specifier[0] === '#') {
     resolved = packageImportsResolve(specifier, base, conditions);
   } else {
-    const url = URL.parse(specifier);
+    const url = URLParse(specifier);
     if (url !== null) {
       resolved = url;
     } else {


### PR DESCRIPTION
This particular exception is responsible for a lot of overhead when debugging with large esm codebases with VS Code and break on caught exceptions is enabled.

VS Code silently suppresses this exception, but the mechanism it uses to do so is a bit slow so avoiding this common exception can speed up loading of esm code.

In my scenario (running a single test from a [particular test suite](https://github.com/microsoft/FluidFramework/tree/main/packages/dds/tree/src/test) un VS Code's debugger) this saved over half of the total run time (over 20 seconds) bring the runtime from over 40 seconds to around 17 (Timing isn't too consistent as it hits a bunch of exceptions I have to continue through along the way).

This should also make debugging without suppression of this exception more pleasant in other tools such as the Chrome dev tools when attached to NodeJs processes.


This is my first attempt at contributing to NodeJS, so I don't know the conventions here very well. If it is the case that this codebase prefers the approach of throwing and catching exceptions in cases like these, and thus does not want to do this change to benefit a specific usage pattern by a third-party tool, that is understandable and, in that case, feel free to just close this PR. This change was simply so easy that it was easier to just propose it as a PR than to ask if this kind of change would be accepted.