### PR TITLE
sqlite: support reading NULL as undefined in result sets

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -154,6 +154,8 @@ changes:
     character (e.g., `foo` instead of `:foo`). **Default:** `true`.
   * `allowUnknownNamedParameters` {boolean} If `true`, unknown named parameters are ignored when binding.
     If `false`, an exception is thrown for unknown named parameters. **Default:** `false`.
+  * `readNullAsUndefined` {boolean} If `true`, SQL `NULL` values are returned as `undefined` instead
+    of `null`. **Default:** `false`.
   * `defensive` {boolean} If `true`, enables the defensive flag. When the defensive flag is enabled,
     language features that allow ordinary SQL to deliberately corrupt the database file are disabled.
     The defensive flag can also be set using `enableDefensive()`.
@@ -473,6 +475,8 @@ added: v22.5.0
     database options or `true`.
   * `allowUnknownNamedParameters` {boolean} If `true`, unknown named parameters
     are ignored. **Default:** inherited from database options or `false`.
+  * `readNullAsUndefined` {boolean} If `true`, SQL `NULL` values are returned
+    as `undefined` instead of `null`. **Default:** `false`.
 * Returns: {StatementSync} The prepared statement.
 
 Compiles a SQL statement into a [prepared statement][]. This method is a wrapper

--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -997,6 +997,21 @@ be used to read `INTEGER` data using JavaScript `BigInt`s. This method has no
 impact on database write operations where numbers and `BigInt`s are both
 supported at all times.
 
+### `statement.setReadNullAsUndefined(enabled)`
+
+<!-- YAML
+added:
+-->
+
+* `enabled` {boolean} Enables or disables returning SQL `NULL` values as
+  JavaScript `undefined` when reading from the database.
+
+When reading from the database, SQLite `NULL` values are mapped to JavaScript
+`null` by default. This method can be used to instead return `undefined` for
+`NULL` values when materialising result rows. This setting only affects how
+result rows are returned and does not impact values passed to user-defined
+functions or aggregate functions.
+
 ### `statement.sourceSQL`
 
 <!-- YAML

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -65,6 +65,14 @@ class DatabaseOpenConfiguration {
     return allow_unknown_named_params_;
   }
 
+  inline void set_read_null_as_undefined(bool flag) {
+    read_null_as_undefined_ = flag;
+  }
+
+  inline bool get_read_null_as_undefined() const {
+    return read_null_as_undefined_;
+  }
+
   inline void set_enable_defensive(bool flag) { defensive_ = flag; }
 
   inline bool get_enable_defensive() const { return defensive_; }
@@ -79,6 +87,7 @@ class DatabaseOpenConfiguration {
   bool return_arrays_ = false;
   bool allow_bare_named_params_ = true;
   bool allow_unknown_named_params_ = false;
+  bool read_null_as_undefined_ = false;
   bool defensive_ = true;
 };
 
