### PR TITLE
[v22.x] doc: supported toolchain with Visual Studio 2022 only

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -160,11 +160,11 @@ platforms. This is true regardless of entries in the table below.
 
 Depending on the host platform, the selection of toolchains may vary.
 
-| Operating System | Compiler Versions                                              |
-| ---------------- | -------------------------------------------------------------- |
-| Linux            | GCC >= 10.1                                                    |
-| Windows          | Visual Studio >= 2022 with the Windows 10 SDK on a 64-bit host |
-| macOS            | Xcode >= 13 (Apple LLVM >= 12)                                 |
+| Operating System | Compiler Versions                                           |
+| ---------------- | ----------------------------------------------------------- |
+| Linux            | GCC >= 10.1                                                 |
+| Windows          | Visual Studio 2022 with the Windows 10 SDK on a 64-bit host |
+| macOS            | Xcode >= 13 (Apple LLVM >= 12)                              |
 
 ### Official binary platforms and toolchains
 
@@ -686,7 +686,7 @@ Optional requirements to build the MSI installer package:
 
 Optional requirements for compiling for Windows on ARM (ARM64):
 
-* Visual Studio 17.6.0 or newer
+* Visual Studio 2022 (17.6.0 or newer)
   > **Note:** There is [a bug](https://github.com/nodejs/build/issues/3739) in `17.10.x`
   > preventing Node.js from compiling.
 * Visual Studio optional components


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/60869
Refs: https://github.com/nodejs/node/issues/61449

## Situation

The [Supported toolchains](https://github.com/nodejs/node/blob/v22.x/BUILDING.md#supported-toolchains) section for v22.x lists Visual Studio >= 2022 with the Windows 10 SDK on a 64-bit host.

By implication, this includes also the latest release of [Microsoft Visual Studio](https://visualstudio.microsoft.com/) which is Visual Studio 2026.

`.\vcbuild` fails to run in the v22.x branch on Windows 11 25H2 in a PowerShell terminal with the [Windows Prerequisites](https://github.com/nodejs/node/blob/v22.x/BUILDING.md#windows-prerequisites) installed, with only Visual Studio Build Tools **2026** installed.

Support for Visual Studio Build Tools 2026 requires a minimum of [gyp-next@0.21.0](https://github.com/nodejs/gyp-next/releases/tag/v0.21.0).

The Node.js v22.x branch includes [gyp-next@0.20.4](https://github.com/nodejs/gyp-next/releases/tag/v0.20.4) in [v22.x/tools/gyp](https://github.com/nodejs/node/tree/v22.x/tools/gyp) and so lacks support for Visual Studio 2026.

### Failure log

```text
.\vcbuild
Looking for Python
Python found in C:\Users\mikem\AppData\Local\Microsoft\WindowsApps\\python.exe
Python 3.14.2
Looking for NASM
Looking for Visual Studio 2022
Failed to find a suitable Visual Studio installation.
Try to run in a "Developer Command Prompt" or consult
https://github.com/nodejs/node/blob/HEAD/BUILDING.md#windows
```

## Change

In [BUILDING.md](https://github.com/nodejs/node/blob/v22.x/BUILDING.md)

- restrict to Visual Studio 2022 for toolchain (see https://github.com/nodejs/node/issues/60869#issuecomment-3772047773 for reasoning)
- tie reference to "Visual Studio 17.6.0 or newer" explicitly to Visual Studio 2022