### PR TITLE
tools: bump sccache to v0.14.0

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.14.0
       - name: Environment Information
         run: npx envinfo
       - name: Download tarball

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.14.0
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.14.0
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.14.0
       - name: Environment Information
         run: npx envinfo
       - name: Build

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.14.0
       - name: Environment Information
         run: npx envinfo
       - name: Build

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.14.0
       - name: Environment Information
         run: npx envinfo
       # The `npm ci` for this step fails a lot as part of the Test step. Run it


### PR DESCRIPTION
I've noticed the test-shared was already using it, it's slightly annoying dependabot doesn't open this kind of PR for us.

Refs: https://github.com/mozilla/sccache/releases/tag/v0.13.0

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
