### PR TITLE
doc: warn about short GCM tags visibly

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -962,6 +962,15 @@ for `CCM` mode or before [`decipher.final()`][] for `GCM` and `OCB` modes and
 `chacha20-poly1305`.
 `decipher.setAuthTag()` can only be called once.
 
+Because the `node:crypto` module was originally designed to closely mirror
+OpenSSL's behavior, this function permits short GCM authentication tags unless
+an explicit authentication tag length was passed to
+[`crypto.createDecipheriv()`][] when the `decipher` object was created. This
+behavior is deprecated and subject to change (see [DEP0182][]). <strong class="critical">
+In the meantime, applications should either set the `authTagLength` option when
+calling `createDecipheriv()` or check the actual
+authentication tag length before passing it to `setAuthTag()`.</strong>
+
 When passing a string as the authentication tag, please consider
 [caveats when using strings as inputs to cryptographic APIs][].
 
@@ -3352,8 +3361,13 @@ The `options` argument controls stream behavior and is optional except when a
 cipher in CCM or OCB mode (e.g. `'aes-128-ccm'`) is used. In that case, the
 `authTagLength` option is required and specifies the length of the
 authentication tag in bytes, see [CCM mode][].
-For AES-GCM and `chacha20-poly1305`, the `authTagLength` option defaults to 16
+For `chacha20-poly1305`, the `authTagLength` option defaults to 16
 bytes and must be set to a different value if a different length is used.
+For AES-GCM, the `authTagLength` option has no default value when decrypting,
+and `setAuthTag()` will accept arbitrarily short authentication tags. This
+behavior is deprecated and subject to change (see [DEP0182][]). <strong class="critical">
+In the meantime, applications should either set the `authTagLength` option or
+check the actual authentication tag length before passing it to `setAuthTag()`.</strong>
 
 The `algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc. On
 recent OpenSSL releases, `openssl list -cipher-algorithms` will
@@ -6508,6 +6522,7 @@ See the [list of SSL OP Flags][] for details.
 [CVE-2021-44532]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44532
 [Caveats]: #support-for-weak-or-compromised-algorithms
 [Crypto constants]: #crypto-constants
+[DEP0182]: deprecations.md#dep0182-short-gcm-authentication-tags-without-explicit-authtaglength
 [FIPS module configuration file]: https://www.openssl.org/docs/man3.0/man5/fips_config.html
 [FIPS provider from OpenSSL 3]: https://www.openssl.org/docs/man3.0/man7/crypto.html#FIPS-provider
 [HTML 5.2]: https://www.w3.org/TR/html52/changes.html#features-removed


### PR DESCRIPTION
As was pointed out by Félix Charette (@Sideni), the existing runtime deprecation warning may not provide enough visibility of the underlying issue. This commit adds a (not so pretty) warning to the documentation of the relevant API function `setAuthTag()`. The warning will be removed when `DEP0182` will be moved to End-of-Life status (https://github.com/nodejs/node/pull/61084), presumably with the next major release.

~(For some reason, `make format-md` forces line 969 to be way too long, not sure what's going on there.)~

Refs: https://github.com/nodejs/node/issues/52327
Refs: https://github.com/nodejs/node/issues/17523

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
