### PR TITLE
test_runner: fix lazy `test.assert` accessor

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -62,14 +62,18 @@ ObjectDefineProperty(module.exports, 'snapshot', {
   },
 });
 
+let lazyAssert;
+
 ObjectDefineProperty(module.exports, 'assert', {
   __proto__: null,
   configurable: true,
   enumerable: true,
   get() {
-    const { register } = require('internal/test_runner/assert');
-    const assert = { __proto__: null, register };
-    ObjectDefineProperty(module.exports, 'assert', assert);
-    return assert;
+    if (lazyAssert === undefined) {
+      const { register } = require('internal/test_runner/assert');
+      lazyAssert = { __proto__: null, register };
+    }
+
+    return lazyAssert;
   },
 });


### PR DESCRIPTION
The intention was for this to be a define-on-access lazy property, but the object passed to `Object.defineProperty` isn't a descriptor, so this never happens. As a result, the `assert` object is currently reconstructed on every access; `test.assert === test.assert` is false at present.

Changed to a conventional lazy getter, in alignment with the other `node:test` property accessors.