### PR TITLE
test: make snapshot path stripping CWD-agnostic

### DIFF
--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -16,17 +16,17 @@ for (const descriptor of Object.values(descriptors)) {
   });
 }
 
-const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
+const urlReg = /^file:\/\/\/(?:.*\/)?test\/es-module\/test-esm-import-meta\.mjs$/;
 assert.match(import.meta.url, urlReg);
 
 // Match *nix paths: `/some/path/test/es-module`
 // Match Windows paths: `d:\\some\\path\\test\\es-module`
-const dirReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module$/;
+const dirReg = /^(?:\/|\w:\\)(?:.*(?:\/|\\))?test(?:\/|\\)es-module$/;
 assert.match(import.meta.dirname, dirReg);
 
 // Match *nix paths: `/some/path/test/es-module/test-esm-import-meta.mjs`
 // Match Windows paths: `d:\\some\\path\\test\\es-module\\test-esm-import-meta.js`
-const fileReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module(\/|\\)test-esm-import-meta\.mjs$/;
+const fileReg = /^(?:\/|\w:\\)(?:.*(?:\/|\\))?test(?:\/|\\)es-module(?:\/|\\)test-esm-import-meta\.mjs$/;
 assert.match(import.meta.filename, fileReg);
 
 // Verify that `data:` imports do not behave like `file:` imports.

--- a/test/parallel/test-assert-snapshot-transform-project-root.js
+++ b/test/parallel/test-assert-snapshot-transform-project-root.js
@@ -1,0 +1,39 @@
+'use strict';
+
+require('../common');
+const assert = require('node:assert/strict');
+const path = require('node:path');
+
+const snapshot = require('../common/assertSnapshot');
+
+// `transformProjectRoot()` is used by many snapshot-based tests to strip the
+// project root from stack traces and other outputs. Ensure it only strips the
+// project root when it is a real path prefix, not when it is part of some other
+// token (e.g., "node_modules" or URLs).
+{
+  const stripProjectRoot = snapshot.transformProjectRoot('');
+  const projectRoot = path.resolve(__dirname, '..', '..');
+
+  assert.strictEqual(
+    stripProjectRoot(`${projectRoot}${path.sep}test${path.sep}fixtures`),
+    `${path.sep}test${path.sep}fixtures`,
+  );
+
+  const shouldNotStrip = `${projectRoot}_modules`;
+  assert.strictEqual(stripProjectRoot(shouldNotStrip), shouldNotStrip);
+
+  const urlLike = `https://${projectRoot}js.org`;
+  assert.strictEqual(stripProjectRoot(urlLike), urlLike);
+
+  if (process.platform === 'win32') {
+    const projectRootPosix = projectRoot.replaceAll(path.win32.sep, path.posix.sep);
+
+    assert.strictEqual(
+      stripProjectRoot(`${projectRootPosix}/test/fixtures`),
+      '/test/fixtures',
+    );
+
+    const shouldNotStripPosix = `${projectRootPosix}_modules`;
+    assert.strictEqual(stripProjectRoot(shouldNotStripPosix), shouldNotStripPosix);
+  }
+}

