### PR TITLE
build: skip build-ci on actions with a separate test step

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -138,4 +138,4 @@ jobs:
       - name: Build
         run: make -C "$TAR_DIR" build-ci -j4 V=1
       - name: Test
-        run: make -C "$TAR_DIR" run-ci -j4 V=1 TEST_CI_ARGS="-p dots --measure-flakiness 9"
+        run: make -C "$TAR_DIR" test-ci -j1 V=1 TEST_CI_ARGS="-p dots --measure-flakiness 9"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Build
         run: make -C node build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn --v8-enable-temporal-support"
       - name: Test
-        run: make -C node run-ci -j4 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"
+        run: make -C node test-ci -j1 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"
       - name: Re-run test in a folder whose name contains unusual chars
         run: |
           mv node "$DIR"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -127,7 +127,7 @@ jobs:
       - name: Free Space After Build
         run: df -h
       - name: Test
-        run: make -C node run-ci -j$(getconf _NPROCESSORS_ONLN) V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"
+        run: make -C node test-ci -j1 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"
       - name: Re-run test in a folder whose name contains unusual chars
         run: |
           mv node "$DIR"


### PR DESCRIPTION
When run `make run-ci` with CONFIG_FLAGS only set in prior
`make build-ci`, `make run-ci` will try to rebuild everything, instead
of re-use the built result from prior `make build-ci`.

https://github.com/nodejs/node/blob/05f8772096f974190b11eabce0ea657bc5c8c1b1/.github/workflows/test-linux.yml#L77-L80

For example, in https://github.com/nodejs/node/actions/runs/20231170130/job/58074218201
the step `Test` tried to re-build, instead of testing with
the binary built in prior `Build` step.