### PR TITLE
doc: clarify process.argv[1] behavior for -e/--eval

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -835,8 +835,10 @@ The `process.argv` property returns an array containing the command-line
 arguments passed when the Node.js process was launched. The first element will
 be [`process.execPath`][]. See `process.argv0` if access to the original value
 of `argv[0]` is needed. The second element will be the path to the JavaScript
-file being executed. The remaining elements will be any additional command-line
-arguments.
+file being executed, if a script file is provided. For no-script execution
+modes such as `-e` or `--eval`, the second element is the first unconsumed
+command-line argument. The remaining elements will be any additional
+command-line arguments.
 
 For example, assuming the following script for `process-args.js`:
 


### PR DESCRIPTION
Fixes #61363