--- a/test/parallel/test-cli-permission-deny-fs.js
+++ b/test/parallel/test-cli-permission-deny-fs.js
@@ -134,7 +134,14 @@ const path = require('path');
 {
   const { root } = path.parse(process.cwd());
   const abs = (p) => path.join(root, p);
-  const firstPath = abs(path.sep + process.cwd().split(path.sep, 2)[1]);
+  let firstPath = abs(path.sep + process.cwd().split(path.sep, 2)[1]);
+  if (path.resolve(firstPath) === root) {
+    // When the repository itself is in the filesystem root (e.g. "/"),
+    // allowing reads from `root` would also allow reading `/etc/passwd` and
+    // make the test meaningless. Allow reads from `<root>/test` instead,
+    // which still contains the fixture entry point.
+    firstPath = path.join(root, 'test');
+  }
   if (firstPath.startsWith('/etc')) {
     common.skip('/etc as firstPath');
   }

--- a/test/parallel/test-node-output-console.mjs
+++ b/test/parallel/test-node-output-console.mjs
@@ -12,8 +12,13 @@ function replaceStackTrace(str) {
 }
 
 describe('console output', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  const stripProjectRoot = snapshot.transformProjectRoot('');
+
   function normalize(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '').replaceAll('/', '*').replaceAll(process.version, '*').replaceAll(/\d+/g, '*');
+    return stripProjectRoot(str)
+      .replaceAll('/', '*')
+      .replaceAll(process.version, '*')
+      .replaceAll(/\d+/g, '*');
   }
   const tests = [
     { name: 'console/2100bytes.js' },

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -9,6 +9,7 @@ import { pathToFileURL } from 'node:url';
 const skipForceColors =
   (common.isWindows && (Number(os.release().split('.')[0]) !== 10 || Number(os.release().split('.')[2]) < 14393)); // See https://github.com/nodejs/node/pull/33132
 
+const stripProjectRoot = snapshot.transformProjectRoot('');
 
 function replaceStackTrace(str) {
   return snapshot.replaceStackTrace(str, '$1at *$7\n');
@@ -22,7 +23,8 @@ function replaceForceColorsStackTrace(str) {
 describe('errors output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   function normalize(str) {
     const baseName = basename(process.argv0 || 'node', '.exe');
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
+    return stripProjectRoot(str)
+      // Also strip the URL-encoded form of cwd (for file:// URLs).
       .replaceAll(pathToFileURL(process.cwd()).pathname, '')
       .replaceAll('//', '*')
       .replaceAll(/\/(\w)/g, '*$1')

--- a/test/parallel/test-node-output-eval.mjs
+++ b/test/parallel/test-node-output-eval.mjs
@@ -8,8 +8,10 @@ import { basename } from 'node:path';
 import { describe, it } from 'node:test';
 
 describe('eval output', { concurrency: true }, () => {
+  const stripProjectRoot = snapshot.transformProjectRoot('');
+
   function normalize(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
+    return stripProjectRoot(str)
       .replaceAll(/\d+:\d+/g, '*:*');
   }
 

--- a/test/parallel/test-node-output-v8-warning.mjs
+++ b/test/parallel/test-node-output-v8-warning.mjs
@@ -14,13 +14,15 @@ function replaceExecName(str) {
 }
 
 describe('v8 output', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  const stripProjectRoot = snapshot.transformProjectRoot('');
+
   function normalize(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
-    .replaceAll(/:\d+/g, ':*')
-    .replaceAll('/', '*')
-    .replaceAll('*test*', '*')
-    .replaceAll(/.*?\*fixtures\*v8\*/g, '(node:*) V8: *') // Replace entire path before fixtures/v8
-    .replaceAll('*fixtures*v8*', '*');
+    return stripProjectRoot(str)
+      .replaceAll(/:\d+/g, ':*')
+      .replaceAll('/', '*')
+      .replaceAll('*test*', '*')
+      .replaceAll(/.*?\*fixtures\*v8\*/g, '(node:*) V8: *') // Replace entire path before fixtures/v8
+      .replaceAll('*fixtures*v8*', '*');
   }
   const common = snapshot
     .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, replaceNodeVersion, replaceExecName);

--- a/test/parallel/test-node-output-vm.mjs
+++ b/test/parallel/test-node-output-vm.mjs
@@ -8,8 +8,14 @@ function replaceNodeVersion(str) {
 }
 
 describe('vm output', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  const stripProjectRoot = snapshot.transformProjectRoot('');
+
   function normalize(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '').replaceAll('//', '*').replaceAll(/\/(\w)/g, '*$1').replaceAll('*test*', '*').replaceAll(/node:vm:\d+:\d+/g, 'node:vm:*');
+    return stripProjectRoot(str)
+      .replaceAll('//', '*')
+      .replaceAll(/\/(\w)/g, '*$1')
+      .replaceAll('*test*', '*')
+      .replaceAll(/node:vm:\d+:\d+/g, 'node:vm:*');
   }
 
   const defaultTransform = snapshot


### PR DESCRIPTION
transformProjectRoot() now strips the project root only when it is a real path prefix, avoiding accidental matches inside tokens like 'node_modules' or URLs when the repository lives in paths such as '/node'.

Also update the node output snapshot tests to use transformProjectRoot(), make permission deny tests handle running from the filesystem root, and relax import.meta path regexes for the same scenario.

Add a regression test for transformProjectRoot().

Refs: #61303