### PR TITLE
doc: fix typos and grammar in BUILDING.md & onboarding.md

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -178,7 +178,7 @@ Binaries at <https://nodejs.org/download/release/> are produced on:
 Starting with Node.js 25, official Linux binaries are linked with `libatomic` and these systems
 must have the `libatomic` runtime installed and available at execution time to run the binaries.
 The package name for the `libatomic` runtime is typically `libatomic` or `libatomic1` depending
-on your Linux distribution.
+on your Linux distibution.
 
 <!--lint disable final-definition-->
 

--- a/onboarding.md
+++ b/onboarding.md
@@ -286,7 +286,7 @@ needs to be pointed out separately during the onboarding.
 * If you are interested in helping to fix coverity reports consider requesting
   access to the projects coverity project as outlined in [static-analysis][].
 * If you are interested in helping out with CI reliability, check out the
-  [reliability respository][] and [guide on how to deal with CI flakes][].
+  [reliability repository][] and [guide on how to deal with CI flakes][].
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
 [Labels]: doc/contributing/collaborator-guide.md#labels


### PR DESCRIPTION
Fixed a few grammatical errors and missing words in `BUILDING.md` to improve readability:

- Windows/Tips: Changed "You may need disable" to "You may need to disable"
- Windows/Tips: Changed "even you never" to "even if you never"
- Windows/ccache: Changed "suggestion missing" to "suggests missing"
- Temporal support: Changed "version temporal_rs" to "version of temporal_rs"