### PR TITLE
assert: prevent OOM when generating diff for large objects

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -19,6 +19,7 @@ const {
 } = primordials;
 
 const { isError } = require('internal/util');
+const { totalmem } = require('os');
 
 const { inspect } = require('internal/util/inspect');
 const colors = require('internal/util/colors');
@@ -43,10 +44,15 @@ const kReadableOperator = {
 
 const kMaxShortStringLength = 12;
 const kMaxLongStringLength = 512;
-// Maximum size for inspect output before truncation to prevent OOM.
-// Objects with many converging paths can produce exponential growth in
-// util.inspect output at high depths, leading to OOM during diff generation.
-const kMaxInspectOutputLength = 2 * 1024 * 1024; // 2MB
+// Truncation limit for inspect output to prevent OOM during diff generation.
+// Scaled to system memory: 512KB under 1GB, 1MB under 2GB, 2MB otherwise.
+const kGB = 1024 ** 3;
+const kMB = 1024 ** 2;
+const totalMem = totalmem();
+const kMaxInspectOutputLength =
+  totalMem < kGB ? kMB / 2 :
+  totalMem < 2 * kGB ? kMB :
+  2 * kMB;
 const kTruncatedByteMarker = '\n... [truncated]';
 
 const kMethodsWithCustomMessageDiff = new SafeSet()

--- a/lib/internal/assert/myers_diff.js
+++ b/lib/internal/assert/myers_diff.js
@@ -2,7 +2,13 @@
 
 const {
   ArrayPrototypePush,
+  ArrayPrototypeSlice,
   Int32Array,
+  MathFloor,
+  MathMax,
+  MathMin,
+  MathRound,
+  RegExpPrototypeExec,
   StringPrototypeEndsWith,
 } = primordials;
 
@@ -14,7 +20,11 @@ const {
 
 const colors = require('internal/util/colors');
 
+const kChunkSize = 512;
 const kNopLinesToCollapse = 5;
+// Lines that are just structural characters make poor alignment anchors
+// because they appear many times and don't uniquely identify a position.
+const kTrivialLinePattern = /^\s*[{}[\],]+\s*$/;
 const kOperations = {
   DELETE: -1,
   NOP: 0,
@@ -31,18 +41,10 @@ function areLinesEqual(actual, expected, checkCommaDisparity) {
   return false;
 }
 
-function myersDiff(actual, expected, checkCommaDisparity = false) {
+function myersDiffInternal(actual, expected, checkCommaDisparity) {
   const actualLength = actual.length;
   const expectedLength = expected.length;
   const max = actualLength + expectedLength;
-
-  if (max > 2 ** 31 - 1) {
-    throw new ERR_OUT_OF_RANGE(
-      'myersDiff input size',
-      '< 2^31',
-      max,
-    );
-  }
 
   const v = new Int32Array(2 * max + 1);
   const trace = [];
@@ -122,6 +124,170 @@ function backtrack(trace, actual, expected, checkCommaDisparity) {
   }
 
   return result;
+}
+
+function myersDiff(actual, expected, checkCommaDisparity = false) {
+  const actualLength = actual.length;
+  const expectedLength = expected.length;
+  const max = actualLength + expectedLength;
+
+  if (max > 2 ** 31 - 1) {
+    throw new ERR_OUT_OF_RANGE(
+      'myersDiff input size',
+      '< 2^31',
+      max,
+    );
+  }
+
+  // For small inputs, run the algorithm directly
+  if (actualLength <= kChunkSize && expectedLength <= kChunkSize) {
+    return myersDiffInternal(actual, expected, checkCommaDisparity);
+  }
+
+  const boundaries = findAlignedBoundaries(
+    actual, expected, checkCommaDisparity,
+  );
+
+  // Process chunks and concatenate results (last chunk first for reversed order)
+  const result = [];
+  for (let i = boundaries.length - 2; i >= 0; i--) {
+    const actualStart = boundaries[i].actualIdx;
+    const actualEnd = boundaries[i + 1].actualIdx;
+    const expectedStart = boundaries[i].expectedIdx;
+    const expectedEnd = boundaries[i + 1].expectedIdx;
+
+    const actualChunk = ArrayPrototypeSlice(actual, actualStart, actualEnd);
+    const expectedChunk = ArrayPrototypeSlice(expected, expectedStart, expectedEnd);
+
+    if (actualChunk.length === 0 && expectedChunk.length === 0) continue;
+
+    if (actualChunk.length === 0) {
+      for (let j = expectedChunk.length - 1; j >= 0; j--) {
+        ArrayPrototypePush(result, [kOperations.DELETE, expectedChunk[j]]);
+      }
+      continue;
+    }
+
+    if (expectedChunk.length === 0) {
+      for (let j = actualChunk.length - 1; j >= 0; j--) {
+        ArrayPrototypePush(result, [kOperations.INSERT, actualChunk[j]]);
+      }
+      continue;
+    }
+
+    const chunkDiff = myersDiffInternal(actualChunk, expectedChunk, checkCommaDisparity);
+    for (let j = 0; j < chunkDiff.length; j++) {
+      ArrayPrototypePush(result, chunkDiff[j]);
+    }
+  }
+
+  return result;
+}
+
+function findAlignedBoundaries(actual, expected, checkCommaDisparity) {
+  const actualLen = actual.length;
+  const expectedLen = expected.length;
+  const boundaries = [{ actualIdx: 0, expectedIdx: 0 }];
+  const searchRadius = kChunkSize / 2;
+
+  const numTargets = MathMax(
+    MathFloor((actualLen - 1) / kChunkSize),
+    1,
+  );
+
+  for (let i = 1; i <= numTargets; i++) {
+    const targetActual = MathMin(i * kChunkSize, actualLen);
+    if (targetActual >= actualLen) {
+      break;
+    }
+
+    const targetExpected = MathMin(
+      MathRound(targetActual * expectedLen / actualLen),
+      expectedLen - 1,
+    );
+    const prevBoundary = boundaries[boundaries.length - 1];
+
+    const anchor = findAnchorNear(
+      actual, expected, targetActual, targetExpected,
+      prevBoundary, searchRadius, checkCommaDisparity,
+    );
+
+    if (anchor !== undefined) {
+      ArrayPrototypePush(boundaries, anchor);
+    } else {
+      // Fallback: use proportional position, ensuring strictly increasing
+      const fallbackActual = MathMax(targetActual, prevBoundary.actualIdx + 1);
+      const fallbackExpected = MathMax(targetExpected, prevBoundary.expectedIdx + 1);
+      if (fallbackActual < actualLen && fallbackExpected < expectedLen) {
+        ArrayPrototypePush(boundaries, { actualIdx: fallbackActual, expectedIdx: fallbackExpected });
+      }
+    }
+  }
+
+  ArrayPrototypePush(boundaries, { actualIdx: actualLen, expectedIdx: expectedLen });
+  return boundaries;
+}
+
+// Search outward from targetActual and targetExpected for a non-trivial
+// line that matches in both arrays, with adjacent context verification.
+function findAnchorNear(actual, expected, targetActual, targetExpected,
+                        prevBoundary, searchRadius, checkCommaDisparity) {
+  const actualLen = actual.length;
+  const expectedLen = expected.length;
+
+  for (let offset = 0; offset <= searchRadius; offset++) {
+    const candidates = offset === 0 ? [targetActual] : [targetActual + offset, targetActual - offset];
+
+    for (let i = 0; i < candidates.length; i++) {
+      const actualIdx = candidates[i];
+      if (actualIdx <= prevBoundary.actualIdx || actualIdx >= actualLen) {
+        continue;
+      }
+
+      const line = actual[actualIdx];
+      if (isTrivialLine(line)) {
+        continue;
+      }
+
+      const searchStart = MathMax(prevBoundary.expectedIdx + 1, targetExpected - searchRadius);
+      const searchEnd = MathMin(expectedLen - 1, targetExpected + searchRadius);
+
+      for (let j = 0; j <= searchRadius; j++) {
+        const offsets = j === 0 ? [0] : [j, -j];
+        for (let k = 0; k < offsets.length; k++) {
+          const expectedIdx = targetExpected + offsets[k];
+          if (expectedIdx < searchStart || expectedIdx > searchEnd || expectedIdx <= prevBoundary.expectedIdx) {
+            continue;
+          }
+
+          if (
+              areLinesEqual(line, expected[expectedIdx], checkCommaDisparity) &&
+              hasAdjacentMatch(actual, expected, actualIdx, expectedIdx, checkCommaDisparity)
+            ) {
+            return { actualIdx, expectedIdx };
+          }
+        }
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function hasAdjacentMatch(actual, expected, actualIdx, expectedIdx, checkCommaDisparity) {
+  if (actualIdx > 0 && expectedIdx > 0 &&
+      areLinesEqual(actual[actualIdx - 1], expected[expectedIdx - 1], checkCommaDisparity)) {
+    return true;
+  }
+  if (actualIdx < actual.length - 1 && expectedIdx < expected.length - 1 &&
+      areLinesEqual(actual[actualIdx + 1], expected[expectedIdx + 1], checkCommaDisparity)) {
+    return true;
+  }
+  return false;
+}
+
+function isTrivialLine(line) {
+  return RegExpPrototypeExec(kTrivialLinePattern, line) !== null;
 }
 
 function printSimpleMyersDiff(diff) {

--- a/test/parallel/test-assert-large-object-diff-oom.js
+++ b/test/parallel/test-assert-large-object-diff-oom.js
@@ -6,8 +6,16 @@
 // growth in util.inspect output, which previously led to OOM during error
 // message generation.
 
-require('../common');
+const common = require('../common');
+const os = require('os');
 const assert = require('assert');
+
+// This test creates objects with exponential inspect output that requires
+// significant memory. Skip on systems with less than 1GB total memory.
+const totalMemMB = os.totalmem() / 1024 / 1024;
+if (totalMemMB < 1024) {
+  common.skip(`insufficient system memory (${Math.round(totalMemMB)}MB, need 1024MB)`);
+}
 
 // Test: should throw AssertionError, not OOM
 {

--- a/test/parallel/test-assert-myers-diff.js
+++ b/test/parallel/test-assert-myers-diff.js
@@ -6,6 +6,7 @@ const assert = require('assert');
 
 const { myersDiff } = require('internal/assert/myers_diff');
 
+// Test: myersDiff input size limit
 {
   const arr1 = { length: 2 ** 31 - 1 };
   const arr2 = { length: 2 };
@@ -22,4 +23,185 @@ const { myersDiff } = require('internal/assert/myers_diff');
                 `Received ${max}`
     })
   );
+}
+
+// Test: small input correctness
+{
+  const actual = ['a', 'b', 'X', 'c', 'd'];
+  const expected = ['a', 'b', 'c', 'd'];
+  const ops = diffToForwardOps(myersDiff(actual, expected));
+
+  const inserts = ops.filter((o) => o.op === 1);
+  const deletes = ops.filter((o) => o.op === -1);
+  const nops = ops.filter((o) => o.op === 0);
+
+  assert.strictEqual(inserts.length, 1);
+  assert.strictEqual(inserts[0].value, 'X');
+  assert.strictEqual(deletes.length, 0);
+  assert.strictEqual(nops.length, 4);
+}
+
+// Test: aligned boundary correctness - extra lines in the middle
+// When expected has extra lines, aligned boundaries should produce
+// only real INSERT/DELETE/NOP operations with no phantom diffs.
+{
+  const { actual, expected } = createAlignedTestArrays({ lineCount: 600, extraLineAt: 100 });
+
+  const result = myersDiff(actual, expected);
+  const ops = diffToForwardOps(result);
+
+  const inserts = ops.filter((o) => o.op === 1);
+  const deletes = ops.filter((o) => o.op === -1);
+  const nops = ops.filter((o) => o.op === 0);
+
+  assert.strictEqual(inserts.length, 1);
+  assert.strictEqual(inserts[0].value, 'EXTRA_100');
+  assert.strictEqual(deletes.length, 0, 'should produce no phantom DELETEs');
+  assert.strictEqual(nops.length, 600);
+}
+
+// Test: multiple extra lines across chunk boundaries
+{
+  const expected = [];
+  for (let i = 0; i < 1200; i++) expected.push('line_' + i);
+
+  const actual = [];
+  for (let i = 0; i < 1200; i++) {
+    if (i === 100) {
+      actual.push('EXTRA_A');
+      actual.push('EXTRA_B');
+    }
+    actual.push('line_' + i);
+  }
+
+  const result = myersDiff(actual, expected);
+  const ops = diffToForwardOps(result);
+
+  const inserts = ops.filter((o) => o.op === 1);
+  const deletes = ops.filter((o) => o.op === -1);
+
+  assert.strictEqual(inserts.length, 2);
+  assert.strictEqual(inserts[0].value, 'EXTRA_A');
+  assert.strictEqual(inserts[1].value, 'EXTRA_B');
+  assert.strictEqual(deletes.length, 0, 'should produce no phantom DELETEs');
+}
+
+// Test: large identical inputs produce all NOPs
+{
+  const lines = [];
+  for (let i = 0; i < 600; i++) lines.push('line_' + i);
+
+  const result = myersDiff(lines, lines);
+  const ops = diffToForwardOps(result);
+
+  assert.strictEqual(ops.length, 600);
+  assert.ok(ops.every((o) => o.op === 0));
+}
+
+// Test: one side much longer than the other
+// Diff should be correct (rebuild both sides from ops matches originals)
+{
+  const actual = [];
+  for (let i = 0; i < 700; i++) actual.push('line_' + i);
+
+  const expected = [];
+  for (let i = 0; i < 200; i++) expected.push('line_' + i);
+
+  const result = myersDiff(actual, expected);
+  const ops = diffToForwardOps(result);
+
+  // Verify correctness: rebuild both sides from diff ops
+  const { rebuiltActual, rebuiltExpected } = rebuildFromOps(ops);
+  assert.deepStrictEqual(rebuiltActual, actual);
+  assert.deepStrictEqual(rebuiltExpected, expected);
+
+  // Chunked diff with fallback boundaries may not find all 200 shared lines,
+  // but the diff must still be correct (rebuilds match originals).
+  const nops = ops.filter((o) => o.op === 0);
+  const inserts = ops.filter((o) => o.op === 1);
+  const deletes = ops.filter((o) => o.op === -1);
+  assert.ok(nops.length >= 146, `expected at least 146 NOPs, got ${nops.length}`);
+  assert.strictEqual(nops.length + inserts.length, actual.length);
+  assert.strictEqual(nops.length + deletes.length, expected.length);
+}
+
+// Test: expected side longer (deletions)
+{
+  const actual = [];
+  for (let i = 0; i < 200; i++) actual.push('line_' + i);
+
+  const expected = [];
+  for (let i = 0; i < 700; i++) expected.push('line_' + i);
+
+  const result = myersDiff(actual, expected);
+  const ops = diffToForwardOps(result);
+
+  const { rebuiltActual, rebuiltExpected } = rebuildFromOps(ops);
+  assert.deepStrictEqual(rebuiltActual, actual);
+  assert.deepStrictEqual(rebuiltExpected, expected);
+
+  const nops = ops.filter((o) => o.op === 0);
+  const inserts = ops.filter((o) => o.op === 1);
+  const deletes = ops.filter((o) => o.op === -1);
+  assert.ok(nops.length >= 146, `expected at least 146 NOPs, got ${nops.length}`);
+  assert.strictEqual(nops.length + inserts.length, actual.length);
+  assert.strictEqual(nops.length + deletes.length, expected.length);
+}
+
+// Test: no matching anchor available (all unique lines)
+// Should gracefully fall back and still produce a valid diff
+{
+  const actual = [];
+  const expected = [];
+  for (let i = 0; i < 600; i++) {
+    actual.push('actual_unique_' + i);
+    expected.push('expected_unique_' + i);
+  }
+
+  const result = myersDiff(actual, expected);
+  const ops = diffToForwardOps(result);
+
+  const inserts = ops.filter((o) => o.op === 1);
+  const deletes = ops.filter((o) => o.op === -1);
+
+  // All lines are different, so we should get 600 inserts and 600 deletes
+  assert.strictEqual(inserts.length, 600);
+  assert.strictEqual(deletes.length, 600);
+}
+
+function diffToForwardOps(diff) {
+  const ops = [];
+  for (let i = diff.length - 1; i >= 0; i--) {
+    ops.push({ op: diff[i][0], value: diff[i][1] });
+  }
+  return ops;
+}
+
+function rebuildFromOps(ops) {
+  const rebuiltActual = [];
+  const rebuiltExpected = [];
+  for (let i = 0; i < ops.length; i++) {
+    if (ops[i].op === 0) {
+      rebuiltActual.push(ops[i].value);
+      rebuiltExpected.push(ops[i].value);
+    } else if (ops[i].op === 1) {
+      rebuiltActual.push(ops[i].value);
+    } else {
+      rebuiltExpected.push(ops[i].value);
+    }
+  }
+  return { rebuiltActual, rebuiltExpected };
+}
+
+function createAlignedTestArrays({ lineCount, extraLineAt } = {}) {
+  const expected = [];
+  for (let i = 0; i < lineCount; i++) expected.push('line_' + i);
+
+  const actual = [];
+  for (let i = 0; i < lineCount; i++) {
+    if (i === extraLineAt) actual.push('EXTRA_' + extraLineAt);
+    actual.push('line_' + i);
+  }
+
+  return { actual, expected };
 }


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/61346

## Solution

Add a 2MB limit to `inspectValue()` output in `assertion_error.js`. When truncation occurs:
- A `... [truncated]` marker is added to the output
- The error message indicates lines were skipped

The assertion logic is unaffected; only the error output is truncated.

## Trade-offs

If both objects produce very large inspect output and happen to match exactly in the first 2MB but differ later, the diff would appear identical. However:
- The alternative is an OOM crash, which is worse
- The assertion result is still correct (`===` failed)
- A truncation marker indicates output was cut off
- Users can examine `error.actual` and `error.expected` programmatically

## Alternative approaches considered

1. **Skip diff entirely for huge objects** - Just show "Objects are not equal (output too large to diff)"
2. **Smarter truncation** - Find where objects differ first, truncate around that area. However, this is complex and the performance benefit is unclear: for objects with exponential paths, even traversing them could be expensive, and the subtree around the difference may still contain references to shared objects.