### PR TITLE
doc: correct typo in api contributing doc

### DIFF
--- a/doc/contributing/api-documentation.md
+++ b/doc/contributing/api-documentation.md
@@ -54,7 +54,7 @@ meant to be a guide on how to write documentation for Node.js.
   it as a reference for the structure of the documentation.
 * The
   [Stability Index](https://nodejs.org/dist/latest/docs/api/documentation.html#stability-index)
-  is used to community the Stability of a given Node.js module. The Stability
+  is used to describe the Stability of a given Node.js module. The Stability
   levels include:
   * Stability 0: Deprecated. (This module is Deprecated)
   * Stability 1: Experimental. (This module is Experimental)


### PR DESCRIPTION
In [doc/contributing/api-documentation.md#vocabulary--good-to-knows](https://github.com/nodejs/node/blob/main/doc/contributing/api-documentation.md#vocabulary--good-to-knows) and viewing the sentence:

> * The [Stability Index](https://nodejs.org/dist/latest/docs/api/documentation.html#stability-index) is used to community the Stability of a given Node.js module.

the word "community" doesn't fit.

Perhaps "communicate" was intended?

I'm suggesting to change it to "describe" instead, so it changes to:

> * The [Stability Index](https://nodejs.org/dist/latest/docs/api/documentation.html#stability-index) is used to describe the Stability of a given Node.js module.