### PR TITLE
tools: copyedit Nix files

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -6,7 +6,6 @@
   loadJSBuiltinsDynamically ? true, # Load `lib/**.js` from disk instead of embedding
   ninja ? pkgs.ninja,
   extraConfigFlags ? [
-    "--without-npm"
     "--debug-node"
   ],
 
@@ -87,13 +86,9 @@ pkgs.mkShell {
     ++ pkgs.lib.optional (ninja != null) "--ninja"
     ++ pkgs.lib.optional loadJSBuiltinsDynamically "--node-builtin-modules-path=${builtins.toString ./.}"
     ++ pkgs.lib.concatMap (name: [
-      "--shared-${builtins.replaceStrings [ "c-ares" ] [ "cares" ] name}"
-      "--shared-${builtins.replaceStrings [ "c-ares" ] [ "cares" ] name}-libpath=${
-        pkgs.lib.getLib sharedLibDeps.${name}
-      }/lib"
-      "--shared-${builtins.replaceStrings [ "c-ares" ] [ "cares" ] name}-include=${
-        pkgs.lib.getInclude sharedLibDeps.${name}
-      }/include"
+      "--shared-${name}"
+      "--shared-${name}-libpath=${pkgs.lib.getLib sharedLibDeps.${name}}/lib"
+      "--shared-${name}-include=${pkgs.lib.getInclude sharedLibDeps.${name}}/include"
     ]) (builtins.attrNames sharedLibDeps)
   );
   NOSQLITE = pkgs.lib.optionalString (!withSQLite) "1";

--- a/tools/nix/sharedLibDeps.nix
+++ b/tools/nix/sharedLibDeps.nix
@@ -8,7 +8,6 @@
   inherit (pkgs)
     ada
     brotli
-    c-ares
     gtest
     libuv
     nbytes
@@ -20,6 +19,7 @@
     zlib
     zstd
     ;
+  cares = pkgs.c-ares;
   hdr-histogram = pkgs.hdrhistogram_c;
   http-parser = pkgs.llhttp;
   nghttp2 = pkgs.nghttp2.overrideAttrs {


### PR DESCRIPTION
This PR removes two small inconsistencies that have been inherited from my personal config, but do not really make sense:

- `--without-npm` only matters when running `make install`, i.e. won't be relevant for most devs. However, since github.com/nodejs/devcontainer/pull/22 and https://github.com/nodejs/node/pull/61414, it probably makes sense to remove this flag and use the default instead.
- `c-ares` was the odd one out where Nix would accept both `c-ares` and `cares` as key in `sharedLibDeps`, the path to the least surprise is certainly to remove the exception and only accept `cares`, matching the `configure.py` flag.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
