### PR TITLE
doc: document error event on readline InterfaceConstructor

### DIFF
--- a/doc/api/readline.md
+++ b/doc/api/readline.md
@@ -108,7 +108,8 @@ emitted.
 added: v16.0.0
 -->
 
-The `'error'` event is emitted when an error occurs on the `input` stream  associated with the `readline` `Interface`.
+The `'error'` event is emitted when an error occurs on the `input` stream
+associated with the `node:readline` `Interface`.
 
 The listener function is called with an `Error` object passed as the single argument.
 


### PR DESCRIPTION
Aims to document the `'error'` event introduced by cb3020d in v16.0.0.

Fixes: https://github.com/nodejs/node/issues/58289
Fixes: https://github.com/nodejs/node/issues/61037