### PR TITLE
zlib: add CHECK to validate fast path input

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -1685,6 +1685,7 @@ static uint32_t FastCRC32(v8::Local<v8::Value> receiver,
                           v8::FastApiCallbackOptions& options) {
   TRACK_V8_FAST_API_CALL("zlib.crc32");
   v8::HandleScope handle_scope(options.isolate);
+  CHECK(data->IsArrayBufferView() || data->IsString());
   return CRC32Impl(options.isolate, data, value);
 }
 


### PR DESCRIPTION
Add missing CHECK in FastCRC32 to match the slow path.