### PR TITLE
fs: remove duplicate getValidatedPath calls

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -1641,7 +1641,7 @@ function statfs(path, options = { bigint: false }, callback) {
 
     callback(err, getStatFsFromBinding(stats));
   };
-  binding.statfs(getValidatedPath(path), options.bigint, req);
+  binding.statfs(path, options.bigint, req);
 }
 
 /**
@@ -1676,7 +1676,7 @@ function lstatSync(path, options = { bigint: false, throwIfNoEntry: true }) {
     throw new ERR_ACCESS_DENIED('Access to this API has been restricted', 'FileSystemRead', resource);
   }
   const stats = binding.lstat(
-    getValidatedPath(path),
+    path,
     options.bigint,
     undefined,
     options.throwIfNoEntry,


### PR DESCRIPTION
already validated earlier in the function
https://github.com/nodejs/node/blob/main/lib/fs.js#L1635