### PR TITLE
sqlite: mark as release candidate

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -5,6 +5,9 @@
 <!-- YAML
 added: v22.5.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/61262
+    description: SQLite is now a release candidate.
   - version:
     - v23.4.0
     - v22.13.0
@@ -12,7 +15,7 @@ changes:
     description: SQLite is no longer behind `--experimental-sqlite` but still experimental.
 -->
 
-> Stability: 1.1 - Active development.
+> Stability: 1.2 - Release candidate.
 
 <!-- source_link=lib/sqlite.js -->
 

--- a/lib/sqlite.js
+++ b/lib/sqlite.js
@@ -1,6 +1,3 @@
 'use strict';
-const { emitExperimentalWarning } = require('internal/util');
-
-emitExperimentalWarning('SQLite');
 
 module.exports = internalBinding('sqlite');


### PR DESCRIPTION
Mark the SQLite module as release candidate and remove the experimental warning.