### PR TITLE
build,win: improve logs when ClangCL is missing

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -246,7 +246,7 @@ call :getnodeversion || exit /b 1
 set NODE_MAJOR_VERSION=
 for /F "tokens=1 delims=." %%i in ("%NODE_VERSION%") do set "NODE_MAJOR_VERSION=%%i"
 if %NODE_MAJOR_VERSION% GEQ 24 (
-  echo Using ClangCL because the Node.js version being compiled is ^>= 24.
+  echo ClangCL is required because the Node.js version being compiled is ^>= 24.
   set clang_cl=1
 )
 
@@ -324,7 +324,7 @@ goto msbuild-found
 
 :msbuild-not-found
 set "clang_echo="
-if defined clang_cl set "clang_echo= or Clang compiler/LLVM toolset"
+if defined clang_cl set "clang_echo= with Clang compiler/LLVM toolset"
 echo Failed to find a suitable Visual Studio installation%clang_echo%.
 echo Try to run in a "Developer Command Prompt" or consult
 echo https://github.com/nodejs/node/blob/HEAD/BUILDING.md#windows


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/61437

## Situation

If Visual Studio is installed without ClangCL on Node.js >= 24, the logs from executing `.\vcbuild` on Windows could be misinterpreted as suggesting that Visual Studio was missing, not ClangCL.

## Change

Make minor text changes in [vcbuild.bat](https://github.com/nodejs/node/blob/main/vcbuild.bat) to ease troubleshooting when ClangCL has not been installed according to [BUILDING.md](https://github.com/nodejs/node/blob/main/BUILDING.md#option-1-manual-install) instructions.

## Example logs after change applied

### Visual Studio missing

```text
.\vcbuild
Looking for Python
Python found in C:\Users\mikem\AppData\Local\Microsoft\WindowsApps\\python.exe
Python 3.14.2
Looking for NASM
ClangCL is required because the Node.js version being compiled is >= 24.
Looking for Visual Studio 2026
Looking for Visual Studio 2022
Failed to find a suitable Visual Studio installation with Clang compiler/LLVM toolset.
Try to run in a "Developer Command Prompt" or consult
https://github.com/nodejs/node/blob/HEAD/BUILDING.md#windows
```

### Visual Studio 2026 Build Tools installed incompletely

https://aka.ms/vs/stable/vs_BuildTools.exe installed 18.2.0

The failure logs are the same whether only "Desktop development with C++" is missing or ClangCL is missing, or both are missing:

```text
.\vcbuild
Looking for Python
Python found in C:\Users\mikem\AppData\Local\Microsoft\WindowsApps\\python.exe
Python 3.14.2
Looking for NASM
ClangCL is required because the Node.js version being compiled is >= 24.
Looking for Visual Studio 2026
Looking for Visual Studio 2022
Failed to find a suitable Visual Studio installation with Clang compiler/LLVM toolset.
Try to run in a "Developer Command Prompt" or consult
https://github.com/nodejs/node/blob/HEAD/BUILDING.md#windows
```

### Prerequisites installed

Logs with all prerequisites installed and no errors reported concerning missing components:

```text
.\vcbuild
Looking for Python
Python found in C:\Users\mikem\AppData\Local\Microsoft\WindowsApps\\python.exe
Python 3.14.2
Looking for NASM
ClangCL is required because the Node.js version being compiled is >= 24.
Looking for Visual Studio 2026
calling: "C:\Program Files (x86)\Microsoft Visual Studio\18\BuildTools\VC\\Auxiliary\Build\vcvarsall.bat" amd64
**********************************************************************
** Visual Studio 2026 Developer Command Prompt v18.2.0
** Copyright (c) 2025 Microsoft Corporation
**********************************************************************
[DEBUG:ext\vcvars.bat] Found potential v145 version file: 'Microsoft.VCToolsVersion.VC.14.50.18.0.txt'
[DEBUG:ext\vcvars.bat] Testing v145 version file: 'Microsoft.VCToolsVersion.VC.14.50.18.0.txt'
[vcvarsall.bat] Environment initialized for: 'x64'
Found MSVS version 18.0
Found Clang version 20.1.8
configure  --dest-cpu=x64 --clang-cl=20.1.8
[WARNING] A shebang '/bin/sh' was found but does not match any supported template (e.g. '/usr/bin/python'), so it will be treated as an arbitrary command.
[WARNING] To prevent execution of programs that are not Python runtimes, set 'shebang_can_run_anything' to 'false' in your configuration file.
Node.js configure: Found Python 3.14.2...
```
