### PR TITLE
tools: simplify `notify-on-push`

### DIFF
--- a/.github/workflows/notify-on-push.yml
+++ b/.github/workflows/notify-on-push.yml
@@ -27,36 +27,20 @@ jobs:
           SLACK_USERNAME: nodejs-bot
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
-  notifyOnMissingMetadata:
-    name: Notify on Push on `main` that lacks metadata
+  validateCommitMessage:
+    name: Notify on Push on `main` with invalid message
     if: github.repository == 'nodejs/node'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           persist-credentials: false
       - name: Check commit message
-        run: npx -q core-validate-commit ${{ github.event.after }} || echo "INVALID_COMMIT_MESSAGE=1" >> $GITHUB_ENV
-      - name: Retrieve PR number if possible
-        if: env.INVALID_COMMIT_MESSAGE
-        run: |
-          COMMIT_TITLE=$(git --no-pager log --oneline -1 --no-color) node <<'EOF' >> $GITHUB_ENV || true
-          const invalidCommitMessageMatch = /\s\(\#(\d+)\)$/.exec(process.env.COMMIT_TITLE);
-          if (invalidCommitMessageMatch == null) process.exit(1)
-          console.log(`PR_ID=${invalidCommitMessageMatch[1]}`)
-          EOF
-      - name: Comment on the Pull Request
-        if: ${{ env.PR_ID }}
-        run: |
-          gh pr comment ${{ env.PR_ID }} --repo "${{ github.repository }}" \
-            --body "A commit referencing this Pull Request was pushed to `${{ github.ref_name }}` by @${{ github.actor }} with an invalid commit message."
+        run: npx -q core-validate-commit "$COMMIT"
         env:
-          GH_TOKEN: ${{ github.token }}
+          COMMIT: ${{ github.event.after }}
       - name: Slack Notification
-        if: ${{ env.INVALID_COMMIT_MESSAGE }}
+        if: failure()
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661  # 2.3.3
         env:
           SLACK_COLOR: '#DE512A'


### PR DESCRIPTION
Now that we have the repo setup to reject commits that do not contain any metadata, we can remove the custom logic that was trying to catch commits merged using the default commit message.

This will also make invalid message being reported as a failure, which IMO makes more sense that the current setting that always report a success.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
