### PR TITLE
v8: use primordials in startup_snapshot.js

### DIFF
--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -1,6 +1,11 @@
 'use strict';
 
 const {
+  ArrayPrototypePush,
+  ArrayPrototypeShift,
+} = primordials;
+
+const {
   validateFunction,
 } = require('internal/validators');
 const {
@@ -38,7 +43,7 @@ const deserializeCallbacks = [];
 let deserializeCallbackIsSet = false;
 function runDeserializeCallbacks() {
   while (deserializeCallbacks.length > 0) {
-    const { 0: callback, 1: data } = deserializeCallbacks.shift();
+    const { 0: callback, 1: data } = ArrayPrototypeShift(deserializeCallbacks);
     callback(data);
   }
 }
@@ -54,18 +59,18 @@ function addDeserializeCallback(callback, data) {
     setDeserializeCallback(runDeserializeCallbacks);
     deserializeCallbackIsSet = true;
   }
-  deserializeCallbacks.push([callback, data]);
+  ArrayPrototypePush(deserializeCallbacks, [callback, data]);
 }
 
 const serializeCallbacks = [];
 const afterUserSerializeCallbacks = [];  // Callbacks to run after user callbacks
 function runSerializeCallbacks() {
   while (serializeCallbacks.length > 0) {
-    const { 0: callback, 1: data } = serializeCallbacks.shift();
+    const { 0: callback, 1: data } = ArrayPrototypeShift(serializeCallbacks);
     callback(data);
   }
   while (afterUserSerializeCallbacks.length > 0) {
-    const { 0: callback, 1: data } = afterUserSerializeCallbacks.shift();
+    const { 0: callback, 1: data } = ArrayPrototypeShift(afterUserSerializeCallbacks);
     callback(data);
   }
 }
@@ -73,11 +78,11 @@ function runSerializeCallbacks() {
 function addSerializeCallback(callback, data) {
   throwIfNotBuildingSnapshot();
   validateFunction(callback, 'callback');
-  serializeCallbacks.push([callback, data]);
+  ArrayPrototypePush(serializeCallbacks, [callback, data]);
 }
 
 function addAfterUserSerializeCallback(callback, data) {
-  afterUserSerializeCallbacks.push([callback, data]);
+  ArrayPrototypePush(afterUserSerializeCallbacks, [callback, data]);
 }
 
 function initializeCallbacks() {


### PR DESCRIPTION
Replace native array methods (.push, .shift) with primordials (ArrayPrototypePush, ArrayPrototypeShift) in lib/internal/v8/startup_snapshot.js for consistency and security.

This improves protection against prototype pollution and aligns with the primordials pattern used throughout the codebase.