### PR TITLE
fs: defer path resolution in realpath functions

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -2681,7 +2681,6 @@ function realpathSync(p, options) {
     p += '';
   }
   validatePath(p);
-  p = pathModule.resolve(p);
 
   const cache = options[realpathCacheKey];
   const maybeCachedResult = cache?.get(p);
@@ -2800,6 +2799,8 @@ function realpathSync(p, options) {
     }
   }
 
+  p = pathModule.resolve(p);
+
   cache?.set(original, p);
   return encodeRealpathResult(p, options);
 }
@@ -2842,7 +2843,6 @@ function realpath(p, options, callback) {
     p += '';
   }
   validatePath(p);
-  p = pathModule.resolve(p);
 
   const seenLinks = new SafeMap();
   const knownHard = new SafeSet();
@@ -2875,6 +2875,7 @@ function realpath(p, options, callback) {
   function LOOP() {
     // Stop if scanned past end of path
     if (pos >= p.length) {
+      p = pathModule.resolve(p);
       return callback(null, encodeRealpathResult(p, options));
     }
 
@@ -2896,6 +2897,7 @@ function realpath(p, options, callback) {
     if (knownHard.has(base)) {
       if (isFileType(statValues, S_IFIFO) ||
           isFileType(statValues, S_IFSOCK)) {
+        p = pathModule.resolve(p);
         return callback(null, encodeRealpathResult(p, options));
       }
       return process.nextTick(LOOP);


### PR DESCRIPTION
In `fs.realpath` and `fs.realpathSync`, path resolution is now performed after symlink traversal instead of before, ensuring correct behavior when dealing with parent directory references (`..`) in paths containing symlinks.

Fixes: https://github.com/nodejs/node/issues/60779

I may be unaware of full implications of this change, feel free to let me know if it's not the right way to fix it.