### PR TITLE
test: make buffer sizes 32bit-aware in test-internal-util-construct-sab

### DIFF
--- a/test/parallel/test-internal-util-construct-sab.js
+++ b/test/parallel/test-internal-util-construct-sab.js
@@ -3,16 +3,20 @@
 
 require('../common');
 const assert = require('assert');
+const { kMaxLength } = require('buffer');
 const { isSharedArrayBuffer } = require('util/types');
 const { constructSharedArrayBuffer } = require('internal/util');
 
 // We're testing that we can construct a SAB even when the global is not exposed.
 assert.strictEqual(typeof SharedArrayBuffer, 'undefined');
 
-for (const length of [undefined, 0, 1, 2 ** 32]) {
+for (const length of [undefined, 0, 1, 2 ** 16]) {
   assert(isSharedArrayBuffer(constructSharedArrayBuffer(length)));
 }
 
-for (const length of [-1, Number.MAX_SAFE_INTEGER + 1, 2 ** 64]) {
+// Specifically test the following cases:
+// - out-of-range allocation requests should not crash the process
+// - no int64 overflow
+for (const length of [-1, kMaxLength + 1, 2 ** 64]) {
   assert.throws(() => constructSharedArrayBuffer(length), RangeError);
 }


### PR DESCRIPTION
Fixes: #61025
Refs: #60497

The range checks for bound SharedArrayBuffer construction weren't compatible with the maximum array buffer size on 32-bit architectures.