### PR TITLE
doc: replace alpn with protocol in quic.md

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -40,8 +40,8 @@ import { connect } from 'node:quic';
 import { Buffer } from 'node:buffer';
 
 const enc = new TextEncoder();
-const alpn = 'foo';
-const client = await connect('123.123.123.123:8888', { alpn });
+const protocol = 'foo';
+const client = await connect('123.123.123.123:8888', { protocol });
 await client.createUnidirectionalStream({
   body: enc.encode('hello world'),
 });
@@ -1110,16 +1110,6 @@ while establishing a new connection.
 added: v23.8.0
 -->
 
-#### `sessionOptions.alpn`
-
-<!-- YAML
-added: v23.8.0
--->
-
-* Type: {string}
-
-The ALPN protocol identifier.
-
 #### `sessionOptions.ca`
 
 <!-- YAML
@@ -1254,6 +1244,18 @@ added: v23.8.0
 
 When the remote peer advertises a preferred address, this option specifies whether
 to use it or ignore it.
+
+#### `sessionOptions.protocol`
+
+<!-- YAML
+added: v23.8.0
+-->
+
+* Type: {string}
+
+The ALPN protocol identifier. This option specifies the application layer protocol
+negotiation (ALPN) protocol to use for the session. Common values include `'h3'` for
+HTTP/3, `'h2'` for HTTP/2, or custom protocol identifiers.
 
 #### `sessionOptions.qlog`
 
@@ -1549,7 +1551,7 @@ added: v23.8.0
 
 * `this` {quic.QuicSession}
 * `sni` {string}
-* `alpn` {string}
+* `protocol` {string}
 * `cipher` {string}
 * `cipherVersion` {string}
 * `validationErrorReason` {string}


### PR DESCRIPTION
The code was refactored in commit 062ae6f3cb5 to use 'protocol' instead of 'alpn' 
for the ALPN protocol identifier option. However, the documentation was not updated 
to reflect this change.

This commit updates the documentation to match the actual implementation:
- Removes the non-functional 'alpn' option from SessionOptions
- Adds the 'protocol' option with proper description
- Updates example code to use 'protocol' instead of 'alpn'
- Updates OnHandshakeCallback parameter from 'alpn' to 'protocol'

**Why this change is necessary:**

The destructuring assignment in `processTlsOptions()` expects a `protocol` property:
pt
const { protocol } = tls; 

Therefore, using `alpn` will not work:

// This won't work
const alpn = 'h3';
connect(address, { alpn }); // protocol will be undefined

// This is correct
const protocol = 'h3';
connect(address, { protocol });

Refs: https://github.com/nodejs/node/commit/062ae6f3cb5
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
