### PR TITLE
lib,test: enforce use of `assert.fail` via a lint rule

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -1682,6 +1682,8 @@ If no arguments are passed in at all `message` will be set to the string:
 Be aware that in the `repl` the error message will be different to the one
 thrown in a file! See below for further details.
 
+<!-- eslint-skip -->
+
 ```mjs
 import assert from 'node:assert/strict';
 
@@ -1716,6 +1718,8 @@ assert.ok(0);
 //
 //   assert.ok(0)
 ```
+
+<!-- eslint-skip -->
 
 ```cjs
 const assert = require('node:assert/strict');
@@ -1756,20 +1760,20 @@ assert.ok(0);
 import assert from 'node:assert/strict';
 
 // Using `assert()` works the same:
-assert(0);
+assert(2 + 2 > 5);
 // AssertionError: The expression evaluated to a falsy value:
 //
-//   assert(0)
+//   assert(2 + 2 > 5)
 ```
 
 ```cjs
 const assert = require('node:assert');
 
 // Using `assert()` works the same:
-assert(0);
+assert(2 + 2 > 5);
 // AssertionError: The expression evaluated to a falsy value:
 //
-//   assert(0)
+//   assert(2 + 2 > 5)
 ```
 
 ## `assert.rejects(asyncFn[, error][, message])`

--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1786,7 +1786,7 @@ This function creates a hook that runs before executing a suite.
 describe('tests', async () => {
   before(() => console.log('about to run some test'));
   it('is a subtest', () => {
-    assert.ok('some relevant assertion here');
+    // Some relevant assertions here
   });
 });
 ```
@@ -1816,7 +1816,7 @@ This function creates a hook that runs after executing a suite.
 describe('tests', async () => {
   after(() => console.log('finished running tests'));
   it('is a subtest', () => {
-    assert.ok('some relevant assertion here');
+    // Some relevant assertion here
   });
 });
 ```
@@ -1849,7 +1849,7 @@ This function creates a hook that runs before each test in the current suite.
 describe('tests', async () => {
   beforeEach(() => console.log('about to run a test'));
   it('is a subtest', () => {
-    assert.ok('some relevant assertion here');
+    // Some relevant assertion here
   });
 });
 ```
@@ -1880,7 +1880,7 @@ The `afterEach()` hook is run even if the test fails.
 describe('tests', async () => {
   afterEach(() => console.log('finished running a test'));
   it('is a subtest', () => {
-    assert.ok('some relevant assertion here');
+    // Some relevant assertion here
   });
 });
 ```
@@ -3472,7 +3472,7 @@ test('top level test', async (t) => {
   await t.test(
     'This is a subtest',
     (t) => {
-      assert.ok('some relevant assertion here');
+      // Some relevant assertion here
     },
   );
 });
@@ -3503,7 +3503,7 @@ finishes.
 ```js
 test('top level test', async (t) => {
   t.after((t) => t.diagnostic(`finished running ${t.name}`));
-  assert.ok('some relevant assertion here');
+  // Some relevant assertion here
 });
 ```
 
@@ -3535,7 +3535,7 @@ test('top level test', async (t) => {
   await t.test(
     'This is a subtest',
     (t) => {
-      assert.ok('some relevant assertion here');
+      // Some relevant assertion here
     },
   );
 });

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -97,7 +97,7 @@ function getDecoder(decoder, encoding) {
     if (normalizedEncoding === undefined) {
       throw new ERR_UNKNOWN_ENCODING(encoding);
     }
-    assert(false, 'Cannot change encoding');
+    assert.fail('Cannot change encoding');
   }
   return decoder;
 }

--- a/test/abort/test-abort-fatal-error.js
+++ b/test/abort/test-abort-fatal-error.js
@@ -36,7 +36,7 @@ exec(...cmdline, common.mustCall((err, stdout, stderr) => {
   if (!err) {
     console.log(stdout);
     console.log(stderr);
-    assert(false, 'this test should fail');
+    assert.fail('this test should fail');
   }
 
   assert(common.nodeProcessAborted(err.code, err.signal));

--- a/test/message/internal_assert.js
+++ b/test/message/internal_assert.js
@@ -4,4 +4,4 @@
 require('../common');
 
 const assert = require('internal/assert');
-assert(false);
+assert(2 + 2 > 5);

--- a/test/parallel/test-cluster-bind-twice.js
+++ b/test/parallel/test-cluster-bind-twice.js
@@ -102,7 +102,7 @@ if (!id) {
     }));
   }, 2));
 } else {
-  assert(0); // Bad command line argument
+  assert.fail('Bad command line argument');
 }
 
 function startWorker() {

--- a/test/parallel/test-cluster-eaddrinuse.js
+++ b/test/parallel/test-cluster-eaddrinuse.js
@@ -58,5 +58,5 @@ if (id === 'undefined') {
     }));
   }));
 } else {
-  assert(0);  // Bad argument.
+  assert.fail('Bad argument');
 }

