### PR TITLE
doc: note resume build should not be on node-test-commit

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -269,9 +269,9 @@ request, try the "🔄 Re-run all jobs" button, on the right-hand side of the
 
 If there are Jenkins CI failures unrelated to the change in the pull
 request, try "Resume Build".  It is in the left navigation of the relevant
-`node-test-pull-request` job (Do not be tempted to do this on the lower
+`node-test-pull-request` job. (Do not be tempted to do this on the lower
 level `node-test-commit` job as it will not report the updated result back
-to the PR).  It will preserve all the green results from the current job but
+to the PR.)  It will preserve all the green results from the current job but
 re-run everything else.  Start a fresh CI by pressing "Retry" if more than
 seven days have elapsed since the original failing CI as the compiled
 binaries for the Windows and ARM platforms are only kept for seven days.


### PR DESCRIPTION
Minor update  to tell people explicitly not to use the "resume build" on `node-test-commit` as it will not report the updated result back to the originating PR.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
