### PR TITLE
test: make cwd path stripping url-safe

### DIFF
--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -79,7 +79,13 @@ function transformProjectRoot(replacement = '') {
       const isBoundary = after === str.length || nextChar === '/';
       out += str.slice(index, match);
       out += isBoundary ? `${fileUrlPrefix}${replacement}` : needle;
-      index = after;
+
+      // If the next character is a '/' and the replacement is empty, skip the next character.
+      if (isBoundary && replacement === '' && nextChar === '/') {
+        index = after + 1;
+      } else {
+        index = after;
+      }
     }
   };
   return (str) => {

--- a/test/es-module/test-esm-import-meta.mjs
+++ b/test/es-module/test-esm-import-meta.mjs
@@ -1,5 +1,7 @@
 import '../common/index.mjs';
 import assert from 'assert';
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
 
 assert.strictEqual(Object.getPrototypeOf(import.meta), null);
 
@@ -16,18 +18,14 @@ for (const descriptor of Object.values(descriptors)) {
   });
 }
 
-const urlReg = /^file:\/\/\/.*\/test\/es-module\/test-esm-import-meta\.mjs$/;
-assert.match(import.meta.url, urlReg);
+const filePath = fileURLToPath(import.meta.url);
+assert.ok(path.isAbsolute(filePath));
+assert.strictEqual(import.meta.url, pathToFileURL(filePath).href);
 
-// Match *nix paths: `/some/path/test/es-module`
-// Match Windows paths: `d:\\some\\path\\test\\es-module`
-const dirReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module$/;
-assert.match(import.meta.dirname, dirReg);
-
-// Match *nix paths: `/some/path/test/es-module/test-esm-import-meta.mjs`
-// Match Windows paths: `d:\\some\\path\\test\\es-module\\test-esm-import-meta.js`
-const fileReg = /^(\/|\w:\\).*(\/|\\)test(\/|\\)es-module(\/|\\)test-esm-import-meta\.mjs$/;
-assert.match(import.meta.filename, fileReg);
+const suffix = path.join('test', 'es-module', 'test-esm-import-meta.mjs');
+assert.ok(filePath.endsWith(suffix));
+assert.strictEqual(import.meta.filename, filePath);
+assert.strictEqual(import.meta.dirname, path.dirname(filePath));
 
 // Verify that `data:` imports do not behave like `file:` imports.
 import dataDirname from 'data:text/javascript,export default "dirname" in import.meta';

--- a/test/parallel/test-assert-snapshot-transform-project-root.js
+++ b/test/parallel/test-assert-snapshot-transform-project-root.js
@@ -1,0 +1,45 @@
+'use strict';
+
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const snapshot = require('../common/assertSnapshot');
+
+// Coverage: boundary strip, URL tokens, file:// root, % encoding.
+{
+  const stripProjectRoot = snapshot.transformProjectRoot('');
+  const projectRoot = path.resolve(__dirname, '..', '..');
+
+  assert.strictEqual(
+    stripProjectRoot(`${projectRoot}${path.sep}test${path.sep}fixtures`),
+    `${path.sep}test${path.sep}fixtures`,
+  );
+
+  const shouldNotStrip = `${projectRoot}_modules`;
+  assert.strictEqual(stripProjectRoot(shouldNotStrip), shouldNotStrip);
+
+  const urlLike = `https://${projectRoot}js.org`;
+  assert.strictEqual(stripProjectRoot(urlLike), urlLike);
+
+  const shouldNotStripSuffix = `${projectRoot}suffix/test`;
+  assert.strictEqual(stripProjectRoot(shouldNotStripSuffix), shouldNotStripSuffix);
+
+  const fileUrl = pathToFileURL(projectRoot).href;
+  assert.strictEqual(stripProjectRoot(`${fileUrl}/test/fixtures`), 'file:///test/fixtures');
+
+  const fileUrlWithSpace = pathToFileURL(path.join(projectRoot, 'spaced dir')).href;
+  assert.strictEqual(stripProjectRoot(fileUrlWithSpace), 'file:///spaced%20dir');
+
+  if (process.platform === 'win32') {
+    const projectRootPosix = projectRoot.replaceAll(path.win32.sep, path.posix.sep);
+
+    assert.strictEqual(
+      stripProjectRoot(`${projectRootPosix}/test/fixtures`),
+      '/test/fixtures',
+    );
+
+    const shouldNotStripPosix = `${projectRootPosix}_modules`;
+    assert.strictEqual(stripProjectRoot(shouldNotStripPosix), shouldNotStripPosix);
+  }
+}

