### PR TITLE
fs: remove duplicate fd validation in sync functions

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -598,7 +598,6 @@ function openAsBlob(path, options = kEmptyObject) {
  */
 function read(fd, buffer, offsetOrOptions, length, position, callback) {
   fd = getValidatedFd(fd);
-
   let offset = offsetOrOptions;
   let params = null;
   if (arguments.length <= 4) {
@@ -690,8 +689,6 @@ ObjectDefineProperty(read, kCustomPromisifyArgsSymbol,
  * @returns {number}
  */
 function readSync(fd, buffer, offsetOrOptions, length, position) {
-  fd = getValidatedFd(fd);
-
   validateBuffer(buffer);
 
   let offset = offsetOrOptions;
@@ -780,7 +777,6 @@ ObjectDefineProperty(readv, kCustomPromisifyArgsSymbol,
  * @returns {number}
  */
 function readvSync(fd, buffers, position) {
-  fd = getValidatedFd(fd);
   validateBufferArray(buffers);
 
   if (typeof position !== 'number')
@@ -810,7 +806,6 @@ function write(fd, buffer, offsetOrOptions, length, position, callback) {
   }
 
   fd = getValidatedFd(fd);
-
   let offset = offsetOrOptions;
   if (isArrayBufferView(buffer)) {
     callback ||= position || length || offset;
@@ -881,7 +876,6 @@ ObjectDefineProperty(write, kCustomPromisifyArgsSymbol,
  * @returns {number}
  */
 function writeSync(fd, buffer, offsetOrOptions, length, position) {
-  fd = getValidatedFd(fd);
   const ctx = {};
   let result;
 
@@ -971,7 +965,6 @@ ObjectDefineProperty(writev, kCustomPromisifyArgsSymbol, {
  * @returns {number}
  */
 function writevSync(fd, buffers, position) {
-  fd = getValidatedFd(fd);
   validateBufferArray(buffers);
 
   if (buffers.length === 0) {

--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -2314,8 +2314,10 @@ static void WriteBuffer(const FunctionCallbackInfo<Value>& args) {
   const int argc = args.Length();
   CHECK_GE(argc, 4);
 
-  CHECK(args[0]->IsInt32());
-  const int fd = args[0].As<Int32>()->Value();
+  int fd;
+  if (!GetValidatedFd(env, args[0]).To(&fd)) {
+    return;
+  }
 
   CHECK(Buffer::HasInstance(args[1]));
   Local<Object> buffer_obj = args[1].As<Object>();
@@ -2381,8 +2383,10 @@ static void WriteBuffers(const FunctionCallbackInfo<Value>& args) {
   const int argc = args.Length();
   CHECK_GE(argc, 3);
 
-  CHECK(args[0]->IsInt32());
-  const int fd = args[0].As<Int32>()->Value();
+  int fd;
+  if (!GetValidatedFd(env, args[0]).To(&fd)) {
+    return;
+  }
 
   CHECK(args[1]->IsArray());
   Local<Array> chunks = args[1].As<Array>();
@@ -2441,8 +2445,10 @@ static void WriteString(const FunctionCallbackInfo<Value>& args) {
 
   const int argc = args.Length();
   CHECK_GE(argc, 4);
-  CHECK(args[0]->IsInt32());
-  const int fd = args[0].As<Int32>()->Value();
+  int fd;
+  if (!GetValidatedFd(env, args[0]).To(&fd)) {
+    return;
+  }
 
   const int64_t pos = GetOffset(args[2]);
 
@@ -2634,8 +2640,10 @@ static void Read(const FunctionCallbackInfo<Value>& args) {
   const int argc = args.Length();
   CHECK_GE(argc, 5);
 
-  CHECK(args[0]->IsInt32());
-  const int fd = args[0].As<Int32>()->Value();
+  int fd;
+  if (!GetValidatedFd(env, args[0]).To(&fd)) {
+    return;
+  }
 
   CHECK(Buffer::HasInstance(args[1]));
   Local<Object> buffer_obj = args[1].As<Object>();
@@ -2765,8 +2773,10 @@ static void ReadBuffers(const FunctionCallbackInfo<Value>& args) {
   const int argc = args.Length();
   CHECK_GE(argc, 3);
 
-  CHECK(args[0]->IsInt32());
-  const int fd = args[0].As<Int32>()->Value();
+  int fd;
+  if (!GetValidatedFd(env, args[0]).To(&fd)) {
+    return;
+  }
 
   CHECK(args[1]->IsArray());
   Local<Array> buffers = args[1].As<Array>();


### PR DESCRIPTION
I removed the repeated fd validation in synchronization functions; C++ already validates this via GetValidatedFd.

Asynchronous functions keep JS validation for error ordering.

readSync: 1,793K → 1,923K ops/sec

passed all fs tests

test-fs-read.js
test-fs-write.js
test-fs-readv-sync.js
test-fs-writev-sync.js