### PR TITLE
[v25.x] deps: V8: backport 209d2db9e24a

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.15',
+    'v8_embedder_string': '-node.16',
 
     ##### V8 defaults for Node.js #####
 


### PR DESCRIPTION
This PR fixes JIT compilation error and disassembling error when enabling the RISC-V C extension in V8.

This is only need in v25.x, the v8 version on the main branch already contains the fix.

Original commit message:

    [riscv] Fix compilation error and disassembling error when enabling the RISC-V C extension

    Change-Id: I34a930f7bcda514698ce64d132cbe05fa32b323c
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6934163
    Reviewed-by: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
    Reviewed-by: Kasper Lund <kasperl@rivosinc.com>
    Commit-Queue: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
    Cr-Commit-Position: refs/heads/main@{#102431}

Refs: https://github.com/v8/v8/commit/209d2db9e24a744e3a5bf924e4d5176da0d6be94

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Thanks for @luyahan for pointing out the fix and @RevySR for verifying it on node v25.2.1!