### PR TITLE
deps: brotli: cherry-pick e230f474b87 fix LoongArch64 architecture build failed

### DIFF
--- a/deps/brotli/c/common/platform.h
+++ b/deps/brotli/c/common/platform.h
@@ -213,6 +213,10 @@ OR:
 #define BROTLI_TARGET_MIPS64
 #endif
 
+#if defined(__ia64__) || defined(_M_IA64)
+#define BROTLI_TARGET_IA64
+#endif
+
 #if defined(BROTLI_TARGET_X64) || defined(BROTLI_TARGET_ARMV8_64) || \
     defined(BROTLI_TARGET_POWERPC64) || defined(BROTLI_TARGET_RISCV64) || \
     defined(BROTLI_TARGET_LOONGARCH64) || defined(BROTLI_TARGET_MIPS64)
@@ -665,13 +669,14 @@ BROTLI_UNUSED_FUNCTION void BrotliSuppressUnusedFunctions(void) {
 #undef BROTLI_TEST
 #endif
 
-#if BROTLI_GNUC_HAS_ATTRIBUTE(model, 3, 0, 3)
+#if !defined(BROTLI_MODEL) && BROTLI_GNUC_HAS_ATTRIBUTE(model, 3, 0, 3) && \
+    !defined(BROTLI_TARGET_IA64) && !defined(BROTLI_TARGET_LOONGARCH64)
 #define BROTLI_MODEL(M) __attribute__((model(M)))
 #else
 #define BROTLI_MODEL(M) /* M */
 #endif
 
-#if BROTLI_GNUC_HAS_ATTRIBUTE(cold, 4, 3, 0)
+#if !defined(BROTLI_COLD) && BROTLI_GNUC_HAS_ATTRIBUTE(cold, 4, 3, 0)
 #define BROTLI_COLD __attribute__((cold))
 #else
 #define BROTLI_COLD /* cold */


### PR DESCRIPTION
issue:#60835
LoongArch64 CI is in a failed state (https://ci.nodejs.org/job/node-test-commit-loongarch64/nodes=clfs23-64/852)

After upgrading Brotli to 1.2.0, the LoongArch64 architecture compilation fails with the error "invalid argument of ‘model’ attribute". 
```
../deps/brotli/c/common/constants.h:196:23: error: invalid argument of ‘model’ attribute
  196 | BrotliPrefixCodeRange _kBrotliPrefixCodeRanges[BROTLI_NUM_BLOCK_LEN_SYMBOLS];
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~
../deps/brotli/c/common/constants.c:10:23: error: invalid argument of ‘model’ attribute
   10 | BrotliPrefixCodeRange _kBrotliPrefixCodeRanges[BROTLI_NUM_BLOCK_LEN_SYMBOLS] = {
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~
make[2]: *** [deps/brotli/brotli.target.mk:122：/home/iojs/build/workspace/node-test-commit-loongarch64/out/Release/obj.target/brotli/deps/brotli/c/common/constants.o] 错误 1
make[2]: *** 正在等待未完成的任务....
```
Origin commit message:

	disable BROTLI_MODEL macro for some targets

	PiperOrigin-RevId: 827486322

Refs: https://github.com/google/brotli/commit/e230f474b87134e8c6c85b630084c612057f253e