### PR TITLE
fix(util): handle non-own errors property in inspect

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -323,7 +323,7 @@ function getUserOptions(ctx, isCrossContext) {
     ObjectSetPrototypeOf(ret, null);
     for (const key of ObjectKeys(ret)) {
       if ((typeof ret[key] === 'object' || typeof ret[key] === 'function') &&
-          ret[key] !== null) {
+        ret[key] !== null) {
         delete ret[key];
       }
     }
@@ -624,7 +624,7 @@ function highlightRegExp(regexpString) {
         i++;
         inClass = false;
       } else if (ch === '-' && regexpString[i - 1] !== '[' &&
-                 i + 1 < regexpString.length && regexpString[i + 1] !== ']') {
+        i + 1 < regexpString.length && regexpString[i + 1] !== ']') {
         writeDepth('-', 1, 1);
       } else {
         write(ch);
@@ -799,7 +799,7 @@ function strEscape(str) {
     if (!StringPrototypeIncludes(str, '"')) {
       singleQuote = -1;
     } else if (!StringPrototypeIncludes(str, '`') &&
-               !StringPrototypeIncludes(str, '${')) {
+      !StringPrototypeIncludes(str, '${')) {
       singleQuote = -2;
     }
     if (singleQuote !== 39) {
@@ -821,9 +821,9 @@ function strEscape(str) {
   for (let i = 0; i < str.length; i++) {
     const point = StringPrototypeCharCodeAt(str, i);
     if (point === singleQuote ||
-        point === 92 ||
-        point < 32 ||
-        (point > 126 && point < 160)) {
+      point === 92 ||
+      point < 32 ||
+      (point > 126 && point < 160)) {
       if (last === i) {
         result += meta[point];
       } else {
@@ -922,12 +922,12 @@ function getConstructorName(obj, ctx, recurseTimes, protoProps) {
     }
     const descriptor = ObjectGetOwnPropertyDescriptor(obj, 'constructor');
     if (descriptor !== undefined &&
-        typeof descriptor.value === 'function' &&
-        descriptor.value.name !== '' &&
-        isInstanceof(tmp, descriptor.value)) {
+      typeof descriptor.value === 'function' &&
+      descriptor.value.name !== '' &&
+      isInstanceof(tmp, descriptor.value)) {
       if (protoProps !== undefined &&
-         (firstProto !== obj ||
-         !builtInObjects.has(descriptor.value.name))) {
+        (firstProto !== obj ||
+          !builtInObjects.has(descriptor.value.name))) {
         addPrototypeProperties(
           ctx, tmp, firstProto || tmp, recurseTimes, protoProps);
       }
@@ -981,8 +981,8 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
       // Stop as soon as a built-in object type is detected.
       const descriptor = ObjectGetOwnPropertyDescriptor(obj, 'constructor');
       if (descriptor !== undefined &&
-          typeof descriptor.value === 'function' &&
-          builtInObjects.has(descriptor.value.name)) {
+        typeof descriptor.value === 'function' &&
+        builtInObjects.has(descriptor.value.name)) {
         return;
       }
     }
@@ -998,8 +998,8 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
     for (const key of keys) {
       // Ignore the `constructor` property and keys that exist on layers above.
       if (key === 'constructor' ||
-          ObjectPrototypeHasOwnProperty(main, key) ||
-          (depth !== 0 && keySet.has(key))) {
+        ObjectPrototypeHasOwnProperty(main, key) ||
+        (depth !== 0 && keySet.has(key))) {
         continue;
       }
       const desc = ObjectGetOwnPropertyDescriptor(obj, key);
@@ -1016,9 +1016,9 @@ function addPrototypeProperties(ctx, main, obj, recurseTimes, output) {
       }
     }
     ArrayPrototypePop(ctx.seen);
-  // Limit the inspection to up to three prototype layers. Using `recurseTimes`
-  // is not a good choice here, because it's as if the properties are declared
-  // on the current object from the users perspective.
+    // Limit the inspection to up to three prototype layers. Using `recurseTimes`
+    // is not a good choice here, because it's as if the properties are declared
+    // on the current object from the users perspective.
   } while (++depth !== 3);
 }
 
@@ -1065,7 +1065,7 @@ function getKeys(value, showHidden) {
       keys = ObjectKeys(value);
     } catch (err) {
       assert(isNativeError(err) && err.name === 'ReferenceError' &&
-             isModuleNamespaceObject(value));
+        isModuleNamespaceObject(value));
       keys = ObjectGetOwnPropertyNames(value);
     }
     if (symbols.length !== 0) {
@@ -1108,8 +1108,8 @@ function formatProxy(ctx, proxy, recurseTimes) {
 function formatValue(ctx, value, recurseTimes, typedArray) {
   // Primitive types cannot have properties.
   if (typeof value !== 'object' &&
-      typeof value !== 'function' &&
-      !isUndetectableObject(value)) {
+    typeof value !== 'function' &&
+    !isUndetectableObject(value)) {
     return formatPrimitive(ctx.stylize, value, ctx);
   }
   if (value === null) {
@@ -1136,10 +1136,10 @@ function formatValue(ctx, value, recurseTimes, typedArray) {
   if (ctx.customInspect) {
     const maybeCustom = value[customInspectSymbol];
     if (typeof maybeCustom === 'function' &&
-        // Filter out the util module, its inspect function is special.
-        maybeCustom !== inspect &&
-        // Also filter out any prototype objects using the circular check.
-        ObjectGetOwnPropertyDescriptor(value, 'constructor')?.value?.prototype !== value) {
+      // Filter out the util module, its inspect function is special.
+      maybeCustom !== inspect &&
+      // Also filter out any prototype objects using the circular check.
+      ObjectGetOwnPropertyDescriptor(value, 'constructor')?.value?.prototype !== value) {
       // This makes sure the recurseTimes are reported as before while using
       // a counter internally.
       const depth = ctx.depth === null ? null : ctx.depth - recurseTimes;
@@ -1207,12 +1207,12 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   // Only list the tag in case it's non-enumerable / not an own property.
   // Otherwise we'd print this twice.
   if (typeof tag !== 'string' ||
-      (tag !== '' &&
+    (tag !== '' &&
       (ctx.showHidden ?
         ObjectPrototypeHasOwnProperty :
         ObjectPrototypePropertyIsEnumerable)(
-        value, SymbolToStringTag,
-      ))) {
+          value, SymbolToStringTag,
+        ))) {
     tag = '';
   }
   let base = '';
@@ -1324,7 +1324,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         base = `${prefix}${base}`;
       base = ctx.stylize(base, 'regexp');
       if ((keys.length === 0 && protoProps === undefined) ||
-          (recurseTimes > ctx.depth && ctx.depth !== null)) {
+        (recurseTimes > ctx.depth && ctx.depth !== null)) {
         return base;
       }
     } else if (isDate(value)) {
@@ -1353,7 +1353,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
         formatter = formatArrayBuffer;
       } else if (keys.length === 0 && protoProps === undefined) {
         return prefix +
-              `{ [byteLength]: ${formatNumber(ctx.stylize, value.byteLength, false)} }`;
+          `{ [byteLength]: ${formatNumber(ctx.stylize, value.byteLength, false)} }`;
       }
       braces[0] = `${prefix}{`;
       extraKeys = ['byteLength'];
@@ -1555,7 +1555,7 @@ function getFunctionBase(ctx, value, constructor, tag) {
     const slice = StringPrototypeSlice(stringified, 5, -1);
     const bracketIndex = StringPrototypeIndexOf(slice, '{');
     if (bracketIndex !== -1 &&
-        (!StringPrototypeIncludes(StringPrototypeSlice(slice, 0, bracketIndex), '(') ||
+      (!StringPrototypeIncludes(StringPrototypeSlice(slice, 0, bracketIndex), '(') ||
         // Slow path to guarantee that it's indeed a class.
         RegExpPrototypeExec(classRegExp, RegExpPrototypeSymbolReplace(stripCommentsRegExp, slice)) !== null)
     ) {
@@ -1679,7 +1679,7 @@ function getDuplicateErrorFrameRanges(frames) {
 
     let duplicateRanges = 0;
 
-    for (let nextStart = i + range; /* ignored */ ; nextStart += range) {
+    for (let nextStart = i + range; /* ignored */; nextStart += range) {
       let equalFrames = 0;
       for (let j = 0; j < range; j++) {
         if (frames[i + j] !== frames[nextStart + j]) {
@@ -1802,13 +1802,13 @@ function improveStack(stack, constructor, name, tag) {
   }
 
   if (constructor === null ||
-      (StringPrototypeEndsWith(name, 'Error') &&
+    (StringPrototypeEndsWith(name, 'Error') &&
       StringPrototypeStartsWith(stack, name) &&
       (stack.length === len || stack[len] === ':' || stack[len] === '\n'))) {
     let fallback = 'Error';
     if (constructor === null) {
       const start = RegExpPrototypeExec(/^([A-Z][a-z_ A-Z0-9[\]()-]+)(?::|\n {4}at)/, stack) ||
-      RegExpPrototypeExec(/^([a-z_A-Z0-9-]*Error)$/, stack);
+        RegExpPrototypeExec(/^([a-z_A-Z0-9-]*Error)$/, stack);
       fallback = (start?.[1]) || '';
       len = fallback.length;
       fallback ||= 'Error';
@@ -1956,7 +1956,7 @@ function formatError(err, constructor, tag, ctx, keys) {
   name ??= 'Error';
 
   if ('cause' in err &&
-      (keys.length === 0 || !ArrayPrototypeIncludes(keys, 'cause'))) {
+    (keys.length === 0 || !ArrayPrototypeIncludes(keys, 'cause'))) {
     ArrayPrototypePush(keys, 'cause');
   }
 
@@ -2051,7 +2051,7 @@ function groupArrayElements(ctx, output, value) {
   // entry is longer than 1/5 of all other entries combined). Otherwise the
   // space in-between small entries would be enormous.
   if (actualMax * 3 + ctx.indentationLvl < ctx.breakLength &&
-      (totalLength / actualMax > 5 || maxLength <= 6)) {
+    (totalLength / actualMax > 5 || maxLength <= 6)) {
 
     const approxCharHeights = 2.5;
     const averageBias = MathSqrt(actualMax - totalLength / output.length);
@@ -2115,9 +2115,9 @@ function groupArrayElements(ctx, output, value) {
       }
       if (order === StringPrototypePadStart) {
         const padding = maxLineLength[j - i] +
-                        output[j].length -
-                        dataLen[j] -
-                        separatorSpace;
+          output[j].length -
+          dataLen[j] -
+          separatorSpace;
         str += StringPrototypePadStart(output[j], padding, ' ');
       } else {
         str += output[j];
@@ -2137,7 +2137,7 @@ function handleMaxCallStackSize(ctx, err, constructorName, indentationLvl) {
   ctx.indentationLvl = indentationLvl;
   return ctx.stylize(
     `[${constructorName}: Inspection interrupted ` +
-      'prematurely. Maximum call stack size exceeded.]',
+    'prematurely. Maximum call stack size exceeded.]',
     'special',
   );
 }
@@ -2194,11 +2194,9 @@ function formatNumber(fn, number, numericSeparator) {
   const integerPart = StringPrototypeSlice(numberString, 0, decimalIndex);
   const fractionalPart = StringPrototypeSlice(numberString, decimalIndex + 1);
 
-  return fn(`${
-    addNumericSeparator(integerPart)
-  }.${
-    addNumericSeparatorEnd(fractionalPart)
-  }`, 'number');
+  return fn(`${addNumericSeparator(integerPart)
+    }.${addNumericSeparatorEnd(fractionalPart)
+    }`, 'number');
 }
 
 function formatBigInt(fn, bigint, numericSeparator) {
@@ -2218,11 +2216,11 @@ function formatPrimitive(fn, value, ctx) {
       trailer = `... ${remaining} more character${remaining > 1 ? 's' : ''}`;
     }
     if (ctx.compact !== true &&
-        // We do not support handling unicode characters width with
-        // the readline getStringWidth function as there are
-        // performance implications.
-        value.length > kMinLineLength &&
-        value.length > ctx.breakLength - ctx.indentationLvl - 4) {
+      // We do not support handling unicode characters width with
+      // the readline getStringWidth function as there are
+      // performance implications.
+      value.length > kMinLineLength &&
+      value.length > ctx.breakLength - ctx.indentationLvl - 4) {
       return ArrayPrototypeJoin(
         ArrayPrototypeMap(
           RegExpPrototypeSymbolSplit(/(?<=\n)/, value),
@@ -2250,7 +2248,7 @@ function formatNamespaceObject(keys, ctx, value, recurseTimes) {
   for (let i = 0; i < keys.length; i++) {
     try {
       output[i] = formatProperty(ctx, value, recurseTimes, keys[i],
-                                 kObjectType);
+        kObjectType);
     } catch (err) {
       assert(isNativeError(err) && err.name === 'ReferenceError');
       // Use the existing functionality. This makes sure the indentation and
@@ -2262,7 +2260,7 @@ function formatNamespaceObject(keys, ctx, value, recurseTimes) {
       // We have to find the last whitespace and have to replace that value as
       // it will be visualized as a regular string.
       output[i] = StringPrototypeSlice(output[i], 0, pos + 1) +
-                  ctx.stylize('<uninitialized>', 'special');
+        ctx.stylize('<uninitialized>', 'special');
     }
   }
   // Reset the keys to an empty array. This prevents duplicated inspection.
@@ -2525,10 +2523,11 @@ function formatExtraProperties(ctx, value, recurseTimes, key, typedArray) {
 }
 
 function formatProperty(ctx, value, recurseTimes, key, type, desc,
-                        original = value) {
+  original = value) {
   let name, str;
   let extra = ' ';
-  desc ??= ObjectGetOwnPropertyDescriptor(value, key);
+  desc ??= ObjectGetOwnPropertyDescriptor(value, key) ||
+    { value: value[key], enumerable: true };
   if (desc.value !== undefined) {
     const diff = (ctx.compact !== true || type !== kObjectType) ? 2 : 3;
     ctx.indentationLvl += diff;
@@ -2542,8 +2541,8 @@ function formatProperty(ctx, value, recurseTimes, key, type, desc,
     const s = ctx.stylize;
     const sp = 'special';
     if (ctx.getters && (ctx.getters === true ||
-          (ctx.getters === 'get' && desc.set === undefined) ||
-          (ctx.getters === 'set' && desc.set !== undefined))) {
+      (ctx.getters === 'get' && desc.set === undefined) ||
+      (ctx.getters === 'set' && desc.set !== undefined))) {
       ctx.indentationLvl += 2;
       try {
         const tmp = FunctionPrototypeCall(desc.get, original);
@@ -2641,12 +2640,12 @@ function reduceToSingleString(
       // `ctx.compact`, as long as the properties are smaller than
       // `ctx.breakLength`.
       if (ctx.currentDepth - recurseTimes < ctx.compact &&
-          entries === output.length) {
+        entries === output.length) {
         // Line up all entries on a single line in case the entries do not
         // exceed `breakLength`. Add 10 as constant to start next to all other
         // factors that may reduce `breakLength`.
         const start = output.length + ctx.indentationLvl +
-                      braces[0].length + base.length + 10;
+          braces[0].length + base.length + 10;
         if (isBelowBreakLength(ctx, output, start, base)) {
           const joinedOutput = join(output, ', ');
           if (!StringPrototypeIncludes(joinedOutput, '\n')) {
@@ -2743,7 +2742,7 @@ function tryStringify(arg) {
       }
     }
     if (err.name === 'TypeError' &&
-        firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE) {
+      firstErrorLine(err) === CIRCULAR_ERROR_MESSAGE) {
       return '[Circular]';
     }
     throw err;
@@ -2800,8 +2799,8 @@ function formatWithOptionsInternal(inspectOptions, args) {
               } else if (typeof tempArg === 'bigint') {
                 tempStr = formatBigIntNoColor(tempArg, inspectOptions);
               } else if (typeof tempArg !== 'object' ||
-                         tempArg === null ||
-                         !hasBuiltInToString(tempArg)) {
+                tempArg === null ||
+                !hasBuiltInToString(tempArg)) {
                 tempStr = String(tempArg);
               } else {
                 tempStr = inspect(tempArg, {

--- a/test/parallel/test-util-inspect-error-non-own-errors.js
+++ b/test/parallel/test-util-inspect-error-non-own-errors.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const util = require('util');
+
+// Test that inspecting an object with a non-own 'errors' property does not crash.
+// Regression test for https://github.com/nodejs/node/issues/60808 (conceptually)
+
+class MockError extends Error {
+    constructor() {
+        super('foo');
+    }
+    // 'errors' is a getter on the prototype, not an own property
+    get errors() {
+        return ['bar'];
+    }
+}
+
+const err = new MockError();
+assert.doesNotThrow(() => util.inspect(err));


### PR DESCRIPTION
Fixes a crash in util.inspect when an object has an 'errors' property that is not an own property (e.g. ZodError). Ensures formatProperty falls back safely when Object.getOwnPropertyDescriptor returns undefined.