### PR TITLE
typings: add typing for string_decoder

### DIFF
--- a/typings/globals.d.ts
+++ b/typings/globals.d.ts
@@ -18,6 +18,7 @@ import { OSBinding } from './internalBinding/os';
 import { ProcessBinding } from './internalBinding/process';
 import { SeaBinding } from './internalBinding/sea';
 import { SerdesBinding } from './internalBinding/serdes';
+import { StringDecoderBinding } from './internalBinding/string_decoder';
 import { SymbolsBinding } from './internalBinding/symbols';
 import { TimersBinding } from './internalBinding/timers';
 import { TypesBinding } from './internalBinding/types';
@@ -52,6 +53,7 @@ interface InternalBindingMap {
   process: ProcessBinding;
   sea: SeaBinding;
   serdes: SerdesBinding;
+  string_decoder: StringDecoderBinding;
   symbols: SymbolsBinding;
   timers: TimersBinding;
   types: TypesBinding;

--- a/typings/internalBinding/string_decoder.d.ts
+++ b/typings/internalBinding/string_decoder.d.ts
@@ -1,0 +1,19 @@
+declare namespace InternalStringDecoderBinding {
+  type Buffer = Uint8Array;
+}
+
+export interface StringDecoderBinding {
+  readonly kIncompleteCharactersStart: number;
+  readonly kIncompleteCharactersEnd: number;
+  readonly kMissingBytes: number;
+  readonly kBufferedBytes: number;
+  readonly kEncodingField: number;
+  readonly kNumFields: number;
+  readonly kSize: number;
+
+  readonly encodings: string[];
+
+  decode(decoder: InternalStringDecoderBinding.Buffer, buffer: ArrayBufferView): string;
+  flush(decoder: InternalStringDecoderBinding.Buffer): string;
+}
+


### PR DESCRIPTION
Add TypeScript type definitions for the string_decoder internalBinding
used in string_decoder and util modules.

This PR includes:
- Constants: kIncompleteCharactersStart, kIncompleteCharactersEnd,
  kMissingBytes, kBufferedBytes, kEncodingField, kNumFields, kSize
- Array: encodings (encoding names)
- Functions: decode, flush
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
