### PR TITLE
test: avoid RegExp.prototype.test in crypto error assertion

### DIFF
--- a/test/parallel/test-crypto-no-algorithm.js
+++ b/test/parallel/test-crypto-no-algorithm.js
@@ -22,8 +22,9 @@ if (isMainThread) {
     if (err) {
       assert.match(err.message, /digital envelope routines::unsupported/);
       const expected = /random number generator::unable to fetch drbg/;
-      assert(err.opensslErrorStack.some((msg) => expected.test(msg)),
-             `did not find ${expected} in ${err.opensslErrorStack}`);
+      assert(
+        err.opensslErrorStack.some((msg) => msg.match(expected)),
+        `did not find ${expected} in ${err.opensslErrorStack}`);
     }
   }));
 }


### PR DESCRIPTION
This PR updates `test/parallel/test-crypto-no-algorithm.js` to align with the ongoing test cleanup and modernization work across the Node.js codebase.

As part of recent efforts, tests are being standardized to avoid using `RegExp.prototype.test()` directly inside assertions in favor of clearer, more explicit matching patterns. This change applies that same approach to a crypto test that validates OpenSSL error output.

## What was changed

Previously:

```js
assert(
  err.opensslErrorStack.some((msg) => expected.test(msg)),
  `did not find ${expected} in ${err.opensslErrorStack}`
);
```
Updated to: 

```js
assert(
  err.opensslErrorStack.some((msg) => msg.match(expected)),
  `did not find ${expected} in ${err.opensslErrorStack}`
);
``` 
## Why this change
- Aligns the test with modern Node.js assertion patterns used elsewhere in the test suite
- Improves readability by expressing intent as string matching rather than invoking `RegExp.prototype.test()`
- Keeps assertion style consistent with recent test modernizations

## Additional notes
- No functional or behavioral changes are intended
- Test logic, coverage, and failure messages remain unchanged
- All tests continue to pass