### PR TITLE
fs: fix rmSync to handle non-ASCII characters

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1634,7 +1634,7 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
   ToNamespacedPath(env, &path);
   THROW_IF_INSUFFICIENT_PERMISSIONS(
       env, permission::PermissionScope::kFileSystemWrite, path.ToStringView());
-  auto file_path = std::filesystem::path(path.ToStringView());
+  auto file_path = path.ToPath();
   std::error_code error;
   auto file_status = std::filesystem::status(file_path, error);
 
@@ -1649,8 +1649,7 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
   // File is a directory and recursive is false
   if (file_status.type() == std::filesystem::file_type::directory &&
       !recursive) {
-    return THROW_ERR_FS_EISDIR(
-        isolate, "Path is a directory: %s", file_path.c_str());
+    return THROW_ERR_FS_EISDIR(isolate, "Path is a directory: %s", path);
   }
 
   // Allowed errors are:

--- a/test/parallel/test-fs-rmSync-special-char.js
+++ b/test/parallel/test-fs-rmSync-special-char.js
@@ -1,0 +1,32 @@
+'use strict';
+require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// This test ensures that fs.rmSync handles non-ASCII characters in file paths,
+// and that errors contain correctly encoded paths and err.path values.
+
+tmpdir.refresh(); // Prepare a clean temporary directory
+
+// Define paths with non-ASCII characters
+const dirPath = path.join(tmpdir.path, '速_dir');
+const filePath = path.join(tmpdir.path, '速.txt');
+
+// Create a directory and a file with non-ASCII characters
+fs.mkdirSync(dirPath);
+fs.writeFileSync(filePath, 'This is a test file with special characters.');
+fs.rmSync(filePath);
+assert.strictEqual(fs.existsSync(filePath), false);
+
+// Ensure rmSync throws an error when trying to remove a directory without recursive
+assert.throws(() => {
+  fs.rmSync(dirPath, { recursive: false });
+}, (err) => {
+  // Assert the error code and check that the error message includes the correct non-ASCII path
+  assert.strictEqual(err.code, 'ERR_FS_EISDIR');
+  assert(err.message.includes(dirPath), 'Error message should include the directory path');
+  assert.strictEqual(err.path, dirPath);
+  return true;
+});


### PR DESCRIPTION
This is a fresh version of PR https://github.com/nodejs/node/pull/56934

Update fs.rmSync to properly handle file paths that include non-ASCII characters. This change prevents crashes and errors when attempting to delete files with international or special characters in their names.

Add a test in test/parallel to ensure that files with non-ASCII characters can be deleted without issues. This covers cases that previously caused unexpected behavior or crashes on certain file systems.

Fixes: https://github.com/nodejs/node/issues/56049

If this gets merged, I will be working on the additional errors part.

@joyeecheung Please review this. Thank you!