### PR TITLE
doc: clarify TypedArray properties on Buffer

### DIFF
--- a/doc/api/buffer.md
+++ b/doc/api/buffer.md
@@ -243,7 +243,7 @@ changes:
 -->
 
 `Buffer` instances are also JavaScript {Uint8Array} and {TypedArray}
-instances. All {TypedArray} properties are available on `Buffer`s. There are,
+instances. All {TypedArray} methods and properties are available on `Buffer`s. There are,
 however, subtle incompatibilities between the `Buffer` API and the
 {TypedArray} API.
 


### PR DESCRIPTION
Add "properties" to clarify presence of non-method properties like `byteLength`. This follows MDN which also distinguishes methods and properties.

Fixes: https://github.com/nodejs/node/issues/34946
Ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray/byteLength