### PR TITLE
doc: update Python 3.14 manual install instructions (Windows)

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -736,7 +736,7 @@ Refs:
 ##### Option 1: Manual install
 
 * The current [version of Python][Python downloads] by following the instructions in
-  [Using Python on Windows][Using Python on Windows]
+  [Using Python on Windows][].
 * The "Desktop development with C++" workload from
   [Visual Studio 2022 (17.13 or newer)](https://visualstudio.microsoft.com/downloads/)
   or the "C++ build tools" workload from the


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/61427
Refs: https://github.com/nodejs/node-gyp/issues/3264

## Current documentation

The document section [BUILDING > Windows Prerequisites > Option 1: Manual install](https://github.com/nodejs/node/blob/main/BUILDING.md#option-1-manual-install) provides the following instructions to install Python, that are correct only up to Python 3.13:

> **Manual install**<br>
The current [version of Python](https://devguide.python.org/versions/) from the [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation)

Python has [deprecated the full installer](https://docs.python.org/3/using/windows.html#the-full-installer-deprecated) since version 3.14 and provides instead the [Python Install Manager](https://docs.python.org/3/using/windows.html#pymanager). The [Microsoft Store](https://apps.microsoft.com/store/search?publisher=Python+Software+Foundation) displays only the versions Python 3.12 and 3.13.

The instructions in the [node-gyp/README > On Windows](https://github.com/nodejs/node-gyp/blob/main/README.md#on-windows) repo documentation section have already been updated and now read:

> Follow the instructions in [Using Python on Windows](https://docs.python.org/3/using/windows.html) to install the current [version of Python](https://www.python.org/downloads/) on Windows.

## Updated documentation

The updated [node-gyp/README > On Windows](https://github.com/nodejs/node-gyp/blob/main/README.md#on-windows) instructions are copied to the [node/BUILDING > Windows Prerequisites > Option 1: Manual install](https://github.com/nodejs/node/blob/main/BUILDING.md#option-1-manual-install) document section in this repo. This covers installing all Python 3 versions, including Python 3.14.

