### PR TITLE
tools,doc: fix format-md files list

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -798,6 +798,11 @@ for /D %%D IN (doc\*) do (
   for %%F IN (%%D\*.md) do (
     set "lint_md_files="%%F" !lint_md_files!"
   )
+  for /D %%S IN (%%D\*) do (
+    for %%F IN (%%S\*.md) do (
+      set "lint_md_files="%%F" !lint_md_files!"
+    )
+  )
 )
 %node_exe% tools\lint-md\lint-md.mjs %lint_md_files%
 ENDLOCAL
@@ -812,6 +817,11 @@ set lint_md_files=
 for /D %%D IN (doc\*) do (
   for %%F IN (%%D\*.md) do (
     set "lint_md_files="%%F" !lint_md_files!"
+  )
+  for /D %%S IN (%%D\*) do (
+    for %%F IN (%%S\*.md) do (
+      set "lint_md_files="%%F" !lint_md_files!"
+    )
   )
 )
 %node_exe% tools\lint-md\lint-md.mjs --format %lint_md_files%


### PR DESCRIPTION
A minor fix to `format-md` and `lint-md`in `vcbuild.bat`, which adds files from `doc/contributing/maintaining` to the list of files to be processed.

Fixes: https://github.com/nodejs/node/issues/55216