### PR TITLE
build,win: update WinGet configurations to Python 3.14

### DIFF
--- a/.configurations/configuration.dsc.yaml
+++ b/.configurations/configuration.dsc.yaml
@@ -5,11 +5,11 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: pythonPackage
       directives:
-        description: Install Python 3.12
+        description: Install Python 3.14
         module: Microsoft.WinGet.DSC
         allowPrerelease: true
       settings:
-        id: Python.Python.3.12
+        id: Python.Python.3.14
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
@@ -51,4 +51,4 @@ properties:
       settings:
         id: Nasm.Nasm
         source: winget
-  configurationVersion: 0.1.0
+  configurationVersion: 0.1.1

--- a/.configurations/configuration.vsEnterprise.dsc.yaml
+++ b/.configurations/configuration.vsEnterprise.dsc.yaml
@@ -5,11 +5,11 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: pythonPackage
       directives:
-        description: Install Python 3.12
+        description: Install Python 3.14
         module: Microsoft.WinGet.DSC
         allowPrerelease: true
       settings:
-        id: Python.Python.3.12
+        id: Python.Python.3.14
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
@@ -51,4 +51,4 @@ properties:
       settings:
         id: Nasm.Nasm
         source: winget
-  configurationVersion: 0.1.0
+  configurationVersion: 0.1.1

--- a/.configurations/configuration.vsProfessional.dsc.yaml
+++ b/.configurations/configuration.vsProfessional.dsc.yaml
@@ -5,11 +5,11 @@ properties:
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: pythonPackage
       directives:
-        description: Install Python 3.12
+        description: Install Python 3.14
         module: Microsoft.WinGet.DSC
         allowPrerelease: true
       settings:
-        id: Python.Python.3.12
+        id: Python.Python.3.14
         source: winget
     - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: vsPackage
@@ -51,4 +51,4 @@ properties:
       settings:
         id: Nasm.Nasm
         source: winget
-  configurationVersion: 0.1.0
+  configurationVersion: 0.1.1

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -780,12 +780,12 @@ easily. These files will install the following
 [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) packages:
 
 * Git for Windows with the `git` and Unix tools added to the `PATH`
-* `Python 3.12`
+* `Python 3.14`
 * `Visual Studio 2022` (Community, Enterprise or Professional)
 * `Visual Studio 2022 Build Tools` with Visual C++ workload, Clang and ClangToolset
 * `NetWide Assembler`
 
-To install Node.js prerequisites from Powershell Terminal:
+To install Node.js prerequisites from PowerShell Terminal:
 
 ```powershell
 winget configure .\.configurations\configuration.dsc.yaml


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/61427

## Situation

The [BUILDING > Windows Prerequisites](https://github.com/nodejs/node/blob/main/BUILDING.md#windows-prerequisites) documentation section [2: Automated install with WinGet](https://github.com/nodejs/node/blob/main/BUILDING.md#option-2-automated-install-with-winget), using the [.configurations](https://github.com/nodejs/node/tree/main/.configurations) files, installs [Python](https://www.python.org/downloads/) 3.12 (currently 3.12.10).

This is behind the version used by [GitHub Actions workflows](https://github.com/nodejs/node/tree/main/.github/workflows) that use `PYTHON_VERSION: '3.14'` (current highest supported).

## Change

Update to Python 3.14 in:

- documentation [2: Automated install with WinGet](https://github.com/nodejs/node/blob/main/BUILDING.md#option-2-automated-install-with-winget)
- [.configurations](https://github.com/nodejs/node/tree/main/.configurations) `configuration*.yaml` files