### PR TITLE
stream: fix Writable.toWeb() hang on synchronous drain

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -238,6 +238,9 @@ function newWritableStreamFromStreamWritable(streamWritable, options = kEmptyObj
         }
         if (streamWritable.writableNeedDrain || !streamWritable.write(chunk)) {
           backpressurePromise = PromiseWithResolvers();
+          if (!streamWritable.writableNeedDrain) {
+            backpressurePromise.resolve();
+          }
           return SafePromisePrototypeFinally(
             backpressurePromise.promise, () => {
               backpressurePromise = undefined;

--- a/test/parallel/test-whatwg-webstreams-adapters-to-writablestream.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-writablestream.js
@@ -197,3 +197,26 @@ class TestWritable extends Writable {
     assert.strictEqual(chunk, arrayBuffer);
   }));
 }
+
+{
+  // Test that the stream doesn't hang when the underlying Writable
+  // emits 'drain' synchronously during write().
+  // Fixes: https://github.com/nodejs/node/issues/61145
+  const writable = new Writable({
+    write(chunk, encoding, callback) {
+      callback();
+    },
+  });
+
+  // Force synchronous 'drain' emission during write()
+  // to simulate a stream that doesn't have Node.js's built-in kSync protection.
+  writable.write = function(chunk) {
+    this.emit('drain');
+    return false;
+  };
+
+  const writableStream = newWritableStreamFromStreamWritable(writable);
+  const writer = writableStream.getWriter();
+  writer.write(new Uint8Array([1, 2, 3])).then(common.mustCall());
+  writer.write(new Uint8Array([4, 5, 6])).then(common.mustCall());
+}


### PR DESCRIPTION
  This PR fixes a race condition in Writable.toWeb() where the resulting WritableStream would hang if the underlying Node.js
  Writable emitted the 'drain' event synchronously during a write() call.

  This issue typically manifests when highWaterMark is set to 0, or in custom stream implementations that do not defer 'drain'
  emissions. In such cases, the 'drain' event could fire before the adapter had a chance to set up the backpressurePromise and the
  listener, causing the adapter to wait indefinitely for an event that had already occurred.

  The fix involves checking streamWritable.writableNeedDrain immediately after write() returns false. If the stream is already
  drained (i.e., writableNeedDrain is false), the backpressure promise is resolved immediately.

  Related Issue

  Fixes: #61145
  
  
<img width="1013" height="102" alt="image" src="https://github.com/user-attachments/assets/c5603503-07ec-45a6-ae83-4cfed3e4c049" />
