### PR TITLE
doc: note corepack package removal in distribution doc

### DIFF
--- a/doc/contributing/distribution.md
+++ b/doc/contributing/distribution.md
@@ -28,4 +28,4 @@ that doing so is not a breaking change.
 
 ## History
 
-- [corepack](https://github.com/nodejs/corepack) was added in Node.js v14.9.0 and v16.9.0. It is no longer distributed as of Node.js v25.0.0.
+* [corepack](https://github.com/nodejs/corepack) was added in Node.js v14.9.0 and v16.9.0. It is no longer distributed as of Node.js v25.0.0.


### PR DESCRIPTION
## Situation

The Node.js Technical Steering Committee completed a [vote](https://github.com/nodejs/TSC/pull/1697#issuecomment-2737093616) on Mar 19, 2025 which resulted in the strategy decision:

> Phase out later: stop distributing Corepack (i.e. the distribution will no longer contain a corepack executable) on future (i.e. 25+) release lines of Node.js – existing release lines as well as the very next (i.e. 24.x) will keep it as experimental.

This is reflected in https://nodejs.org/docs/latest-v24.x/api/corepack.html, which states

> Corepack will no longer be distributed starting with Node.js v25.

This distribution strategy change is however not yet mentioned in the [Node.js Distribution Policy document](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md).

## Change

Add a corresponding comment to [Node.js Distribution Policy document](https://github.com/nodejs/node/blob/main/doc/contributing/distribution.md) about the removal of the [corepack](https://github.com/nodejs/corepack) module starting with Node.js v25.
