### PR TITLE
[v24.x backport] build: test on Python 3.14

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -30,7 +30,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
 
 permissions:

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
   CC: sccache clang
   CXX: sccache clang++

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
   CC: sccache clang
   CXX: sccache clang++

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
 
 permissions:

--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -13,7 +13,7 @@ on:
     - cron: 30 0 * * *
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
 
 permissions:
   contents: read

--- a/.github/workflows/lint-release-proposal.yml
+++ b/.github/workflows/lint-release-proposal.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   NODE_VERSION: lts/*
 
 permissions:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   NODE_VERSION: lts/*
 
 permissions:

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
   CC: sccache clang
   CXX: sccache clang++

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
   CC: sccache clang
   CXX: sccache clang++

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   XCODE_VERSION: '16.1'
   FLAKY_TESTS: keep_retrying
 

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -43,7 +43,7 @@ on:
           - zstd
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
 
 permissions:
   contents: read

--- a/android-configure
+++ b/android-configure
@@ -4,6 +4,7 @@
 # Note that the mix of single and double quotes is intentional,
 # as is the fact that the ] goes on a new line.
 _=[ 'exec' '/bin/sh' '-c' '''
+command -v python3.14 >/dev/null && exec python3.14 "$0" "$@"
 command -v python3.13 >/dev/null && exec python3.13 "$0" "$@"
 command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
 command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
@@ -22,7 +23,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js android configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9))
+acceptable_pythons = ((3, 14), (3, 13), (3, 12), (3, 11), (3, 10), (3, 9))
 if sys.version_info[:2] in acceptable_pythons:
   import android_configure
 else:

--- a/configure
+++ b/configure
@@ -4,6 +4,7 @@
 # Note that the mix of single and double quotes is intentional,
 # as is the fact that the ] goes on a new line.
 _=[ 'exec' '/bin/sh' '-c' '''
+command -v python3.14 >/dev/null && exec python3.14 "$0" "$@"
 command -v python3.13 >/dev/null && exec python3.13 "$0" "$@"
 command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
 command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
@@ -22,7 +23,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9))
+acceptable_pythons = ((3, 14), (3, 13), (3, 12), (3, 11), (3, 10), (3, 9))
 if sys.version_info[:2] in acceptable_pythons:
   import configure
 else:


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc3

PR-URL: https://github.com/nodejs/node/pull/59983
Reviewed-By: Marco Ippolito <marcoippolito54@gmail.com>
Reviewed-By: Stefan Stojanovic <stefan.stojanovic@janeasystems.com>
Reviewed-By: Stewart X Addison <sxa@redhat.com>

---

Refs: https://github.com/nodejs/node/issues/60874 

## Situation

Node.js 24.x (Active LTS) build fails with Python 3.14.

Python 3.14 is:

- the current highest [supported Python version](https://devguide.python.org/versions/)
- the system-default on Fedora 43
- the version installed on Windows using `py install default`

## Change

Backports https://github.com/nodejs/node/pull/59983 (commit https://github.com/nodejs/node/commit/8bc7dfd16fb95d5585eaaf0cea678ba1f9f4a755) to v24.x branch.

The commit message from the backport should be modified, removing the outdated "release candidate 3" text. It is currently:

> build: test on Python 3.14 release candidate 3

[Python 3.14 was released as GA](https://devguide.python.org/versions/) on 2025-10-07 and is therefore no longer pre-release.
https://www.python.org/downloads/release/python-3140rc3/ states:
> Note: Python 3.14.0rc3 has been superseded by [Python 3.14.2](https://www.python.org/downloads/release/python-3142/).

Although the PR title https://github.com/nodejs/node/pull/59983 was edited to remove the reference to "release candidate 3", the single commit it contained (https://github.com/nodejs/node/pull/59983/changes/109d743cee8ba5624eb5bcacd778b0b69460bb87) retained the text "release candidate 3".

Use of the GitHub Actions' [actions/setup-python](https://github.com/actions/setup-python) flag setting [`allow-prereleases: true`](https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases) is removed from the backport as suggested by @richardlau in https://github.com/nodejs/node/issues/60874 and explicitly requested by @aduh95. Since the workflow uses `PYTHON_VERSION: '3.14'` and this is a [released Python version](https://www.python.org/downloads/), the flag is not necessary.
