### PR TITLE
lib: gbk decoder is gb18030 decoder per spec

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -430,7 +430,9 @@ function makeTextDecoderICU() {
 
     #prepareConverter() {
       if (this[kHandle] !== undefined) return;
-      const handle = getConverter(this[kEncoding], this[kFlags]);
+      let icuEncoding = this[kEncoding];
+      if (icuEncoding === 'gbk') icuEncoding = 'gb18030'; // 10.1.1. GBK's decoder is gb18030's decoder
+      const handle = getConverter(icuEncoding, this[kFlags]);
       if (handle === undefined)
         throw new ERR_ENCODING_NOT_SUPPORTED(this[kEncoding]);
       this[kHandle] = handle;


### PR DESCRIPTION
Tracking: #61041 

Spec ref: https://encoding.spec.whatwg.org/#gbk-decoder

Without this, TextDecoder fails tests on `gbk` encoding
