### PR TITLE
stream: use primordials in pipeline.js

### DIFF
--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -5,6 +5,9 @@
 
 const {
   ArrayIsArray,
+  ArrayPrototypePop,
+  ArrayPrototypePush,
+  ArrayPrototypeShift,
   Promise,
   SymbolAsyncIterator,
   SymbolDispose,
@@ -73,7 +76,7 @@ function popCallback(streams) {
   // a single stream. Therefore optimize for the average case instead of
   // checking for length === 0 as well.
   validateFunction(streams[streams.length - 1], 'streams[stream.length - 1]');
-  return streams.pop();
+  return ArrayPrototypePop(streams);
 }
 
 function makeAsyncIterable(val) {
@@ -236,7 +239,7 @@ function pipelineImpl(streams, callback, opts) {
     }
 
     while (destroys.length) {
-      destroys.shift()(error);
+      ArrayPrototypeShift(destroys)(error);
     }
 
     disposable?.[SymbolDispose]();
@@ -266,10 +269,10 @@ function pipelineImpl(streams, callback, opts) {
 
       if (end) {
         const { destroy, cleanup } = destroyer(stream, reading, writing);
-        destroys.push(destroy);
+        ArrayPrototypePush(destroys, destroy);
 
         if (isReadable(stream) && isLastStream) {
-          lastStreamCleanup.push(cleanup);
+          ArrayPrototypePush(lastStreamCleanup, cleanup);
         }
       }
 
@@ -285,7 +288,7 @@ function pipelineImpl(streams, callback, opts) {
       }
       stream.on('error', onError);
       if (isReadable(stream) && isLastStream) {
-        lastStreamCleanup.push(() => {
+        ArrayPrototypePush(lastStreamCleanup, () => {
           stream.removeListener('error', onError);
         });
       }
@@ -363,9 +366,9 @@ function pipelineImpl(streams, callback, opts) {
         ret = pt;
 
         const { destroy, cleanup } = destroyer(ret, false, true);
-        destroys.push(destroy);
+        ArrayPrototypePush(destroys, destroy);
         if (isLastStream) {
-          lastStreamCleanup.push(cleanup);
+          ArrayPrototypePush(lastStreamCleanup, cleanup);
         }
       }
     } else if (isNodeStream(stream)) {
@@ -373,7 +376,7 @@ function pipelineImpl(streams, callback, opts) {
         finishCount += 2;
         const cleanup = pipe(ret, stream, finish, finishOnlyHandleError, { end });
         if (isReadable(stream) && isLastStream) {
-          lastStreamCleanup.push(cleanup);
+          ArrayPrototypePush(lastStreamCleanup, cleanup);
         }
       } else if (isTransformStream(ret) || isReadableStream(ret)) {
         const toRead = ret.readable || ret;


### PR DESCRIPTION
Replace native methods with primordials for consistency and security. This improves protection against prototype pollution.