### PR TITLE
build: support building crates (temporal) on windows

### DIFF
--- a/deps/crates/crates.gyp
+++ b/deps/crates/crates.gyp
@@ -17,6 +17,14 @@
         'libraries': [
           '<(node_crates_libpath)',
         ],
+        'conditions': [
+          ['OS=="win"', {
+            'libraries': [
+              '-lntdll',
+              '-luserenv'
+            ],
+          }],
+        ],
       },
       'actions': [
         {
@@ -50,18 +58,6 @@
           '<(cargo_vendor_dir)/temporal_capi/bindings/cpp',
         ],
       },
-      'conditions': [
-        ['OS=="win"', {
-          'direct_dependent_settings': {
-            'link_settings': {
-              'libraries': [
-                '-lntdll',
-                '-luserenv'
-              ],
-            },
-          },
-        }],
-      ],
     },
   ]
 }


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

configure --v8-enable-temporal-support --with-ltcg --dest-cpu=x64 --clang-cl=20.1.8

Fixed an error when building crates.gyp on Windows, and correctly set the lib file extension and system library dependencies.

### Current error
1.
```log
     Compiling temporal_rs v0.1.0
     Compiling temporal_capi v0.1.0
     Compiling node_crates v0.1.0 (D:\1\nodejs\deps\crates)
      Finished `release` profile [optimized] target(s) in 9.09s
E:\sdk\vs\MSBuild\Microsoft\VC\v180\Microsoft.CppCommon.targets(254,5): warning MSB8065: Custom build for item "Cargo.toml" succeeded, but specified output "d:\1\nodejs\out\release\obj\global_intermediate\release\libnode_crates.a" has not been created. This may cause incremental build to work incorrectly. [D:\1\nodejs\deps\crates\node_crates.vcxproj]
```

2.
```log
[31;1mlld-link : error : undefined symbol: __declspec(dllimport) NtReadFile [D:\1\nodejs\tools\v8_gypfiles\mksnapshot.vcxproj]
[m  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\io\mod.rs:484
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::io::default_read_to_end::hae912e80507d6821)
  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\io\mod.rs:484
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::io::default_read_to_end::hfa170b960d79e0a1)
  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\sys\pal\windows\handle.rs:155
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::sys::pal::windows::handle::Handle::read_to_end::hcf0b8f778f1125e4)
  >>> referenced 1 more times
  
[31;1mlld-link : error : undefined symbol: __declspec(dllimport) RtlNtStatusToDosError [D:\1\nodejs\tools\v8_gypfiles\mksnapshot.vcxproj]
[m  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\io\mod.rs:484
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::io::default_read_to_end::hae912e80507d6821)
  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\io\mod.rs:484
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::io::default_read_to_end::hfa170b960d79e0a1)
  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\sys\fs\windows.rs:1362
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::sys::fs::windows::remove_dir_all::hc765fc4a95a44ac9)
  >>> referenced 9 more times
  
[31;1mlld-link : error : undefined symbol: __declspec(dllimport) GetUserProfileDirectoryW [D:\1\nodejs\tools\v8_gypfiles\mksnapshot.vcxproj]
[m  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\env.rs:644
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::env::home_dir::h208640d7371dbbd7)
  
[31;1mlld-link : error : undefined symbol: __declspec(dllimport) NtOpenFile [D:\1\nodejs\tools\v8_gypfiles\mksnapshot.vcxproj]
[m  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\sys\fs\windows.rs:1362
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::sys::fs::windows::remove_dir_all::hc765fc4a95a44ac9)
  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\sys\fs\windows.rs:1362
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::sys::fs::windows::remove_dir_all::hc765fc4a95a44ac9)
  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\sys\fs\windows\remove_dir_all.rs:101
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::sys::fs::windows::remove_dir_all::open_link_no_reparse::hc86ad9e73694d67a)
  >>> referenced 3 more times
  
[31;1mlld-link : error : undefined symbol: __declspec(dllimport) NtCreateNamedPipeFile [D:\1\nodejs\tools\v8_gypfiles\mksnapshot.vcxproj]
[m  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\sys\pal\windows\pipe.rs:115
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::sys::pal::windows::pipe::anon_pipe::hb590bfe084a23905)
  
[31;1mlld-link : error : undefined symbol: __declspec(dllimport) NtWriteFile [D:\1\nodejs\tools\v8_gypfiles\mksnapshot.vcxproj]
[m  >>> referenced by /rustc/ed61e7d7e242494fb7057f2657300d9e77bb4fcb/library\std\src\sys\pal\windows\handle.rs:314
  >>>               node_crates.lib(std-80c6612147140e42.std.fe2f9c68055895e3-cgu.0.rcgu.o):(std::sys::pal::windows::handle::Handle::synchronous_write::hadd9a6025901175c)
```

### After repair
Node.js has been successfully built on windows

`Temporal.Now.plainDateISO().toString()` outputs `'2025-12-24'`
