### PR TITLE
build: update test-wpt-report to use NODE instead of OUT_NODE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -655,6 +655,10 @@ test-test426: all ## Run the Web Platform Tests.
 test-wpt: all ## Run the Web Platform Tests.
 	$(PYTHON) tools/test.py $(PARALLEL_ARGS) wpt
 
+# https://github.com/nodejs/node/blob/a00d95c73dcac8fc2b316238fb978a7d5aa650c6/.github/workflows/daily-wpt-fyi.yml#L71-L97
+# This uses NODE instead of OUT_NODE and if changes are to be made they'd need to be made on all
+# non-EOL release lines' since the wpt.fyi job checks out the repository in a state of a given release
+# to ensure future changes to the WPT runner don't need to be backported.
 .PHONY: test-wpt-report
 test-wpt-report: ## Run the Web Platform Tests and generate a report.
 	$(RM) -r out/wpt


### PR DESCRIPTION
#60850 updated a target that never runs with Debug builds, this broke the ability for CI to upload daily wpt.fyi reports

This PR reverts the `test-wpt-report` target to use NODE which is what CI consistently sets

Refs: https://openjs-foundation.slack.com/archives/C03BJP63CH0/p1765400746909869