### PR TITLE
url: use ArrayPrototypePush in URLSearchParams methods

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -551,7 +551,7 @@ class URLSearchParams {
     name = StringPrototypeToWellFormed(`${name}`);
     for (let i = 0; i < list.length; i += 2) {
       if (list[i] === name) {
-        values.push(list[i + 1]);
+        ArrayPrototypePush(values, list[i + 1]);
       }
     }
     return values;
@@ -1259,11 +1259,11 @@ function parseParams(qs) {
         buf += qs.slice(lastPos, i);
       if (encoded)
         buf = querystring.unescape(buf);
-      out.push(buf);
+      ArrayPrototypePush(out, buf);
 
       // If `buf` is the key, add an empty value.
       if (!seenSep)
-        out.push('');
+        ArrayPrototypePush(out, '');
 
       seenSep = false;
       buf = '';
@@ -1280,7 +1280,7 @@ function parseParams(qs) {
         buf += qs.slice(lastPos, i);
       if (encoded)
         buf = querystring.unescape(buf);
-      out.push(buf);
+      ArrayPrototypePush(out, buf);
 
       seenSep = true;
       buf = '';


### PR DESCRIPTION
Replace native array.push() with ArrayPrototypePush in URLSearchParams.getAll() and parseParams() for consistency with the primordials pattern.
This improves security against prototype pollution and aligns with existing patterns in the file.