### PR TITLE
tls: use primordials in wrap.js

### DIFF
--- a/lib/internal/tls/wrap.js
+++ b/lib/internal/tls/wrap.js
@@ -22,6 +22,7 @@
 'use strict';
 
 const {
+  ArrayPrototypePush,
   FunctionPrototypeCall,
   ObjectAssign,
   ObjectDefineProperty,
@@ -246,7 +247,7 @@ function callALPNCallback(protocolsBuffer) {
     const protocol = protocolsBuffer.slice(offset, offset + protocolLen);
     offset += protocolLen;
 
-    protocols.push(protocol.toString('ascii'));
+    ArrayPrototypePush(protocols, protocol.toString('ascii'));
   }
 
   const selectedProtocol = socket[kALPNCallback]({
@@ -1550,7 +1551,7 @@ Server.prototype.addContext = function(servername, context) {
 
   const secureContext =
     context instanceof common.SecureContext ? context : tls.createSecureContext(context);
-  this._contexts.push([re, secureContext.context]);
+  ArrayPrototypePush(this._contexts, [re, secureContext.context]);
 };
 
 Server.prototype[EE.captureRejectionSymbol] = function(


### PR DESCRIPTION
Replace native array methods (.push) with primordials (ArrayPrototypePush) in lib/internal/tls/wrap.js for consistency and security. This improves protection against prototype pollution and aligns with the primordials pattern used throughout the codebase.