### PR TITLE
build: fix misplaced comma in ldflags

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -412,7 +412,7 @@
               'conditions': [
                 ['OS in "linux freebsd openharmony" and node_shared=="false"', {
                   'ldflags': [
-                    '-Wl,--whole-archive,'
+                    '-Wl,--whole-archive',
                       '<(obj_dir)/deps/openssl/<(openssl_product)',
                     '-Wl,--no-whole-archive',
                   ],


### PR DESCRIPTION
During my build of Node.js, the linker (lld) threw the following error:

```
error: unsupported linker arg: /root/node-v24.12.0/out/Release/obj.target/deps/openssl/libopenssl.a
```

After investigation, I found that a comma was misplaced inside the quotes. It should be outside the string to correctly separate the list elements. This PR corrects the syntax.