--- a/test/parallel/test-assert-snapshot-transform-project-root.js
+++ b/test/parallel/test-assert-snapshot-transform-project-root.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const common = require('../common');
 const assert = require('node:assert/strict');
 const path = require('node:path');
 const { pathToFileURL } = require('node:url');

--- a/test/parallel/test-assert-snapshot-transform-project-root.js
+++ b/test/parallel/test-assert-snapshot-transform-project-root.js
@@ -32,7 +32,7 @@ const snapshot = require('../common/assertSnapshot');
   const fileUrlWithSpace = pathToFileURL(path.join(projectRoot, 'spaced dir')).href;
   assert.strictEqual(stripProjectRoot(fileUrlWithSpace), 'file:///spaced%20dir');
 
-  if (process.platform === 'win32') {
+  if (common.isWindows) {
     const projectRootPosix = projectRoot.replaceAll(path.win32.sep, path.posix.sep);
 
     assert.strictEqual(

--- a/test/parallel/test-cli-permission-deny-fs.js
+++ b/test/parallel/test-cli-permission-deny-fs.js
@@ -132,9 +132,10 @@ const path = require('path');
 }
 
 {
-  const { root } = path.parse(process.cwd());
-  const abs = (p) => path.join(root, p);
-  const firstPath = abs(path.sep + process.cwd().split(path.sep, 2)[1]);
+  const repoRoot = path.resolve(process.cwd());
+  const root = path.parse(repoRoot).root;
+  const [firstDir] = path.relative(root, repoRoot).split(path.sep);
+  const firstPath = firstDir ? path.join(root, firstDir) : path.join(root, 'test');
   if (firstPath.startsWith('/etc')) {
     common.skip('/etc as firstPath');
   }

--- a/test/parallel/test-node-output-console.mjs
+++ b/test/parallel/test-node-output-console.mjs
@@ -12,9 +12,12 @@ function replaceStackTrace(str) {
 }
 
 describe('console output', { concurrency: !process.env.TEST_PARALLEL }, () => {
-  function normalize(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '').replaceAll('/', '*').replaceAll(process.version, '*').replaceAll(/\d+/g, '*');
-  }
+  const normalize = snapshot.transform(
+    snapshot.transformProjectRoot(''),
+    (str) => str.replaceAll('/', '*')
+      .replaceAll(process.version, '*')
+      .replaceAll(/\d+/g, '*'),
+  );
   const tests = [
     { name: 'console/2100bytes.js' },
     { name: 'console/console_low_stack_space.js' },

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -4,11 +4,9 @@ import * as snapshot from '../common/assertSnapshot.js';
 import * as os from 'node:os';
 import { describe, it } from 'node:test';
 import { basename } from 'node:path';
-import { pathToFileURL } from 'node:url';
 
 const skipForceColors =
   (common.isWindows && (Number(os.release().split('.')[0]) !== 10 || Number(os.release().split('.')[2]) < 14393)); // See https://github.com/nodejs/node/pull/33132
-
 
 function replaceStackTrace(str) {
   return snapshot.replaceStackTrace(str, '$1at *$7\n');
@@ -22,8 +20,7 @@ function replaceForceColorsStackTrace(str) {
 describe('errors output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   function normalize(str) {
     const baseName = basename(process.argv0 || 'node', '.exe');
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
-      .replaceAll(pathToFileURL(process.cwd()).pathname, '')
+    return str
       .replaceAll('//', '*')
       .replaceAll(/\/(\w)/g, '*$1')
       .replaceAll('*test*', '*')
@@ -36,7 +33,11 @@ describe('errors output', { concurrency: !process.env.TEST_PARALLEL }, () => {
     return normalize(str).replaceAll(/\d+:\d+/g, '*:*').replaceAll(/:\d+/g, ':*').replaceAll('*fixtures*message*', '*');
   }
   const common = snapshot
-    .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths);
+    .transform(
+      snapshot.replaceWindowsLineEndings,
+      snapshot.replaceWindowsPaths,
+      snapshot.transformProjectRoot(''),
+    );
   const defaultTransform = snapshot.transform(common, normalize, snapshot.replaceNodeVersion);
   const errTransform = snapshot.transform(common, normalizeNoNumbers, snapshot.replaceNodeVersion);
   const promiseTransform = snapshot.transform(common, replaceStackTrace,

--- a/test/parallel/test-node-output-eval.mjs
+++ b/test/parallel/test-node-output-eval.mjs
@@ -8,10 +8,10 @@ import { basename } from 'node:path';
 import { describe, it } from 'node:test';
 
 describe('eval output', { concurrency: true }, () => {
-  function normalize(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
-      .replaceAll(/\d+:\d+/g, '*:*');
-  }
+  const normalize = snapshot.transform(
+    snapshot.transformProjectRoot(''),
+    (str) => str.replaceAll(/\d+:\d+/g, '*:*'),
+  );
 
   const defaultTransform = snapshot.transform(
     normalize,

--- a/test/parallel/test-node-output-v8-warning.mjs
+++ b/test/parallel/test-node-output-v8-warning.mjs
@@ -14,14 +14,14 @@ function replaceExecName(str) {
 }
 
 describe('v8 output', { concurrency: !process.env.TEST_PARALLEL }, () => {
-  function normalize(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '')
-    .replaceAll(/:\d+/g, ':*')
-    .replaceAll('/', '*')
-    .replaceAll('*test*', '*')
-    .replaceAll(/.*?\*fixtures\*v8\*/g, '(node:*) V8: *') // Replace entire path before fixtures/v8
-    .replaceAll('*fixtures*v8*', '*');
-  }
+  const normalize = snapshot.transform(
+    snapshot.transformProjectRoot(''),
+    (str) => str.replaceAll(/:\d+/g, ':*')
+      .replaceAll('/', '*')
+      .replaceAll('*test*', '*')
+      .replaceAll(/.*?\*fixtures\*v8\*/g, '(node:*) V8: *') // Replace entire path before fixtures/v8
+      .replaceAll('*fixtures*v8*', '*'),
+  );
   const common = snapshot
     .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, replaceNodeVersion, replaceExecName);
   const defaultTransform = snapshot.transform(common, normalize);

--- a/test/parallel/test-node-output-vm.mjs
+++ b/test/parallel/test-node-output-vm.mjs
@@ -8,9 +8,13 @@ function replaceNodeVersion(str) {
 }
 
 describe('vm output', { concurrency: !process.env.TEST_PARALLEL }, () => {
-  function normalize(str) {
-    return str.replaceAll(snapshot.replaceWindowsPaths(process.cwd()), '').replaceAll('//', '*').replaceAll(/\/(\w)/g, '*$1').replaceAll('*test*', '*').replaceAll(/node:vm:\d+:\d+/g, 'node:vm:*');
-  }
+  const normalize = snapshot.transform(
+    snapshot.transformProjectRoot(''),
+    (str) => str.replaceAll('//', '*')
+      .replaceAll(/\/(\w)/g, '*$1')
+      .replaceAll('*test*', '*')
+      .replaceAll(/node:vm:\d+:\d+/g, 'node:vm:*'),
+  );
 
   const defaultTransform = snapshot
     .transform(snapshot.replaceWindowsLineEndings, snapshot.replaceWindowsPaths, normalize, replaceNodeVersion);


### PR DESCRIPTION
## Issue
- #61303

## Summary
- make cwd/project-root stripping boundary-aware and file:// safe
- switch node-output tests to the shared transform pipeline
- keep permission test meaningful when repo is at "/"
- validate import.meta via file URL round-trip
- add regression coverage for URL tokens and % encoding
- fix file:// URL root stripping to avoid duplicate slashes

## Motivation
Snapshot normalization used raw cwd/path string replacement, which can
corrupt non-path tokens (e.g. URLs) when cwd matches substrings like
"/node". This keeps normalization cwd-agnostic by stripping only true
path prefixes and handling file:// forms without touching other schemes.

## Changes
- `test/common/assertSnapshot.js`
  - boundary-aware prefix stripping and file:// handling
  - avoid `file:////` by consuming the extra boundary slash when replacement is empty
- `test/parallel/test-node-output-*.mjs`
  - use transformProjectRoot() instead of process.cwd() replaces
- `test/parallel/test-cli-permission-deny-fs.js`
  - derive firstPath from repo root even when repo is "/"
- `test/es-module/test-esm-import-meta.mjs`
  - validate import.meta via fileURLToPath/pathToFileURL
- `test/parallel/test-assert-snapshot-transform-project-root.js`
  - regression cases for URL tokens, file:// roots, suffixes, and % encoding

## Tests
- `python3 tools/test.py -m release test/parallel/test-assert-snapshot-transform-project-root.js`
- `python3 tools/test.py -m release test/parallel/test-node-output-*.mjs`
- `python3 tools/test.py -m release test/es-module/test-esm-import-meta.mjs`