### PR TITLE
doc, child_process: clean up Windows example

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -118,51 +118,45 @@ operating systems (Unix, Linux, macOS) [`child_process.execFile()`][] can be
 more efficient because it does not spawn a shell by default. On Windows,
 however, `.bat` and `.cmd` files are not executable on their own without a
 terminal, and therefore cannot be launched using [`child_process.execFile()`][].
-When running on Windows, `.bat` and `.cmd` files can be invoked using
-[`child_process.spawn()`][] with the `shell` option set, with
-[`child_process.exec()`][], or by spawning `cmd.exe` and passing the `.bat` or
-`.cmd` file as an argument (which is what the `shell` option and
-[`child_process.exec()`][] do). In any case, if the script filename contains
-spaces it needs to be quoted.
+When running on Windows, `.bat` and `.cmd` files can be invoked by:
+
+* using [`child_process.spawn()`][] with the `shell` option set, or
+* using [`child_process.exec()`][], or
+* spawning `cmd.exe` and passing the `.bat` or `.cmd` file as an argument
+  (which is what the `shell` option and [`child_process.exec()`][] do).
+
+In any case, if the script filename contains spaces, it needs to be quoted.
 
 ```cjs
-// OR...
 const { exec, spawn } = require('node:child_process');
 
-exec('my.bat', (err, stdout, stderr) => {
-  if (err) {
-    console.error(err);
-    return;
-  }
-  console.log(stdout);
-});
+// 1. child_process.spawn() with the shell option set
+const myBat = spawn('my.bat', { shell: true });
 
-// Script with spaces in the filename:
-const bat = spawn('"my script.cmd" a b', { shell: true });
-// or:
-exec('"my script.cmd" a b', (err, stdout, stderr) => {
-  // ...
-});
+// 2. child_process.exec()
+exec('my.bat', (err, stdout, stderr) => { /* ... */ });
+
+// 3. spawning cmd.exe and passing the .bat or .cmd file as an argument
+const bat = spawn('cmd.exe', ['/c', 'my.bat']);
+
+// If the script filename contains spaces, it needs to be quoted
+exec('"my script.cmd" a b', (err, stdout, stderr) => { /* ... */ });
 ```
 
 ```mjs
-// OR...
 import { exec, spawn } from 'node:child_process';
 
-exec('my.bat', (err, stdout, stderr) => {
-  if (err) {
-    console.error(err);
-    return;
-  }
-  console.log(stdout);
-});
+// 1. child_process.spawn() with the shell option set
+const myBat = spawn('my.bat', { shell: true });
 
-// Script with spaces in the filename:
-const bat = spawn('"my script.cmd" a b', { shell: true });
-// or:
-exec('"my script.cmd" a b', (err, stdout, stderr) => {
-  // ...
-});
+// 2. child_process.exec()
+exec('my.bat', (err, stdout, stderr) => { /* ... */ });
+
+// 3. spawning cmd.exe and passing the .bat or .cmd file as an argument
+const bat = spawn('cmd.exe', ['/c', 'my.bat']);
+
+// If the script filename contains spaces, it needs to be quoted
+exec('"my script.cmd" a b', (err, stdout, stderr) => { /* ... */ });
 ```
 
 ### `child_process.exec(command[, options][, callback])`


### PR DESCRIPTION
In #53616, we added MJS snippets for the page. In the section about Windows batch files, we also combined two previous snippets who demonstrated the three ways of using `spawn`/`exec` described in the above paragraph.

The first snippet showed the `spawn` of `cmd.exe` way:

https://github.com/nodejs/node/blob/dc74f17f6c37b1bb2d675216066238f33790ed29/doc/api/child_process.md?plain=1#L112-L114

The other snippet showed the `exec` and `spawn` with `shell: true` ways:

https://github.com/nodejs/node/blob/dc74f17f6c37b1bb2d675216066238f33790ed29/doc/api/child_process.md?plain=1#L130-L132 https://github.com/nodejs/node/blob/dc74f17f6c37b1bb2d675216066238f33790ed29/doc/api/child_process.md?plain=1#L141

This makes these changes:

- remove the `// OR...` comment, since we only have one snippet now, so there's nothing to "or" with :)
- bring back the `spawn('cmd.exe')` example, which got lost in the shuffle
- reorder the examples to match the way they're presented in the paragraph
- remove the `exec` callback body, since the focus of the snippet is just the invocations of `spawn`/`exec`, not the usage of `exec` specifically
- split the prose of the three ways into a list so it's easier to read

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