--- a/test/parallel/test-fastutf8stream-sync.js
+++ b/test/parallel/test-fastutf8stream-sync.js
@@ -181,10 +181,6 @@ assert.throws(() => {
   assert.ok(stream.write('hello world 👀\n'));
   assert.ok(stream.write('another line 👀\n'));
 
-  // Check internal buffer length (may not be available in Utf8Stream)
-  // This is implementation-specific, so we just verify writes succeeded
-  assert.ok(true, 'writes completed successfully');
-
   stream.end();
 }
 
@@ -200,7 +196,6 @@ assert.throws(() => {
   }
 
   // Check internal buffer length (implementation-specific)
-  assert.ok(true, 'writes completed successfully');
   readFile(dest, 'utf8', common.mustSucceed((data) => {
     assert.strictEqual(data, str);
   }));

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -529,7 +529,6 @@ describe('glob - with restricted directory', function() {
       for await (const match of asyncGlob('*', { cwd: restrictedDir })) {
         results.push(match);
       }
-      assert.ok(true, 'glob completed without throwing on readdir error');
     } finally {
       try {
         chmodSync(restrictedDir, 0o755);

--- a/test/parallel/test-http.js
+++ b/test/parallel/test-http.js
@@ -46,7 +46,7 @@ const server = http.Server(common.mustCall((req, res) => {
       assert.strictEqual(req.headers.cookie, 'abc=123; def=456; ghi=789');
       break;
     default:
-      assert(false, `Unexpected request for ${req.url}`);
+      assert.fail(`Unexpected request for ${req.url}`);
   }
 
   if (expectedRequests.length === 0)

--- a/test/parallel/test-inspector-network-http2.js
+++ b/test/parallel/test-inspector-network-http2.js
@@ -96,7 +96,7 @@ const handleStream = common.mustCallAtLeast((stream, headers) => {
       }));
       break;
     default:
-      assert(false, `Unexpected path: ${path}`);
+      assert.fail(`Unexpected path: ${path}`);
   }
 });
 

--- a/test/parallel/test-stream-duplex-readable-writable.js
+++ b/test/parallel/test-stream-duplex-readable-writable.js
@@ -39,7 +39,7 @@ const assert = require('assert');
   duplex.on('end', common.mustNotCall());
   async function run() {
     for await (const chunk of duplex) {
-      assert(false, chunk);
+      assert.fail(chunk);
     }
   }
   run().then(common.mustCall());

--- a/test/parallel/test-vm-module-basic.js
+++ b/test/parallel/test-vm-module-basic.js
@@ -52,7 +52,7 @@ const util = require('util');
   const m = new SourceTextModule('while (true) {}');
   await m.link(common.mustNotCall());
   await m.evaluate({ timeout: 500 })
-    .then(() => assert(false), () => {});
+    .then(() => assert.fail(), () => {});
 })().then(common.mustCall());
 
 // Check the generated identifier for each module

--- a/test/pummel/test-fs-watch-file-slow.js
+++ b/test/pummel/test-fs-watch-file-slow.js
@@ -53,7 +53,7 @@ fs.watchFile(FILENAME, { interval: TIMEOUT - 250 }, common.mustCall((curr, prev)
       fs.unwatchFile(FILENAME);
       break;
     default:
-      assert(0);
+      assert.fail();
   }
 }, 4));
 

--- a/test/system-ca/test-set-default-ca-certificates-override-system.mjs
+++ b/test/system-ca/test-set-default-ca-certificates-override-system.mjs
@@ -45,7 +45,7 @@ const server = https.createServer({
       res.end('bundled ca works');
       break;
     default:
-      assert(false, `Unexpected path: ${path}`);
+      assert.fail(`Unexpected path: ${path}`);
   }
 }, 1));
 

--- a/tools/eslint/eslint.config_utils.mjs
+++ b/tools/eslint/eslint.config_utils.mjs
@@ -20,6 +20,13 @@ export const noRestrictedSyntaxCommonAll = [
     selector: "CallExpression[callee.property.name='substr']",
     message: 'Use String.prototype.slice() or String.prototype.substring() instead of String.prototype.substr()',
   },
+  {
+    selector: `CallExpression:matches(${[
+      '[callee.name="assert"]',
+      '[callee.object.name="assert"][callee.property.name="ok"]',
+    ]})[arguments.0.type="Literal"]`,
+    message: 'Do not use a literal for the first argument of assert(), use assert.fail() instead or remove the call',
+  },
 ];
 
 export const noRestrictedSyntaxCommonLib = [


### PR DESCRIPTION
`assert.fail` communicates the intent better than `assert(false)` IMO

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
