### PR TITLE
test-runner: fix rerun ambiguous test failures

### DIFF
--- a/lib/internal/test_runner/reporter/rerun.js
+++ b/lib/internal/test_runner/reporter/rerun.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayPrototypeMap,
   ArrayPrototypePush,
   JSONStringify,
 } = primordials;
@@ -11,19 +12,55 @@ function reportReruns(previousRuns, globalOptions) {
   return async function reporter(source) {
     const obj = { __proto__: null };
     const disambiguator = { __proto__: null };
+    let currentSuite = null;
+    const roots = [];
+
+    function getTestId(data) {
+      return `${relative(globalOptions.cwd, data.file)}:${data.line}:${data.column}`;
+    }
+
+    function startTest(data) {
+      const originalSuite = currentSuite;
+      currentSuite = { __proto__: null, data, parent: currentSuite, children: [] };
+      if (originalSuite?.children) {
+        ArrayPrototypePush(originalSuite.children, currentSuite);
+      }
+      if (!currentSuite.parent) {
+        ArrayPrototypePush(roots, currentSuite);
+      }
+    }
 
     for await (const { type, data } of source) {
+      let currentTest;
+      if (type === 'test:start') {
+        startTest(data);
+      } else if (type === 'test:fail' || type === 'test:pass') {
+        if (!currentSuite) {
+          startTest({ __proto__: null, name: 'root', nesting: 0 });
+        }
+        if (currentSuite.data.name !== data.name || currentSuite.data.nesting !== data.nesting) {
+          startTest(data);
+        }
+        currentTest = currentSuite;
+        if (currentSuite?.data.nesting === data.nesting) {
+          currentSuite = currentSuite.parent;
+        }
+      }
+
+
       if (type === 'test:pass') {
-        let identifier = `${relative(globalOptions.cwd, data.file)}:${data.line}:${data.column}`;
+        let identifier = getTestId(data);
         if (disambiguator[identifier] !== undefined) {
           identifier += `:(${disambiguator[identifier]})`;
           disambiguator[identifier] += 1;
         } else {
           disambiguator[identifier] = 1;
         }
+        const children = ArrayPrototypeMap(currentTest.children, (child) => child.data);
         obj[identifier] = {
           __proto__: null,
           name: data.name,
+          children,
           passed_on_attempt: data.details.passed_on_attempt ?? data.details.attempt,
         };
       }

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -698,10 +698,18 @@ class Test extends AsyncResource {
         this.root.testDisambiguator.set(testIdentifier, 1);
       }
       this.attempt = this.root.harness.previousRuns.length;
-      const previousAttempt = this.root.harness.previousRuns[this.attempt - 1]?.[testIdentifier]?.passed_on_attempt;
+      const previousAttempt = this.root.harness.previousRuns[this.attempt - 1]?.[testIdentifier];
       if (previousAttempt != null) {
-        this.passedAttempt = previousAttempt;
-        this.fn = noop;
+        this.passedAttempt = previousAttempt.passed_on_attempt;
+        this.fn = () => {
+          for (let i = 0; i < (previousAttempt.children?.length ?? 0); i++) {
+            const child = previousAttempt.children[i];
+            this.createSubtest(Test, child.name, { __proto__: null }, noop, {
+              __proto__: null,
+              loc: [child.line, child.column, child.file],
+            }, noop).start();
+          }
+        };
       }
     }
   }

--- a/test/fixtures/test-runner/rerun.js
+++ b/test/fixtures/test-runner/rerun.js
@@ -23,3 +23,18 @@ function ambiguousTest(expectedAttempts) {
 
 ambiguousTest(0);
 ambiguousTest(1);
+
+function nestedAmbiguousTest(expectedAttempts) {
+  return async (t) => {
+    await t.test('nested', async (tt) => {
+      await tt.test('2 levels deep', () => {});
+      if (t.attempt < expectedAttempts) {
+        throw new Error(`This test is expected to fail on the first ${expectedAttempts} attempts`);
+      }
+    });
+    await t.test('ok', () => {});
+  };
+}
+
+test('nested ambiguous (expectedAttempts=0)', nestedAmbiguousTest(0));
+test('nested ambiguous (expectedAttempts=1)', nestedAmbiguousTest(2));


### PR DESCRIPTION
this is a fix for the previously added fature `--test-rerun-failures`
in a case there are nested ambiguous tests with the same name and same exact location, a following rerun won't run the failing test.
see the changes to the tests in this PR for a reproduction
the most effective way to solve this is to emit tests in the rerun for the entire tree of tests that have previously succeded - this also makes more sense in terms of the reproted output to the test stream