### PR TITLE
src: use starts_with instead of rfind/find

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -169,7 +169,7 @@ BuiltinLoader::BuiltinCategories BuiltinLoader::GetBuiltinCategories() const {
       if (prefix.length() > id.length()) {
         continue;
       }
-      if (id.find(prefix) == 0 &&
+      if (id.starts_with(prefix) &&
           builtin_categories.can_be_required.count(id) == 0) {
         builtin_categories.cannot_be_required.emplace(id);
       }

--- a/src/path.cc
+++ b/src/path.cc
@@ -341,7 +341,7 @@ void FromNamespacedPath(std::string* path) {
 
 // Check if a path looks like an absolute path or file URL.
 bool IsAbsoluteFilePath(std::string_view path) {
-  if (path.rfind("file://", 0) == 0) {
+  if (path.starts_with("file://")) {
     return true;
   }
 #ifdef _WIN32
@@ -357,7 +357,7 @@ bool IsAbsoluteFilePath(std::string_view path) {
 std::string NormalizeFileURLOrPath(Environment* env, std::string_view path) {
   std::string normalized_string(path);
   constexpr std::string_view file_scheme = "file://";
-  if (normalized_string.rfind(file_scheme, 0) == 0) {
+  if (normalized_string.starts_with(file_scheme)) {
     auto out = ada::parse<ada::url_aggregator>(normalized_string);
     auto file_path = url::FileURLToPath(env, *out);
     if (!file_path.has_value()) {


### PR DESCRIPTION
Using `starts_with` makes the code more readable than using`rfind()` and avoids the inefficiency of the forward search incurred by `find()`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
