### PR TITLE
docs: document ALPNCallback option for TLSSocket

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -899,11 +899,7 @@ changes:
   * `rejectUnauthorized`: See [`tls.createServer()`][]
   * `ALPNProtocols`: See [`tls.createServer()`][]
   * `SNICallback`: See [`tls.createServer()`][]
-    * `ALPNCallback` {Function} A callback function that will be called when a
-    client supports ALPN to select a protocol from the list offered by the
-    client. The callback receives an object with `servername` and `protocols`
-    properties. Should return a string from the `protocols` list or `undefined`
-    if none match. Only used when `isServer` is `true`.
+  * `ALPNCallback`: See [`tls.createServer()`][]
   * `session` {Buffer} A `Buffer` instance containing a TLS session.
   * `requestOCSP` {boolean} If `true`, specifies that the OCSP status request
     extension will be added to the client hello and an `'OCSPResponse'` event


### PR DESCRIPTION
Fixes #61047

Added documentation for the `ALPNCallback` option in `new tls.TLSSocket()` 
which was previously undocumented but functional.

This option allows server-side TLS sockets to dynamically select ALPN 
protocols when `isServer` is true.
