### PR TITLE
stream: sync resume on drain

### DIFF
--- a/benchmark/streams/pipe-backpressure.js
+++ b/benchmark/streams/pipe-backpressure.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const common = require('../common');
+const { Readable, Writable } = require('stream');
+
+const bench = common.createBenchmark(main, {
+  n: [5e6],
+});
+
+function main({ n }) {
+  const b = Buffer.alloc(1024);
+  const r = new Readable();
+  const w = new Writable();
+
+  let i = 0;
+
+  r._read = () => r.push(i++ === n ? null : b);
+  w._write = (data, enc, cb) => queueMicrotask(cb);
+
+  bench.start();
+
+  r.pipe(w);
+  w.on('finish', () => bench.end(n));
+}

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1091,7 +1091,7 @@ function pipeOnDrain(src, dest) {
 
     if ((!state.awaitDrainWriters || state.awaitDrainWriters.size === 0) &&
       (state[kState] & kDataListening) !== 0) {
-      src.resume();
+      resume(stream, state, dest.listenerCount('drain') <= 1);
     }
   };
 }
@@ -1232,7 +1232,10 @@ function nReadingNextTick(self) {
 // pause() and resume() are remnants of the legacy readable stream API
 // If the user uses them, then switch into old mode.
 Readable.prototype.resume = function() {
-  const state = this._readableState;
+  return resume(this, this._readableState, false);
+};
+
+function resume(stream, state, sync) {
   if ((state[kState] & kFlowing) === 0) {
     debug('resume');
     // We flow only if there is no one listening
@@ -1244,18 +1247,18 @@ Readable.prototype.resume = function() {
     } else {
       state[kState] &= ~kFlowing;
     }
-    resume(this, state);
+    if ((state[kState] & kResumeScheduled) === 0) {
+      if (sync) {
+        resume_(stream, state, false);
+      } else {
+        state[kState] |= kResumeScheduled;
+        process.nextTick(resume_, stream, state);
+      }
+    }
   }
   state[kState] |= kHasPaused;
   state[kState] &= ~kPaused;
-  return this;
-};
-
-function resume(stream, state) {
-  if ((state[kState] & kResumeScheduled) === 0) {
-    state[kState] |= kResumeScheduled;
-    process.nextTick(resume_, stream, state);
-  }
+  return stream;
 }
 
 function resume_(stream, state) {


### PR DESCRIPTION
Inside drain context we are already async and don't need to defer resume.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
