### PR TITLE
async_hooks: add --allow-async-hooks flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -139,6 +139,46 @@ Error: Cannot load native addon because loading addons is disabled.
 }
 ```
 
+### `--allow-async-hooks`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Allow use of `async_hooks.createHook()`. This flag is required to enable
+the `createHook` API, which is disabled by default.
+
+Example:
+
+```mjs
+import { createHook } from 'node:async_hooks';
+
+createHook({ init() {} }).enable();
+```
+
+```cjs
+const { createHook } = require('node:async_hooks');
+
+createHook({ init() {} }).enable();
+```
+
+```console
+$ node index.js
+node:async_hooks:160
+    throw new ERR_ASYNC_HOOKS_CREATE_HOOK_DISABLED();
+    ^
+
+Error [ERR_ASYNC_HOOKS_CREATE_HOOK_DISABLED]: async_hooks.createHook() is disabled. Use --allow-async-hooks to enable it.
+    at createHook (node:async_hooks:160:11)
+    at Object.<anonymous> (/home/user/index.js:3:1)
+    ...
+```
+
+```console
+$ node --allow-async-hooks index.js
+# Works without error
+```
+
 ### `--allow-child-process`
 
 <!-- YAML

--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -16,6 +16,7 @@ const {
 
 const {
   ERR_ASYNC_CALLBACK,
+  ERR_ASYNC_HOOKS_CREATE_HOOK_DISABLED,
   ERR_ASYNC_TYPE,
   ERR_INVALID_ASYNC_ID,
 } = require('internal/errors').codes;
@@ -26,6 +27,7 @@ const {
   validateFunction,
   validateString,
 } = require('internal/validators');
+const { getOptionValue } = require('internal/options');
 const internal_async_hooks = require('internal/async_hooks');
 
 const AsyncContextFrame = require('internal/async_context_frame');
@@ -154,6 +156,9 @@ class AsyncHook {
 
 
 function createHook(fns) {
+  if (!getOptionValue('--allow-async-hooks')) {
+    throw new ERR_ASYNC_HOOKS_CREATE_HOOK_DISABLED();
+  }
   return new AsyncHook(fns);
 }
 

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1137,6 +1137,8 @@ E('ERR_AMBIGUOUS_ARGUMENT', 'The "%s" argument is ambiguous. %s', TypeError);
 E('ERR_ARG_NOT_ITERABLE', '%s must be iterable', TypeError);
 E('ERR_ASSERTION', '%s', Error);
 E('ERR_ASYNC_CALLBACK', '%s must be a function', TypeError);
+E('ERR_ASYNC_HOOKS_CREATE_HOOK_DISABLED',
+  'async_hooks.createHook() is disabled. Use --allow-async-hooks to enable it.', Error);
 E('ERR_ASYNC_LOADER_REQUEST_NEVER_SETTLED',
   'Async loader request never settled', Error);
 E('ERR_ASYNC_TYPE', 'Invalid name for async "type": %s', TypeError);

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -653,6 +653,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             kAllowedInEnvvar,
             false,
             OptionNamespaces::kPermissionNamespace);
+  AddOption("--allow-async-hooks",
+            "allow use of async_hooks.createHook",
+            &EnvironmentOptions::allow_async_hooks,
+            kAllowedInEnvvar);
   AddOption("--experimental-repl-await",
             "experimental await keyword support in REPL",
             &EnvironmentOptions::experimental_repl_await,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -146,6 +146,7 @@ class EnvironmentOptions : public Options {
   bool allow_net = false;
   bool allow_wasi = false;
   bool allow_worker_threads = false;
+  bool allow_async_hooks = false;
   bool experimental_repl_await = true;
   bool experimental_vm_modules = false;
   bool async_context_frame = true;

--- a/test/addons/async-resource/test.js
+++ b/test/addons/async-resource/test.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../../common');
 const assert = require('assert');

--- a/test/addons/callback-scope/test-async-hooks.js
+++ b/test/addons/callback-scope/test-async-hooks.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../../common');
 const assert = require('assert');

--- a/test/async-hooks/init-hooks.js
+++ b/test/async-hooks/init-hooks.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-async-await.js
+++ b/test/async-hooks/test-async-await.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 
 // This test ensures async hooks are being properly called

--- a/test/async-hooks/test-async-exec-resource-http-32060.js
+++ b/test/async-hooks/test-async-exec-resource-http-32060.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const {

--- a/test/async-hooks/test-async-exec-resource-http-agent.js
+++ b/test/async-hooks/test-async-exec-resource-http-agent.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 

--- a/test/async-hooks/test-async-exec-resource-http.js
+++ b/test/async-hooks/test-async-exec-resource-http.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-async-exec-resource-match.js
+++ b/test/async-hooks/test-async-exec-resource-match.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-async-local-storage-gcable.js
+++ b/test/async-hooks/test-async-local-storage-gcable.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_gc --expose-internals
+// Flags: --allow-async-hooks --expose_gc --expose-internals
 
 // This test ensures that AsyncLocalStorage gets gced once it was disabled
 // and no strong references remain in userland.

--- a/test/async-hooks/test-callback-error.js
+++ b/test/async-hooks/test-callback-error.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const { spawnSync } = require('child_process');

--- a/test/async-hooks/test-crypto-pbkdf2.js
+++ b/test/async-hooks/test-crypto-pbkdf2.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasCrypto) {

--- a/test/async-hooks/test-crypto-randomBytes.js
+++ b/test/async-hooks/test-crypto-randomBytes.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasCrypto) {

--- a/test/async-hooks/test-destroy-not-blocked.js
+++ b/test/async-hooks/test-destroy-not-blocked.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_gc
+// Flags: --allow-async-hooks --expose_gc
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-disable-in-init.js
+++ b/test/async-hooks/test-disable-in-init.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const async_hooks = require('async_hooks');

--- a/test/async-hooks/test-embedder.api.async-resource-no-type.js
+++ b/test/async-hooks/test-embedder.api.async-resource-no-type.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-embedder.api.async-resource.js
+++ b/test/async-hooks/test-embedder.api.async-resource.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-emit-after-on-destroyed.js
+++ b/test/async-hooks/test-emit-after-on-destroyed.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/async-hooks/test-emit-before-after.js
+++ b/test/async-hooks/test-emit-before-after.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-emit-before-on-destroyed.js
+++ b/test/async-hooks/test-emit-before-on-destroyed.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/async-hooks/test-emit-init.js
+++ b/test/async-hooks/test-emit-init.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-enable-disable.js
+++ b/test/async-hooks/test-enable-disable.js
@@ -81,6 +81,7 @@
 
 
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-enable-in-init.js
+++ b/test/async-hooks/test-enable-in-init.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const async_hooks = require('async_hooks');

--- a/test/async-hooks/test-filehandle-no-reuse.js
+++ b/test/async-hooks/test-filehandle-no-reuse.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const initHooks = require('./init-hooks');

--- a/test/async-hooks/test-fseventwrap.js
+++ b/test/async-hooks/test-fseventwrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 
 const assert = require('assert');

--- a/test/async-hooks/test-fsreqcallback-access.js
+++ b/test/async-hooks/test-fsreqcallback-access.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-fsreqcallback-readFile.js
+++ b/test/async-hooks/test-fsreqcallback-readFile.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-getaddrinforeqwrap.js
+++ b/test/async-hooks/test-getaddrinforeqwrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-getnameinforeqwrap.js
+++ b/test/async-hooks/test-getnameinforeqwrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-graph.fsreq-readFile.js
+++ b/test/async-hooks/test-graph.fsreq-readFile.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const initHooks = require('./init-hooks');

--- a/test/async-hooks/test-graph.http.js
+++ b/test/async-hooks/test-graph.http.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasIPv6)

--- a/test/async-hooks/test-graph.intervals.js
+++ b/test/async-hooks/test-graph.intervals.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const initHooks = require('./init-hooks');

--- a/test/async-hooks/test-graph.pipe.js
+++ b/test/async-hooks/test-graph.pipe.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const initHooks = require('./init-hooks');

--- a/test/async-hooks/test-graph.pipeconnect.js
+++ b/test/async-hooks/test-graph.pipeconnect.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const initHooks = require('./init-hooks');

--- a/test/async-hooks/test-graph.shutdown.js
+++ b/test/async-hooks/test-graph.shutdown.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasIPv6)

--- a/test/async-hooks/test-graph.signal.js
+++ b/test/async-hooks/test-graph.signal.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (common.isWindows) {

--- a/test/async-hooks/test-graph.statwatcher.js
+++ b/test/async-hooks/test-graph.statwatcher.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 require('../common');
 const commonPath = require.resolve('../common');

--- a/test/async-hooks/test-graph.tcp.js
+++ b/test/async-hooks/test-graph.tcp.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasIPv6)

--- a/test/async-hooks/test-graph.timeouts.js
+++ b/test/async-hooks/test-graph.timeouts.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const initHooks = require('./init-hooks');

--- a/test/async-hooks/test-graph.tls-write.js
+++ b/test/async-hooks/test-graph.tls-write.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasCrypto)

--- a/test/async-hooks/test-http-agent-handle-reuse-parallel.js
+++ b/test/async-hooks/test-http-agent-handle-reuse-parallel.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 const common = require('../common');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');

--- a/test/async-hooks/test-http-agent-handle-reuse-serial.js
+++ b/test/async-hooks/test-http-agent-handle-reuse-serial.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 const common = require('../common');
 const initHooks = require('./init-hooks');
 const { checkInvocations } = require('./hook-checks');

--- a/test/async-hooks/test-httpparser-reuse.js
+++ b/test/async-hooks/test-httpparser-reuse.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-httpparser.request.js
+++ b/test/async-hooks/test-httpparser.request.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-httpparser.response.js
+++ b/test/async-hooks/test-httpparser.response.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-immediate.js
+++ b/test/async-hooks/test-immediate.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/async-hooks/test-improper-unwind.js
+++ b/test/async-hooks/test-improper-unwind.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/async-hooks/test-late-hook-enable.js
+++ b/test/async-hooks/test-late-hook-enable.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/async-hooks/test-nexttick-default-trigger.js
+++ b/test/async-hooks/test-nexttick-default-trigger.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 
 // This tests ensures that the triggerId of the nextTick function sets the

--- a/test/async-hooks/test-pipeconnectwrap.js
+++ b/test/async-hooks/test-pipeconnectwrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-pipewrap.js
+++ b/test/async-hooks/test-pipewrap.js
@@ -1,7 +1,7 @@
 // NOTE: this also covers process wrap as one is created along with the pipes
 // when we launch the sleep process
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-promise.chain-promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.chain-promise-before-init-hooks.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-promise.js
+++ b/test/async-hooks/test-promise.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 

--- a/test/async-hooks/test-promise.promise-before-init-hooks.js
+++ b/test/async-hooks/test-promise.promise-before-init-hooks.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-querywrap.js
+++ b/test/async-hooks/test-querywrap.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-queue-microtask.js
+++ b/test/async-hooks/test-queue-microtask.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 
 const assert = require('assert');

--- a/test/async-hooks/test-shutdownwrap.js
+++ b/test/async-hooks/test-shutdownwrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-signalwrap.js
+++ b/test/async-hooks/test-signalwrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 
 if (common.isWindows) {

--- a/test/async-hooks/test-statwatcher.js
+++ b/test/async-hooks/test-statwatcher.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const tmpdir = require('../common/tmpdir');

--- a/test/async-hooks/test-tcpwrap.js
+++ b/test/async-hooks/test-tcpwrap.js
@@ -1,5 +1,6 @@
 // Covers TCPWRAP and related TCPCONNECTWRAP
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasIPv6)

--- a/test/async-hooks/test-timers.setInterval.js
+++ b/test/async-hooks/test-timers.setInterval.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-timers.setTimeout.js
+++ b/test/async-hooks/test-timers.setTimeout.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-tlswrap.js
+++ b/test/async-hooks/test-tlswrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasCrypto)

--- a/test/async-hooks/test-ttywrap.readstream.js
+++ b/test/async-hooks/test-ttywrap.readstream.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-udpsendwrap.js
+++ b/test/async-hooks/test-udpsendwrap.js
@@ -1,4 +1,4 @@
-// Flags: --test-udp-no-try-send
+// Flags: --allow-async-hooks --test-udp-no-try-send
 'use strict';
 
 const common = require('../common');

--- a/test/async-hooks/test-udpwrap.js
+++ b/test/async-hooks/test-udpwrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-unhandled-exception-valid-ids.js
+++ b/test/async-hooks/test-unhandled-exception-valid-ids.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const initHooks = require('./init-hooks');

--- a/test/async-hooks/test-unhandled-rejection-context.js
+++ b/test/async-hooks/test-unhandled-rejection-context.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 

--- a/test/async-hooks/test-writewrap.js
+++ b/test/async-hooks/test-writewrap.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/async-hooks/test-zlib.zlib-binding.deflate.js
+++ b/test/async-hooks/test-zlib.zlib-binding.deflate.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/es-module/test-vm-compile-function-leak.js
+++ b/test/es-module/test-vm-compile-function-leak.js
@@ -1,4 +1,4 @@
-// Flags: --max-old-space-size=16 --trace-gc
+// Flags: --allow-async-hooks --max-old-space-size=16 --trace-gc
 'use strict';
 
 // This tests that vm.compileFunction with dynamic import callback does not leak.

--- a/test/es-module/test-vm-contextified-script-leak.js
+++ b/test/es-module/test-vm-contextified-script-leak.js
@@ -1,4 +1,4 @@
-// Flags: --max-old-space-size=16 --trace-gc
+// Flags: --allow-async-hooks --max-old-space-size=16 --trace-gc
 'use strict';
 
 // This tests that vm.Script with dynamic import callback does not leak.

--- a/test/es-module/test-vm-source-text-module-leak.js
+++ b/test/es-module/test-vm-source-text-module-leak.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-vm-modules --max-old-space-size=16 --trace-gc
+// Flags: --allow-async-hooks --experimental-vm-modules --max-old-space-size=16 --trace-gc
 'use strict';
 
 // This tests that vm.SourceTextModule() does not leak.

--- a/test/es-module/test-vm-synthetic-module-leak.js
+++ b/test/es-module/test-vm-synthetic-module-leak.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-vm-modules --max-old-space-size=16
+// Flags: --allow-async-hooks --experimental-vm-modules --max-old-space-size=16
 'use strict';
 
 // This tests that vm.SyntheticModule does not leak.

--- a/test/node-api/test_async/test-async-hooks.js
+++ b/test/node-api/test_async/test-async-hooks.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/node-api/test_async_context/test-gcable-callback.js
+++ b/test/node-api/test_async_context/test-gcable-callback.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --gc-interval=100 --gc-global
+// Flags: --allow-async-hooks --gc-interval=100 --gc-global
 
 const common = require('../../common');
 const assert = require('assert');

--- a/test/node-api/test_async_context/test.js
+++ b/test/node-api/test_async_context/test.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --gc-interval=100 --gc-global
+// Flags: --allow-async-hooks --gc-interval=100 --gc-global
 
 const common = require('../../common');
 const assert = require('assert');

--- a/test/node-api/test_callback_scope/test-async-hooks.js
+++ b/test/node-api/test_callback_scope/test-async-hooks.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../../common');
 const assert = require('assert');

--- a/test/node-api/test_make_callback/test-async-hooks.js
+++ b/test/node-api/test_make_callback/test-async-hooks.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../../common');
 const assert = require('assert');

--- a/test/parallel/test-async-hooks-async-await.js
+++ b/test/parallel/test-async-hooks-async-await.js
@@ -1,6 +1,7 @@
 // Test async-hooks fired on right
 // asyncIds & triggerAsyncId for async-await
 'use strict';
+// Flags: --allow-async-hooks
 
 require('../common');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-asyncresource-constructor.js
+++ b/test/parallel/test-async-hooks-asyncresource-constructor.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 // This tests that AsyncResource throws an error if bad parameters are passed
 

--- a/test/parallel/test-async-hooks-close-during-destroy.js
+++ b/test/parallel/test-async-hooks-close-during-destroy.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 // Test that async ids that are added to the destroy queue while running a
 // `destroy` callback are handled correctly.
 

--- a/test/parallel/test-async-hooks-constructor.js
+++ b/test/parallel/test-async-hooks-constructor.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 // This tests that AsyncHooks throws an error if bad parameters are passed.
 

--- a/test/parallel/test-async-hooks-correctly-switch-promise-hook.js
+++ b/test/parallel/test-async-hooks-correctly-switch-promise-hook.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-create-hook-disabled.js
+++ b/test/parallel/test-async-hooks-create-hook-disabled.js
@@ -1,0 +1,15 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { createHook } = require('async_hooks');
+
+// async_hooks.createHook is disabled by default (without --allow-async-hooks)
+{
+  assert.throws(() => {
+    createHook({ init() {} });
+  }, common.expectsError({
+    code: 'ERR_ASYNC_HOOKS_CREATE_HOOK_DISABLED',
+    message: 'async_hooks.createHook() is disabled. Use --allow-async-hooks to enable it.',
+  }));
+}

--- a/test/parallel/test-async-hooks-create-hook-enabled.js
+++ b/test/parallel/test-async-hooks-create-hook-enabled.js
@@ -1,0 +1,20 @@
+// Flags: --allow-async-hooks
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const { createHook } = require('async_hooks');
+
+// When --allow-async-hooks is passed, createHook should work
+{
+  // doesNotThrow
+  const hook = createHook({
+    init() {},
+    before() {},
+    after() {},
+    destroy() {},
+  });
+  hook.enable();
+  hook.disable();
+  assert.ok(true, 'createHook works with --allow-async-hooks');
+}

--- a/test/parallel/test-async-hooks-destroy-on-gc.js
+++ b/test/parallel/test-async-hooks-destroy-on-gc.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_gc
+// Flags: --allow-async-hooks --expose_gc
 
 // This test ensures that userland-only AsyncResources cause a destroy event to
 // be emitted when they get gced.

--- a/test/parallel/test-async-hooks-disable-during-promise.js
+++ b/test/parallel/test-async-hooks-disable-during-promise.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const async_hooks = require('async_hooks');
 const { isMainThread } = require('worker_threads');

--- a/test/parallel/test-async-hooks-disable-gc-tracking.js
+++ b/test/parallel/test-async-hooks-disable-gc-tracking.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_gc
+// Flags: --allow-async-hooks --expose_gc
 
 // This test ensures that userland-only AsyncResources cause a destroy event to
 // be emitted when they get gced.

--- a/test/parallel/test-async-hooks-enable-before-promise-resolve.js
+++ b/test/parallel/test-async-hooks-enable-before-promise-resolve.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-enable-disable-enable.js
+++ b/test/parallel/test-async-hooks-enable-disable-enable.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-enable-disable.js
+++ b/test/parallel/test-async-hooks-enable-disable.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-enable-during-promise.js
+++ b/test/parallel/test-async-hooks-enable-during-promise.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const async_hooks = require('async_hooks');
 

--- a/test/parallel/test-async-hooks-enable-recursive.js
+++ b/test/parallel/test-async-hooks-enable-recursive.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-execution-async-resource-await.js
+++ b/test/parallel/test-async-hooks-execution-async-resource-await.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const sleep = require('util').promisify(setTimeout);

--- a/test/parallel/test-async-hooks-execution-async-resource.js
+++ b/test/parallel/test-async-hooks-execution-async-resource.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-async-hooks-fatal-error.js
+++ b/test/parallel/test-async-hooks-fatal-error.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 require('../common');
 const assert = require('assert');
 const childProcess = require('child_process');

--- a/test/parallel/test-async-hooks-http-agent-destroy.js
+++ b/test/parallel/test-async-hooks-http-agent-destroy.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 const common = require('../common');
 const assert = require('assert');
 const { async_id_symbol } = require('internal/async_hooks').symbols;

--- a/test/parallel/test-async-hooks-http-agent.js
+++ b/test/parallel/test-async-hooks-http-agent.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 const common = require('../common');
 const assert = require('assert');
 const { async_id_symbol } = require('internal/async_hooks').symbols;

--- a/test/parallel/test-async-hooks-http-parser-destroy.js
+++ b/test/parallel/test-async-hooks-http-parser-destroy.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-prevent-double-destroy.js
+++ b/test/parallel/test-async-hooks-prevent-double-destroy.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose_gc
+// Flags: --allow-async-hooks --expose_gc
 
 // This test ensures that userland-only AsyncResources cause a destroy event to
 // be emitted when they get gced.

--- a/test/parallel/test-async-hooks-promise-enable-disable.js
+++ b/test/parallel/test-async-hooks-promise-enable-disable.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-async-hooks-promise-triggerid.js
+++ b/test/parallel/test-async-hooks-promise-triggerid.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-promise.js
+++ b/test/parallel/test-async-hooks-promise.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-recursive-stack-runInAsyncScope.js
+++ b/test/parallel/test-async-hooks-recursive-stack-runInAsyncScope.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-async-hooks-run-in-async-scope-caught-exception.js
+++ b/test/parallel/test-async-hooks-run-in-async-scope-caught-exception.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 require('../common');
 const { AsyncResource } = require('async_hooks');

--- a/test/parallel/test-async-hooks-run-in-async-scope-this-arg.js
+++ b/test/parallel/test-async-hooks-run-in-async-scope-this-arg.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 // Test that passing thisArg to runInAsyncScope() works.
 

--- a/test/parallel/test-async-hooks-top-level-clearimmediate.js
+++ b/test/parallel/test-async-hooks-top-level-clearimmediate.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 // Regression test for https://github.com/nodejs/node/issues/13262
 

--- a/test/parallel/test-async-hooks-vm-gc.js
+++ b/test/parallel/test-async-hooks-vm-gc.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 'use strict';
 
 require('../common');

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-1.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-1.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const { Worker } = require('worker_threads');
 

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-2.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-2.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const { Worker } = require('worker_threads');
 

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-3.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-3.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const { Worker } = require('worker_threads');
 

--- a/test/parallel/test-async-hooks-worker-asyncfn-terminate-4.js
+++ b/test/parallel/test-async-hooks-worker-asyncfn-terminate-4.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const { Worker } = require('worker_threads');

--- a/test/parallel/test-async-wrap-constructor.js
+++ b/test/parallel/test-async-wrap-constructor.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 // This tests that using falsy values in createHook throws an error.
 

--- a/test/parallel/test-async-wrap-destroyid.js
+++ b/test/parallel/test-async-wrap-destroyid.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-async-wrap-pop-id-during-load.js
+++ b/test/parallel/test-async-wrap-pop-id-during-load.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 require('../common');
 

--- a/test/parallel/test-async-wrap-promise-after-enabled.js
+++ b/test/parallel/test-async-wrap-promise-after-enabled.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 // Regression test for https://github.com/nodejs/node/issues/13237
 

--- a/test/parallel/test-async-wrap-tlssocket-asyncreset.js
+++ b/test/parallel/test-async-wrap-tlssocket-asyncreset.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 if (!common.hasCrypto) common.skip('missing crypto');
 const fixtures = require('../common/fixtures');

--- a/test/parallel/test-async-wrap-trigger-id.js
+++ b/test/parallel/test-async-wrap-trigger-id.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 require('../common');
 
 const assert = require('assert');

--- a/test/parallel/test-async-wrap-uncaughtexception.js
+++ b/test/parallel/test-async-wrap-uncaughtexception.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasCrypto)

--- a/test/parallel/test-common-gc.js
+++ b/test/parallel/test-common-gc.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 const common = require('../common');
 const { onGC } = require('../common/gc');
 

--- a/test/parallel/test-diagnostics-channel-memory-leak.js
+++ b/test/parallel/test-diagnostics-channel-memory-leak.js
@@ -1,4 +1,4 @@
-// Flags: --max-old-space-size=16
+// Flags: --allow-async-hooks --max-old-space-size=16
 'use strict';
 
 // This test ensures that diagnostic channel references aren't leaked.

--- a/test/parallel/test-domain-async-id-map-leak.js
+++ b/test/parallel/test-domain-async-id-map-leak.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 'use strict';
 const common = require('../common');
 const { onGC } = require('../common/gc');

--- a/test/parallel/test-emit-after-uncaught-exception.js
+++ b/test/parallel/test-emit-after-uncaught-exception.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-eventemitter-asyncresource.js
+++ b/test/parallel/test-eventemitter-asyncresource.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 const { EventEmitterAsyncResource } = require('events');

--- a/test/parallel/test-fs-existssync-memleak-longpath.js
+++ b/test/parallel/test-fs-existssync-memleak-longpath.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc --expose-internals
+// Flags: --allow-async-hooks --expose-gc --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-gc-http-client-connaborted.js
+++ b/test/parallel/test-gc-http-client-connaborted.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 // just like test-gc-http-client.js,
 // but aborting every connection that comes in.
 

--- a/test/parallel/test-gc-net-timeout.js
+++ b/test/parallel/test-gc-net-timeout.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 // just like test-gc-http-client-timeout.js,
 // but using a net server/client instead
 

--- a/test/parallel/test-gc-tls-external-memory.js
+++ b/test/parallel/test-gc-tls-external-memory.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 // Tests that memoryUsage().external doesn't go negative
 // when a lot tls connections are opened and closed

--- a/test/parallel/test-heapdump-async-hooks-init-promise.js
+++ b/test/parallel/test-heapdump-async-hooks-init-promise.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 'use strict';
 const common = require('../common');
 const assert = require('assert');

--- a/test/parallel/test-http-agent-domain-reused-gc.js
+++ b/test/parallel/test-http-agent-domain-reused-gc.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc --expose-internals
+// Flags: --allow-async-hooks --expose-gc --expose-internals
 'use strict';
 const common = require('../common');
 const http = require('http');

--- a/test/parallel/test-http-client-leaky-with-double-response.js
+++ b/test/parallel/test-http-client-leaky-with-double-response.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 const common = require('../common');
 const http = require('http');
 const assert = require('assert');

--- a/test/parallel/test-http-server-connections-checking-leak.js
+++ b/test/parallel/test-http-server-connections-checking-leak.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 // Check that creating a server without listening does not leak resources.
 

--- a/test/parallel/test-http-server-keepalive-req-gc.js
+++ b/test/parallel/test-http-server-keepalive-req-gc.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 'use strict';
 const common = require('../common');
 const { onGC } = require('../common/gc');

--- a/test/parallel/test-http-uncaught-from-request-callback.js
+++ b/test/parallel/test-http-uncaught-from-request-callback.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const asyncHooks = require('async_hooks');
 const http = require('http');

--- a/test/parallel/test-http2-ping.js
+++ b/test/parallel/test-http2-ping.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 
 const common = require('../common');
 if (!common.hasCrypto)

--- a/test/parallel/test-https-server-connections-checking-leak.js
+++ b/test/parallel/test-https-server-connections-checking-leak.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 // Check that creating a server without listening does not leak resources.
 

--- a/test/parallel/test-inspector-contexts.js
+++ b/test/parallel/test-inspector-contexts.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 const common = require('../common');
 common.skipIfInspectorDisabled();

--- a/test/parallel/test-inspector-debug-async-hook.js
+++ b/test/parallel/test-inspector-debug-async-hook.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 common.skipIfInspectorDisabled();
 const test = require('node:test');

--- a/test/parallel/test-internal-util-weakreference.js
+++ b/test/parallel/test-internal-util-weakreference.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals --expose-gc
+// Flags: --allow-async-hooks --expose-internals --expose-gc
 'use strict';
 require('../common');
 const { gcUntil } = require('../common/gc');

--- a/test/parallel/test-messageport-hasref.js
+++ b/test/parallel/test-messageport-hasref.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 
 const { MessageChannel } = require('worker_threads');

--- a/test/parallel/test-net-connect-memleak.js
+++ b/test/parallel/test-net-connect-memleak.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 const common = require('../common');
 const { onGC } = require('../common/gc');

--- a/test/parallel/test-primitive-timer-leak.js
+++ b/test/parallel/test-primitive-timer-leak.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 require('../common');
 const { onGC } = require('../common/gc');
 

--- a/test/parallel/test-promise-hook-create-hook.js
+++ b/test/parallel/test-promise-hook-create-hook.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const { promiseHooks } = require('v8');

--- a/test/parallel/test-queue-microtask-uncaught-asynchooks.js
+++ b/test/parallel/test-queue-microtask-uncaught-asynchooks.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const assert = require('assert');
 const async_hooks = require('async_hooks');

--- a/test/parallel/test-shadow-realm-gc-module.js
+++ b/test/parallel/test-shadow-realm-gc-module.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-shadow-realm --max-old-space-size=20
+// Flags: --allow-async-hooks --experimental-shadow-realm --max-old-space-size=20
 'use strict';
 
 /**

--- a/test/parallel/test-shadow-realm-gc.js
+++ b/test/parallel/test-shadow-realm-gc.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-shadow-realm --max-old-space-size=20
+// Flags: --allow-async-hooks --experimental-shadow-realm --max-old-space-size=20
 'use strict';
 
 /**

--- a/test/parallel/test-source-map-cjs-require-cache.js
+++ b/test/parallel/test-source-map-cjs-require-cache.js
@@ -1,4 +1,4 @@
-// Flags: --enable-source-maps --max-old-space-size=10 --expose-gc
+// Flags: --allow-async-hooks --enable-source-maps --max-old-space-size=10 --expose-gc
 
 /**
  * This test verifies that the source map of a CJS module is cleared after the

--- a/test/parallel/test-stream-finished-bindAsyncResource-path.js
+++ b/test/parallel/test-stream-finished-bindAsyncResource-path.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals
+// Flags: --allow-async-hooks --expose-internals
 'use strict';
 
 const common = require('../common');

--- a/test/parallel/test-stream-writable-samecb-singletick.js
+++ b/test/parallel/test-stream-writable-samecb-singletick.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const { Console } = require('console');
 const { Writable } = require('stream');

--- a/test/parallel/test-tls-connect-memleak.js
+++ b/test/parallel/test-tls-connect-memleak.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 const common = require('../common');
 if (!common.hasCrypto)

--- a/test/parallel/test-v8-serialize-leak.js
+++ b/test/parallel/test-v8-serialize-leak.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 
 const common = require('../common');
 const { gcUntil } = require('../common/gc');

--- a/test/parallel/test-worker-hasref.js
+++ b/test/parallel/test-worker-hasref.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 
 const { Worker } = require('worker_threads');

--- a/test/parallel/test-worker-message-port-inspect-during-init-hook.js
+++ b/test/parallel/test-worker-message-port-inspect-during-init-hook.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 const util = require('util');
 const assert = require('assert');

--- a/test/parallel/test-worker-messageport-hasref.js
+++ b/test/parallel/test-worker-messageport-hasref.js
@@ -1,4 +1,5 @@
 'use strict';
+// Flags: --allow-async-hooks
 const common = require('../common');
 
 const { Worker } = require('worker_threads');

--- a/test/parallel/test-zlib-invalid-input-memory.js
+++ b/test/parallel/test-zlib-invalid-input-memory.js
@@ -1,4 +1,4 @@
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 'use strict';
 const common = require('../common');
 const { onGC } = require('../common/gc');

--- a/test/pseudo-tty/test-async-wrap-getasyncid-tty.js
+++ b/test/pseudo-tty/test-async-wrap-getasyncid-tty.js
@@ -1,4 +1,4 @@
-// Flags: --expose-internals --no-warnings
+// Flags: --allow-async-hooks --expose-internals --no-warnings
 'use strict';
 
 // See also test/sequential/test-async-wrap-getasyncid.js

--- a/test/sequential/test-async-wrap-getasyncid.js
+++ b/test/sequential/test-async-wrap-getasyncid.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc --expose-internals --no-warnings --test-udp-no-try-send
+// Flags: --allow-async-hooks --expose-gc --expose-internals --no-warnings --test-udp-no-try-send
 
 const common = require('../common');
 const { internalBinding } = require('internal/test/binding');

--- a/test/sequential/test-gc-http-client-onerror.js
+++ b/test/sequential/test-gc-http-client-onerror.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 // just like test-gc-http-client.js,
 // but with an on('error') handler that does nothing.
 

--- a/test/sequential/test-gc-http-client-timeout.js
+++ b/test/sequential/test-gc-http-client-timeout.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 // Like test-gc-http-client.js, but with a timeout set.
 
 const common = require('../common');

--- a/test/sequential/test-gc-http-client.js
+++ b/test/sequential/test-gc-http-client.js
@@ -1,5 +1,5 @@
 'use strict';
-// Flags: --expose-gc
+// Flags: --allow-async-hooks --expose-gc
 // just a simple http server and client.
 
 const common = require('../common');


### PR DESCRIPTION
## Summary

Add a new `--allow-async-hooks` flag that must be passed to enable `async_hooks.createHook()`. This is a breaking change - createHook is now disabled by default.

### Changes

- Added `--allow-async-hooks` CLI flag (disabled by default)
- `async_hooks.createHook()` now throws `ERR_ASYNC_HOOKS_CREATE_HOOK_DISABLED` when called without the flag
- Updated all existing tests that use `createHook()` to include the flag
- Added new tests for both enabled and disabled behaviors

### Breaking Change

`async_hooks.createHook()` now requires the `--allow-async-hooks` flag to be passed when starting Node.js. 

Most APM tools should now use `AsyncLocalStorage` instead, which is not affected by this change.

### Migration

Add `--allow-async-hooks` to your Node.js command line or `NODE_OPTIONS`:

```bash
node --allow-async-hooks app.js
# or
NODE_OPTIONS="--allow-async-hooks" node app.js
```