### PR TITLE
build: infer cargo mode with gyp var build_type directly

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1864,11 +1864,6 @@ def configure_library(lib, output, pkgname=None):
       output['libraries'] += pkg_libs.split()
 
 
-def configure_rust(o, configs):
-  set_configuration_variable(configs, 'cargo_build_mode', release='release', debug='debug')
-  set_configuration_variable(configs, 'cargo_build_flags', release=['--release'], debug=[])
-
-
 def configure_v8(o, configs):
   set_configuration_variable(configs, 'v8_enable_v8_checks', release=1, debug=0)
 
@@ -2468,7 +2463,6 @@ configure_intl(output)
 configure_static(output)
 configure_inspector(output)
 configure_section_file(output)
-configure_rust(output, configurations)
 
 # remove builtins that have been disabled
 if options.without_amaro:

--- a/deps/crates/crates.gyp
+++ b/deps/crates/crates.gyp
@@ -1,8 +1,20 @@
 {
   'variables': {
     'cargo_vendor_dir': './vendor',
-    'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/>(cargo_build_mode)/<(STATIC_LIB_PREFIX)node_crates<(STATIC_LIB_SUFFIX)',
   },
+  'conditions': [
+    ['build_type == "Release"', {
+      'variables': {
+        'cargo_build_flags': ['--release'],
+        'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/release/<(STATIC_LIB_PREFIX)node_crates<(STATIC_LIB_SUFFIX)',
+      },
+    }, {
+      'variables': {
+        'cargo_build_flags': [],
+        'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/debug/<(STATIC_LIB_PREFIX)node_crates<(STATIC_LIB_SUFFIX)',
+      },
+    }]
+  ],
   'targets': [
     {
       'target_name': 'node_crates',
@@ -38,7 +50,7 @@
           'action': [
             'cargo',
             'rustc',
-            '>@(cargo_build_flags)',
+            '<@(cargo_build_flags)',
             '--frozen',
             '--target-dir',
             '<(SHARED_INTERMEDIATE_DIR)'


### PR DESCRIPTION
GYP configurations don't work well with variable expansions as the configuration
is merged after the variable expansion.

Refs: https://github.com/nodejs/node/pull/61327#discussion_r2683064734
Refs: https://github.com/nodejs/gyp-next/blob/main/docs/InputFormatReference.md#processing-order