### PR TITLE
crypto: move DEP0182 to End-of-Life

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -925,6 +925,11 @@ When passing a string as the `buffer`, please consider
 <!-- YAML
 added: v1.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/61084
+    description: Using GCM tag lengths other than 128 bits without specifying
+                 the `authTagLength` option when creating `decipher` is not
+                 allowed anymore.
   - version:
     - v22.0.0
     - v20.13.0
@@ -961,15 +966,6 @@ The `decipher.setAuthTag()` method must be called before [`decipher.update()`][]
 for `CCM` mode or before [`decipher.final()`][] for `GCM` and `OCB` modes and
 `chacha20-poly1305`.
 `decipher.setAuthTag()` can only be called once.
-
-Because the `node:crypto` module was originally designed to closely mirror
-OpenSSL's behavior, this function permits short GCM authentication tags unless
-an explicit authentication tag length was passed to
-[`crypto.createDecipheriv()`][] when the `decipher` object was created. This
-behavior is deprecated and subject to change (see [DEP0182][]). <strong class="critical">
-In the meantime, applications should either set the `authTagLength` option when
-calling `createDecipheriv()` or check the actual
-authentication tag length before passing it to `setAuthTag()`.</strong>
 
 When passing a string as the authentication tag, please consider
 [caveats when using strings as inputs to cryptographic APIs][].
@@ -3361,13 +3357,8 @@ The `options` argument controls stream behavior and is optional except when a
 cipher in CCM or OCB mode (e.g. `'aes-128-ccm'`) is used. In that case, the
 `authTagLength` option is required and specifies the length of the
 authentication tag in bytes, see [CCM mode][].
-For `chacha20-poly1305`, the `authTagLength` option defaults to 16
+For AES-GCM and `chacha20-poly1305`, the `authTagLength` option defaults to 16
 bytes and must be set to a different value if a different length is used.
-For AES-GCM, the `authTagLength` option has no default value when decrypting,
-and `setAuthTag()` will accept arbitrarily short authentication tags. This
-behavior is deprecated and subject to change (see [DEP0182][]). <strong class="critical">
-In the meantime, applications should either set the `authTagLength` option or
-check the actual authentication tag length before passing it to `setAuthTag()`.</strong>
 
 The `algorithm` is dependent on OpenSSL, examples are `'aes192'`, etc. On
 recent OpenSSL releases, `openssl list -cipher-algorithms` will
@@ -6522,7 +6513,6 @@ See the [list of SSL OP Flags][] for details.
 [CVE-2021-44532]: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44532
 [Caveats]: #support-for-weak-or-compromised-algorithms
 [Crypto constants]: #crypto-constants
-[DEP0182]: deprecations.md#dep0182-short-gcm-authentication-tags-without-explicit-authtaglength
 [FIPS module configuration file]: https://www.openssl.org/docs/man3.0/man5/fips_config.html
 [FIPS provider from OpenSSL 3]: https://www.openssl.org/docs/man3.0/man7/crypto.html#FIPS-provider
 [HTML 5.2]: https://www.w3.org/TR/html52/changes.html#features-removed

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -3992,6 +3992,9 @@ Please use the [`crypto.createHmac()`][] method to create Hmac instances.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/61084
+    description: End-of-Life.
   - version: v23.0.0
     pr-url: https://github.com/nodejs/node/pull/52552
     description: Runtime deprecation.
@@ -4000,15 +4003,15 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-Applications that intend to use authentication tags that are shorter than the
-default authentication tag length must set the `authTagLength` option of the
+For ciphers in GCM mode, the [`decipher.setAuthTag()`][] function used to accept
+authentication tags of any valid length (see also [DEP0090](#DEP0090)). This
+exception has been removed to better align with recommendations per
+[NIST SP 800-38D][], and applications that intend to use authentication tags
+that are shorter than the default authentication tag length (i.e., shorter than
+16 bytes for AES-GCM) must explicitly set the `authTagLength` option of the
 [`crypto.createDecipheriv()`][] function to the appropriate length.
-
-For ciphers in GCM mode, the [`decipher.setAuthTag()`][] function accepts
-authentication tags of any valid length (see [DEP0090](#DEP0090)). This behavior
-is deprecated to better align with recommendations per [NIST SP 800-38D][].
 
 ### DEP0183: OpenSSL engine-based APIs
 

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -554,21 +554,12 @@ void CipherBase::SetAuthTag(const FunctionCallbackInfo<Value>& args) {
     is_valid = cipher->auth_tag_len_ == tag_len;
   }
 
-  if (!is_valid) {
+  // TODO(tniessen): refactor this check.
+  if (!is_valid ||
+      (cipher->ctx_.isGcmMode() && cipher->auth_tag_len_ == kNoAuthTagLength &&
+       tag_len != EVP_GCM_TLS_TAG_LEN)) {
     return THROW_ERR_CRYPTO_INVALID_AUTH_TAG(
       env, "Invalid authentication tag length: %u", tag_len);
-  }
-
-  if (cipher->ctx_.isGcmMode() && cipher->auth_tag_len_ == kNoAuthTagLength &&
-      tag_len != EVP_GCM_TLS_TAG_LEN && env->EmitProcessEnvWarning()) {
-    if (ProcessEmitDeprecationWarning(
-            env,
-            "Using AES-GCM authentication tags of less than 128 bits without "
-            "specifying the authTagLength option when initializing decryption "
-            "is deprecated.",
-            "DEP0182")
-            .IsNothing())
-      return;
   }
 
   cipher->auth_tag_len_ = tag_len;

--- a/test/parallel/test-crypto-gcm-implicit-short-tag.js
+++ b/test/parallel/test-crypto-gcm-implicit-short-tag.js
@@ -3,18 +3,16 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const { createDecipheriv, randomBytes } = require('crypto');
-
-common.expectWarning({
-  DeprecationWarning: [
-    ['Using AES-GCM authentication tags of less than 128 bits without ' +
-     'specifying the authTagLength option when initializing decryption is ' +
-     'deprecated.',
-     'DEP0182'],
-  ]
-});
 
 const key = randomBytes(32);
 const iv = randomBytes(16);
-const tag = randomBytes(12);
-createDecipheriv('aes-256-gcm', key, iv).setAuthTag(tag);
+for (let tagLength = 0; tagLength < 16; tagLength++) {
+  const tag = randomBytes(tagLength);
+  assert.throws(() => {
+    createDecipheriv('aes-256-gcm', key, iv).setAuthTag(tag);
+  }, {
+    message: `Invalid authentication tag length: ${tagLength}`,
+  });
+}


### PR DESCRIPTION
This commit moves support for implicitly short GCM authentication tags to End-of-Life status, thus requiring applications to explicitly specify the `authTagLength` for authentication tags shorter than 128 bits.

There is quite a bit of refactoring to be done in the C++ source code. This commit does not do that; instead, it implements a minimal change only in order to avoid excessive divergence across git branches due to this being a semver-major change.

Fixes: https://github.com/nodejs/node/issues/52327
Refs: https://github.com/nodejs/node/issues/17523

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
