### PR TITLE
module: use primordials in helpers.js

### DIFF
--- a/lib/internal/modules/helpers.js
+++ b/lib/internal/modules/helpers.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayPrototypeForEach,
+  ArrayPrototypePush,
   ObjectDefineProperty,
   ObjectFreeze,
   ObjectPrototypeHasOwnProperty,
@@ -85,7 +86,7 @@ function initializeCjsConditions() {
     ...userConditions,
   ];
   if (getOptionValue('--require-module')) {
-    cjsConditionsArray.push('module-sync');
+    ArrayPrototypePush(cjsConditionsArray, 'module-sync');
   }
   ObjectFreeze(cjsConditionsArray);
   cjsConditions = new SafeSet(cjsConditionsArray);


### PR DESCRIPTION
Replace native array method (.push) with primordials (ArrayPrototypePush) in lib/internal/modules/helpers.js for consistency and security.

This improves protection against prototype pollution and aligns with the primordials pattern used throughout the codebase.