### PR TITLE
stream: export namespace object from internal end-of-stream module

### DIFF
--- a/lib/internal/streams/add-abort-signal.js
+++ b/lib/internal/streams/add-abort-signal.js
@@ -17,7 +17,7 @@ const {
   kControllerErrorFunction,
 } = require('internal/streams/utils');
 
-const eos = require('internal/streams/end-of-stream');
+const { eos } = require('internal/streams/end-of-stream');
 let addAbortListener;
 
 // This method is inlined here for readable-stream

--- a/lib/internal/streams/compose.js
+++ b/lib/internal/streams/compose.js
@@ -23,7 +23,7 @@ const {
     ERR_MISSING_ARGS,
   },
 } = require('internal/errors');
-const eos = require('internal/streams/end-of-stream');
+const { eos } = require('internal/streams/end-of-stream');
 
 module.exports = function compose(...streams) {
   if (streams.length === 0) {

--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -16,7 +16,7 @@ const {
   isReadableStream,
   isWritableStream,
 } = require('internal/streams/utils');
-const eos = require('internal/streams/end-of-stream');
+const { eos } = require('internal/streams/end-of-stream');
 const {
   AbortError,
   codes: {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -344,5 +344,7 @@ function finished(stream, opts) {
   });
 }
 
-module.exports = eos;
-module.exports.finished = finished;
+module.exports = {
+  eos,
+  finished,
+};

--- a/lib/internal/streams/pipeline.js
+++ b/lib/internal/streams/pipeline.js
@@ -10,7 +10,7 @@ const {
   SymbolDispose,
 } = primordials;
 
-const eos = require('internal/streams/end-of-stream');
+const { eos } = require('internal/streams/end-of-stream');
 const { once } = require('internal/util');
 const destroyImpl = require('internal/streams/destroy');
 const Duplex = require('internal/streams/duplex');

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -50,7 +50,7 @@ const {
   addAbortSignal,
   addAbortSignalNoValidate,
 } = require('internal/streams/add-abort-signal');
-const eos = require('internal/streams/end-of-stream');
+const { eos } = require('internal/streams/end-of-stream');
 
 let debug = require('internal/util/debuglog').debuglog('stream', (fn) => {
   debug = fn;

--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -46,7 +46,7 @@ const EE = require('events');
 const Stream = require('internal/streams/legacy').Stream;
 const { Buffer } = require('buffer');
 const destroyImpl = require('internal/streams/destroy');
-const eos = require('internal/streams/end-of-stream');
+const { eos } = require('internal/streams/end-of-stream');
 
 const {
   addAbortSignal,

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -84,7 +84,7 @@ const {
   streamBaseState,
 } = internalBinding('stream_wrap');
 
-const finished = require('internal/streams/end-of-stream');
+const { eos } = require('internal/streams/end-of-stream');
 
 const { UV_EOF } = internalBinding('uv');
 
@@ -176,7 +176,7 @@ function newWritableStreamFromStreamWritable(streamWritable) {
       backpressurePromise.resolve();
   }
 
-  const cleanup = finished(streamWritable, (error) => {
+  const cleanup = eos(streamWritable, (error) => {
     error = handleKnownInternalErrors(error);
 
     cleanup();
@@ -483,7 +483,7 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
 
   streamReadable.pause();
 
-  const cleanup = finished(streamReadable, (error) => {
+  const cleanup = eos(streamReadable, (error) => {
     error = handleKnownInternalErrors(error);
 
     cleanup();

--- a/lib/stream.js
+++ b/lib/stream.js
@@ -45,7 +45,7 @@ const compose = require('internal/streams/compose');
 const { setDefaultHighWaterMark, getDefaultHighWaterMark } = require('internal/streams/state');
 const { pipeline } = require('internal/streams/pipeline');
 const { destroyer } = require('internal/streams/destroy');
-const eos = require('internal/streams/end-of-stream');
+const { eos } = require('internal/streams/end-of-stream');
 const internalBuffer = require('internal/buffer');
 
 const promises = require('stream/promises');


### PR DESCRIPTION
The current structure of `internal/streams/end-of-stream` sets `module.exports` to the `eos` function, and defines other exports as properties on this function.

However, `eos` is exported directly from the public stream API, which currently exposes the rest of the module along with it.

Changed to a conventional module namespace.