### PR TITLE
doc: add missing `passed`  and `error` properties on `TestContext`

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -3686,7 +3686,7 @@ added:
 
 The name of the test.
 
-### `context.passed` {boolean}
+### `context.passed`
 
 <!-- YAML
 added:
@@ -3694,23 +3694,29 @@ added:
   - v20.12.0
 -->
 
-Indicated wether the test succeeded, this defaults to `false` before the test is executed, e.g. in a `beforeEach` hook.
+* Type: {boolean} `false` before the test is executed, e.g. in a `beforeEach` hook.
 
-### `context.error` {Error|null}
+Indicated whether the test succeeded.
+
+### `context.error`
 
 <!-- YAML
 added:
   - v21.7.0
   - v20.12.0
 -->
+
+* Type: {Error|null}
 
 The failure reason for the test/case; wrapped and available via `context.error.cause`.
 
-### `context.attempt` {number}
+### `context.attempt`
 
 <!-- YAML
 added: v25.0.0
 -->
+
+* Type: {number}
 
 Number of times the test has been attempted.
 


### PR DESCRIPTION
`passed` and `error` properties were left undocumented on `TextContext` class

Fixes: https://github.com/nodejs/node/issues/59321
Refs: https://github.com/nodejs/node/pull/51485 <-- passed and error implem
Refs: https://github.com/nodejs/node/pull/59322 <-- Initial PR

PR was already made by someone else but closed prematurely even if valid, see second ref.
I removed this part, which seems wrong because I tested it and even `Error` instances end up wrapped:
> The failure reason for the test/case; if anything other than an instance of `Error` was thrown, that will be wrapped