### PR TITLE
util: use primordials consistently in inspect.js

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -521,7 +521,7 @@ inspect.styles = ObjectAssign({ __proto__: null }, {
 // Define the palette for RegExp group depth highlighting. Can be changed by users.
 inspect.styles.regexp.colors = ['green', 'red', 'yellow', 'cyan', 'magenta'];
 
-const highlightRegExpColors = inspect.styles.regexp.colors.slice();
+const highlightRegExpColors = ArrayPrototypeSlice(inspect.styles.regexp.colors);
 
 /**
  * Colorize a JavaScript RegExp pattern per ECMAScript grammar.
@@ -549,7 +549,7 @@ function highlightRegExp(regexpString) {
 
   const palette = paletteNames.reduce((acc, name) => {
     const color = inspect.colors[name];
-    if (color) acc.push([`\u001b[${color[0]}m`, `\u001b[${color[1]}m`]);
+    if (color) ArrayPrototypePush(acc, [`\u001b[${color[0]}m`, `\u001b[${color[1]}m`]);
     return acc;
   }, []);
 
@@ -1424,7 +1424,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
   }
   recurseTimes += 1;
 
-  ctx.seen.push(value);
+  ArrayPrototypePush(ctx.seen, value);
   ctx.currentDepth = recurseTimes;
   let output;
   const indentationLvl = ctx.indentationLvl;
@@ -1468,7 +1468,7 @@ function formatRaw(ctx, value, recurseTimes, typedArray) {
       }
     }
   }
-  ctx.seen.pop();
+  ArrayPrototypePop(ctx.seen);
 
   if (ctx.sorted) {
     const comparator = ctx.sorted === true ? undefined : ctx.sorted;
@@ -1520,7 +1520,7 @@ function getBoxedBase(value, ctx, keys, constructor, tag) {
     // For boxed Strings, we have to remove the 0-n indexed entries,
     // since they just noisy up the output and are redundant
     // Make boxed primitive Strings look like such
-    keys.splice(0, value.length);
+    ArrayPrototypeSplice(keys, 0, value.length);
   } else if (isBooleanObject(value)) {
     fn = BooleanPrototypeValueOf;
     type = 'Boolean';
@@ -1717,7 +1717,7 @@ function getDuplicateErrorFrameRanges(frames) {
           maxRange = range;
           maxDuplicates = duplicateRanges;
         }
-        range = extraSteps.pop();
+        range = ArrayPrototypePop(extraSteps);
         nextStart = i;
         duplicateRanges = 0;
         continue;
@@ -1731,7 +1731,7 @@ function getDuplicateErrorFrameRanges(frames) {
     }
 
     if (duplicateRanges * range >= 3) {
-      result.push(i + range, range, duplicateRanges);
+      ArrayPrototypePush(result, i + range, range, duplicateRanges);
       // Skip over the collapsed portion to avoid overlapping matches.
       i += range * (duplicateRanges + 1) - 1;
     }
@@ -1751,11 +1751,11 @@ function getStackString(ctx, error) {
     if (typeof stack === 'string') {
       return stack;
     }
-    ctx.seen.push(error);
+    ArrayPrototypePush(ctx.seen, error);
     ctx.indentationLvl += 4;
     const result = formatValue(ctx, stack);
     ctx.indentationLvl -= 4;
-    ctx.seen.pop();
+    ArrayPrototypePop(ctx.seen);
     return `${ErrorPrototypeToString(error)}\n    ${result}`;
   }
   return ErrorPrototypeToString(error);
@@ -1781,7 +1781,7 @@ function getStackFrames(ctx, err, stack) {
       if (len > 0) {
         const skipped = len - 2;
         const msg = `    ... ${skipped} lines matching cause stack trace ...`;
-        frames.splice(offset + 1, skipped, ctx.stylize(msg, 'undefined'));
+        ArrayPrototypeSplice(frames, offset + 1, skipped, ctx.stylize(msg, 'undefined'));
       }
     }
   }
@@ -1800,7 +1800,7 @@ function getStackFrames(ctx, err, stack) {
         (duplicateRanges > 1 ?
           `${length} lines ${duplicateRanges} times...` :
           'lines ...');
-      frames.splice(offset, length * duplicateRanges, ctx.stylize(msg, 'undefined'));
+      ArrayPrototypeSplice(frames, offset, length * duplicateRanges, ctx.stylize(msg, 'undefined'));
     }
   }
 
@@ -2153,7 +2153,7 @@ function groupArrayElements(ctx, output, value) {
 }
 
 function handleMaxCallStackSize(ctx, err, constructorName, indentationLvl) {
-  ctx.seen.pop();
+  ArrayPrototypePop(ctx.seen);
   ctx.indentationLvl = indentationLvl;
   return ctx.stylize(
     `[${constructorName}: Inspection interrupted ` +


### PR DESCRIPTION
Replace native array methods (.push, .pop, .splice, .slice) withprimordials (ArrayPrototypePush, ArrayPrototypePop, ArrayPrototypeSplice,ArrayPrototypeSlice) throughout lib/internal/util/inspect.js for consistency and security.

This improves protection against prototype pollution and aligns with the primordials pattern used throughout the codebase.