### PR TITLE
buffer: recreate pooled ArrayBuffer after transfer

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -160,6 +160,12 @@ function createPool() {
 }
 createPool();
 
+function ensurePool() {
+  // Recreate the pool if it was detached (e.g., via ArrayBuffer.prototype.transfer).
+  if (allocPool.byteLength === 0)
+    createPool();
+}
+
 function alignPool() {
   // Ensure aligned slices
   if (poolOffset & 0x7) {
@@ -436,6 +442,7 @@ function allocate(size) {
     return new FastBuffer();
   }
   if (size < (Buffer.poolSize >>> 1)) {
+    ensurePool();
     if (size > (poolSize - poolOffset))
       createPool();
     const b = new FastBuffer(allocPool, poolOffset, size);
@@ -462,6 +469,7 @@ function fromStringFast(string, ops) {
   if (length >= maxLength)
     return createFromString(string, ops, length);
 
+  ensurePool();
   if (length > (poolSize - poolOffset))
     createPool();
 
@@ -525,6 +533,7 @@ function fromArrayLike(obj) {
   if (obj.length <= 0)
     return new FastBuffer();
   if (obj.length < (Buffer.poolSize >>> 1)) {
+    ensurePool();
     if (obj.length > (poolSize - poolOffset))
       createPool();
     const b = new FastBuffer(allocPool, poolOffset, obj.length);

--- a/test/parallel/test-buffer-pool-untransferable.js
+++ b/test/parallel/test-buffer-pool-untransferable.js
@@ -21,3 +21,16 @@ assert.throws(() => port1.postMessage(a, [ a.buffer ]), {
 // Verify that the pool ArrayBuffer has not actually been transferred:
 assert.strictEqual(a.buffer, b.buffer);
 assert.strictEqual(a.length, length);
+
+if (typeof ArrayBuffer.prototype.transfer !== 'function')
+  common.skip('ArrayBuffer.prototype.transfer is not available');
+
+// Regression test for https://github.com/nodejs/node/issues/61362
+const base64 = 'aGVsbG8='; // "hello"
+const buf = Buffer.from(base64, 'base64');
+buf.buffer.transfer();
+assert.strictEqual(buf.buffer.byteLength, 0);
+assert.doesNotThrow(() => {
+  const out = Buffer.from(base64, 'base64');
+  assert.strictEqual(out.toString(), 'hello');
+});


### PR DESCRIPTION
Fixes #61362

## Summary
- After a Buffer backed by the internal pool has its ArrayBuffer detached (e.g. via `ArrayBuffer.prototype.transfer()`), subsequent `Buffer.from(..., 'base64')` calls would throw `ERR_BUFFER_OUT_OF_BOUNDS`. This change ensures pooled Buffer creation doesn’t rely on a detached pool ArrayBuffer.

## Repro
```js
const base64 = Buffer.from('hello', 'utf8').toString('base64');
const first = Buffer.from(base64, 'base64');
first.buffer.transfer();
Buffer.from(base64, 'base64'); // threw `ERR_BUFFER_OUT_OF_BOUNDS` before, succeeds now
```

## Changes
- Add a pool-detachment guard before pooled allocations.
- Add a regression test for pooled base64 `Buffer.from` after transfer.

## Tests
- `python3 tools/test.py test/parallel/test-buffer-pool-untransferable.js`
- `make -j4 test`

