### PR TITLE
doc: remove Windows Dev Home instructions from BUILDING

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -791,14 +791,6 @@ To install Node.js prerequisites from Powershell Terminal:
 winget configure .\.configurations\configuration.dsc.yaml
 ```
 
-Alternatively, you can use [Dev Home](https://learn.microsoft.com/en-us/windows/dev-home/)
-to install the prerequisites:
-
-* Switch to `Machine Configuration` tab
-* Click on `Configuration File`
-* Choose the corresponding WinGet configuration file
-* Click on `Set up as admin`
-
 ##### Option 3: Automated install with Boxstarter
 
 A [Boxstarter](https://boxstarter.org/) script can be used for easy setup of


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/61424

## Situation

[Dev Home](https://learn.microsoft.com/en-us/windows/dev-home/) instructions in the [BUILDING > Windows > Option 2: Automated install with WinGet](https://github.com/nodejs/node/blob/main/BUILDING.md#option-2-automated-install-with-winget) document section can no longer be used.

[Dev Home](https://learn.microsoft.com/en-us/windows/dev-home/) states:

> Starting May 2025, Dev Home will no longer be supported as a feature in Windows 11.

The source repo https://github.com/microsoft/devhome was archived in June 2025.

Attempting to follow the instructions fails because Dev Home has been deactivated and the follow-on app https://github.com/microsoft/windowsAdvancedSettings does not include any way to execute configuration files.

## Change

Remove references to Dev Home from the [BUILDING.md](https://github.com/nodejs/node/blob/main/BUILDING.md) document.