### PR TITLE
test: check util.parseArgs argv parsing with actual process execution

### DIFF
--- a/test/fixtures/parse-args.js
+++ b/test/fixtures/parse-args.js
@@ -1,0 +1,5 @@
+const { parseArgs } = require('util');
+
+const parsedArgs = parseArgs({ strict: false }).values;
+
+process.stdout.write(JSON.stringify(parsedArgs));


### PR DESCRIPTION
The new --eval tests for `util.parseArgs()` are genuine usage tests that spawn a node instance with command-line args, whereas the existing test for "command-line parsing" just overwrites `process.argv`. Mocking this property is fine for the input parsing tests, but the command-line behaviour should also be genuinely tested here.

Refs: #60814