### PR TITLE
test: forbid use of named imports for fixtures

### DIFF
--- a/test/addons/openssl-providers/test-default-only-config.js
+++ b/test/addons/openssl-providers/test-default-only-config.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const common = require('../../common');
-const { path: fixture } = require('../../common/fixtures');
+const fixtures = require('../../common/fixtures');
 const providers = require('./providers.cjs');
 
 const assert = require('node:assert');
 const { fork } = require('node:child_process');
-const option = `--openssl-config=${fixture('openssl3-conf', 'default_only.cnf')}`;
+const option = `--openssl-config=${fixtures.path('openssl3-conf', 'default_only.cnf')}`;
 
 if (!process.execArgv.includes(option)) {
   const cp = fork(__filename, { execArgv: [option] });

--- a/test/addons/openssl-providers/test-legacy-provider-config.js
+++ b/test/addons/openssl-providers/test-legacy-provider-config.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const common = require('../../common');
-const { path: fixture } = require('../../common/fixtures');
+const fixtures = require('../../common/fixtures');
 const providers = require('./providers.cjs');
 
 const assert = require('node:assert');
 const { fork } = require('node:child_process');
-const option = `--openssl-config=${fixture('openssl3-conf', 'legacy_provider_enabled.cnf')}`;
+const option = `--openssl-config=${fixtures.path('openssl3-conf', 'legacy_provider_enabled.cnf')}`;
 
 if (!process.execArgv.includes(option)) {
   const cp = fork(__filename, { execArgv: [option] });

--- a/test/addons/openssl-providers/test-legacy-provider-inactive-config.js
+++ b/test/addons/openssl-providers/test-legacy-provider-inactive-config.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const common = require('../../common');
-const { path: fixture } = require('../../common/fixtures');
+const fixtures = require('../../common/fixtures');
 const providers = require('./providers.cjs');
 
 const assert = require('node:assert');
 const { fork } = require('node:child_process');
-const option = `--openssl-config=${fixture('openssl3-conf', 'legacy_provider_inactive.cnf')}`;
+const option = `--openssl-config=${fixtures.path('openssl3-conf', 'legacy_provider_inactive.cnf')}`;
 
 if (!process.execArgv.includes(option)) {
   const cp = fork(__filename, { execArgv: [option] });

--- a/test/common/fixtures.js
+++ b/test/common/fixtures.js
@@ -7,16 +7,17 @@ const { pathToFileURL } = require('url');
 const fixturesDir = path.join(__dirname, '..', 'fixtures');
 
 function fixturesPath(...args) {
-  return path.join(fixturesDir, ...args);
+  args.unshift(fixturesDir);
+  return Reflect.apply(path.join, this, args);
 }
 
 function fixturesFileURL(...args) {
-  return pathToFileURL(fixturesPath(...args));
+  return pathToFileURL(Reflect.apply(fixturesPath, this, args));
 }
 
 function readFixtureSync(args, enc) {
   if (Array.isArray(args))
-    return fs.readFileSync(fixturesPath(...args), enc);
+    return fs.readFileSync(Reflect.apply(fixturesPath, this, args), enc);
   return fs.readFileSync(fixturesPath(args), enc);
 }
 

--- a/test/es-module/test-esm-experimental-warnings.mjs
+++ b/test/es-module/test-esm-experimental-warnings.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import { fileURL } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
@@ -10,7 +10,7 @@ describe('ESM: warn for obsolete hooks provided', { concurrency: !process.env.TE
     const { code, signal, stderr } = await spawnPromisified(execPath, [
       '--input-type=module',
       '--eval',
-      `import ${JSON.stringify(fileURL('es-module-loaders', 'module-named-exports.mjs'))}`,
+      `import ${JSON.stringify(fixtures.fileURL('es-module-loaders', 'module-named-exports.mjs'))}`,
     ]);
 
     assert.doesNotMatch(
@@ -28,7 +28,7 @@ describe('ESM: warn for obsolete hooks provided', { concurrency: !process.env.TE
         [
           /`--experimental-loader` may be removed in the future/,
           '--experimental-loader',
-          fileURL('es-module-loaders', 'hooks-custom.mjs'),
+          fixtures.fileURL('es-module-loaders', 'hooks-custom.mjs'),
         ],
       ]
     ) {
@@ -37,7 +37,7 @@ describe('ESM: warn for obsolete hooks provided', { concurrency: !process.env.TE
           ...args,
           '--input-type=module',
           '--eval',
-          `import ${JSON.stringify(fileURL('es-module-loaders', 'module-named-exports.mjs'))}`,
+          `import ${JSON.stringify(fixtures.fileURL('es-module-loaders', 'module-named-exports.mjs'))}`,
         ]);
 
         assert.match(stderr, /ExperimentalWarning/);

--- a/test/es-module/test-esm-import-meta-main-eval.mjs
+++ b/test/es-module/test-esm-import-meta-main-eval.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 

--- a/test/es-module/test-esm-import-meta-resolve.mjs
+++ b/test/es-module/test-esm-import-meta-resolve.mjs
@@ -1,11 +1,11 @@
 // Flags: --experimental-import-meta-resolve
 import { spawnPromisified } from '../common/index.mjs';
-import { fileURL as fixturesFileURL } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'assert';
 import { spawn } from 'child_process';
 import { execPath } from 'process';
 
-const fixtures = `${fixturesFileURL()}/`;
+const fixturesDir = `${fixtures.fileURL()}/`;
 
 assert.strictEqual(import.meta.resolve('./test-esm-import-meta.mjs'),
                    new URL('./test-esm-import-meta.mjs', import.meta.url).href);
@@ -18,14 +18,14 @@ assert.throws(() => {
 });
 assert.strictEqual(
   import.meta.resolve('../fixtures/empty-with-bom.txt'),
-  fixtures + 'empty-with-bom.txt');
-assert.strictEqual(import.meta.resolve('../fixtures/'), fixtures);
+  fixturesDir + 'empty-with-bom.txt');
+assert.strictEqual(import.meta.resolve('../fixtures/'), fixturesDir);
 assert.strictEqual(
   import.meta.resolve('../fixtures/', import.meta.url),
-  fixtures);
+  fixturesDir);
 assert.strictEqual(
   import.meta.resolve('../fixtures/', new URL(import.meta.url)),
-  fixtures);
+  fixturesDir);
 [[], {}, Symbol(), 0, 1, 1n, 1.1, () => {}, true, false].forEach((arg) =>
   assert.throws(() => import.meta.resolve('../fixtures/', arg), {
     code: 'ERR_INVALID_ARG_TYPE',
@@ -33,8 +33,8 @@ assert.strictEqual(
 );
 assert.strictEqual(import.meta.resolve('http://some-absolute/url'), 'http://some-absolute/url');
 assert.strictEqual(import.meta.resolve('some://weird/protocol'), 'some://weird/protocol');
-assert.strictEqual(import.meta.resolve('baz/', fixtures),
-                   fixtures + 'node_modules/baz/');
+assert.strictEqual(import.meta.resolve('baz/', fixturesDir),
+                   fixturesDir + 'node_modules/baz/');
 assert.deepStrictEqual(
   { ...await import('data:text/javascript,export default import.meta.resolve("http://some-absolute/url")') },
   { default: 'http://some-absolute/url' },
@@ -44,8 +44,8 @@ assert.deepStrictEqual(
   { default: 'some://weird/protocol' },
 );
 assert.deepStrictEqual(
-  { ...await import(`data:text/javascript,export default import.meta.resolve("baz/", ${encodeURIComponent(JSON.stringify(fixtures))})`) },
-  { default: fixtures + 'node_modules/baz/' },
+  { ...await import(`data:text/javascript,export default import.meta.resolve("baz/", ${encodeURIComponent(JSON.stringify(fixturesDir))})`) },
+  { default: fixturesDir + 'node_modules/baz/' },
 );
 assert.deepStrictEqual(
   { ...await import('data:text/javascript,export default import.meta.resolve("fs")') },

--- a/test/es-module/test-esm-loader-programmatically.mjs
+++ b/test/es-module/test-esm-loader-programmatically.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';

--- a/test/es-module/test-esm-loader-thenable.mjs
+++ b/test/es-module/test-esm-loader-thenable.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import { fileURL, path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
@@ -9,8 +9,8 @@ describe('ESM: thenable loader hooks', { concurrency: !process.env.TEST_PARALLEL
   it('should behave as a normal promise resolution', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
       '--experimental-loader',
-      fileURL('es-module-loaders', 'thenable-load-hook.mjs').href,
-      path('es-modules', 'test-esm-ok.mjs'),
+      fixtures.fileURL('es-module-loaders', 'thenable-load-hook.mjs').href,
+      fixtures.path('es-modules', 'test-esm-ok.mjs'),
     ]);
 
     assert.strictEqual(code, 0);
@@ -20,8 +20,8 @@ describe('ESM: thenable loader hooks', { concurrency: !process.env.TEST_PARALLEL
   it('should crash the node process rejection with an error', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
       '--experimental-loader',
-      fileURL('es-module-loaders', 'thenable-load-hook-rejected.mjs').href,
-      path('es-modules', 'test-esm-ok.mjs'),
+      fixtures.fileURL('es-module-loaders', 'thenable-load-hook-rejected.mjs').href,
+      fixtures.path('es-modules', 'test-esm-ok.mjs'),
     ]);
 
     assert.notStrictEqual(code, 0);
@@ -32,8 +32,8 @@ describe('ESM: thenable loader hooks', { concurrency: !process.env.TEST_PARALLEL
   it('should just reject without an error (but NOT crash the node process)', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
       '--experimental-loader',
-      fileURL('es-module-loaders', 'thenable-load-hook-rejected-no-arguments.mjs').href,
-      path('es-modules', 'test-esm-ok.mjs'),
+      fixtures.fileURL('es-module-loaders', 'thenable-load-hook-rejected-no-arguments.mjs').href,
+      fixtures.path('es-modules', 'test-esm-ok.mjs'),
     ]);
 
     assert.notStrictEqual(code, 0);

--- a/test/es-module/test-esm-loader-with-syntax-error.mjs
+++ b/test/es-module/test-esm-loader-with-syntax-error.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import { fileURL, path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
@@ -9,8 +9,8 @@ describe('ESM: loader with syntax error', { concurrency: !process.env.TEST_PARAL
   it('should crash the node process', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
       '--experimental-loader',
-      fileURL('es-module-loaders', 'syntax-error.mjs').href,
-      path('print-error-message.js'),
+      fixtures.fileURL('es-module-loaders', 'syntax-error.mjs').href,
+      fixtures.path('print-error-message.js'),
     ]);
 
     assert.match(stderr, /SyntaxError/);

--- a/test/es-module/test-esm-module-not-found-commonjs-hint.mjs
+++ b/test/es-module/test-esm-module-not-found-commonjs-hint.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import { fixturesDir, fileURL as fixtureSubDir } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
@@ -7,7 +7,7 @@ import { describe, it } from 'node:test';
 
 describe('ESM: module not found hint', { concurrency: !process.env.TEST_PARALLEL }, () => {
   for (
-    const { input, expected, cwd = fixturesDir }
+    const { input, expected, cwd = fixtures.fixturesDir }
     of [
       {
         input: 'import "./print-error-message"',
@@ -23,7 +23,7 @@ describe('ESM: module not found hint', { concurrency: !process.env.TEST_PARALLEL
         input: 'import "../folder%25with percentage#/index.js"',
         // Did you mean to import "../es-modules/folder%2525with%20percentage%23/index.js"?
         expected: / "\.\.\/folder%2525with%20percentage%23\/index\.js"\?/,
-        cwd: fixtureSubDir('es-modules/tla/'),
+        cwd: fixtures.fileURL('es-modules/tla/'),
       },
       {
         input: 'import obj from "some_module/obj"',

--- a/test/es-module/test-esm-non-js.mjs
+++ b/test/es-module/test-esm-non-js.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import { fileURL } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
@@ -10,7 +10,7 @@ describe('ESM: non-js extensions fail', { concurrency: !process.env.TEST_PARALLE
     const { code, stderr, signal } = await spawnPromisified(execPath, [
       '--input-type=module',
       '--eval',
-      `import ${JSON.stringify(fileURL('es-modules', 'file.unknown'))}`,
+      `import ${JSON.stringify(fixtures.fileURL('es-modules', 'file.unknown'))}`,
     ]);
 
     assert.match(stderr, /ERR_UNKNOWN_FILE_EXTENSION/);

--- a/test/es-module/test-esm-nowarn-exports.mjs
+++ b/test/es-module/test-esm-nowarn-exports.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
@@ -9,7 +9,7 @@ describe('ESM: experiemental warning for import.meta.resolve', { concurrency: !p
   it('should not warn when caught', async () => {
     const { code, signal, stderr } = await spawnPromisified(execPath, [
       '--experimental-import-meta-resolve',
-      path('es-modules/import-resolve-exports.mjs'),
+      fixtures.path('es-modules/import-resolve-exports.mjs'),
     ]);
 
     assert.strictEqual(stderr, '');

--- a/test/es-module/test-esm-syntax-error.mjs
+++ b/test/es-module/test-esm-syntax-error.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { execPath } from 'node:process';
 import { describe, it } from 'node:test';
@@ -8,7 +8,7 @@ import { describe, it } from 'node:test';
 describe('ESM: importing a module with syntax error(s)', { concurrency: !process.env.TEST_PARALLEL }, () => {
   it('should throw', async () => {
     const { code, stderr } = await spawnPromisified(execPath, [
-      path('es-module-loaders', 'syntax-error.mjs'),
+      fixtures.path('es-module-loaders', 'syntax-error.mjs'),
     ]);
     assert.match(stderr, /SyntaxError:/);
     assert.notStrictEqual(code, 0);

--- a/test/es-module/test-esm-wasm-escape-import-names.mjs
+++ b/test/es-module/test-esm-wasm-escape-import-names.mjs
@@ -1,7 +1,7 @@
 // Test that import names are properly escaped
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-globals-all-types.mjs
+++ b/test/es-module/test-esm-wasm-globals-all-types.mjs
@@ -1,7 +1,7 @@
 // Test that all WebAssembly global types are properly handled
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-js-string-builtins.mjs
+++ b/test/es-module/test-esm-wasm-js-string-builtins.mjs
@@ -1,7 +1,7 @@
 // Test that js-string builtins are supported
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-load-exports.mjs
+++ b/test/es-module/test-esm-wasm-load-exports.mjs
@@ -1,7 +1,7 @@
 // Test that WASM modules can load and export functions correctly
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-module-instances-warning.mjs
+++ b/test/es-module/test-esm-wasm-module-instances-warning.mjs
@@ -3,7 +3,7 @@ import '../common/index.mjs';
 import assert from 'node:assert';
 
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-no-code-injection.mjs
+++ b/test/es-module/test-esm-wasm-no-code-injection.mjs
@@ -1,7 +1,7 @@
 // Test that code injection through export names is not allowed
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-non-identifier-exports.mjs
+++ b/test/es-module/test-esm-wasm-non-identifier-exports.mjs
@@ -1,7 +1,7 @@
 // Test that WASM modules can have non-identifier export names
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-reject-wasm-export-names.mjs
+++ b/test/es-module/test-esm-wasm-reject-wasm-export-names.mjs
@@ -1,7 +1,7 @@
 // Test WASM module with invalid export name starting with 'wasm:'
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-reject-wasm-import-names.mjs
+++ b/test/es-module/test-esm-wasm-reject-wasm-import-names.mjs
@@ -1,7 +1,7 @@
 // Test WASM module with invalid import name starting with 'wasm:'
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-reject-wasm-js-export-names.mjs
+++ b/test/es-module/test-esm-wasm-reject-wasm-js-export-names.mjs
@@ -1,7 +1,7 @@
 // Test WASM module with invalid export name starting with 'wasm-js:'
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-reject-wasm-js-import-module.mjs
+++ b/test/es-module/test-esm-wasm-reject-wasm-js-import-module.mjs
@@ -1,7 +1,7 @@
 // Test WASM module with invalid import module name starting with 'wasm-js:'
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-reject-wasm-js-import-names.mjs
+++ b/test/es-module/test-esm-wasm-reject-wasm-js-import-names.mjs
@@ -1,7 +1,7 @@
 // Test WASM module with invalid import name starting with 'wasm-js:'
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-source-phase-dynamic.mjs
+++ b/test/es-module/test-esm-wasm-source-phase-dynamic.mjs
@@ -1,7 +1,7 @@
 // Test that dynamic source phase imports are supported
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-source-phase-no-execute-dynamic.mjs
+++ b/test/es-module/test-esm-wasm-source-phase-no-execute-dynamic.mjs
@@ -1,7 +1,7 @@
 // Test that dynamic source phase imports don't execute
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-source-phase-no-execute.mjs
+++ b/test/es-module/test-esm-wasm-source-phase-no-execute.mjs
@@ -1,7 +1,7 @@
 // Test that source phase imports don't execute
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-source-phase-not-defined-dynamic.mjs
+++ b/test/es-module/test-esm-wasm-source-phase-not-defined-dynamic.mjs
@@ -1,7 +1,7 @@
 // Test that error is thrown for dynamic source phase imports not defined
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-source-phase-not-defined-static.mjs
+++ b/test/es-module/test-esm-wasm-source-phase-not-defined-static.mjs
@@ -3,7 +3,7 @@ import '../common/index.mjs';
 import assert from 'node:assert';
 
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 const fileUrl = fixtures.fileURL('es-modules/wasm-source-phase.js').href;
 spawnSyncAndAssert(

--- a/test/es-module/test-esm-wasm-source-phase-static.mjs
+++ b/test/es-module/test-esm-wasm-source-phase-static.mjs
@@ -1,7 +1,7 @@
 // Test that static source phase imports are supported
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-top-level-execution.mjs
+++ b/test/es-module/test-esm-wasm-top-level-execution.mjs
@@ -1,7 +1,7 @@
 // Test that WASM modules support top-level execution
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-vm-source-phase-dynamic.mjs
+++ b/test/es-module/test-esm-wasm-vm-source-phase-dynamic.mjs
@@ -1,7 +1,7 @@
 // Test that error is thrown for vm source phase dynamic import
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-esm-wasm-vm-source-phase-static.mjs
+++ b/test/es-module/test-esm-wasm-vm-source-phase-static.mjs
@@ -1,7 +1,7 @@
 // Test that error is thrown for vm source phase static import
 import '../common/index.mjs';
 import { spawnSyncAndAssert } from '../common/child_process.js';
-import * as fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 
 spawnSyncAndAssert(
   process.execPath,

--- a/test/es-module/test-require-module-preload.js
+++ b/test/es-module/test-require-module-preload.js
@@ -2,7 +2,7 @@
 
 require('../common');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { fixturesDir } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 
 function testPreload(preloadFlag) {
   // Test named exports.
@@ -16,7 +16,7 @@ function testPreload(preloadFlag) {
         './printA.js',
       ],
       {
-        cwd: fixturesDir,
+        cwd: fixtures.fixturesDir,
       },
       {
         stdout: 'A',
@@ -36,7 +36,7 @@ function testPreload(preloadFlag) {
         './printA.js',
       ],
       {
-        cwd: fixturesDir,
+        cwd: fixtures.fixturesDir,
       },
       {
         stdout: /^world\s+A$/,
@@ -56,7 +56,7 @@ function testPreload(preloadFlag) {
         './printA.js',
       ],
       {
-        cwd: fixturesDir,
+        cwd: fixtures.fixturesDir,
       },
       {
         stdout: /^ok\s+A$/,
@@ -78,7 +78,7 @@ function testPreload(preloadFlag) {
         './printA.js',
       ],
       {
-        cwd: fixturesDir,
+        cwd: fixtures.fixturesDir,
       },
       {
         stdout: /^world\s+A$/,
@@ -103,7 +103,7 @@ testPreload('--import');
       './printA.js',
     ],
     {
-      cwd: fixturesDir,
+      cwd: fixtures.fixturesDir,
     },
     {
       stdout: /^package-type-module\s+A$/,

--- a/test/eslint.config_partial.mjs
+++ b/test/eslint.config_partial.mjs
@@ -117,6 +117,26 @@ export default [
           selector: 'CallExpression:matches([callee.type="Identifier"][callee.name="assert"], [callee.type="MemberExpression"][callee.object.type="Identifier"][callee.object.name="assert"][callee.property.type="Identifier"][callee.property.name="ok"])[arguments.0.type="UnaryExpression"][arguments.0.operator="!"][arguments.0.argument.type="CallExpression"][arguments.0.argument.callee.type="MemberExpression"][arguments.0.argument.callee.object.regex][arguments.0.argument.callee.property.name="test"]',
           message: 'Use assert.doesNotMatch instead',
         },
+        ...((fixturesSpecifier) => [
+          {
+            selector: `ImportDeclaration[source.value=${fixturesSpecifier.toString().replace('(\\.js)?', '\\.mjs')}]:not(${[
+              'length=1',
+              '0.type="ImportNamespaceSpecifier"',
+            ].map((selector) => `[specifiers.${selector}]`).join('')})`,
+            message: 'Do not use named imports, use `import * as fixtures from` instead',
+          },
+          {
+            selector: `ImportDeclaration[source.value=${fixturesSpecifier}]:not(${[
+              'length=1',
+              '0.type="ImportDefaultSpecifier"',
+            ].map((selector) => `[specifiers.${selector}]`).join('')})`,
+            message: 'Do not use named imports, use `import fixtures from` instead',
+          },
+          {
+            selector: `:not(VariableDeclarator[id.type="Identifier"])>CallExpression[callee.name="require"][arguments.0.value=${fixturesSpecifier}]`,
+            message: 'Do not destructure, use `const fixtures =` instead',
+          },
+        ])(/^(\.\.\u002f)+common\u002ffixtures(\.js)?$/),
       ],
 
       // Stylistic rules.

--- a/test/fixtures/errors/async_error_eval_cjs.js
+++ b/test/fixtures/errors/async_error_eval_cjs.js
@@ -2,8 +2,9 @@
 
 require('../../common');
 const { spawnSync } = require('child_process');
+const fixtures = require('../../common/fixtures');
 
-const four = require('../../common/fixtures')
+const four = fixtures
   .readSync('async-error.js')
   .toString()
   .split('\n')

--- a/test/fixtures/errors/async_error_eval_esm.js
+++ b/test/fixtures/errors/async_error_eval_esm.js
@@ -2,8 +2,9 @@
 
 require('../../common');
 const { spawnSync } = require('child_process');
+const fixtures = require('../../common/fixtures');
 
-const four = require('../../common/fixtures')
+const four = fixtures
   .readSync('async-error.js')
   .toString()
   .split('\n')

--- a/test/known_issues/test-repl-require-context.js
+++ b/test/known_issues/test-repl-require-context.js
@@ -2,12 +2,12 @@
 // Refs: https://github.com/nodejs/node/issues/7788
 const common = require('../common');
 const assert = require('assert');
-const path = require('../common/fixtures').path;
+const fixtures = require('../common/fixtures');
 const repl = require('repl');
 const stream = require('stream');
 const inputStream = new stream.PassThrough();
 const outputStream = new stream.PassThrough();
-const fixture = path('is-object.js');
+const fixture = fixtures.path('is-object.js');
 const r = repl.start({
   input: inputStream,
   output: outputStream,

--- a/test/module-hooks/test-module-hooks-load-url-change-import.mjs
+++ b/test/module-hooks/test-module-hooks-load-url-change-import.mjs
@@ -1,7 +1,7 @@
 import { mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import { registerHooks } from 'node:module';
-import { fileURL } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 
 // This tests shows the url parameter in `load` can be changed in the `nextLoad` call
 // It changes `foo` package name into `redirected-fs` and then loads `redirected-fs`
@@ -16,7 +16,7 @@ const hook = registerHooks({
   }),
   load: mustCall(function load(url, context, nextLoad) {
     assert.strictEqual(url, 'foo://bar');
-    return nextLoad(fileURL('module-hooks', 'redirected-fs.js').href, context);
+    return nextLoad(fixtures.fileURL('module-hooks', 'redirected-fs.js').href, context);
   }),
 });
 

--- a/test/module-hooks/test-module-hooks-resolve-builtin-on-disk-import.mjs
+++ b/test/module-hooks/test-module-hooks-resolve-builtin-on-disk-import.mjs
@@ -1,5 +1,5 @@
 import '../common/index.mjs';
-import { fileURL } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { registerHooks } from 'node:module';
 import process from 'node:process';
@@ -18,7 +18,7 @@ const hook = registerHooks({
       return nextLoad(specifier, context);
     }
     return {
-      url: fileURL(
+      url: fixtures.fileURL(
         'module-hooks',
         `redirected-${specifier.replace('node:', '')}.js`).href,
       shortCircuit: true,

--- a/test/parallel/test-assert-first-line.js
+++ b/test/parallel/test-assert-first-line.js
@@ -5,11 +5,11 @@
 require('../common');
 const assert = require('assert');
 const { test } = require('node:test');
-const { path } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 
 test('Verify that asserting in the very first line produces the expected result', () => {
   assert.throws(
-    () => require(path('assert-first-line')),
+    () => require(fixtures.path('assert-first-line')),
     {
       name: 'AssertionError',
       message: "The expression evaluated to a falsy value:\n\n  ässört.ok('')\n"
@@ -17,7 +17,7 @@ test('Verify that asserting in the very first line produces the expected result'
   );
 
   assert.throws(
-    () => require(path('assert-long-line')),
+    () => require(fixtures.path('assert-long-line')),
     {
       name: 'AssertionError',
       message: "The expression evaluated to a falsy value:\n\n  assert.ok('')\n"

--- a/test/parallel/test-crypto-no-algorithm.js
+++ b/test/parallel/test-crypto-no-algorithm.js
@@ -30,9 +30,9 @@ if (isMainThread) {
 
 {
   // Startup test. Should not hang.
-  const { path } = require('../common/fixtures');
+  const fixtures = require('../common/fixtures');
   const { spawnSync } = require('node:child_process');
-  const baseConf = path('openssl3-conf', 'base_only.cnf');
+  const baseConf = fixtures.path('openssl3-conf', 'base_only.cnf');
   const cp = spawnSync(process.execPath,
                        [ `--openssl-config=${baseConf}`, '-p', '"hello"' ],
                        { encoding: 'utf8' });

--- a/test/parallel/test-debugger-auto-resume.mjs
+++ b/test/parallel/test-debugger-auto-resume.mjs
@@ -2,7 +2,7 @@ import { skipIfInspectorDisabled } from '../common/index.mjs';
 
 skipIfInspectorDisabled();
 
-import { path as _path } from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 import startCLI from '../common/debugger.js';
 import { addLibraryPath } from '../common/shared-lib-util.js';
 
@@ -13,7 +13,7 @@ addLibraryPath(process.env);
 
 // Auto-resume on start if the environment variable is defined.
 {
-  const scriptFullPath = _path('debugger', 'break.js');
+  const scriptFullPath = fixtures.path('debugger', 'break.js');
   const script = relative(process.cwd(), scriptFullPath);
 
   const env = {

--- a/test/parallel/test-debugger-exec-scope.mjs
+++ b/test/parallel/test-debugger-exec-scope.mjs
@@ -2,12 +2,12 @@ import { skipIfInspectorDisabled } from '../common/index.mjs';
 
 skipIfInspectorDisabled();
 
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import startCLI from '../common/debugger.js';
 
 import assert from 'assert';
 
-const cli = startCLI([path('debugger/backtrace.js')]);
+const cli = startCLI([fixtures.path('debugger/backtrace.js')]);
 
 try {
   await cli.waitForInitialBreak();

--- a/test/parallel/test-debugger-extract-function-name.mjs
+++ b/test/parallel/test-debugger-extract-function-name.mjs
@@ -2,12 +2,12 @@ import { skipIfInspectorDisabled } from '../common/index.mjs';
 
 skipIfInspectorDisabled();
 
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import startCLI from '../common/debugger.js';
 
 import assert from 'assert';
 
-const cli = startCLI([path('debugger', 'three-lines.js')]);
+const cli = startCLI([fixtures.path('debugger', 'three-lines.js')]);
 
 try {
   await cli.waitForInitialBreak();

--- a/test/parallel/test-debugger-help.mjs
+++ b/test/parallel/test-debugger-help.mjs
@@ -2,12 +2,12 @@ import { skipIfInspectorDisabled } from '../common/index.mjs';
 
 skipIfInspectorDisabled();
 
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import startCLI from '../common/debugger.js';
 
 import assert from 'assert';
 
-const cli = startCLI([path('debugger', 'empty.js')]);
+const cli = startCLI([fixtures.path('debugger', 'empty.js')]);
 
 try {
   await cli.waitForInitialBreak();

--- a/test/parallel/test-debugger-repeat-last.js
+++ b/test/parallel/test-debugger-repeat-last.js
@@ -1,10 +1,10 @@
 'use strict';
 const common = require('../common');
 common.skipIfInspectorDisabled();
-const path = require('../common/fixtures').path;
+const fixtures = require('../common/fixtures');
 const spawn = require('child_process').spawn;
 const assert = require('assert');
-const fixture = path('debugger-repeat-last.js');
+const fixture = fixtures.path('debugger-repeat-last.js');
 
 const args = [
   'inspect',

--- a/test/parallel/test-debugger-set-context-line-number.mjs
+++ b/test/parallel/test-debugger-set-context-line-number.mjs
@@ -1,12 +1,12 @@
 import { skipIfInspectorDisabled } from '../common/index.mjs';
 skipIfInspectorDisabled();
 
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import startCLI from '../common/debugger.js';
 
 import assert from 'assert';
 
-const script = path('debugger', 'twenty-lines.js');
+const script = fixtures.path('debugger', 'twenty-lines.js');
 const cli = startCLI([script]);
 
 function onFatal(error) {

--- a/test/parallel/test-debugger-watchers.mjs
+++ b/test/parallel/test-debugger-watchers.mjs
@@ -1,12 +1,12 @@
 import { skipIfInspectorDisabled } from '../common/index.mjs';
 skipIfInspectorDisabled();
 
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import startCLI from '../common/debugger.js';
 
 import assert from 'assert';
 
-const script = path('debugger', 'break.js');
+const script = fixtures.path('debugger', 'break.js');
 const cli = startCLI([script]);
 
 function onFatal(error) {

--- a/test/parallel/test-http-url.parse-https.request.js
+++ b/test/parallel/test-http-url.parse-https.request.js
@@ -23,7 +23,7 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const { readKey } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 
 const assert = require('assert');
 const https = require('https');
@@ -31,8 +31,8 @@ const url = require('url');
 
 // https options
 const httpsOptions = {
-  key: readKey('agent1-key.pem'),
-  cert: readKey('agent1-cert.pem')
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 function check(request) {

--- a/test/parallel/test-http2-empty-frame-without-eof.js
+++ b/test/parallel/test-http2-empty-frame-without-eof.js
@@ -2,13 +2,13 @@
 const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
-const { readSync } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 const net = require('net');
 const http2 = require('http2');
 const { once } = require('events');
 
 async function main() {
-  const blobWithEmptyFrame = readSync('emptyframe.http2');
+  const blobWithEmptyFrame = fixtures.readSync('emptyframe.http2');
   const server = net.createServer((socket) => {
     socket.once('data', () => {
       socket.end(blobWithEmptyFrame);

--- a/test/parallel/test-http2-origin.js
+++ b/test/parallel/test-http2-origin.js
@@ -17,11 +17,11 @@ const {
 } = require('http2');
 const Countdown = require('../common/countdown');
 
-const { readKey } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 
-const key = readKey('agent8-key.pem', 'binary');
-const cert = readKey('agent8-cert.pem', 'binary');
-const ca = readKey('fake-startcom-root-cert.pem', 'binary');
+const key = fixtures.readKey('agent8-key.pem', 'binary');
+const cert = fixtures.readKey('agent8-cert.pem', 'binary');
+const ca = fixtures.readKey('fake-startcom-root-cert.pem', 'binary');
 
 {
   const server = createSecureServer({ key, cert });

--- a/test/parallel/test-https-agent-session-eviction.js
+++ b/test/parallel/test-https-agent-session-eviction.js
@@ -7,15 +7,15 @@ if (!common.hasCrypto) {
   common.skip('missing crypto');
 }
 
-const { readKey } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 const { hasOpenSSL } = require('../common/crypto');
 
 const https = require('https');
 const { SSL_OP_NO_TICKET } = require('crypto').constants;
 
 const options = {
-  key: readKey('agent1-key.pem'),
-  cert: readKey('agent1-cert.pem'),
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
   secureOptions: SSL_OP_NO_TICKET,
 };
 

--- a/test/parallel/test-https-keep-alive-drop-requests.js
+++ b/test/parallel/test-https-keep-alive-drop-requests.js
@@ -10,7 +10,7 @@ const http = require('http');
 const net = require('net');
 const assert = require('assert');
 const tls = require('tls');
-const { readKey } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 
 function request(socket) {
   socket.write('GET / HTTP/1.1\r\nHost: localhost\r\nConnection: keep-alive\r\n\r\n\r\n');
@@ -18,8 +18,8 @@ function request(socket) {
 
 // https options
 const httpsOptions = {
-  key: readKey('agent1-key.pem'),
-  cert: readKey('agent1-cert.pem')
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem')
 };
 
 const server = https.createServer(httpsOptions, common.mustCall((req, res) => {

--- a/test/parallel/test-icu-env.js
+++ b/test/parallel/test-icu-env.js
@@ -3,7 +3,7 @@ const common = require('../common');
 const assert = require('assert');
 const { execFileSync } = require('child_process');
 const { readFileSync, globSync } = require('fs');
-const { path } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 const { isMainThread } = require('worker_threads');
 
 // This test checks for regressions in environment variable handling and
@@ -16,7 +16,7 @@ const { isMainThread } = require('worker_threads');
 // Typically, only a few strings change with each ICU update. If this script
 // suddenly generates identical values for all locales, it indicates a bug.
 // Editing json file manually is also fine.
-const localizationDataFile = path(`icu/localizationData-v${process.versions.icu}.json`);
+const localizationDataFile = fixtures.path(`icu/localizationData-v${process.versions.icu}.json`);
 
 let localizationData;
 try {
@@ -31,7 +31,7 @@ try {
   console.log(`The ICU is v${process.versions.icu}, but there is no fixture for this version. ` +
   `Trying the latest known version: v${latestVersion}. If this test fails with a few strings changed ` +
   `after ICU update, run this: \n${process.argv[0]} tools/icu/update-test-data.mjs\n`);
-  localizationData = JSON.parse(readFileSync(path(`icu/localizationData-v${latestVersion}.json`)));
+  localizationData = JSON.parse(readFileSync(fixtures.path(`icu/localizationData-v${latestVersion}.json`)));
 }
 
 

--- a/test/parallel/test-module-run-main-monkey-patch.js
+++ b/test/parallel/test-module-run-main-monkey-patch.js
@@ -4,14 +4,14 @@
 // TODO(joyeecheung): This probably should be deprecated.
 
 require('../common');
-const { path } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 const assert = require('assert');
 const { spawnSync } = require('child_process');
 
 const child = spawnSync(process.execPath, [
   '--require',
-  path('monkey-patch-run-main.js'),
-  path('semicolon.js'),
+  fixtures.path('monkey-patch-run-main.js'),
+  fixtures.path('semicolon.js'),
 ]);
 
 assert.strictEqual(child.status, 0);

--- a/test/parallel/test-parse-args.mjs
+++ b/test/parallel/test-parse-args.mjs
@@ -1,5 +1,5 @@
 import { spawnPromisified } from '../common/index.mjs';
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { suite, test } from 'node:test';
 import { parseArgs } from 'node:util';
@@ -241,7 +241,7 @@ suite('correct default args', () => {
   test('without CLI flags', async () => {
     const { code, signal, stderr, stdout } = await spawnPromisified(
       process.execPath,
-      [path('parse-args.js'), '--foo', '--bar']);
+      [fixtures.path('parse-args.js'), '--foo', '--bar']);
     assert.deepStrictEqual({ code, signal, stderr, stdout: JSON.parse(stdout) }, expected);
   });
 });

--- a/test/parallel/test-quic-handshake-ipv6-only.mjs
+++ b/test/parallel/test-quic-handshake-ipv6-only.mjs
@@ -2,7 +2,7 @@
 
 import { hasQuic, hasIPv6, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
-import { readKey } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -16,8 +16,8 @@ if (!hasIPv6) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const keys = createPrivateKey(readKey('agent1-key.pem'));
-const certs = readKey('agent1-cert.pem');
+const keys = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const certs = fixtures.readKey('agent1-cert.pem');
 
 const check = {
   // The SNI value

--- a/test/parallel/test-quic-handshake.mjs
+++ b/test/parallel/test-quic-handshake.mjs
@@ -2,7 +2,7 @@
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
-import { readKey } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -12,8 +12,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const keys = createPrivateKey(readKey('agent1-key.pem'));
-const certs = readKey('agent1-cert.pem');
+const keys = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const certs = fixtures.readKey('agent1-cert.pem');
 
 const check = {
   // The SNI value

--- a/test/parallel/test-quic-internal-endpoint-listen-defaults.mjs
+++ b/test/parallel/test-quic-internal-endpoint-listen-defaults.mjs
@@ -2,7 +2,7 @@
 import { hasQuic, skip } from '../common/index.mjs';
 
 import assert from 'node:assert';
-import { readKey } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import { SocketAddress } from 'node:net';
 
 if (!hasQuic) {
@@ -14,8 +14,8 @@ const { listen, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { getQuicEndpointState } = (await import('internal/quic/quic')).default;
 
-const keys = createPrivateKey(readKey('agent1-key.pem'));
-const certs = readKey('agent1-cert.pem');
+const keys = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const certs = fixtures.readKey('agent1-cert.pem');
 
 const endpoint = new QuicEndpoint();
 const state = getQuicEndpointState(endpoint);

--- a/test/parallel/test-require-delete-array-iterator.js
+++ b/test/parallel/test-require-delete-array-iterator.js
@@ -9,5 +9,5 @@ const ArrayIteratorPrototype =
 delete Array.prototype[Symbol.iterator];
 delete ArrayIteratorPrototype.next;
 
-require('../common/fixtures');
-import('../fixtures/es-modules/test-esm-ok.mjs').then(common.mustCall());
+const fixtures = require('../common/fixtures');
+import(fixtures.fileURL('es-modules/test-esm-ok.mjs')).then(common.mustCall());

--- a/test/parallel/test-wasm.mjs
+++ b/test/parallel/test-wasm.mjs
@@ -1,6 +1,6 @@
 import '../common/index.mjs';
 import assert from 'node:assert';
-import { readSync } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 
 // Test Wasm JSPI
 {
@@ -33,7 +33,7 @@ import { readSync } from '../common/fixtures.mjs';
    * that suspends on the promise.
    */
 
-  const { instance } = await WebAssembly.instantiate(readSync('wasm/jspi.wasm'), {
+  const { instance } = await WebAssembly.instantiate(fixtures.readSync('wasm/jspi.wasm'), {
     js: {
       async: new WebAssembly.Suspending(asyncImport),
     },

--- a/test/sequential/test-debugger-launch.mjs
+++ b/test/sequential/test-debugger-launch.mjs
@@ -2,12 +2,12 @@ import { skipIfInspectorDisabled } from '../common/index.mjs';
 skipIfInspectorDisabled();
 
 // This must be in sequential because we check that the default port is 9229.
-import { path } from '../common/fixtures.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import startCLI from '../common/debugger.js';
 
 import assert from 'assert';
 
-const script = path('debugger', 'three-lines.js');
+const script = fixtures.path('debugger', 'three-lines.js');
 const cli = startCLI([script], [], {}, { randomPort: false });
 try {
   await cli.waitForInitialBreak();

--- a/test/sequential/test-require-cache-without-stat.js
+++ b/test/sequential/test-require-cache-without-stat.js
@@ -26,7 +26,7 @@
 require('../common');
 const fs = require('fs');
 const assert = require('assert');
-const { fixturesDir } = require('../common/fixtures');
+const fixtures = require('../common/fixtures');
 
 let counter = 0;
 
@@ -47,7 +47,7 @@ fs.stat = function() {
 };
 
 // Load the module 'a' and 'http' once. It should become cached.
-require(`${fixturesDir}/a`);
+require(`${fixtures.fixturesDir}/a`);
 require('../fixtures/a.js');
 require('./../fixtures/a.js');
 require('http');
@@ -58,7 +58,7 @@ const counterBefore = counter;
 // Now load the module a bunch of times with equivalent paths.
 // stat should not be called.
 for (let i = 0; i < 100; i++) {
-  require(`${fixturesDir}/a`);
+  require(`${fixtures.fixturesDir}/a`);
   require('../fixtures/a.js');
   require('./../fixtures/a.js');
 }

--- a/test/system-ca/test-native-root-certs.mjs
+++ b/test/system-ca/test-native-root-certs.mjs
@@ -3,7 +3,7 @@
 import * as common from '../common/index.mjs';
 import assert from 'node:assert/strict';
 import https from 'node:https';
-import fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 import { it, beforeEach, afterEach, describe } from 'node:test';
 import { once } from 'events';
 

--- a/test/system-ca/test-set-default-ca-certificates-append-system-ca.mjs
+++ b/test/system-ca/test-set-default-ca-certificates-append-system-ca.mjs
@@ -6,7 +6,7 @@
 
 import * as common from '../common/index.mjs';
 import assert from 'node:assert/strict';
-import fixtures from '../common/fixtures.js';
+import * as fixtures from '../common/fixtures.mjs';
 import { once } from 'events';
 
 if (!common.hasCrypto) {


### PR DESCRIPTION
Having `import { path } from '../common/fixtures.mjs` results in `path` to refer to a function, which is confusing as it more often refers to `node:path`. In general, most utils of this module benefits from being prefixed with `fixtures.` (i.e. `fileURL(…)` vs `fixtures.fileURL(…)`).

Refs: https://github.com/nodejs/node/pull/61089#discussion_r2653570851
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
