### PR TITLE
tools: improve log output of `create-release-proposal`

### DIFF
--- a/tools/actions/create-release-proposal.sh
+++ b/tools/actions/create-release-proposal.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 
-set -xe
-
 GITHUB_REPOSITORY=${GITHUB_REPOSITORY:-nodejs/node}
 BOT_TOKEN=${BOT_TOKEN:-}
 
@@ -19,10 +17,16 @@ if [ -z "$GITHUB_REPOSITORY" ] || [ -z "$BOT_TOKEN" ]; then
   exit 1
 fi
 
-if ! command -v node || ! command -v gh || ! command -v git || ! command -v awk; then
-  echo "Missing required dependencies"
-  exit 1
-fi
+HAS_MISSING_DEPS=
+for dep in node gh git git-node awk; do
+  command -v "$dep" > /dev/null || {
+    echo "Required dependency $dep is missing" >&2
+    HAS_MISSING_DEPS=1
+  }
+done
+[ -z "$HAS_MISSING_DEPS" ] || exit 1
+
+set -xe
 
 git node release --prepare --skipBranchDiff --yes --releaseDate "$RELEASE_DATE"
 


### PR DESCRIPTION
It was bothering me that we were logging out the `BOT_TOKEN`, the solution was simply to move `set -ex` after the preliminary checks. We were also not checking for the presence of `git-node` in the dependency checks, and not explicitly listing the missing deps.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
