### PR TITLE
doc: exclude compile-time flag features from security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -125,6 +125,26 @@ This policy recognizes that experimental platforms may not compile, may not
 pass the test suite, and do not have the same level of testing and support
 infrastructure as Tier 1 and Tier 2 platforms.
 
+### Experimental features behind compile-time flags
+
+Node.js includes certain experimental features that are only available when
+Node.js is compiled with specific flags. These features are intended for
+development, debugging, or testing purposes and are not enabled in official
+releases.
+
+* Security vulnerabilities that only affect features behind compile-time flags
+  will **not** be accepted as valid security issues.
+* Any issues with these features will be treated as normal bugs.
+* No CVEs will be issued for issues that only affect compile-time flag features.
+* Bug bounty rewards are not available for compile-time flag feature issues.
+
+This policy recognizes that experimental features behind compile-time flags
+are not ready for public consumption and may have incomplete implementations,
+missing security hardening, or other limitations that make them unsuitable
+for production use.
+
+### What constitutes a vulnerability
+
 Being able to cause the following through control of the elements that Node.js
 does not trust is considered a vulnerability:
 


### PR DESCRIPTION
Add a new section to the security model clarifying that experimental features behind compile-time flags are not covered by the vulnerability reporting policy. These features are intended for development only and are not enabled in official releases.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
