### PR TITLE
test: asserts that import.meta.resolve invokes sync loader hooks

### DIFF
--- a/test/es-module/test-esm-import-meta-resolve-hooks.mjs
+++ b/test/es-module/test-esm-import-meta-resolve-hooks.mjs
@@ -1,0 +1,21 @@
+// Flags: --experimental-import-meta-resolve
+import '../common/index.mjs';
+import assert from 'node:assert';
+import { registerHooks } from 'node:module';
+
+// Asserts that import.meta.resolve invokes loader hooks registered via `registerHooks`.
+
+registerHooks({
+  resolve(specifier, context, defaultResolve) {
+    if (specifier === 'custom:hooked') {
+      return {
+        shortCircuit: true,
+        url: new URL('./test-esm-import-meta.mjs', import.meta.url).href,
+      };
+    }
+    return defaultResolve(specifier, context);
+  },
+});
+
+assert.strictEqual(import.meta.resolve('custom:hooked'),
+                   new URL('./test-esm-import-meta.mjs', import.meta.url).href);


### PR DESCRIPTION
Add a test case asserting that `import.meta.resolve` invokes sync loader hooks.