### PR TITLE
src: use validate_ascii_with_errors for buffer.isAscii

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1252,7 +1252,8 @@ static void IsAscii(const FunctionCallbackInfo<Value>& args) {
         env, "Cannot validate on a detached buffer");
   }
 
-  args.GetReturnValue().Set(simdutf::validate_ascii(abv.data(), abv.length()));
+  args.GetReturnValue().Set(
+      !simdutf::validate_ascii_with_errors(abv.data(), abv.length()).error);
 }
 
 void SetBufferPrototype(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
Tracking: #61041 

Don't expect `buffer.isAscii` common-case to be ASCII, as that's exposed as a public API for checks.
The error version has better performance on non-ascii  as it returns early, which could easily be e.g. >10x.

Refs: https://github.com/nodejs/node/pull/46271#discussion_r1081798237,

But somehow the `_errors` version is also faster on ASCII, which was supposed to be a common case for `validate_ascii`?
I'm not sure what's up, might be a simdutf bug?  cc @lemire 

On another note: v8 is also likely using `validate_ascii` incorrectly

`buffer.isAscii` perf:

main:
| Test | Size | Throughput | Mean Time |
|------|------|------------|-----------|
| Latin lipsum (ASCII) | 84.902 KiB | 105.08 GiB/s | 0.001 ms |
| Arabic lipsum | 79.771 KiB | 103.88 GiB/s | 0.001 ms |
| Chinese lipsum | 68.203 KiB | 101.78 GiB/s | 0.001 ms |

PR
| Test | Size | Throughput | Mean Time |
|------|------|------------|-----------|
| Latin lipsum (ASCII) | 84.902 KiB | 117.97 GiB/s | 0.001 ms |
| Arabic lipsum | 79.771 KiB | 1836.47 GiB/s | 0.000 ms |
| Chinese lipsum | 68.203 KiB | 1564.76 GiB/s | 0.000 ms |

