### PR TITLE
lib: use primordials in freelist.js

### DIFF
--- a/lib/internal/freelist.js
+++ b/lib/internal/freelist.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const {
+  ArrayPrototypePop,
+  ArrayPrototypePush,
   ReflectApply,
 } = primordials;
 
@@ -14,13 +16,13 @@ class FreeList {
 
   alloc() {
     return this.list.length > 0 ?
-      this.list.pop() :
+      ArrayPrototypePop(this.list) :
       ReflectApply(this.ctor, this, arguments);
   }
 
   free(obj) {
     if (this.list.length < this.max) {
-      this.list.push(obj);
+      ArrayPrototypePush(this.list, obj);
       return true;
     }
     return false;


### PR DESCRIPTION
Replace native methods with primordials for consistency and security. This improves protection against prototype pollution.