### PR TITLE
tools: fix update-nghttp2 signature verification

### DIFF
--- a/tools/dep_updaters/update-nghttp2.sh
+++ b/tools/dep_updaters/update-nghttp2.sh
@@ -50,12 +50,13 @@ echo "Fetching nghttp2 source archive"
 curl -sL -o "$NGHTTP2_TARBALL" "https://github.com/nghttp2/nghttp2/releases/download/$NGHTTP2_REF/$NGHTTP2_TARBALL"
 
 echo "Verifying PGP signature"
-curl -sL "https://github.com/nghttp2/nghttp2/releases/download/${NGHTTP2_REF}/${NGHTTP2_TARBALL}.asc" \
-| gpgv --keyring "$BASE_DIR/tools/dep_updaters/nghttp.kbx" "$NGHTTP2_TARBALL"
+curl -sL -o "${NGHTTP2_TARBALL}.asc" "https://github.com/nghttp2/nghttp2/releases/download/${NGHTTP2_REF}/${NGHTTP2_TARBALL}.asc"
+gpgv --keyring "$BASE_DIR/tools/dep_updaters/nghttp.kbx" "${NGHTTP2_TARBALL}.asc" "${NGHTTP2_TARBALL}"
 
 echo "Unpacking archive"
 tar xJf "$NGHTTP2_TARBALL"
 rm "$NGHTTP2_TARBALL"
+rm "${NGHTTP2_TARBALL}.asc"
 mv "nghttp2-$NEW_VERSION" nghttp2
 
 echo "Removing everything, except lib/ and COPYING"


### PR DESCRIPTION
Detached signatures must be passed to [`gpgv`](https://www.gnupg.org/documentation/manuals/gnupg/gpgv.html) as a filename before the datafile (which can be stdin but the detached signature file cannot be stdin and cannot be piped in).

Refs: https://github.com/nodejs/node/pull/60113

---

The nghttp2 updater has been failing since https://github.com/nodejs/node/pull/60113.
e.g. https://github.com/nodejs/node/actions/runs/19996542494/job/57344965958#step:6:11
```
Run ./tools/dep_updaters/update-nghttp2.sh > temp-output
gpgv: packet(2) with unknown version 96
gpgv: no signature found
gpgv: the signature could not be verified.
Please remember that the signature file (.sig or .asc)
should be the first file given on the command line.
Error: Process completed with exit code 2.
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
