### PR TITLE
fs: fix rmSync error messages for non-ASCII paths

### DIFF
--- a/src/api/exceptions.cc
+++ b/src/api/exceptions.cc
@@ -20,6 +20,21 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
+static Local<String> StringFromPath(Isolate* isolate, const char* path) {
+#ifdef _WIN32
+  if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
+    return String::Concat(
+        isolate,
+        FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
+        String::NewFromUtf8(isolate, path + 8).ToLocalChecked());
+  } else if (strncmp(path, "\\\\?\\", 4) == 0) {
+    return String::NewFromUtf8(isolate, path + 4).ToLocalChecked();
+  }
+#endif
+
+  return String::NewFromUtf8(isolate, path).ToLocalChecked();
+}
+
 Local<Value> ErrnoException(Isolate* isolate,
                             int errorno,
                             const char* syscall,
@@ -42,7 +57,7 @@ Local<Value> ErrnoException(Isolate* isolate,
   Local<String> path_string;
   if (path != nullptr) {
     // FIXME(bnoordhuis) It's questionable to interpret the file path as UTF-8.
-    path_string = String::NewFromUtf8(isolate, path).ToLocalChecked();
+    path_string = StringFromPath(isolate, path);
   }
 
   if (path_string.IsEmpty() == false) {
@@ -71,22 +86,6 @@ Local<Value> ErrnoException(Isolate* isolate,
 
   return e;
 }
-
-static Local<String> StringFromPath(Isolate* isolate, const char* path) {
-#ifdef _WIN32
-  if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
-    return String::Concat(
-        isolate,
-        FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
-        String::NewFromUtf8(isolate, path + 8).ToLocalChecked());
-  } else if (strncmp(path, "\\\\?\\", 4) == 0) {
-    return String::NewFromUtf8(isolate, path + 4).ToLocalChecked();
-  }
-#endif
-
-  return String::NewFromUtf8(isolate, path).ToLocalChecked();
-}
-
 
 Local<Value> UVException(Isolate* isolate,
                          int errorno,

--- a/src/api/exceptions.cc
+++ b/src/api/exceptions.cc
@@ -8,6 +8,8 @@
 #include "v8.h"
 
 #include <cstring>
+#include <string>
+#include <string_view>
 
 namespace node {
 
@@ -20,19 +22,38 @@ using v8::Object;
 using v8::String;
 using v8::Value;
 
-static Local<String> StringFromPath(Isolate* isolate, const char* path) {
+static Local<String> StringFromPath(Isolate* isolate, std::string_view path) {
 #ifdef _WIN32
-  if (strncmp(path, "\\\\?\\UNC\\", 8) == 0) {
-    return String::Concat(
-        isolate,
-        FIXED_ONE_BYTE_STRING(isolate, "\\\\"),
-        String::NewFromUtf8(isolate, path + 8).ToLocalChecked());
-  } else if (strncmp(path, "\\\\?\\", 4) == 0) {
-    return String::NewFromUtf8(isolate, path + 4).ToLocalChecked();
+  constexpr std::string_view kUncPrefix = "\\\\?\\UNC\\";
+  constexpr std::string_view kLongPrefix = "\\\\?\\";
+
+  if (path.starts_with(kUncPrefix)) {
+    std::string s;
+    s.reserve(2 + (path.size() - kUncPrefix.size()));
+    s.append("\\\\");
+    s.append(path.substr(kUncPrefix.size()));
+    return String::NewFromUtf8(isolate,
+                               s.data(),
+                               v8::NewStringType::kNormal,
+                               static_cast<int>(s.size()))
+        .ToLocalChecked();
+  }
+
+  if (path.starts_with(kLongPrefix)) {
+    auto rest = path.substr(kLongPrefix.size());
+    return String::NewFromUtf8(isolate,
+                               rest.data(),
+                               v8::NewStringType::kNormal,
+                               static_cast<int>(rest.size()))
+        .ToLocalChecked();
   }
 #endif
 
-  return String::NewFromUtf8(isolate, path).ToLocalChecked();
+  return String::NewFromUtf8(isolate,
+                             path.data(),
+                             v8::NewStringType::kNormal,
+                             static_cast<int>(path.size()))
+      .ToLocalChecked();
 }
 
 Local<Value> ErrnoException(Isolate* isolate,
@@ -57,7 +78,7 @@ Local<Value> ErrnoException(Isolate* isolate,
   Local<String> path_string;
   if (path != nullptr) {
     // FIXME(bnoordhuis) It's questionable to interpret the file path as UTF-8.
-    path_string = StringFromPath(isolate, path);
+    path_string = StringFromPath(isolate, std::string_view(path));
   }
 
   if (path_string.IsEmpty() == false) {
@@ -113,7 +134,7 @@ Local<Value> UVException(Isolate* isolate,
   js_msg = String::Concat(isolate, js_msg, js_syscall);
 
   if (path != nullptr) {
-    js_path = StringFromPath(isolate, path);
+    js_path = StringFromPath(isolate, std::string_view(path));
 
     js_msg =
         String::Concat(isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, " '"));
@@ -123,7 +144,7 @@ Local<Value> UVException(Isolate* isolate,
   }
 
   if (dest != nullptr) {
-    js_dest = StringFromPath(isolate, dest);
+    js_dest = StringFromPath(isolate, std::string_view(dest));
 
     js_msg = String::Concat(
         isolate, js_msg, FIXED_ONE_BYTE_STRING(isolate, " -> '"));

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1728,7 +1728,7 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
   }
 
   // On Windows path::c_str() returns wide char, convert to std::string first.
-  std::string file_path_str = file_path.string();
+  std::string file_path_str = ConvertPathToUTF8(file_path);
   const char* path_c_str = file_path_str.c_str();
 #ifdef _WIN32
   int permission_denied_error = EPERM;
@@ -1737,17 +1737,17 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
 #endif  // !_WIN32
 
   if (error == std::errc::operation_not_permitted) {
-    std::string message = "Operation not permitted: " + file_path_str;
+    std::string message = "Operation not permitted: ";
     return env->ThrowErrnoException(EPERM, "rm", message.c_str(), path_c_str);
   } else if (error == std::errc::directory_not_empty) {
-    std::string message = "Directory not empty: " + file_path_str;
+    std::string message = "Directory not empty: ";
     return env->ThrowErrnoException(
         ENOTEMPTY, "rm", message.c_str(), path_c_str);
   } else if (error == std::errc::not_a_directory) {
-    std::string message = "Not a directory: " + file_path_str;
+    std::string message = "Not a directory: ";
     return env->ThrowErrnoException(ENOTDIR, "rm", message.c_str(), path_c_str);
   } else if (error == std::errc::permission_denied) {
-    std::string message = "Permission denied: " + file_path_str;
+    std::string message = "Permission denied: ";
     return env->ThrowErrnoException(
         permission_denied_error, "rm", message.c_str(), path_c_str);
   }

--- a/test/parallel/test-fs-rmSync-special-char-additional-error.js
+++ b/test/parallel/test-fs-rmSync-special-char-additional-error.js
@@ -1,0 +1,51 @@
+'use strict';
+require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('child_process');
+
+tmpdir.refresh(); // Prepare a clean temporary directory
+
+const dirPath = path.join(tmpdir.path, '速速速_dir');
+const filePath = path.join(dirPath, 'test_file.txt');
+
+// Create a directory and a file within it
+fs.mkdirSync(dirPath, { recursive: true });
+fs.writeFileSync(filePath, 'This is a test file.');
+
+// Set permissions to simulate a permission denied scenario
+if (process.platform === 'win32') {
+  // Windows: Deny delete permissions
+  execSync(`icacls "${filePath}" /deny Everyone:(D)`);
+} else {
+  // Unix/Linux: Remove write permissions from the directory
+  fs.chmodSync(dirPath, 0o555); // Read and execute permissions only
+}
+
+// Attempt to delete the directory which should now fail
+try {
+  fs.rmSync(dirPath, { recursive: true });
+} catch (err) {
+  if (process.platform === 'win32') {
+    assert.strictEqual(err.code, 'EPERM');
+  } else {
+    // POSIX: rmSync may surface different errors
+    assert(['EACCES', 'EPERM', 'ENOTEMPTY'].includes(err.code), err.code);
+  }
+  assert.strictEqual(err.path, dirPath);
+  assert(err.message.includes(dirPath), 'Error message should include the path treated as a directory');
+}
+
+// Cleanup - resetting permissions and removing the directory safely
+if (process.platform === 'win32') {
+  // Remove the explicit permissions before attempting to delete
+  execSync(`icacls "${filePath}" /remove:d Everyone`);
+} else {
+  // Reset permissions to allow deletion
+  fs.chmodSync(dirPath, 0o755); // Restore full permissions to the directory
+}
+
+// Attempt to clean up
+fs.rmSync(dirPath, { recursive: true }); // This should now succeed

--- a/test/parallel/test-fs-rmSync-special-char-additional-error.js
+++ b/test/parallel/test-fs-rmSync-special-char-additional-error.js
@@ -4,48 +4,22 @@ const tmpdir = require('../common/tmpdir');
 const assert = require('node:assert');
 const fs = require('node:fs');
 const path = require('node:path');
-const { execSync } = require('child_process');
 
-tmpdir.refresh(); // Prepare a clean temporary directory
+tmpdir.refresh();
 
-const dirPath = path.join(tmpdir.path, '速速速_dir');
-const filePath = path.join(dirPath, 'test_file.txt');
+const file = path.join(tmpdir.path, '速_file');
+fs.writeFileSync(file, 'x');
 
-// Create a directory and a file within it
-fs.mkdirSync(dirPath, { recursive: true });
-fs.writeFileSync(filePath, 'This is a test file.');
-
-// Set permissions to simulate a permission denied scenario
-if (process.platform === 'win32') {
-  // Windows: Deny delete permissions
-  execSync(`icacls "${filePath}" /deny Everyone:(D)`);
-} else {
-  // Unix/Linux: Remove write permissions from the directory
-  fs.chmodSync(dirPath, 0o555); // Read and execute permissions only
-}
+// Treat that file as if it were a directory so the error message
+// includes the path treated as a directory, not the file.
+const badPath = path.join(file, 'child');
 
 // Attempt to delete the directory which should now fail
 try {
-  fs.rmSync(dirPath, { recursive: true });
+  fs.rmSync(badPath, { recursive: true });
 } catch (err) {
-  if (process.platform === 'win32') {
-    assert.strictEqual(err.code, 'EPERM');
-  } else {
-    // POSIX: rmSync may surface different errors
-    assert(['EACCES', 'EPERM', 'ENOTEMPTY'].includes(err.code), err.code);
-  }
-  assert.strictEqual(err.path, dirPath);
-  assert(err.message.includes(dirPath), 'Error message should include the path treated as a directory');
+  // Verify that the error is due to the path being treated as a directory
+  assert.strictEqual(err.code, 'ENOTDIR');
+  assert.strictEqual(err.path, badPath);
+  assert(err.message.includes(badPath), 'Error message should include the path treated as a directory');
 }
-
-// Cleanup - resetting permissions and removing the directory safely
-if (process.platform === 'win32') {
-  // Remove the explicit permissions before attempting to delete
-  execSync(`icacls "${filePath}" /remove:d Everyone`);
-} else {
-  // Reset permissions to allow deletion
-  fs.chmodSync(dirPath, 0o755); // Restore full permissions to the directory
-}
-
-// Attempt to clean up
-fs.rmSync(dirPath, { recursive: true }); // This should now succeed


### PR DESCRIPTION
This PR fixes incorrect and inconsistent error messages produced by `fs.rmSync` when deletion fails, especially for directories containing non-ASCII characters. The issue affected Linux and Windows differently but shared the same root cause: paths were embedded into custom error messages while also being passed separately to `ThrowErrnoException`.

### 1. Duplicate paths in error messages (Linux, ASCII paths)

`fs.rmSync` constructed messages like:

```cpp
std::string message = "Permission denied: " + file_path_str;
env->ThrowErrnoException(err, "rm", message.c_str(), path_c_str);
```

Because `ThrowErrnoException` automatically appends the path, this resulted in duplicated paths when directory names were ASCII-only:

```text
err.path: /tmp/_dir_0
err.message: EACCES, Permission denied: /tmp/_dir_0 '/tmp/_dir_0'
```

### 2. Corrupted paths for non-ASCII directory names (Linux)

When the directory name contained non-ASCII characters, embedding the path into the message caused UTF-8 bytes to be misinterpreted.

Example:

```text
err.path: /tmp/速速速_dir
err.message: EACCES, Permission denied: '/tmp/é速速_dir'
```

Here, the first byte of the UTF-8 sequence was interpreted as a Latin-1 character (`é`), corrupting the path shown in the error message.

### 3. Inconsistent Windows paths (\?\ prefix)
On Windows, `err.path` could expose raw extended-length paths prefixed with `\\?\\`, because the platform-specific normalization logic (`StringFromPath`) was not applied when constructing `ErrnoException`.
Example:
```text
err.path: \\?\\C:\\temp\\速速速_dir
```
This is inconsistent with other fs APIs used in `src/api/exceptions`, which strip the prefix before exposing paths to JavaScript.

This PR fixes the issue by:

* Removing path concatenation from custom error messages
* Passing the path only via the `path` argument to `ThrowErrnoException`
* Relying on Node’s standard error formatting to attach paths safely
* Applying `StringFromPath` in `src/api/exceptions` for Windows so `err.path` is normalized correctly

A new test has been added: `test-fs-rmSync-special-char-additional-error.js` to verify that:
* `fs.rmSync` reports the correct error code
* `err.path` preserves non-ASCII directory names
* `err.message` includes the correct path
* No path corruption or duplication occurs


@joyeecheung @anonrig Please review this when you are available. 


