### PR TITLE
fix(util): correctly handle --eval in parseArgs

### DIFF
--- a/lib/internal/util/parse_args/parse_args.js
+++ b/lib/internal/util/parse_args/parse_args.js
@@ -63,6 +63,16 @@ function getMainArgs() {
     return ArrayPrototypeSlice(process.argv, 1);
   }
 
+  // Fallback: check process.execArgv for --eval=... or --print=...
+  // getOptionValue might miss these if they are one token in execArgv.
+  for (let i = 0; i < process.execArgv.length; i++) {
+    const arg = process.execArgv[i];
+    if (StringPrototypeStartsWith(arg, '--eval=') ||
+      StringPrototypeStartsWith(arg, '--print=')) {
+      return ArrayPrototypeSlice(process.argv, 1);
+    }
+  }
+
   return ArrayPrototypeSlice(process.argv, 2);
 }
 
@@ -217,15 +227,17 @@ function argsToTokens(args, options) {
       let value;
       let inlineValue;
       if (optionsGetOwn(options, longOption, 'type') === 'string' &&
-          isOptionValue(nextArg)) {
+        isOptionValue(nextArg)) {
         // e.g. '-f', 'bar'
         value = ArrayPrototypeShift(remainingArgs);
         inlineValue = false;
       }
       ArrayPrototypePush(
         tokens,
-        { kind: 'option', name: longOption, rawName: arg,
-          index, value, inlineValue });
+        {
+          kind: 'option', name: longOption, rawName: arg,
+          index, value, inlineValue
+        });
       if (value != null) ++index;
       continue;
     }
@@ -259,8 +271,10 @@ function argsToTokens(args, options) {
       const value = StringPrototypeSlice(arg, 2);
       ArrayPrototypePush(
         tokens,
-        { kind: 'option', name: longOption, rawName: `-${shortOption}`,
-          index, value, inlineValue: true });
+        {
+          kind: 'option', name: longOption, rawName: `-${shortOption}`,
+          index, value, inlineValue: true
+        });
       continue;
     }
 
@@ -270,15 +284,17 @@ function argsToTokens(args, options) {
       let value;
       let inlineValue;
       if (optionsGetOwn(options, longOption, 'type') === 'string' &&
-          isOptionValue(nextArg)) {
+        isOptionValue(nextArg)) {
         // e.g. '--foo', 'bar'
         value = ArrayPrototypeShift(remainingArgs);
         inlineValue = false;
       }
       ArrayPrototypePush(
         tokens,
-        { kind: 'option', name: longOption, rawName: arg,
-          index, value, inlineValue });
+        {
+          kind: 'option', name: longOption, rawName: arg,
+          index, value, inlineValue
+        });
       if (value != null) ++index;
       continue;
     }
@@ -290,8 +306,10 @@ function argsToTokens(args, options) {
       const value = StringPrototypeSlice(arg, equalIndex + 1);
       ArrayPrototypePush(
         tokens,
-        { kind: 'option', name: longOption, rawName: `--${longOption}`,
-          index, value, inlineValue: true });
+        {
+          kind: 'option', name: longOption, rawName: `--${longOption}`,
+          index, value, inlineValue: true
+        });
       continue;
     }
 
@@ -388,14 +406,14 @@ const parseArgs = (config = kEmptyObject) => {
 
   // Phase 3: fill in default values for missing args
   ArrayPrototypeForEach(ObjectEntries(options), ({ 0: longOption,
-                                                   1: optionConfig }) => {
+    1: optionConfig }) => {
     const mustSetDefault = useDefaultValueOption(longOption,
-                                                 optionConfig,
-                                                 result.values);
+      optionConfig,
+      result.values);
     if (mustSetDefault) {
       storeDefaultOption(longOption,
-                         objectGetOwn(optionConfig, 'default'),
-                         result.values);
+        objectGetOwn(optionConfig, 'default'),
+        result.values);
     }
   });
 

--- a/test/parallel/test-util-parse-args-eval.js
+++ b/test/parallel/test-util-parse-args-eval.js
@@ -1,0 +1,41 @@
+
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const child = require('child_process');
+
+// Regression test for https://github.com/nodejs/node/issues/60808
+// verify that util.parseArgs works correctly with --eval=...
+
+if (process.argv[2] === 'child') {
+    const { parseArgs } = require('util');
+    const { positionals } = parseArgs({ allowPositionals: true });
+    console.log(JSON.stringify(positionals));
+    return;
+}
+
+{
+    const code = 'console.log(JSON.stringify(require("util").parseArgs({allowPositionals:true}).positionals))';
+
+    // Test with --eval=... syntax
+    child.execFile(process.execPath, [
+        `--eval=${code}`,
+        '--',
+        'arg1',
+        'arg2'
+    ], common.mustSucceed((stdout) => {
+        assert.strictEqual(stdout.trim(), '["arg1","arg2"]');
+    }));
+
+
+    // Test with --print=... syntax
+    const codePrint = 'JSON.stringify(require("util").parseArgs({allowPositionals:true}).positionals)';
+    child.execFile(process.execPath, [
+        `--print=${codePrint}`,
+        '--',
+        'arg1',
+        'arg2'
+    ], common.mustSucceed((stdout) => {
+        assert.strictEqual(stdout.trim(), '["arg1","arg2"]');
+    }));
+}


### PR DESCRIPTION
Fixes a bug where util.parseArgs omits the first positional argument when running with --eval or --print. Includes regression test.