### PR TITLE
lib: add `process.loadedModules` list

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -2696,6 +2696,30 @@ process.kill(process.pid, 'SIGHUP');
 When `SIGUSR1` is received by a Node.js process, Node.js will start the
 debugger. See [Signal Events][].
 
+## `process.loadedModules`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string\[]}
+  The `process.loadedModules` property returns an array of core modules that
+  were loaded during the current Node.js process execution.
+
+```mjs
+import process from 'node:process';
+
+console.log(process.loadedModules);
+// ['events', 'buffer', 'diagnostics_channel', 'async_hooks', ...]
+```
+
+```cjs
+const process = require('node:process');
+
+console.log(process.loadedModules);
+// ['events', 'buffer', 'diagnostics_channel', 'async_hooks', ...]
+```
+
 ## `process.loadEnvFile(path)`
 
 <!-- YAML

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -80,6 +80,15 @@ ObjectDefineProperty(process, 'moduleLoadList', {
   writable: false,
 });
 
+// Set up process.loadedModules
+const loadedModules = [];
+ObjectDefineProperty(process, 'loadedModules', {
+  __proto__: null,
+  get() { return ArrayPrototypeSlice(loadedModules); },
+  configurable: true,
+  enumerable: true,
+});
+
 
 // processBindingAllowList contains the name of bindings that are allowed
 // for access via process.binding(). This is used to provide a transition
@@ -405,6 +414,9 @@ class BuiltinModule {
     // "NativeModule" is a legacy name of "BuiltinModule". We keep it
     // here to avoid breaking users who parse process.moduleLoadList.
     ArrayPrototypePush(moduleLoadList, `NativeModule ${id}`);
+    if (!StringPrototypeStartsWith(id, 'internal/')) {
+      ArrayPrototypePush(loadedModules, id);
+    }
     return this.exports;
   }
 }

--- a/lib/internal/bootstrap/realm.js
+++ b/lib/internal/bootstrap/realm.js
@@ -85,7 +85,7 @@ const loadedModules = [];
 ObjectDefineProperty(process, 'loadedModules', {
   __proto__: null,
   get() { return ArrayPrototypeSlice(loadedModules); },
-  configurable: true,
+  configurable: false,
   enumerable: true,
 });
 

--- a/test/parallel/test-process-loadedmodules.js
+++ b/test/parallel/test-process-loadedmodules.js
@@ -1,0 +1,7 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+assert.ok(Array.isArray(process.loadedModules));
+assert.throws(() => process.loadedModules = 'foo', /^TypeError: Cannot set property loadedModules of #<process> which has only a getter$/);

--- a/test/parallel/test-process-loadedmodules.js
+++ b/test/parallel/test-process-loadedmodules.js
@@ -3,5 +3,19 @@
 require('../common');
 const assert = require('assert');
 
+
+for (const mod of process.loadedModules) {
+  assert.strictEqual(typeof mod, 'string');
+}
+
+assert.strictEqual(
+  new Set(process.loadedModules).size,
+  process.loadedModules.length
+);
+
+assert.ok(!process.loadedModules.includes('cluster'))
+require('cluster');
+assert.ok(process.loadedModules.includes('cluster'))
+
 assert.ok(Array.isArray(process.loadedModules));
 assert.throws(() => process.loadedModules = 'foo', /^TypeError: Cannot set property loadedModules of #<process> which has only a getter$/);

--- a/test/parallel/test-process-loadedmodules.js
+++ b/test/parallel/test-process-loadedmodules.js
@@ -13,9 +13,9 @@ assert.strictEqual(
   process.loadedModules.length
 );
 
-assert.ok(!process.loadedModules.includes('cluster'))
+assert.ok(!process.loadedModules.includes('cluster'));
 require('cluster');
-assert.ok(process.loadedModules.includes('cluster'))
+assert.ok(process.loadedModules.includes('cluster'));
 
 assert.ok(Array.isArray(process.loadedModules));
 assert.throws(() => process.loadedModules = 'foo', /^TypeError: Cannot set property loadedModules of #<process> which has only a getter$/);


### PR DESCRIPTION
Add a new `process.loadedModules` property that returns an array of public core module names that have been loaded during the current Node.js process execution. This provides a cleaner, documented API for accessing loaded module information compared to the undocumented `process.moduleLoadList`.

Fixes: https://github.com/nodejs/node/issues/41233
Refs: https://github.com/nodejs/node/pull/61276