### PR TITLE
node-api: fix `node_api_create_object_with_properties` name

### DIFF
--- a/benchmark/napi/create_object_with_properties/binding.cc
+++ b/benchmark/napi/create_object_with_properties/binding.cc
@@ -58,7 +58,7 @@ static napi_value CreateObjectWithPropertiesNew(napi_env env,
 
   for (uint32_t i = 0; i < params.count; i++) {
     napi_value obj;
-    napi_create_object_with_properties(
+    node_api_create_object_with_properties(
         env, null_prototype, global_names, global_values, 20, &obj);
   }
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -2645,7 +2645,7 @@ It is the equivalent of doing `new Object()` in JavaScript.
 The JavaScript `Object` type is described in [Section object type][] of the
 ECMAScript Language Specification.
 
-#### `napi_create_object_with_properties`
+#### `node_api_create_object_with_properties`
 
 <!-- YAML
 added:
@@ -2656,12 +2656,12 @@ added:
 > Stability: 1 - Experimental
 
 ```cpp
-napi_status napi_create_object_with_properties(napi_env env,
-                                               napi_value prototype_or_null,
-                                               const napi_value* property_names,
-                                               const napi_value* property_values,
-                                               size_t property_count,
-                                               napi_value* result)
+napi_status node_api_create_object_with_properties(napi_env env,
+                                                   napi_value prototype_or_null,
+                                                   const napi_value* property_names,
+                                                   const napi_value* property_values,
+                                                   size_t property_count,
+                                                   napi_value* result)
 ```
 
 * `[in] env`: The environment that the API is invoked under.

--- a/src/js_native_api.h
+++ b/src/js_native_api.h
@@ -53,12 +53,12 @@ NAPI_EXTERN napi_status NAPI_CDECL napi_create_object(napi_env env,
 #ifdef NAPI_EXPERIMENTAL
 #define NODE_API_EXPERIMENTAL_HAS_CREATE_OBJECT_WITH_PROPERTIES
 NAPI_EXTERN napi_status NAPI_CDECL
-napi_create_object_with_properties(napi_env env,
-                                   napi_value prototype_or_null,
-                                   napi_value* property_names,
-                                   napi_value* property_values,
-                                   size_t property_count,
-                                   napi_value* result);
+node_api_create_object_with_properties(napi_env env,
+                                       napi_value prototype_or_null,
+                                       napi_value* property_names,
+                                       napi_value* property_values,
+                                       size_t property_count,
+                                       napi_value* result);
 #endif  // NAPI_EXPERIMENTAL
 
 NAPI_EXTERN napi_status NAPI_CDECL napi_create_array(napi_env env,

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -1614,12 +1614,12 @@ napi_status NAPI_CDECL napi_create_object(napi_env env, napi_value* result) {
 }
 
 napi_status NAPI_CDECL
-napi_create_object_with_properties(napi_env env,
-                                   napi_value prototype_or_null,
-                                   napi_value* property_names,
-                                   napi_value* property_values,
-                                   size_t property_count,
-                                   napi_value* result) {
+node_api_create_object_with_properties(napi_env env,
+                                       napi_value prototype_or_null,
+                                       napi_value* property_names,
+                                       napi_value* property_values,
+                                       size_t property_count,
+                                       napi_value* result) {
   CHECK_ENV_NOT_IN_GC(env);
   CHECK_ARG(env, result);
 

--- a/test/js-native-api/test_object/test_object.c
+++ b/test/js-native-api/test_object/test_object.c
@@ -732,7 +732,7 @@ static napi_value TestCreateObjectWithProperties(napi_env env,
   napi_value null_prototype;
   NODE_API_CALL(env, napi_get_null(env, &null_prototype));
   NODE_API_CALL(env,
-                napi_create_object_with_properties(
+                node_api_create_object_with_properties(
                     env, null_prototype, names, values, 3, &result));
 
   return result;
@@ -742,9 +742,9 @@ static napi_value TestCreateObjectWithPropertiesEmpty(napi_env env,
                                                       napi_callback_info info) {
   napi_value result;
 
-  NODE_API_CALL(
-      env,
-      napi_create_object_with_properties(env, NULL, NULL, NULL, 0, &result));
+  NODE_API_CALL(env,
+                node_api_create_object_with_properties(
+                    env, NULL, NULL, NULL, 0, &result));
 
   return result;
 }
@@ -777,7 +777,7 @@ static napi_value TestCreateObjectWithCustomPrototype(napi_env env,
   NODE_API_CALL(env, napi_create_int32(env, 42, &values[0]));
 
   NODE_API_CALL(env,
-                napi_create_object_with_properties(
+                node_api_create_object_with_properties(
                     env, prototype, names, values, 1, &result));
 
   return result;


### PR DESCRIPTION
PR #59953 added the new `napi_create_object_with_properties` function to Node-API.
Unfortunately, we did not catch in the PR review that it uses the old function prefix.
This PR addresses the issue by renaming it to `node_api_create_object_with_properties` where we use the proper `node_api_` prefix.