### PR TITLE
util: use primordials in util.js

### DIFF
--- a/lib/internal/util.js
+++ b/lib/internal/util.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayFrom,
+  ArrayPrototypePop,
   ArrayPrototypePush,
   ArrayPrototypeSlice,
   ArrayPrototypeSort,
@@ -552,7 +553,7 @@ function join(output, separator) {
 function spliceOne(list, index) {
   for (; index + 1 < list.length; index++)
     list[index] = list[index + 1];
-  list.pop();
+  ArrayPrototypePop(list);
 }
 
 const kNodeModulesRE = /^(?:.*)[\\/]node_modules[\\/]/;


### PR DESCRIPTION
Replace native methods with primordials for consistency and security. This improves protection against prototype pollution.
