### PR TITLE
tools: add tool that fills `pr-url` as code review suggestion

### DIFF
--- a/.github/workflows/suggest-fill-prurl.yml
+++ b/.github/workflows/suggest-fill-prurl.yml
@@ -26,5 +26,3 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}
-          REPO: ${{ github.repository }}
-          SHA: ${{ github.sha }}

--- a/.github/workflows/suggest-fill-prurl.yml
+++ b/.github/workflows/suggest-fill-prurl.yml
@@ -7,6 +7,7 @@ on:
       - doc/api/**/*.md
 
 permissions:
+  contents: read
   pull-requests: write
 
 jobs:

--- a/.github/workflows/suggest-fill-prurl.yml
+++ b/.github/workflows/suggest-fill-prurl.yml
@@ -1,0 +1,29 @@
+name: Suggest PR URL
+
+on:
+  pull_request:
+    types: [opened]
+    paths:
+      - doc/api/**/*.md
+
+permissions:
+  pull-requests: write
+
+jobs:
+  suggest-fill-prurl:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3  # v6.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: /tools/actions/suggest-fill-prurl.mjs
+          sparse-checkout-cone-mode: false
+      - uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903  # v6.0.0
+        with:
+          node-version: latest
+      - run: ./tools/actions/suggest-fill-prurl.mjs
+        env:
+          GH_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}

--- a/tools/actions/suggest-fill-prurl.mjs
+++ b/tools/actions/suggest-fill-prurl.mjs
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+
+// Replaces:
+// pr-url: https://github.com/nodejs/node/pull/FILLME
+// With:
+// pr-url: https://github.com/nodejs/node/pull/ACTUAL_PR_NUMBER
+// And posts it as ```suggestion``` on pull request on GitHub
+
+import { env } from 'node:process';
+
+const { GH_TOKEN, PR_NUMBER, REPO, SHA } = env;
+if (!GH_TOKEN || !PR_NUMBER || !REPO || !SHA) {
+  throw new Error('Missing required environment variables');
+}
+
+const PLACEHOLDER = 'FILLME';
+const placeholderReg = new RegExp(`^\\+.*${RegExp.escape(`https://github.com/${REPO}/pull/${PLACEHOLDER}`)}`);
+
+const headers = new Headers({
+  'Accept': 'application/vnd.github+json',
+  'Authorization': `Bearer ${GH_TOKEN}`,
+  'User-Agent': 'nodejs-bot',
+  'X-GitHub-Api-Version': '2022-11-28',
+});
+
+// https://docs.github.com/en/rest/pulls/pulls?apiVersion=2022-11-28#list-pull-requests-files
+const res = await fetch(
+  new URL(`repos/${REPO}/pulls/${PR_NUMBER}/files`, 'https://api.github.com'),
+  { headers },
+);
+if (!res.ok) {
+  throw new Error(`Failed to fetch PR files, status=${res.status}`);
+}
+
+const files = await res.json();
+
+const comments = files.flatMap(({ status, filename, patch }) => {
+  if (!patch || !['added', 'modified'].includes(status)) {
+    return [];
+  }
+
+  return patch.split('\n').map((line, position) => {
+    if (!placeholderReg.test(line)) {
+      return false;
+    }
+    const suggestion = line
+      .slice(1)
+      .replace(`https://github.com/${REPO}/pull/${PLACEHOLDER}`, `https://github.com/${REPO}/pull/${PR_NUMBER}`);
+    return {
+      path: filename,
+      position,
+      body: `Replace ${PLACEHOLDER} with PR number ${PR_NUMBER}\n` +
+        '```suggestion\n' +
+        `${suggestion}\n` +
+        '```\n',
+    };
+  }).filter(Boolean);
+});
+
+if (comments.length) {
+  const payload = {
+    comments,
+    commit_id: SHA,
+    event: 'COMMENT',
+  };
+
+  // https://docs.github.com/en/rest/pulls/reviews?apiVersion=2022-11-28#create-a-review-for-a-pull-request
+  await fetch(
+    new URL(`repos/${REPO}/pulls/${PR_NUMBER}/reviews`, 'https://api.github.com'),
+    {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(payload),
+    },
+  );
+}


### PR DESCRIPTION
Having to fill `pr-url` in docs is sometimes annoying, since there's no guaranteed way to predict the PR number before pushing the changes.
This PR adds tool that searches for `https://github.com/nodejs/node/pull/FILLME` and posts `https://github.com/nodejs/node/pull/12345` (where `12345` is actual PR number) as code review suggestion (` ```suggestion `).
To avoid unnecessary flooding, it triggers only on initial open, and only if pr-url was explicitly set as `https://github.com/nodejs/node/pull/FILLME` in the files.

This also could be addressed as local tool, or even as ncu feature (e.g. `git node i-feel-lucky` to guess the next number, fill and commit).