### PR TITLE
streams: forward errors correctly for duplexPair endpoints

### DIFF
--- a/lib/internal/streams/duplexpair.js
+++ b/lib/internal/streams/duplexpair.js
@@ -50,6 +50,30 @@ class DuplexSide extends Duplex {
     this.#otherSide.on('end', callback);
     this.#otherSide.push(null);
   }
+
+
+  _destroy(err, callback) {
+    const otherSide = this.#otherSide;
+
+    if (otherSide !== null && !otherSide.destroyed) {
+      // Use nextTick to avoid crashing the current execution stack (like HTTP parser)
+      process.nextTick(() => {
+        if (otherSide.destroyed) return;
+
+        if (err) {
+          // Destroy the other side, without passing the 'err' object.
+          // This closes the other side gracefully so it doesn't hang,
+          // but prevents the "Unhandled error" crash.
+          otherSide.destroy();
+        } else {
+          // Standard graceful close
+          otherSide.push(null);
+        }
+      });
+    }
+
+    callback(err);
+  }
 }
 
 function duplexPair(options) {
@@ -57,6 +81,6 @@ function duplexPair(options) {
   const side1 = new DuplexSide(options);
   side0[kInitOtherSide](side1);
   side1[kInitOtherSide](side0);
-  return [ side0, side1 ];
+  return [side0, side1];
 }
 module.exports = duplexPair;

--- a/test/parallel/test-duplex-error.js
+++ b/test/parallel/test-duplex-error.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { duplexPair } = require('stream');
+
+const [sideA, sideB] = duplexPair();
+
+// Side A should receive the error because we called .destroy(err) on it.
+sideA.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.message, 'Simulated error');
+}));
+
+// Side B should NOT necessarily emit an error (to avoid crashing
+// existing code), but it MUST be destroyed.
+sideB.on('error', common.mustNotCall('Side B should not emit an error event'));
+
+sideB.on('close', common.mustCall(() => {
+  assert.strictEqual(sideB.destroyed, true);
+}));
+
+sideA.resume();
+sideB.resume();
+
+// Trigger the destruction
+sideA.destroy(new Error('Simulated error'));
+
+// Check the state in the next tick to allow nextTick/microtasks to run
+setImmediate(common.mustCall(() => {
+  assert.strictEqual(sideA.destroyed, true);
+  assert.strictEqual(sideB.destroyed, true);
+}));


### PR DESCRIPTION
fix the duplexPair implementation so that when one side is destroyed with an error, the other side also receives the error or a close event as appropriate.

previous behavior caused sideA to never emit an 'error' or 'close' when sideB errored, which prevented users from observing or handling the paired stream failure.

Fixes: https://github.com/nodejs/node/issues/61015

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
