### PR TITLE
node-api: use Node-API in comments

### DIFF
--- a/benchmark/napi/function_args/index.js
+++ b/benchmark/napi/function_args/index.js
@@ -1,5 +1,5 @@
 // Show the difference between calling a V8 binding C++ function
-// relative to a comparable N-API C++ function,
+// relative to a comparable Node-API C++ function,
 // in various types/numbers of arguments.
 // Reports n of calls per second.
 'use strict';
@@ -19,7 +19,7 @@ try {
 try {
   napi = require(`./build/${common.buildType}/napi_binding`);
 } catch {
-  console.error(`${__filename}: NAPI-Binding failed to load`);
+  console.error(`${__filename}: Node-API binding failed to load`);
   process.exit(0);
 }
 

--- a/benchmark/napi/function_call/index.js
+++ b/benchmark/napi/function_call/index.js
@@ -24,7 +24,7 @@ let napi_binding;
 try {
   napi_binding = require(`./build/${common.buildType}/napi_binding`);
 } catch {
-  console.error('misc/function_call/index.js NAPI-Binding failed to load');
+  console.error('misc/function_call/index.js Node-API binding failed to load');
   process.exit(0);
 }
 const napi = napi_binding.hello;

--- a/src/js_native_api_types.h
+++ b/src/js_native_api_types.h
@@ -7,12 +7,11 @@
 #ifdef NAPI_EXPERIMENTAL
 #define NAPI_VERSION NAPI_VERSION_EXPERIMENTAL
 #else
-// The baseline version for N-API.
-// The NAPI_VERSION controls which version will be used by default when
-// compilling a native addon. If the addon developer specifically wants to use
-// functions available in a new version of N-API that is not yet ported in all
-// LTS versions, they can set NAPI_VERSION knowing that they have specifically
-// depended on that version.
+// The baseline version for Node-API.
+// NAPI_VERSION controls which version is used by default when compiling
+// a native addon. If the addon developer wants to use functions from a
+// newer Node-API version not yet available in all LTS versions, they can
+// set NAPI_VERSION to explicitly depend on that version.
 #define NAPI_VERSION 8
 #endif
 #endif
@@ -31,7 +30,7 @@
 
 // This file needs to be compatible with C compilers.
 // This is a public include file, and these includes have essentially
-// became part of it's API.
+// become part of its API.
 #include <stddef.h>  // NOLINT(modernize-deprecated-headers)
 #include <stdint.h>  // NOLINT(modernize-deprecated-headers)
 

--- a/src/js_native_api_v8.cc
+++ b/src/js_native_api_v8.cc
@@ -18,7 +18,7 @@
 #define CHECK_TO_NUMBER(env, context, result, src)                             \
   CHECK_TO_TYPE((env), Number, (context), (result), (src), napi_number_expected)
 
-// n-api defines NAPI_AUTO_LENGTH as the indicator that a string
+// Node-API defines NAPI_AUTO_LENGTH as the indicator that a string
 // is null terminated. For V8 the equivalent is -1. The assert
 // validates that our cast of NAPI_AUTO_LENGTH results in -1 as
 // needed by V8.
@@ -225,7 +225,7 @@ inline napi_status V8NameFromPropertyDescriptor(
   return napi_ok;
 }
 
-// convert from n-api property attributes to v8::PropertyAttribute
+// convert from Node-API property attributes to v8::PropertyAttribute
 inline v8::PropertyAttribute V8PropertyAttributesFromDescriptor(
     const napi_property_descriptor* descriptor) {
   unsigned int attribute_flags = v8::PropertyAttribute::None;
@@ -378,11 +378,10 @@ inline napi_status Unwrap(napi_env env,
 
 //=== Function napi_callback wrapper =================================
 
-// Use this data structure to associate callback data with each N-API function
-// exposed to JavaScript. The structure is stored in a v8::External which gets
-// passed into our callback wrapper. This reduces the performance impact of
-// calling through N-API.
-// Ref: benchmark/misc/function_call
+// Use this data structure to associate callback data with each Node-API
+// function exposed to JavaScript. The structure is stored in a v8::External
+// which gets passed into our callback wrapper. This reduces the performance
+// impact of calling through Node-API. Ref: benchmark/misc/function_call
 // Discussion (incl. perf. data): https://github.com/nodejs/node/pull/21072
 class CallbackBundle {
  public:
@@ -407,7 +406,7 @@ class CallbackBundle {
   }
 
  public:
-  napi_env env;   // Necessary to invoke C++ NAPI callback
+  napi_env env;   // Necessary to invoke C++ Node-API callback
   void* cb_data;  // The user provided callback data
   napi_callback cb;
 
@@ -2126,7 +2125,7 @@ napi_status NAPI_CDECL napi_get_null(napi_env env, napi_value* result) {
 
 // Gets all callback info in a single call. (Ugly, but faster.)
 napi_status NAPI_CDECL napi_get_cb_info(
-    napi_env env,               // [in] NAPI environment handle
+    napi_env env,               // [in] Node-API environment handle
     napi_callback_info cbinfo,  // [in] Opaque callback-info handle
     size_t* argc,      // [in-out] Specifies the size of the provided argv array
                        // and receives the actual count of args.

--- a/src/js_native_api_v8_internals.h
+++ b/src/js_native_api_v8_internals.h
@@ -1,14 +1,14 @@
 #ifndef SRC_JS_NATIVE_API_V8_INTERNALS_H_
 #define SRC_JS_NATIVE_API_V8_INTERNALS_H_
 
-// The V8 implementation of N-API, including `js_native_api_v8.h` uses certain
-// idioms which require definition here. For example, it uses a variant of
-// persistent references which need not be reset in the constructor. It is the
-// responsibility of this file to define these idioms. Optionally, this file
-// may also define `NAPI_VERSION` and set it to the version of N-API to be
+// The V8 implementation of Node-API, including `js_native_api_v8.h` uses
+// certain idioms which require definition here. For example, it uses a variant
+// of persistent references which need not be reset in the constructor. It is
+// the responsibility of this file to define these idioms. Optionally, this file
+// may also define `NAPI_VERSION` and set it to the version of Node-API to be
 // exposed.
 
-// In the case of the Node.js implementation of N-API some of the idioms are
+// In the case of the Node.js implementation of Node-API some of the idioms are
 // imported directly from Node.js by including `node_internals.h` below. Others
 // are bridged to remove references to the `node` namespace. `node_version.h`,
 // included below, defines `NAPI_VERSION`.

--- a/src/node_api.cc
+++ b/src/node_api.cc
@@ -56,10 +56,10 @@ static void ThrowNodeApiVersionError(node::Environment* node_env,
   result = new node_napi_env__(context, module_filename, module_api_version);
   // TODO(addaleax): There was previously code that tried to delete the
   // napi_env when its v8::Context was garbage collected;
-  // However, as long as N-API addons using this napi_env are in place,
+  // However, as long as Node-API addons using this napi_env are in place,
   // the Context needs to be accessible and alive.
   // Ideally, we'd want an on-addon-unload hook that takes care of this
-  // once all N-API addons using this napi_env are unloaded.
+  // once all Node-API addons using this napi_env are unloaded.
   // For now, a per-Environment cleanup hook is the best we can do.
   result->node_env()->AddCleanupHook(
       [](void* arg) { static_cast<napi_env>(arg)->Unref(); },
@@ -150,7 +150,7 @@ void node_napi_env__::CallbackIntoModule(T&& call) {
         !enforceUncaughtExceptionPolicy) {
       ProcessEmitDeprecationWarning(
           node_env,
-          "Uncaught N-API callback exception detected, please run node "
+          "Uncaught Node-API callback exception detected, please run node "
           "with option --force-node-api-uncaught-exceptions-policy=true "
           "to handle those exceptions properly.",
           "DEP0168");
@@ -675,8 +675,8 @@ class AsyncContext {
 }  // end of namespace v8impl
 
 // Intercepts the Node-V8 module registration callback. Converts parameters
-// to NAPI equivalents and then calls the registration callback specified
-// by the NAPI module.
+// to Node-API equivalents and then calls the registration callback specified
+// by the Node-API module.
 static void napi_module_register_cb(v8::Local<v8::Object> exports,
                                     v8::Local<v8::Value> module,
                                     v8::Local<v8::Context> context,
@@ -796,7 +796,7 @@ node_module napi_module_to_node_module(const napi_module* mod) {
 }
 }  // namespace node
 
-// Registers a NAPI module.
+// Registers a Node-API module.
 void NAPI_CDECL napi_module_register(napi_module* mod) {
   node::node_module* nm =
       new node::node_module(node::napi_module_to_node_module(mod));
@@ -839,7 +839,7 @@ struct napi_async_cleanup_hook_handle__ {
     if (done_cb_ != nullptr) done_cb_(done_data_);
 
     // Release the `env` handle asynchronously since it would be surprising if
-    // a call to a N-API function would destroy `env` synchronously.
+    // a call to a Node-API function would destroy `env` synchronously.
     static_cast<node_napi_env>(env_)->node_env()->SetImmediate(
         [env = env_](node::Environment*) { env->Unref(); });
   }

--- a/src/node_binding.cc
+++ b/src/node_binding.cc
@@ -526,7 +526,7 @@ void DLOpen(const FunctionCallbackInfo<Value>& args) {
       }
     }
 
-    // -1 is used for N-API modules
+    // -1 is used for Node-API modules
     if ((mp->nm_version != -1) && (mp->nm_version != NODE_MODULE_VERSION)) {
       // Even if the module did self-register, it may have done so with the
       // wrong version. We must only give up after having checked to see if it

--- a/test/benchmark/test-benchmark-napi.js
+++ b/test/benchmark/test-benchmark-napi.js
@@ -3,7 +3,7 @@
 const common = require('../common');
 
 if (common.isWindows) {
-  common.skip('vcbuild.bat doesn\'t build the n-api benchmarks yet');
+  common.skip('vcbuild.bat doesn\'t build the Node-API benchmarks yet');
 }
 
 const { isMainThread } = require('worker_threads');

--- a/test/cctest/test_linked_binding.cc
+++ b/test/cctest/test_linked_binding.cc
@@ -348,7 +348,8 @@ TEST_F(LinkedBindingTest, ManyBindingsTest) {
   AddLinkedBinding(*test_env, "local_linked1", InitializeLocalBinding, &calls);
   AddLinkedBinding(*test_env, "local_linked2", InitializeLocalBinding, &calls);
   AddLinkedBinding(*test_env, "local_linked3", InitializeLocalBinding, &calls);
-  AddLinkedBinding(*test_env, local_linked_napi);  // Add a N-API addon as well.
+  AddLinkedBinding(*test_env,
+                   local_linked_napi);  // Add a Node-API addon as well.
   AddLinkedBinding(*test_env, "local_linked4", InitializeLocalBinding, &calls);
   AddLinkedBinding(*test_env, "local_linked5", InitializeLocalBinding, &calls);
 

--- a/test/js-native-api/test_constructor/test_null.js
+++ b/test/js-native-api/test_constructor/test_null.js
@@ -2,7 +2,7 @@
 const common = require('../../common');
 const assert = require('assert');
 
-// Test passing NULL to object-related N-APIs.
+// Test passing NULL to object-related Node-APIs.
 const { testNull } = require(`./build/${common.buildType}/test_constructor`);
 const expectedResult = {
   envIsNull: 'Invalid argument',

--- a/test/js-native-api/test_date/test.js
+++ b/test/js-native-api/test_date/test.js
@@ -2,7 +2,7 @@
 
 const common = require('../../common');
 
-// This tests the date-related n-api calls
+// This tests the date-related Node-API calls
 
 const assert = require('assert');
 const test_date = require(`./build/${common.buildType}/test_date`);

--- a/test/js-native-api/test_object/test_null.js
+++ b/test/js-native-api/test_object/test_null.js
@@ -2,7 +2,7 @@
 const common = require('../../common');
 const assert = require('assert');
 
-// Test passing NULL to object-related N-APIs.
+// Test passing NULL to object-related Node-APIs.
 const { testNull } = require(`./build/${common.buildType}/test_object`);
 
 const expectedForProperty = {

--- a/test/js-native-api/test_promise/test.js
+++ b/test/js-native-api/test_promise/test.js
@@ -2,7 +2,7 @@
 
 const common = require('../../common');
 
-// This tests the promise-related n-api calls
+// This tests the promise-related Node-API calls
 
 const assert = require('assert');
 const test_promise = require(`./build/${common.buildType}/test_promise`);

--- a/test/js-native-api/test_string/test_null.js
+++ b/test/js-native-api/test_string/test_null.js
@@ -2,7 +2,7 @@
 const common = require('../../common');
 const assert = require('assert');
 
-// Test passing NULL to object-related N-APIs.
+// Test passing NULL to object-related Node-APIs.
 const { testNull } = require(`./build/${common.buildType}/test_string`);
 
 const expectedResult = {

--- a/test/node-api/test_callback_scope/test-async-hooks.js
+++ b/test/node-api/test_callback_scope/test-async-hooks.js
@@ -5,7 +5,7 @@ const assert = require('assert');
 const async_hooks = require('async_hooks');
 
 // The async_hook that we enable would register the process.emitWarning()
-// call from loading the N-API addon as asynchronous activity because
+// call from loading the Node-API addon as asynchronous activity because
 // it contains a process.nextTick() call. Monkey patch it to be a no-op
 // before we load the addon in order to avoid this.
 process.emitWarning = () => {};

--- a/test/node-api/test_fatal/test_fatal.c
+++ b/test/node-api/test_fatal/test_fatal.c
@@ -2,7 +2,7 @@
 // on a threading library for a new project it bears remembering that in the
 // future libuv may introduce API changes which may render it non-ABI-stable,
 // which, in turn, may affect the ABI stability of the project despite its use
-// of N-API.
+// of Node-API.
 #include <uv.h>
 #include <node_api.h>
 #include "../../js-native-api/common.h"

--- a/test/node-api/test_threadsafe_function/binding.c
+++ b/test/node-api/test_threadsafe_function/binding.c
@@ -2,7 +2,7 @@
 // on a threading library for a new project it bears remembering that in the
 // future libuv may introduce API changes which may render it non-ABI-stable,
 // which, in turn, may affect the ABI stability of the project despite its use
-// of N-API.
+// of Node-API.
 #include <uv.h>
 #include <node_api.h>
 #include "../../js-native-api/common.h"
@@ -207,8 +207,11 @@ static napi_value StartThreadInternal(napi_env env,
 
   NODE_API_ASSERT(env, (ts_fn == NULL), "Existing thread-safe function");
   napi_value async_name;
-  NODE_API_CALL(env, napi_create_string_utf8(env,
-      "N-API Thread-safe Function Test", NAPI_AUTO_LENGTH, &async_name));
+  NODE_API_CALL(env,
+                napi_create_string_utf8(env,
+                                        "Node-API Thread-safe Function Test",
+                                        NAPI_AUTO_LENGTH,
+                                        &async_name));
   NODE_API_CALL(env,
       napi_get_value_uint32(env, argv[3], &ts_info.max_queue_size));
   NODE_API_CALL(env, napi_create_threadsafe_function(env,

--- a/test/node-api/test_worker_buffer_callback/test_worker_buffer_callback.c
+++ b/test/node-api/test_worker_buffer_callback/test_worker_buffer_callback.c
@@ -25,9 +25,9 @@ NAPI_MODULE_INIT() {
   NODE_API_CALL(env, napi_define_properties(
       env, exports, sizeof(properties) / sizeof(*properties), properties));
 
-  // This is a slight variation on the non-N-API test: We create an ArrayBuffer
-  // rather than a Node.js Buffer, since testing the latter would only test
-  // the same code paths and not the ones specific to N-API.
+  // This is a slight variation on the non-Node-API test: We create an
+  // ArrayBuffer rather than a Node.js Buffer, since testing the latter would
+  // only test the same code paths and not the ones specific to Node-API.
   napi_value buffer;
 
   char* data = malloc(sizeof(char));

--- a/test/node-api/test_worker_terminate/test.js
+++ b/test/node-api/test_worker_terminate/test.js
@@ -5,7 +5,7 @@ const { Worker, isMainThread, workerData } = require('worker_threads');
 
 if (isMainThread) {
   // Load the addon in the main thread first.
-  // This checks that N-API addons can be loaded from multiple contexts
+  // This checks that Node-API addons can be loaded from multiple contexts
   // when they are not loaded through NAPI_MODULE().
   require(`./build/${common.buildType}/test_worker_terminate`);
 


### PR DESCRIPTION
This is a comment-only change that does not affect the actual code.
The PR updates a number of comments and test strings where we still use `NAPI` and `N-API` instead of the `Node-API`.
In some cases, the comments are reflowed by the formatter after the changes.