### PR TITLE
tools: use sparse-checkout in linter jobs

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -28,13 +28,6 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           persist-credentials: false
-          sparse-checkout: |
-            *
-            !doc/
-            !lib/
-            !.github/
-            !.devcontainer/
-          sparse-checkout-cone-mode: false
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
@@ -50,13 +43,6 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           persist-credentials: false
-          sparse-checkout: |
-            *
-            !doc/
-            !lib/
-            !.github/
-            !.devcontainer/
-          sparse-checkout-cone-mode: false
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@83679a892e2d95755f2dac6acb0bfd1e9ac5d548  # v6.1.0
         with:
@@ -74,13 +60,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-          sparse-checkout: |
-            *
-            !doc/
-            !lib/
-            !.github/
-            !.devcontainer/
-          sparse-checkout-cone-mode: false
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
@@ -119,13 +98,6 @@ jobs:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
         with:
           persist-credentials: false
-          sparse-checkout: |
-            *
-            !deps/
-            !src/
-            !.github/
-            !.devcontainer/
-          sparse-checkout-cone-mode: false
       - name: Use Node.js ${{ env.NODE_VERSION }}
         uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
         with:
@@ -220,8 +192,8 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: |
-            Makefile
-            tools/pip/
+            /Makefile
+            /tools/pip/
             *.yml
             *.yaml
           sparse-checkout-cone-mode: false
@@ -245,7 +217,7 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: |
-            tools/lint-sh.mjs
+            /tools/lint-sh.mjs
             *.sh
           sparse-checkout-cone-mode: false
       - run: shellcheck -V
@@ -270,8 +242,8 @@ jobs:
           fetch-depth: 2
           persist-credentials: false
           sparse-checkout: |
-            tools/lint-pr-url.mjs
-            doc/api/
+            /tools/lint-pr-url.mjs
+            /doc/api/
           sparse-checkout-cone-mode: false
       # GH Actions squashes all PR commits, HEAD^ refers to the base branch.
       - run: git diff HEAD^ HEAD -G"pr-url:" -- "*.md" | ./tools/lint-pr-url.mjs ${{ github.event.pull_request.html_url }}
@@ -283,7 +255,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             README.md
-            tools/lint-readme-lists.mjs
+            /tools/lint-readme-lists.mjs
           sparse-checkout-cone-mode: false
       - name: Get team members if possible
         if: ${{ (github.event.pull_request && github.event.pull_request.base.ref == github.event.pull_request.base.repo.default_branch) || github.event.ref == github.event.repository.default_branch }}


### PR DESCRIPTION
We can reduce out usage by avoiding to download files we don't need. It seems to hold true only if the list of files is small, for jobs that need almost all files in the repo, it's still faster to download the full repo, so no sparse checkout for them.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
