### PR TITLE
http2: tune control flow defaults

### DIFF
--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3544,10 +3544,10 @@ properties.
   permitted on the `Http2Session` instances. **Default:** `true`.
 * `initialWindowSize` {number} Specifies the _sender's_ initial window size in
   bytes for stream-level flow control. The minimum allowed value is 0. The
-  maximum allowed value is 2<sup>32</sup>-1. **Default:** `65535`.
+  maximum allowed value is 2<sup>32</sup>-1. **Default:** `262144`.
 * `maxFrameSize` {number} Specifies the size in bytes of the largest frame
   payload. The minimum allowed value is 16,384. The maximum allowed value is
-  2<sup>24</sup>-1. **Default:** `16384`.
+  2<sup>24</sup>-1. **Default:** `32768`.
 * `maxConcurrentStreams` {number} Specifies the maximum number of concurrent
   streams permitted on an `Http2Session`. There is no default value which
   implies, at least theoretically, 2<sup>32</sup>-1 streams may be open

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3302,6 +3302,10 @@ function connectionListener(socket) {
 
   socket[kServer] = this;
 
+  // NGHTTP2_INITIAL_CONNECTION_WINDOW_SIZE default is 64KB, but we want to allow more data to be
+  // buffered without applying backpressure.
+  session.setLocalWindowSize(512 * 1024);
+
   this.emit('session', session);
 }
 
@@ -3309,7 +3313,7 @@ function initializeOptions(options) {
   assertIsObject(options, 'options');
   options = { ...options };
   assertIsObject(options.settings, 'options.settings');
-  options.settings = { ...options.settings };
+  options.settings = { ...getDefaultSettings(), ...options.settings };
 
   assertIsArray(options.remoteCustomSettings, 'options.remoteCustomSettings');
   if (options.remoteCustomSettings) {
@@ -3531,6 +3535,8 @@ function connect(authority, options, listener) {
 
   assertIsObject(options, 'options');
   options = { ...options };
+  assertIsObject(options.settings, 'options.settings');
+  options.settings = { ...getDefaultSettings(), ...options.settings };
 
   assertIsArray(options.remoteCustomSettings, 'options.remoteCustomSettings');
   if (options.remoteCustomSettings) {
@@ -3575,6 +3581,10 @@ function connect(authority, options, listener) {
   }
 
   const session = new ClientHttp2Session(options, socket);
+
+  // NGHTTP2_INITIAL_CONNECTION_WINDOW_SIZE default is 64KB, but we want to allow more data to be
+  // buffered without applying backpressure.
+  session.setLocalWindowSize(512 * 1024);
 
   session[kAuthority] = `${options.servername || host}:${port}`;
   session[kProtocol] = protocol;

--- a/lib/internal/http2/util.js
+++ b/lib/internal/http2/util.js
@@ -364,6 +364,13 @@ function getDefaultSettings() {
       settingsBuffer[IDX_SETTINGS_ENABLE_CONNECT_PROTOCOL] === 1;
   }
 
+  // NGHTTP2_INITIAL_WINDOW_SIZE default is 64KB, but we want to allow more data to be
+  // buffered without applying backpressure.
+  holder.initialWindowSize = MathMax(holder.initialWindowSize, 256 * 1024);
+
+  // Default is 16KB.
+  holder.maxFrameSize = MathMax(32 * 1024, holder.maxFrameSize);
+
   if (settingsBuffer[IDX_SETTINGS_FLAGS + 1]) holder.customSettings = addCustomSettingsToObj();
 
   return holder;

--- a/test/parallel/test-http2-binding.js
+++ b/test/parallel/test-http2-binding.js
@@ -17,8 +17,8 @@ const settings = http2.getDefaultSettings();
 assert.strictEqual(settings.headerTableSize, 4096);
 assert.strictEqual(settings.enablePush, true);
 assert.strictEqual(settings.maxConcurrentStreams, 4294967295);
-assert.strictEqual(settings.initialWindowSize, 65535);
-assert.strictEqual(settings.maxFrameSize, 16384);
+assert.strictEqual(settings.initialWindowSize, 256 * 1024);
+assert.strictEqual(settings.maxFrameSize, 32 * 1024);
 
 assert.strictEqual(binding.nghttp2ErrorString(-517),
                    'GOAWAY has already been sent');


### PR DESCRIPTION
The current defaults are unnecessarily conservative which makes http2 control flow over high latency connections (such as public internet) unbearably slow.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
