### PR TITLE
test_runner: replace native methods with primordials

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -405,7 +405,7 @@ function runTestFile(path, filesWatcher, opts) {
     const stdio = ['pipe', 'pipe', 'pipe'];
     const env = { __proto__: null, ...process.env, NODE_TEST_CONTEXT: 'child-v8' };
     if (watchMode) {
-      stdio.push('ipc');
+      ArrayPrototypePush(stdio, 'ipc');
       env.WATCH_REPORT_DEPENDENCIES = '1';
     }
     if (opts.root.harness.shouldColorizeTestFiles) {


### PR DESCRIPTION
Replace native methods with primordials.
