### PR TITLE
build: fix crate vendor file checksums on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,7 @@
 test/fixtures/* -text
 vcbuild.bat text eol=crlf
+# disable eol conversion in vendored files.
+deps/crates/vendor/**/* -text
 deps/npm/bin/npm text eol=lf
 deps/npm/bin/npx text eol=lf
 deps/corepack/shims/corepack text eol=lf


### PR DESCRIPTION
Fix cargo checksum on the `deps/crates/vendor` on Windows. This prevents git from changing the
vendored file EOL, which would result in checksum mismatch.