### PR TITLE
fix: keep proxies opaque in util.inspect when showProxy is false

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1125,10 +1125,14 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
     if (proxy === null || proxy[0] === null) {
       return ctx.stylize('<Revoked Proxy>', 'special');
     }
+
     if (ctx.showProxy) {
       return formatProxy(ctx, proxy, recurseTimes);
     }
-    value = proxy;
+
+    // Treat proxies as opaque when showProxy is false,
+    // but preserve the original target for inspection.
+    value = proxy[0];
   }
 
   // Provide a hook for user-specified inspect functions.

--- a/test/parallel/test-util-inspect-proxy.js
+++ b/test/parallel/test-util-inspect-proxy.js
@@ -179,3 +179,22 @@ const expected10 = '[Function (anonymous)]';
 const expected11 = '[Function (anonymous)]';
 assert.strictEqual(util.inspect(proxy10), expected10);
 assert.strictEqual(util.inspect(proxy11), expected11);
+
+// Regression test for https://github.com/nodejs/node/issues/61061
+{
+  const throwingProxy = new Proxy({}, {
+    get() {
+      throw new EvalError('boom');
+    }
+  });
+
+  const nestedThrowingProxy = new Proxy(throwingProxy, {});
+
+  // showProxy: false must NOT trigger proxy traps
+  // Directly inspect proxies; it should not throw
+  const result1 = util.inspect(throwingProxy, { showProxy: false });
+  assert.strictEqual(result1, '{}');
+
+  const result2 = util.inspect(nestedThrowingProxy, { showProxy: false });
+  assert.strictEqual(result2, '{}');
+}


### PR DESCRIPTION
Currently, `util.inspect` unwraps proxies even when `showProxy` is false, 
which can trigger traps for nested proxies and lead to unexpected errors.

This change:
- Treats proxies as opaque when `showProxy` is false.
- Keeps the original target for internal inspection.
- Adds a regression test to ensure that accessing nested proxies does not throw when `showProxy` is disabled.

Refs: https://github.com/nodejs/node/issues/61061
