### PR TITLE
assert,util: improve comparison performance

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -335,7 +335,7 @@ function objectComparisonStart(val1, val2, mode, memos) {
         return false;
       }
     } else if (mode === kLoose &&
-              (isFloat32Array(val1) || isFloat64Array(val1) || isFloat16Array(val1))) {
+               (isFloat32Array(val1) || isFloat64Array(val1) || isFloat16Array(val1))) {
       if (!areSimilarFloatArrays(val1, val2)) {
         return false;
       }
@@ -353,7 +353,7 @@ function objectComparisonStart(val1, val2, mode, memos) {
     }
     return keyCheck(val1, val2, mode, memos, kNoIterator, keys2);
   } else if (isDate(val1)) {
-    if (!isDate(val2)) {
+    if (!isDate(val2) || hasUnequalTag(val1, val2)) {
       return false;
     }
     const time1 = DatePrototypeGetTime(val1);


### PR DESCRIPTION
This makes sure that the toStringTag symbol is used, if available instead of calculating the toString() value each time, if not needed (the type checks make a brand check, so there is no need to check the toStringTag, if non is defined on the object).
