### PR TITLE
util: use primordials consistently in comparisons.js

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -719,7 +719,7 @@ function setEquiv(a, b, mode, memo) {
       // If the specified value doesn't exist in the second set it's a object
       // (or in loose mode: a non-matching primitive). Find the
       // deep-(mode-)equal element in a set copy to reduce duplicate checks.
-      array.push(val);
+      ArrayPrototypePush(array, val);
     }
   }
 
@@ -843,7 +843,7 @@ function mapEquiv(a, b, mode, memo) {
         }
         array = [];
       }
-      array.push(key2);
+      ArrayPrototypePush(array, key2);
     } else {
       // By directly retrieving the value we prevent another b.has(key2) check in
       // almost all possible cases.
@@ -859,7 +859,7 @@ function mapEquiv(a, b, mode, memo) {
         if (array === undefined) {
           array = [];
         }
-        array.push(key2);
+        ArrayPrototypePush(array, key2);
       }
     }
   }


### PR DESCRIPTION
Replace native array.push() with ArrayPrototypePush in lib/internal/util/comparisons.js for consistency and security.

This improves protection against prototype pollution and aligns with the primordials pattern used throughout the codebase.