### PR TITLE
build: add `--shared-gtest` configure flag

### DIFF
--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -18,6 +18,7 @@ on:
       - deps/cares/**
       - deps/crates/**
       - deps/corepack/**
+      - deps/googletest/**
       - deps/icu-small/**
       - deps/icu-tmp/**
       - deps/llhttp/**
@@ -64,6 +65,7 @@ on:
       - deps/cares/**
       - deps/crates/**
       - deps/corepack/**
+      - deps/googletest/**
       - deps/icu-small/**
       - deps/icu-tmp/**
       - deps/llhttp/**

--- a/Makefile
+++ b/Makefile
@@ -1237,6 +1237,7 @@ ifeq ($(SKIP_SHARED_DEPS), 1)
 	$(RM) -r $(TARNAME)/deps/brotli
 	$(RM) -r $(TARNAME)/deps/cares
 	$(RM) -r $(TARNAME)/deps/crates
+	$(RM) -r $(TARNAME)/deps/googletest
 	$(RM) -r $(TARNAME)/deps/icu-small
 	$(RM) -r $(TARNAME)/deps/icu-tmp
 	$(RM) -r $(TARNAME)/deps/llhttp

--- a/configure.py
+++ b/configure.py
@@ -263,6 +263,28 @@ parser.add_argument('--openssl-system-ca-path',
     help='Use the specified path to system CA (PEM format) in addition to '
          'the OpenSSL supplied CA store or compiled-in Mozilla CA copy.')
 
+shared_optgroup.add_argument('--shared-gtest',
+    action='store_true',
+    dest='shared_gtest',
+    default=None,
+    help='link to a shared googletest DLL instead of static linking')
+
+shared_optgroup.add_argument('--shared-gtest-includes',
+    action='store',
+    dest='shared_gtest_includes',
+    help='directory containing googletest header files')
+
+shared_optgroup.add_argument('--shared-gtest-libname',
+    action='store',
+    dest='shared_gtest_libname',
+    default='gtest',
+    help='alternative lib name to link to [default: %(default)s]')
+
+shared_optgroup.add_argument('--shared-gtest-libpath',
+    action='store',
+    dest='shared_gtest_libpath',
+    help='a directory to search for the shared googletest DLL')
+
 parser.add_argument('--experimental-http-parser',
     action='store_true',
     dest='experimental_http_parser',
@@ -2409,6 +2431,7 @@ configure_library('simdjson', output)
 configure_library('simdutf', output)
 configure_library('brotli', output, pkgname=['libbrotlidec', 'libbrotlienc'])
 configure_library('cares', output, pkgname='libcares')
+configure_library('gtest', output)
 configure_library('nghttp2', output, pkgname='libnghttp2')
 configure_library('nghttp3', output, pkgname='libnghttp3')
 configure_library('ngtcp2', output, pkgname='libngtcp2')

--- a/node.gyp
+++ b/node.gyp
@@ -4,36 +4,37 @@
     'v8_trace_maps%': 0,
     'v8_enable_pointer_compression%': 0,
     'v8_enable_31bit_smis_on_64bit_arch%': 0,
-    'node_no_browser_globals%': 'false',
-    'node_snapshot_main%': '',
-    'node_use_node_snapshot%': 'false',
-    'node_use_v8_platform%': 'true',
-    'node_use_bundled_v8%': 'true',
-    'node_shared%': 'false',
-    'node_write_snapshot_as_string_literals': 'true',
     'force_dynamic_crt%': 0,
-    'ossfuzz' : 'false',
+    'node_builtin_modules_path%': '',
+    'node_core_target_name%': 'node',
+    'node_enable_v8_vtunejit%': 'false',
+    'node_intermediate_lib_type%': 'static_library',
+    'node_lib_target_name%': 'libnode',
     'node_module_version%': '',
-    'node_use_amaro%': 'true',
+    'node_no_browser_globals%': 'false',
     'node_shared_brotli%': 'false',
-    'node_shared_zstd%': 'false',
-    'node_shared_zlib%': 'false',
-    'node_shared_http_parser%': 'false',
     'node_shared_cares%': 'false',
+    'node_shared_gtest%': 'false',
+    'node_shared_http_parser%': 'false',
     'node_shared_libuv%': 'false',
+    'node_shared_nghttp2%': 'false',
+    'node_shared_openssl%': 'false',
     'node_shared_sqlite%': 'false',
     'node_shared_temporal_capi%': 'false',
     'node_shared_uvwasi%': 'false',
-    'node_shared_nghttp2%': 'false',
+    'node_shared_zlib%': 'false',
+    'node_shared_zstd%': 'false',
+    'node_shared%': 'false',
+    'node_snapshot_main%': '',
+    'node_use_amaro%': 'true',
+    'node_use_bundled_v8%': 'true',
+    'node_use_node_snapshot%': 'false',
     'node_use_openssl%': 'true',
     'node_use_sqlite%': 'true',
-    'node_shared_openssl%': 'false',
+    'node_use_v8_platform%': 'true',
     'node_v8_options%': '',
-    'node_enable_v8_vtunejit%': 'false',
-    'node_core_target_name%': 'node',
-    'node_lib_target_name%': 'libnode',
-    'node_intermediate_lib_type%': 'static_library',
-    'node_builtin_modules_path%': '',
+    'node_write_snapshot_as_string_literals': 'true',
+    'ossfuzz' : 'false',
     'linked_module_files': [
     ],
     # We list the deps/ files out instead of globbing them in js2c.cc since we
@@ -865,7 +866,6 @@
         '<(SHARED_INTERMEDIATE_DIR)' # for node_natives.h
       ],
       'dependencies': [
-        'deps/googletest/googletest.gyp:gtest_prod',
         'deps/histogram/histogram.gyp:histogram',
         'deps/nbytes/nbytes.gyp:nbytes',
         'tools/v8_gypfiles/abseil.gyp:abseil',
@@ -928,6 +928,11 @@
           'sources': [
             'src/node_snapshot_stub.cc',
           ]
+        }],
+        [ 'node_shared_gtest=="false"', {
+          'dependencies': [
+            'deps/googletest/googletest.gyp:gtest_prod',
+          ],
         }],
         [ 'node_use_sqlite=="true"', {
           'sources': [
@@ -1154,7 +1159,6 @@
       'type': 'executable',
       'dependencies': [
         '<(node_lib_target_name)',
-        'deps/googletest/googletest.gyp:gtest_prod',
         'deps/histogram/histogram.gyp:histogram',
         'deps/nbytes/nbytes.gyp:nbytes',
       ],
@@ -1179,6 +1183,11 @@
         'test/fuzzers/fuzz_strings.cc',
       ],
       'conditions': [
+        [ 'node_shared_gtest=="false"', {
+          'dependencies': [
+            'deps/googletest/googletest.gyp:gtest_prod',
+          ],
+        }],
         [ 'node_shared_uvwasi=="false"', {
           'dependencies': [ 'deps/uvwasi/uvwasi.gyp:uvwasi' ],
           'include_dirs': [ 'deps/uvwasi/include' ],
@@ -1202,8 +1211,6 @@
 
       'dependencies': [
         '<(node_lib_target_name)',
-        'deps/googletest/googletest.gyp:gtest',
-        'deps/googletest/googletest.gyp:gtest_main',
         'deps/histogram/histogram.gyp:histogram',
         'deps/nbytes/nbytes.gyp:nbytes',
         'tools/v8_gypfiles/abseil.gyp:abseil',
@@ -1231,6 +1238,15 @@
       'sources': [ '<@(node_cctest_sources)' ],
 
       'conditions': [
+        [ 'node_shared_gtest=="false"', {
+          'dependencies': [
+            'deps/googletest/googletest.gyp:gtest',
+            'deps/googletest/googletest.gyp:gtest_main',
+          ],
+        }],
+        [ 'node_shared_gtest=="true"', {
+          'libraries': [ '-lgtest_main' ],
+        }],
         [ 'node_use_openssl=="true"', {
           'defines': [
             'HAVE_OPENSSL=1',

--- a/tools/nix/sharedLibDeps.nix
+++ b/tools/nix/sharedLibDeps.nix
@@ -9,6 +9,7 @@
     ada
     brotli
     c-ares
+    gtest
     libuv
     nghttp3
     ngtcp2


### PR DESCRIPTION
googletest is listed as dependency of libnode, it seems useful to support getting it as a shared lib.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
