### PR TITLE
doc: add reusePort error behavior to net module

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -951,7 +951,7 @@ changes:
     port, even if another process has already bound a socket on it. Incoming
     datagrams are distributed to listening sockets. The option is available
     only on some platforms, such as Linux 3.9+, DragonFlyBSD 3.6+, FreeBSD 12.0+,
-    Solaris 11.4, and AIX 7.2.5+. On unsupported platforms this option raises an
+    Solaris 11.4, and AIX 7.2.5+. On unsupported platforms, this option raises
     an error when the socket is bound.
     **Default:** `false`.
   * `ipv6Only` {boolean} Setting `ipv6Only` to `true` will

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -558,7 +558,8 @@ changes:
     multiple sockets on the same host to bind to the same port. Incoming connections
     are distributed by the operating system to listening sockets. This option is
     available only on some platforms, such as Linux 3.9+, DragonFlyBSD 3.6+, FreeBSD 12.0+,
-    Solaris 11.4, and AIX 7.2.5+. **Default:** `false`.
+    Solaris 11.4, and AIX 7.2.5+. On unsupported platforms, this option raises
+    an error. **Default:** `false`.
   * `path` {string} Will be ignored if `port` is specified. See
     [Identifying paths for IPC connections][].
   * `port` {number}


### PR DESCRIPTION
This PR documents the error behavior for the `reusePort` option in net module.

Currently, dgram docs mention that `reusePort` raises an error on unsupported platforms, but net docs don't. This inconsistency can confuse users when their server unexpectedly terminates on platforms like Windows or older Linux.

Changes:
- net.md: Added note that `reusePort` raises an error on unsupported platforms
- dgram.md: Fixed typo ("an an error" → "an error")

Now both modules have consistent documentation for this option.

Fixes: https://github.com/nodejs/node/issues/61018