### PR TITLE
src: use bool literals in TraceEnvVarOptions

### DIFF
--- a/src/node_env_var.cc
+++ b/src/node_env_var.cc
@@ -360,9 +360,9 @@ Maybe<void> KVStore::AssignToObject(v8::Isolate* isolate,
 }
 
 struct TraceEnvVarOptions {
-  bool print_message : 1 = 0;
-  bool print_js_stack : 1 = 0;
-  bool print_native_stack : 1 = 0;
+  bool print_message : 1 = false;
+  bool print_js_stack : 1 = false;
+  bool print_native_stack : 1 = false;
 };
 
 template <typename... Args>
@@ -387,13 +387,13 @@ TraceEnvVarOptions GetTraceEnvVarOptions(Environment* env) {
                          ? env->options()
                          : per_process::cli_options->per_isolate->per_env;
   if (cli_options->trace_env) {
-    options.print_message = 1;
+    options.print_message = true;
   };
   if (cli_options->trace_env_js_stack) {
-    options.print_js_stack = 1;
+    options.print_js_stack = true;
   };
   if (cli_options->trace_env_native_stack) {
-    options.print_native_stack = 1;
+    options.print_native_stack = true;
   };
   return options;
 }


### PR DESCRIPTION
The bit fields are declared as `bool` fields, yet are assigned integer values.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
