### PR TITLE
build,tools: fix addon build deadlock on errors

### DIFF
--- a/tools/build_addons.py
+++ b/tools/build_addons.py
@@ -58,8 +58,8 @@ def rebuild_addons(args):
 
       # We buffer the output and print it out once the process is done in order
       # to avoid interleaved output from multiple builds running at once.
-      return_code = process.wait()
       stdout, stderr = process.communicate()
+      return_code = process.returncode
       if return_code != 0:
         print(f'Failed to build addon in {test_dir}:')
         if stdout:


### PR DESCRIPTION
While working on the PR #60916 I had often saw a deadlock during build of Node-API test addons.
The issue is that if there are too many errors and the `stderr` buffer becomes full, then the `process.wait()` is causing a deadlock.
This behavior was observed it on Windows. I did not check the other platforms.
The fix removes the use of the `process.wait()` to avoid the deadlock.