### PR TITLE
quic: move quic behind compile time flag

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -970,6 +970,12 @@ parser.add_argument('--without-sqlite',
     default=None,
     help='build without SQLite (disables SQLite and Web Storage API)')
 
+parser.add_argument('--experimental-quic',
+    action='store_true',
+    dest='experimental_quic',
+    default=None,
+    help='build with experimental QUIC support')
+
 parser.add_argument('--ninja',
     action='store_true',
     dest='use_ninja',
@@ -2035,6 +2041,10 @@ def configure_sqlite(o):
 
   configure_library('sqlite', o, pkgname='sqlite3')
 
+def configure_quic(o):
+  o['variables']['node_use_quic'] = b(options.experimental_quic and
+                                      not options.without_ssl)
+
 def configure_static(o):
   if options.fully_static or options.partly_static:
     if flavor == 'mac':
@@ -2487,6 +2497,7 @@ configure_library('uvwasi', output)
 configure_library('zstd', output, pkgname='libzstd')
 configure_v8(output, configurations)
 configure_openssl(output)
+configure_quic(output)
 configure_intl(output)
 configure_static(output)
 configure_inspector(output)

--- a/lib/internal/bootstrap/node.js
+++ b/lib/internal/bootstrap/node.js
@@ -288,7 +288,8 @@ const features = {
   get quic() {
     // TODO(@jasnell): When the implementation is updated to support Boring,
     // then this should be refactored to depend not only on the OpenSSL version.
-    return !openSSLIsBoringSSL &&
+    return process.config.variables.node_use_quic &&
+           !openSSLIsBoringSSL &&
            getOptionValue('--experimental-quic') &&
            process.config.variables.openssl_version >= 810549279; // >= 3.5.1
   },

--- a/node.gyp
+++ b/node.gyp
@@ -32,6 +32,7 @@
     'node_use_bundled_v8%': 'true',
     'node_use_node_snapshot%': 'false',
     'node_use_openssl%': 'true',
+    'node_use_quic%': 'false',
     'node_use_sqlite%': 'true',
     'node_use_v8_platform%': 'true',
     'node_v8_options%': '',
@@ -190,22 +191,6 @@
       'src/udp_wrap.cc',
       'src/util.cc',
       'src/uv.cc',
-      'src/quic/bindingdata.cc',
-      'src/quic/cid.cc',
-      'src/quic/data.cc',
-      'src/quic/logstream.cc',
-      'src/quic/packet.cc',
-      'src/quic/preferredaddress.cc',
-      'src/quic/sessionticket.cc',
-      'src/quic/tokens.cc',
-      'src/quic/application.cc',
-      'src/quic/endpoint.cc',
-      'src/quic/http3.cc',
-      'src/quic/session.cc',
-      'src/quic/streams.cc',
-      'src/quic/tlscontext.cc',
-      'src/quic/transportparams.cc',
-      'src/quic/quic.cc',
       # headers to make for a more pleasant IDE experience
       'src/aliased_buffer.h',
       'src/aliased_buffer-inl.h',
@@ -343,6 +328,24 @@
       'src/udp_wrap.h',
       'src/util.h',
       'src/util-inl.h',
+    ],
+    'node_quic_sources': [
+      'src/quic/bindingdata.cc',
+      'src/quic/cid.cc',
+      'src/quic/data.cc',
+      'src/quic/logstream.cc',
+      'src/quic/packet.cc',
+      'src/quic/preferredaddress.cc',
+      'src/quic/sessionticket.cc',
+      'src/quic/tokens.cc',
+      'src/quic/application.cc',
+      'src/quic/endpoint.cc',
+      'src/quic/http3.cc',
+      'src/quic/session.cc',
+      'src/quic/streams.cc',
+      'src/quic/tlscontext.cc',
+      'src/quic/transportparams.cc',
+      'src/quic/quic.cc',
       'src/quic/bindingdata.h',
       'src/quic/cid.h',
       'src/quic/data.h',
@@ -425,6 +428,8 @@
       'test/cctest/test_crypto_clienthello.cc',
       'test/cctest/test_node_crypto.cc',
       'test/cctest/test_node_crypto_env.cc',
+    ],
+    'node_cctest_quic_sources': [
       'test/cctest/test_quic_cid.cc',
       'test/cctest/test_quic_error.cc',
       'test/cctest/test_quic_preferredaddress.cc',
@@ -998,6 +1003,11 @@
             '<@(node_sqlite_sources)',
           ],
         }],
