### PR TITLE
tools: fix vcbuild lint-js-build

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -752,7 +752,7 @@ if errorlevel 1 goto exit
 goto lint-cpp
 
 :lint-cpp
-if not defined lint_cpp goto lint-js
+if not defined lint_cpp goto lint-js-build
 if defined NODEJS_MAKE goto run-make-lint
 where make > NUL 2>&1 && make -v | findstr /C:"GNU Make" 1> NUL
 if "%ERRORLEVEL%"=="0" set "NODEJS_MAKE=make PYTHON=python" & goto run-make-lint
@@ -760,7 +760,7 @@ where wsl > NUL 2>&1
 if "%ERRORLEVEL%"=="0" set "NODEJS_MAKE=wsl make" & goto run-make-lint
 echo Could not find GNU Make, needed for linting C/C++
 echo Alternatively, you can use WSL
-goto lint-js
+goto lint-js-build
 
 :run-make-lint
 %NODEJS_MAKE% lint-cpp


### PR DESCRIPTION
Currently on Windows we cannot run `vcbuild.bat lint-js`  because the `lint-js-build` is skipped: after the `lint-cpp:` label we go to the `lint-js:` label. Since the `lint-js-build` is never run, we cannot run the `lint-js`.

This PR fixes the issue by going to `lint-js-build:` label after probing the `lint-cpp:` label.

It also fixes running the `vcbuild.bat lint-md` on Windows.

This change was originally added in the PR #60916, but it is better to address this issue in a separate PR.