### PR TITLE
src: use C++ nullptr in webstorage

### DIFF
--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -170,14 +170,17 @@ Maybe<void> Storage::Open() {
 
   int r = sqlite3_open(location_.c_str(), &db);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Nothing<void>());
-  r = sqlite3_exec(db, init_sql_v0.data(), 0, 0, nullptr);
+  r = sqlite3_exec(db, init_sql_v0.data(), nullptr, nullptr, nullptr);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Nothing<void>());
 
   // Get the current schema version, used to determine schema migrations.
   sqlite3_stmt* s = nullptr;
-  r = sqlite3_prepare_v2(
-      db, get_schema_version_sql.data(), get_schema_version_sql.size(), &s, 0);
-  r = sqlite3_exec(db, init_sql_v0.data(), 0, 0, nullptr);
+  r = sqlite3_prepare_v2(db,
+                         get_schema_version_sql.data(),
+                         get_schema_version_sql.size(),
+                         &s,
+                         nullptr);
+  r = sqlite3_exec(db, init_sql_v0.data(), nullptr, nullptr, nullptr);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Nothing<void>());
   auto stmt = stmt_unique_ptr(s);
   CHECK_ERROR_OR_THROW(
@@ -197,7 +200,8 @@ Maybe<void> Storage::Open() {
     std::string set_user_version_sql =
         "UPDATE nodejs_webstorage_state SET schema_version = " +
         std::to_string(kCurrentSchemaVersion) + ";";
-    r = sqlite3_exec(db, set_user_version_sql.c_str(), 0, 0, nullptr);
+    r = sqlite3_exec(
+        db, set_user_version_sql.c_str(), nullptr, nullptr, nullptr);
     CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Nothing<void>());
   }
 
@@ -236,7 +240,7 @@ Maybe<void> Storage::Clear() {
   sqlite3_stmt* s = nullptr;
   CHECK_ERROR_OR_THROW(
       env(),
-      sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, 0),
+      sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr),
       SQLITE_OK,
       Nothing<void>());
   auto stmt = stmt_unique_ptr(s);
@@ -252,7 +256,7 @@ MaybeLocal<Array> Storage::Enumerate() {
 
   static constexpr std::string_view sql = "SELECT key FROM nodejs_webstorage";
   sqlite3_stmt* s = nullptr;
-  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, 0);
+  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Local<Array>());
   auto stmt = stmt_unique_ptr(s);
   LocalVector<Value> values(env()->isolate());
@@ -282,7 +286,7 @@ MaybeLocal<Value> Storage::Length() {
   static constexpr std::string_view sql =
       "SELECT count(*) FROM nodejs_webstorage";
   sqlite3_stmt* s = nullptr;
-  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, 0);
+  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Local<Value>());
   auto stmt = stmt_unique_ptr(s);
   CHECK_ERROR_OR_THROW(
@@ -305,7 +309,7 @@ MaybeLocal<Value> Storage::Load(Local<Name> key) {
   static constexpr std::string_view sql =
       "SELECT value FROM nodejs_webstorage WHERE key = ? LIMIT 1";
   sqlite3_stmt* s = nullptr;
-  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, 0);
+  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Local<Value>());
   auto stmt = stmt_unique_ptr(s);
   TwoByteValue utf16key(env()->isolate(), key);
@@ -338,7 +342,7 @@ MaybeLocal<Value> Storage::LoadKey(const int index) {
   static constexpr std::string_view sql =
       "SELECT key FROM nodejs_webstorage LIMIT 1 OFFSET ?";
   sqlite3_stmt* s = nullptr;
-  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, 0);
+  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Local<Value>());
   auto stmt = stmt_unique_ptr(s);
   r = sqlite3_bind_int(stmt.get(), 1, index);
@@ -376,7 +380,7 @@ Maybe<void> Storage::Remove(Local<Name> key) {
   static constexpr std::string_view sql =
       "DELETE FROM nodejs_webstorage WHERE key = ?";
   sqlite3_stmt* s = nullptr;
-  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, 0);
+  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Nothing<void>());
   auto stmt = stmt_unique_ptr(s);
   TwoByteValue utf16key(env()->isolate(), key);
@@ -411,7 +415,7 @@ Maybe<void> Storage::Store(Local<Name> key, Local<Value> value) {
   sqlite3_stmt* s = nullptr;
   TwoByteValue utf16key(env()->isolate(), key);
   TwoByteValue utf16val(env()->isolate(), val);
-  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, 0);
+  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr);
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_OK, Nothing<void>());
   auto stmt = stmt_unique_ptr(s);
   auto key_size = utf16key.length() * sizeof(uint16_t);


### PR DESCRIPTION
Using the C-style constant `0` to represent a null pointer is less type safe than the C++-style constant `nullptr`, so we should always be using `nullptr` instead of `0`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