+        [ 'node_use_quic=="true"', {
+          'sources': [
+            '<@(node_quic_sources)',
+          ],
+        }],
         [ 'OS in "linux freebsd mac solaris openharmony" and '
           'target_arch=="x64" and '
           'node_target_type=="executable"', {
@@ -1291,6 +1301,13 @@
           ],
         }, {
           'sources!': [ '<@(node_cctest_openssl_sources)' ],
+        }],
+        [ 'node_use_quic=="true"', {
+          'defines': [
+            'HAVE_QUIC=1',
+          ],
+        }, {
+          'sources!': [ '<@(node_cctest_quic_sources)' ],
         }],
         ['v8_enable_inspector==1', {
           'defines': [

--- a/node.gypi
+++ b/node.gypi
@@ -385,13 +385,9 @@
           'defines': [ 'OPENSSL_API_COMPAT=0x10100000L', ],
           'dependencies': [
             './deps/openssl/openssl.gyp:openssl',
-            './deps/ngtcp2/ngtcp2.gyp:ngtcp2',
-            './deps/ngtcp2/ngtcp2.gyp:nghttp3',
 
             # For tests
             './deps/openssl/openssl.gyp:openssl-cli',
-            './deps/ngtcp2/ngtcp2.gyp:ngtcp2_test_server',
-            './deps/ngtcp2/ngtcp2.gyp:ngtcp2_test_client',
           ],
           'conditions': [
             # -force_load or --whole-archive are not applicable for
@@ -442,6 +438,23 @@
       'defines': [ 'HAVE_SQLITE=1' ],
     }, {
       'defines': [ 'HAVE_SQLITE=0' ]
+    }],
+    [ 'node_use_quic=="true"', {
+      'defines': [ 'HAVE_QUIC=1' ],
+      'conditions': [
+        [ 'node_shared_openssl=="false"', {
+          'dependencies': [
+            './deps/ngtcp2/ngtcp2.gyp:ngtcp2',
+            './deps/ngtcp2/ngtcp2.gyp:nghttp3',
+
+            # For tests
+            './deps/ngtcp2/ngtcp2.gyp:ngtcp2_test_server',
+            './deps/ngtcp2/ngtcp2.gyp:ngtcp2_test_client',
+          ],
+        }],
+      ],
+    }, {
+      'defines': [ 'HAVE_QUIC=0' ]
     }],
   ],
 }

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "application.h"
@@ -639,4 +639,4 @@ std::unique_ptr<Session::Application> Session::SelectApplication(
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "bindingdata.h"
@@ -224,4 +224,4 @@ JS_METHOD_IMPL(IllegalConstructor) {
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/cid.cc
+++ b/src/quic/cid.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include <crypto/crypto_util.h>
@@ -151,4 +151,4 @@ const CID::Factory& CID::Factory::random() {
 
 }  // namespace node::quic
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSS
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/data.cc
+++ b/src/quic/data.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "data.h"
@@ -394,4 +394,4 @@ const QuicError QuicError::INTERNAL_ERROR = ForNgtcp2Error(NGTCP2_ERR_INTERNAL);
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "endpoint.h"
@@ -1740,4 +1740,4 @@ JS_METHOD_IMPL(Endpoint::Ref) {
 }  // namespace quic
 }  // namespace node
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/http3.cc
+++ b/src/quic/http3.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "http3.h"
@@ -996,4 +996,4 @@ std::unique_ptr<Session::Application> Http3Application::Create(
 }  // namespace quic
 }  // namespace node
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/logstream.cc
+++ b/src/quic/logstream.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "logstream.h"
@@ -137,4 +137,4 @@ void LogStream::ensure_space(size_t amt) {
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/packet.cc
+++ b/src/quic/packet.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "packet.h"
@@ -405,4 +405,4 @@ BaseObjectPtr<Packet> Packet::CreateVersionNegotiationPacket(
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/preferredaddress.cc
+++ b/src/quic/preferredaddress.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include <env-inl.h>
@@ -156,4 +156,4 @@ const CID PreferredAddress::cid() const {
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/quic.cc
+++ b/src/quic/quic.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 
@@ -56,4 +56,4 @@ NODE_BINDING_PER_ISOLATE_INIT(quic, node::quic::CreatePerIsolateProperties)
 NODE_BINDING_EXTERNAL_REFERENCE(quic, node::quic::RegisterExternalReferences)
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "session.h"
@@ -2876,4 +2876,4 @@ void Session::InitPerContext(Realm* realm, Local<Object> target) {
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/sessionticket.cc
+++ b/src/quic/sessionticket.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "sessionticket.h"
@@ -182,4 +182,4 @@ SessionTicket::AppData::Status SessionTicket::AppData::Extract(SSL* ssl) {
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "streams.h"
@@ -1322,4 +1322,4 @@ void Stream::Unschedule() {
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include <async_wrap-inl.h>
@@ -834,4 +834,4 @@ void TLSSession::MemoryInfo(MemoryTracker* tracker) const {
 }  // namespace quic
 }  // namespace node
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/tokens.cc
+++ b/src/quic/tokens.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "tokens.h"
@@ -303,4 +303,4 @@ RegularToken::operator const char*() const {
 }  // namespace node::quic
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/src/quic/transportparams.cc
+++ b/src/quic/transportparams.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include "transportparams.h"
@@ -304,4 +304,4 @@ void TransportParams::Initialize(Environment* env, Local<Object> target) {
 }  // namespace node
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/test/cctest/test_quic_cid.cc
+++ b/test/cctest/test_quic_cid.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "quic/guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include <env-inl.h>
@@ -117,4 +117,4 @@ TEST(CID, Basic) {
   }
 }
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/test/cctest/test_quic_error.cc
+++ b/test/cctest/test_quic_error.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "quic/guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include <env-inl.h>
@@ -126,4 +126,4 @@ TEST(QuicError, TlsAlert) {
 }
 
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/test/cctest/test_quic_preferredaddress.cc
+++ b/test/cctest/test_quic_preferredaddress.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "quic/guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include <env-inl.h>
@@ -81,4 +81,4 @@ TEST(PreferredAddress, SetTransportParams) {
   CHECK_EQ(ipv4_2.address, "123.123.123.123");
 }
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/test/cctest/test_quic_tokens.cc
+++ b/test/cctest/test_quic_tokens.cc
@@ -1,4 +1,4 @@
-#if HAVE_OPENSSL
+#if HAVE_OPENSSL && HAVE_QUIC
 #include "quic/guard.h"
 #ifndef OPENSSL_NO_QUIC
 #include <gtest/gtest.h>
@@ -169,4 +169,4 @@ TEST(RegularToken, Basic) {
   CHECK(!token.Validate(NGTCP2_PROTO_VER_MAX, address, secret, 10000000000));
 }
 #endif  // OPENSSL_NO_QUIC
-#endif  // HAVE_OPENSSL
+#endif  // HAVE_OPENSSL && HAVE_QUIC


### PR DESCRIPTION
Move node:quic behind a compile-time flag, disabled by default. Use --experimental-quic at configure time to enable.

- Add --experimental-quic flag to configure.py
- Add node_use_quic variable and HAVE_QUIC define
- Make QUIC sources conditional in node.gyp
- Move ngtcp2/nghttp3 deps under QUIC condition in node.gypi
- Update C++ guards to check HAVE_QUIC
- Update process.features.quic to check node_use_quic

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
