### PR TITLE
doc: correct description of `error.stack` accessor behavior

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -379,12 +379,16 @@ The location information will be one of:
   represents a call in a user program (using ES module system), or
   its dependencies.
 
-The string representing the stack trace is lazily generated when the
-`error.stack` property is **accessed**.
-
 The number of frames captured by the stack trace is bounded by the smaller of
 `Error.stackTraceLimit` or the number of available frames on the current event
 loop tick.
+
+`error.stack` is a getter/setter for a hidden internal property which is only
+present on builtin `Error` objects (those for which [`Error.isError`][] returns
+true). If `error` is not a builtin error object, then the `error.stack` getter
+will always return `undefined`, and the setter will do nothing. This can occur
+if `error` is an object that has had its prototype set to `Error.prototype`,
+but was not constructed by a builtin `Error` constructor.
 
 ## Class: `AssertionError`
 
@@ -4381,6 +4385,7 @@ An error occurred trying to allocate memory. This should never happen.
 [`ERR_MISSING_MESSAGE_PORT_IN_TRANSFER_LIST`]: #err_missing_message_port_in_transfer_list
 [`ERR_MISSING_TRANSFERABLE_IN_TRANSFER_LIST`]: #err_missing_transferable_in_transfer_list
 [`ERR_REQUIRE_ASYNC_MODULE`]: #err_require_async_module
+[`Error.isError`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError
 [`EventEmitter`]: events.md#class-eventemitter
 [`MessagePort`]: worker_threads.md#class-messageport
 [`Object.getPrototypeOf`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getPrototypeOf

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -387,8 +387,8 @@ loop tick.
 present on builtin `Error` objects (those for which [`Error.isError`][] returns
 true). If `error` is not a builtin error object, then the `error.stack` getter
 will always return `undefined`, and the setter will do nothing. This can occur
-if `error` is an object that has had its prototype set to `Error.prototype`,
-but was not constructed by a builtin `Error` constructor.
+if the accessor is manually invoked with a `this` value that is not a builtin
+error object, such as a {Proxy}.
 
 ## Class: `AssertionError`
 


### PR DESCRIPTION
The existing description in errors.md is outdated as of v21.x:

- The hidden internal stack trace property is set at construct time, and is no longer lazily generated.
- The accessors now perform a brand check, and do nothing if the `this` value passed to the getter/setter is not a native error.

This behaviour isn't mentioned in V8/Chromium documentation nor MDN, so it's worth spelling out here.

`Error.isError()` doesn't exist in v22.x, so this will need a specific PR referencing `util.types.isNativeError()` instead.

Refs: #60862