### PR TITLE
test: skip sea tests on riscv64

### DIFF
--- a/test/sea/sea.status
+++ b/test/sea/sea.status
@@ -14,6 +14,10 @@ test-single-executable-application*: SKIP
 # https://github.com/nodejs/node/issues/59561
 test-single-executable-application*: SKIP
 
+[$system==linux && $arch==riscv64]
+# https://github.com/nodejs/node/issues/61110
+test-single-executable-application*: SKIP
+
 [$system==win32]
 # https://github.com/nodejs/node/issues/49630
 test-single-executable-application-snapshot: PASS, FLAKY


### PR DESCRIPTION
As documented in https://github.com/nodejs/node/issues/61110 - these tests do not pass on most currently available RISC-V systems.

This matches the approach used for [macos/x64](https://github.com/nodejs/node/pull/60250) and [Linux/ppc64le](https://github.com/nodejs/node/pull/59563).