### PR TITLE
test_runner: use primordials in utils.js

### DIFF
--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -431,7 +431,7 @@ function formatLinesToRanges(values) {
     if ((index > 0) && ((current - array[index - 1]) === 1)) {
       prev[prev.length - 1][1] = current;
     } else {
-      prev.push([current]);
+      ArrayPrototypePush(prev, [current]);
     }
     return prev;
   }, []), (range) => ArrayPrototypeJoin(range, '-'));


### PR DESCRIPTION
Replace native array method (.push) with primordials (ArrayPrototypePush) in lib/internal/test_runner/utils.js for consistency and security. This improves protection against prototype pollution and aligns with the primordials pattern used throughout the codebase.
