### PR TITLE
module: throw error for ESM syntax in explicit commonjs entry

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1722,13 +1722,20 @@ function wrapSafe(filename, content, cjsModuleInstance, format) {
 
   let shouldDetectModule = false;
   if (format !== 'commonjs') {
-    if (cjsModuleInstance?.[kIsMainSymbol]) {
-      // For entry points, format detection is used unless explicitly disabled.
-      shouldDetectModule = getOptionValue('--experimental-detect-module');
-    } else {
-      // For modules being loaded by `require()`, if require(esm) is disabled,
-      // don't try to reparse to detect format and just throw for ESM syntax.
-      shouldDetectModule = getOptionValue('--require-module');
+    // Also check if we're in an explicit commonjs package, even if format wasn't
+    // set (e.g., for extensionless files). In explicit commonjs packages, we should
+    // not detect module syntax and instead let the syntax error propagate.
+    const pkg = packageJsonReader.getNearestParentPackageJSON(filename);
+    const explicitCommonJS = pkg?.data.type === 'commonjs';
+    if (!explicitCommonJS) {
+      if (cjsModuleInstance?.[kIsMainSymbol]) {
+        // For entry points, format detection is used unless explicitly disabled.
+        shouldDetectModule = getOptionValue('--experimental-detect-module');
+      } else {
+        // For modules being loaded by `require()`, if require(esm) is disabled,
+        // don't try to reparse to detect format and just throw for ESM syntax.
+        shouldDetectModule = getOptionValue('--require-module');
+      }
     }
   }
   const result = compileFunctionForCJSLoader(content, filename, false /* is_sea_main */, shouldDetectModule);

--- a/test/es-module/test-esm-syntax-in-cjs-main.js
+++ b/test/es-module/test-esm-syntax-in-cjs-main.js
@@ -1,0 +1,19 @@
+// Flags: --no-warnings
+'use strict';
+
+// Test that running a main entry point with ESM syntax in a "type": "commonjs"
+// package throws an error instead of silently failing with exit code 0.
+// Regression test for https://github.com/nodejs/node/issues/61104
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const fixtures = require('../common/fixtures.js');
+const { execPath } = require('node:process');
+
+const mainScript = fixtures.path('es-modules/package-type-commonjs-esm-syntax/esm-script.js');
+
+spawnSyncAndAssert(execPath, [mainScript], {
+  status: 1,
+  signal: null,
+  stderr: /import { version } from 'node:process'/,
+});

--- a/test/fixtures/es-modules/package-type-commonjs-esm-syntax/esm-script.js
+++ b/test/fixtures/es-modules/package-type-commonjs-esm-syntax/esm-script.js
@@ -1,0 +1,4 @@
+// This file has ESM syntax but is in a "type": "commonjs" package
+console.log('script STARTED');
+import { version } from 'node:process';
+console.log(version);

--- a/test/fixtures/es-modules/package-type-commonjs-esm-syntax/package.json
+++ b/test/fixtures/es-modules/package-type-commonjs-esm-syntax/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}


### PR DESCRIPTION
When a main entry point contains ESM syntax but is in a package with `"type": "commonjs"` in package.json, the module would silently exit with code 0 without executing or showing any error. This happened because the CJS loader detected ESM syntax, attempted to defer to ESM loading, but the async execution never completed before the process exited.

This change throws ERR_REQUIRE_ESM for main modules with ESM syntax in explicitly CommonJS-typed packages, providing a clear error message instead of silent failure.

Fixes: https://github.com/nodejs/node/issues/61104