### PR TITLE
tls: use primordials in common.js

### DIFF
--- a/lib/internal/tls/common.js
+++ b/lib/internal/tls/common.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  ArrayPrototypePush,
   JSONParse,
 } = primordials;
 
@@ -141,10 +142,10 @@ function translatePeerCertificate(c) {
                      // so this should never throw.
                      val = JSONParse(val);
                    }
-                   if (key in c.infoAccess)
-                     c.infoAccess[key].push(val);
-                   else
-                     c.infoAccess[key] = [val];
+                  if (key in c.infoAccess)
+                    ArrayPrototypePush(c.infoAccess[key], val);
+                  else
+                    c.infoAccess[key] = [val];
                  });
   }
   return c;


### PR DESCRIPTION
Replace native array method (.push) with primordials (ArrayPrototypePush) in lib/internal/tls/common.js for consistency and security. This improves protection against prototype pollution and aligns with the primordials pattern used throughout the codebase.