### PR TITLE
test: remove unneccessary repl magic_mode tests

### DIFF
--- a/test/parallel/test-repl-mode.js
+++ b/test/parallel/test-repl-mode.js
@@ -11,7 +11,6 @@ if (process.env.TERM === 'dumb') {
 const tests = [
   testSloppyMode,
   testStrictMode,
-  testAutoMode,
   testStrictModeTerminal,
 ];
 
@@ -55,15 +54,4 @@ function testStrictModeTerminal() {
   assert.ok(
     output.accumulator.includes('\n// ReferenceError: xyz is not defined')
   );
-}
-
-function testAutoMode() {
-  const { input, output } = startNewREPLServer({ replMode: repl.REPL_MODE_MAGIC, terminal: false, prompt: '> ' });
-
-  input.emit('data', 'x = 3\n');
-  assert.strictEqual(output.accumulator, '> 3\n> ');
-  output.accumulator = '';
-
-  input.emit('data', 'let y = 3\n');
-  assert.strictEqual(output.accumulator, 'undefined\n> ');
 }

--- a/test/parallel/test-repl-underscore.js
+++ b/test/parallel/test-repl-underscore.js
@@ -9,7 +9,6 @@ const testingReplPrompt = '_REPL_TESTING_PROMPT_>';
 
 testSloppyMode();
 testStrictMode();
-testMagicMode();
 testResetContext();
 testResetContextGlobal();
 testError();
@@ -86,46 +85,9 @@ function testStrictMode() {
   ]);
 }
 
-function testMagicMode() {
-  const { replServer, output } = startNewREPLServer({
-    prompt: testingReplPrompt,
-    mode: repl.REPL_MODE_MAGIC,
-  });
-
-  replServer.write(`_;          // initial value undefined
-          x = 10;      //
-          _;           // last eval - 10
-          let _ = 20;  // undefined
-          _;           // 20 from user input
-          _ = 30;      // make sure we can set it twice and no prompt
-          _;           // 30 from user input
-          var y = 40;  // make sure eval doesn't change _
-          _;           // remains 30 from user input
-          function f() { let _ = 50; return _; } // undefined
-          f();         // 50
-          _;           // remains 30 from user input
-          `);
-
-  assertOutput(output, [
-    'undefined',
-    '10',
-    '10',
-    'undefined',
-    '20',
-    '30',
-    '30',
-    'undefined',
-    '30',
-    'undefined',
-    '50',
-    '30',
-  ]);
-}
-
 function testResetContext() {
   const { replServer, output } = startNewREPLServer({
     prompt: testingReplPrompt,
-    mode: repl.REPL_MODE_MAGIC,
   });
 
   replServer.write(`_ = 10;     // explicitly set to 10


### PR DESCRIPTION
REPL magic mode has been fully removed in 2018 (https://github.com/nodejs/node/pull/19187) there are however a couple of tests that still test magic_mode. These tests are completely redundant since they are basically simply duplicating equivalent tests of sloppy mode (since that's the mode that REPL will use when it encounters the unrecognized magic mode flag). That's why I'm removing them here.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