@@ -93,7 +102,8 @@ class StatementExecutionHelper {
                                        DatabaseSync* db,
                                        sqlite3_stmt* stmt,
                                        bool return_arrays,
-                                       bool use_big_ints);
+                                       bool use_big_ints,
+                                       bool read_null_as_undefined);
   static v8::MaybeLocal<v8::Object> Run(Environment* env,
                                         DatabaseSync* db,
                                         sqlite3_stmt* stmt,
@@ -103,7 +113,8 @@ class StatementExecutionHelper {
   static v8::MaybeLocal<v8::Value> ColumnToValue(Environment* env,
                                                  sqlite3_stmt* stmt,
                                                  const int column,
-                                                 bool use_big_ints);
+                                                 bool use_big_ints,
+                                                 bool read_null_as_undefined);
   static v8::MaybeLocal<v8::Name> ColumnNameToName(Environment* env,
                                                    sqlite3_stmt* stmt,
                                                    const int column);
@@ -111,7 +122,8 @@ class StatementExecutionHelper {
                                        DatabaseSync* db,
                                        sqlite3_stmt* stmt,
                                        bool return_arrays,
-                                       bool use_big_ints);
+                                       bool use_big_ints,
+                                       bool read_null_as_undefined);
 };
 
 class DatabaseSync : public BaseObject {
@@ -167,6 +179,9 @@ class DatabaseSync : public BaseObject {
   }
   bool allow_unknown_named_params() const {
     return open_config_.get_allow_unknown_named_params();
+  }
+  bool read_null_as_undefined() const {
+    return open_config_.get_read_null_as_undefined();
   }
   sqlite3* Connection();
 
@@ -226,6 +241,8 @@ class StatementSync : public BaseObject {
       const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetReadBigInts(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void SetReturnArrays(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void SetReadNullAsUndefined(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
   v8::MaybeLocal<v8::Value> ColumnToValue(const int column);
   v8::MaybeLocal<v8::Name> ColumnNameToName(const int column);
   void Finalize();
@@ -242,6 +259,7 @@ class StatementSync : public BaseObject {
   bool use_big_ints_;
   bool allow_bare_named_params_;
   bool allow_unknown_named_params_;
+  bool read_null_as_undefined_;
   std::optional<std::map<std::string, std::string>> bare_named_params_;
   bool BindParams(const v8::FunctionCallbackInfo<v8::Value>& args);
   bool BindValue(const v8::Local<v8::Value>& value, const int index);

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -854,3 +854,108 @@ suite('options.allowBareNamedParameters', () => {
     );
   });
 });
+
+suite('StatementSync.prototype.setReadNullAsUndefined()', () => {
+  test('NULL conversion can be toggled', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+
+    db.exec(`
+      CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
+      INSERT INTO data (key, val) VALUES (1, NULL);
+    `);
+
+    const query = db.prepare('SELECT val FROM data WHERE key = 1');
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, val: null });
+
+    t.assert.strictEqual(query.setReadNullAsUndefined(true), undefined);
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, val: undefined });
+
+    t.assert.strictEqual(query.setReadNullAsUndefined(false), undefined);
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, val: null });
+  });
+
+  test('throws when input is not a boolean', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+
+    db.exec('CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;');
+
+    const stmt = db.prepare('SELECT val FROM data');
+    t.assert.throws(() => {
+      stmt.setReadNullAsUndefined();
+    }, {
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: /The "readNullAsUndefined" argument must be a boolean/,
+    });
+  });
+
+  test('returns array rows with undefined when both flags are set', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+
+    db.exec(`
+      CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
+      INSERT INTO data (key, val) VALUES (1, NULL);
+    `);
+
+    const query = db.prepare('SELECT key, val FROM data WHERE key = 1');
+    query.setReturnArrays(true);
+    query.setReadNullAsUndefined(true);
+
+    t.assert.deepStrictEqual(query.get(), [1, undefined]);
+  });
+
+  test('applies to all()', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+
+    db.exec(`
+      CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
+      INSERT INTO data (key, val) VALUES (1, NULL), (2, 'two');
+    `);
+
+    const query = db.prepare('SELECT key, val FROM data ORDER BY key');
+    query.setReadNullAsUndefined(true);
+
+    t.assert.deepStrictEqual(query.all(), [
+      { __proto__: null, key: 1, val: undefined },
+      { __proto__: null, key: 2, val: 'two' },
+    ]);
+  });
+
+  test('applies to iterate()', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+
+    db.exec(`
+      CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
+      INSERT INTO data (key, val) VALUES (1, NULL), (2, NULL);
+    `);
+
+    const query = db.prepare('SELECT key, val FROM data ORDER BY key');
+    query.setReadNullAsUndefined(true);
+
+    const iter = query.iterate();
+    t.assert.deepStrictEqual(iter.next().value, { __proto__: null, key: 1, val: undefined });
+    t.assert.deepStrictEqual(iter.next().value, { __proto__: null, key: 2, val: undefined });
+    t.assert.strictEqual(iter.next().done, true);
+  });
+
+  test('does not change NULL passed to user-defined functions', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+
+    db.exec('CREATE TABLE data(val TEXT) STRICT; INSERT INTO data VALUES (NULL);');
+
+    let seen;
+    db.function('echo', (x) => { seen = x; return x; });
+
+    const query = db.prepare('SELECT echo(val) AS out FROM data');
+    query.setReadNullAsUndefined(true);
+
+    t.assert.deepStrictEqual(query.get(), { __proto__: null, out: undefined });
+    t.assert.strictEqual(seen, null);
+  });
+});
+


### PR DESCRIPTION
Add a statement-level flag to control how SQL NULL values are materialised in results. Expose setReadNullAsUndefined() on StatementSync and apply it to row-reading paths (get, all, iterate, columnToValue) without affecting function arguments or write paths.

Fixes: https://github.com/nodejs/node/issues/59457

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
