### PR TITLE
test_runner: fix coverage report when a directory is named file

### DIFF
--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -551,7 +551,7 @@ function getCoverageReport(pad, summary, symbol, color, table) {
 
   function printCoverageBodyTree(tree, depth = 0) {
     for (const key in tree) {
-      if (tree[key].file) {
+      if (tree[key].file?.path) {
         const file = tree[key].file;
         const fileName = ArrayPrototypePop(StringPrototypeSplit(file.path, sep));
 

--- a/test/fixtures/test-runner/coverage-file-name/file/file
+++ b/test/fixtures/test-runner/coverage-file-name/file/file
@@ -1,0 +1,4 @@
+'use strict';
+module.exports.fn = function() {
+  return 1;
+};

--- a/test/fixtures/test-runner/coverage-file-name/test.js
+++ b/test/fixtures/test-runner/coverage-file-name/test.js
@@ -1,0 +1,7 @@
+'use strict';
+const { fn } = require('./file/file');
+const test = require('node:test');
+
+test('coverage with file/file directory structure', () => {
+  fn();
+});

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -550,3 +550,19 @@ test('correctly prints the coverage report of files contained in parent director
   assert(result.stdout.toString().includes(report));
   assert.strictEqual(result.status, 0);
 });
+
+// Regression test for https://github.com/nodejs/node/issues/61080
+test('coverage with directory and file named "file"', skipIfNoInspector, () => {
+  const fixture = fixtures.path('test-runner', 'coverage-file-name', 'test.js');
+  const args = [
+    '--experimental-test-coverage',
+    '--test-reporter',
+    'tap',
+    fixture,
+  ];
+  const result = spawnSync(process.execPath, args);
+
+  assert.strictEqual(result.stderr.toString(), '');
+  assert.strictEqual(result.status, 0);
+  assert(result.stdout.toString().includes('start of coverage report'));
+});


### PR DESCRIPTION
The coverage tree traversal checked `tree[key].file` to detect file
entries. When a directory named "file" contained a file also named
"file", this check incorrectly matched the child entry instead of
file metadata, causing a TypeError when accessing `.path`.

Check for `.file?.path` instead to correctly identify file metadata.

Fixes: https://github.com/nodejs/node/issues/61080