### PR TITLE
url: enable simdutf for ada

### DIFF
--- a/deps/ada/ada.gyp
+++ b/deps/ada/ada.gyp
@@ -6,10 +6,19 @@
     {
       'target_name': 'ada',
       'type': 'static_library',
-      'include_dirs': ['.'],
+      'include_dirs': [
+        '.',
+        '<(DEPTH)/deps/v8/third_party/simdutf',
+      ],
       'direct_dependent_settings': {
         'include_dirs': ['.'],
       },
+      'defines': [
+        'ADA_USE_SIMDUTF=1',
+      ],
+      'dependencies': [
+        '../../tools/v8_gypfiles/v8.gyp:simdutf',
+      ],
       'sources': [ '<@(ada_sources)' ]
     },
   ]


### PR DESCRIPTION
Speeds up encoding operations.

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1785/

<details><summary>Results</summary>

```
confidence improvement accuracy (*)    (**)   (***)
url/legacy-url-get-prop.js e=1 type='auth'                                                                                                     -1.42 %       ±3.99%  ±5.32%  ±6.95%
url/legacy-url-get-prop.js e=1 type='dot'                                                                                                       0.65 %       ±3.22%  ±4.30%  ±5.64%
url/legacy-url-get-prop.js e=1 type='file'                                                                                               *     -6.03 %       ±4.97%  ±6.69%  ±8.85%
url/legacy-url-get-prop.js e=1 type='idn'                                                                                                *     -2.94 %       ±2.85%  ±3.83%  ±5.06%
url/legacy-url-get-prop.js e=1 type='javascript'                                                                                               -1.00 %       ±2.95%  ±3.93%  ±5.11%
url/legacy-url-get-prop.js e=1 type='long'                                                                                                      1.65 %       ±7.97% ±10.60% ±13.81%
url/legacy-url-get-prop.js e=1 type='percent'                                                                                                   0.13 %       ±4.86%  ±6.47%  ±8.42%
url/legacy-url-get-prop.js e=1 type='short'                                                                                                    -0.17 %       ±4.01%  ±5.33%  ±6.95%
url/legacy-url-get-prop.js e=1 type='wpt'                                                                                                      13.73 %      ±15.41% ±20.61% ±27.05%
url/legacy-url-get-prop.js e=1 type='ws'                                                                                                        1.25 %       ±3.87%  ±5.15%  ±6.71%
url/legacy-url-parse.js e=1 type='auth'                                                                                                  *     22.45 %      ±22.07% ±29.36% ±38.21%
url/legacy-url-parse.js e=1 type='dot'                                                                                                          0.12 %       ±0.94%  ±1.25%  ±1.62%
url/legacy-url-parse.js e=1 type='file'                                                                                                        -0.98 %       ±2.00%  ±2.67%  ±3.51%
url/legacy-url-parse.js e=1 type='idn'                                                                                                         -1.31 %       ±1.85%  ±2.48%  ±3.27%
url/legacy-url-parse.js e=1 type='javascript'                                                                                            *      1.25 %       ±0.98%  ±1.30%  ±1.69%
url/legacy-url-parse.js e=1 type='long'                                                                                                        17.49 %      ±20.69% ±27.54% ±35.88%
url/legacy-url-parse.js e=1 type='percent'                                                                                                      0.44 %       ±1.81%  ±2.42%  ±3.18%
url/legacy-url-parse.js e=1 type='short'                                                                                                        0.06 %       ±0.69%  ±0.92%  ±1.20%
url/legacy-url-parse.js e=1 type='wpt'                                                                                                          4.09 %       ±5.09%  ±6.79%  ±8.86%
url/legacy-url-parse.js e=1 type='ws'                                                                                                          -5.12 %      ±20.93% ±27.84% ±36.24%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='altspaces'                                                0.17 %       ±0.59%  ±0.78%  ±1.02%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='encodefake'                                        *      1.14 %       ±1.11%  ±1.47%  ±1.92%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='encodelast'                                               0.29 %       ±1.16%  ±1.55%  ±2.03%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='encodemany'                                              -0.29 %       ±1.20%  ±1.60%  ±2.09%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='manyblankpairs'                                           0.90 %       ±1.82%  ±2.42%  ±3.16%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='manypairs'                                               -0.45 %       ±1.39%  ±1.85%  ±2.41%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='multicharsep'                                            -0.06 %       ±1.16%  ±1.54%  ±2.00%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='multivalue'                                              -0.78 %       ±1.16%  ±1.55%  ±2.01%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='multivaluemany'                                           0.83 %       ±1.53%  ±2.04%  ±2.67%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='legacy' searchParam='noencode'                                                 0.01 %       ±0.93%  ±1.24%  ±1.61%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='altspaces'                                               -0.63 %       ±0.90%  ±1.20%  ±1.57%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='encodefake'                                        *     -1.19 %       ±1.13%  ±1.51%  ±1.97%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='encodelast'                                              -0.31 %       ±0.94%  ±1.25%  ±1.63%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='encodemany'                                               0.09 %       ±0.46%  ±0.62%  ±0.80%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='manyblankpairs'                                           0.10 %       ±2.15%  ±2.87%  ±3.73%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='manypairs'                                               -0.31 %       ±1.22%  ±1.62%  ±2.11%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='multicharsep'                                            -0.01 %       ±0.90%  ±1.20%  ±1.56%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='multivalue'                                               0.44 %       ±1.19%  ±1.59%  ±2.08%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='multivaluemany'                                    *     -0.52 %       ±0.51%  ±0.68%  ±0.89%
url/legacy-vs-whatwg-url-searchparams-parse.js n=1000000 method='whatwg' searchParam='noencode'                                                -0.99 %       ±1.59%  ±2.12%  ±2.76%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='altspaces'                                           -0.19 %       ±0.62%  ±0.82%  ±1.07%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='encodefake'                                          -0.12 %       ±0.74%  ±0.98%  ±1.28%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='encodelast'                                          -0.09 %       ±1.33%  ±1.77%  ±2.31%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='encodemany'                                          -0.06 %       ±1.33%  ±1.77%  ±2.30%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='manyblankpairs'                                       2.58 %       ±4.84%  ±6.44%  ±8.39%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='manypairs'                                     *     -1.61 %       ±1.54%  ±2.05%  ±2.67%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='multicharsep'                                         0.54 %       ±1.27%  ±1.69%  ±2.20%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='multivalue'                                           0.20 %       ±0.99%  ±1.32%  ±1.72%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='multivaluemany'                                *     -0.96 %       ±0.87%  ±1.16%  ±1.51%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='legacy' searchParam='noencode'                                             0.20 %       ±1.06%  ±1.41%  ±1.84%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='altspaces'                                           -0.28 %       ±0.63%  ±0.84%  ±1.10%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='encodefake'                                           0.10 %       ±0.75%  ±1.00%  ±1.30%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='encodelast'                                           0.24 %       ±1.04%  ±1.39%  ±1.80%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='encodemany'                                           0.62 %       ±0.98%  ±1.31%  ±1.70%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='manyblankpairs'                                      -0.50 %       ±1.94%  ±2.58%  ±3.36%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='manypairs'                                            0.28 %       ±1.05%  ±1.40%  ±1.82%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='multicharsep'                                        -0.33 %       ±0.90%  ±1.20%  ±1.57%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='multivalue'                                          -0.76 %       ±0.79%  ±1.06%  ±1.39%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='multivaluemany'                                       0.15 %       ±0.40%  ±0.54%  ±0.70%
url/legacy-vs-whatwg-url-searchparams-serialize.js n=1000000 method='whatwg' searchParam='noencode'                                            -0.48 %       ±0.68%  ±0.91%  ±1.19%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='auth'                                                                           1.25 %       ±2.79%  ±3.74%  ±4.94%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='dot'                                                                           -1.14 %       ±3.14%  ±4.21%  ±5.57%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='file'                                                                          -0.94 %       ±1.84%  ±2.45%  ±3.21%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='idn'                                                                            0.33 %       ±3.74%  ±4.97%  ±6.48%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='javascript'                                                                     0.32 %       ±0.94%  ±1.26%  ±1.65%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='long'                                                                          -0.58 %       ±3.41%  ±4.54%  ±5.91%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='percent'                                                                        2.44 %       ±3.42%  ±4.60%  ±6.10%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='short'                                                                         -0.96 %       ±1.00%  ±1.33%  ±1.73%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='wpt'                                                                            1.37 %       ±3.63%  ±4.84%  ±6.33%
url/legacy-vs-whatwg-url-serialize.js e=1 method='legacy' type='ws'                                                                            -0.74 %       ±2.73%  ±3.65%  ±4.81%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='auth'                                                                           0.21 %       ±0.70%  ±0.93%  ±1.21%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='dot'                                                                            1.50 %       ±3.60%  ±4.79%  ±6.25%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='file'                                                                           1.58 %       ±3.04%  ±4.09%  ±5.41%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='idn'                                                                            0.50 %       ±3.50%  ±4.66%  ±6.07%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='javascript'                                                                    -1.53 %       ±2.79%  ±3.74%  ±4.95%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='long'                                                                          -0.31 %       ±3.94%  ±5.24%  ±6.82%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='percent'                                                                        0.14 %       ±0.94%  ±1.26%  ±1.64%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='short'                                                                         -0.03 %       ±0.84%  ±1.12%  ±1.45%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='wpt'                                                                            0.66 %       ±3.51%  ±4.67%  ±6.09%
url/legacy-vs-whatwg-url-serialize.js e=1 method='whatwg' type='ws'                                                                            -0.05 %       ±1.04%  ±1.39%  ±1.82%
url/url-format.js n=25000000 type='file'                                                                                                       -0.28 %       ±1.35%  ±1.79%  ±2.33%
url/url-format.js n=25000000 type='slashes'                                                                                                     0.91 %       ±1.40%  ±1.86%  ±2.42%
url/url-parse.js n=10000000 type='escaped'                                                                                                     -0.33 %       ±0.79%  ±1.06%  ±1.38%
url/url-parse.js n=10000000 type='normal'                                                                                              ***     -1.37 %       ±0.43%  ±0.58%  ±0.75%
url/url-resolve.js n=100000 path='down' href='auth'                                                                                            -0.11 %       ±0.71%  ±0.95%  ±1.24%
url/url-resolve.js n=100000 path='down' href='dot'                                                                                              0.16 %       ±0.73%  ±0.97%  ±1.27%
url/url-resolve.js n=100000 path='down' href='file'                                                                                             0.47 %       ±0.80%  ±1.07%  ±1.39%
url/url-resolve.js n=100000 path='down' href='idn'                                                                                     ***     -1.41 %       ±0.70%  ±0.93%  ±1.22%
url/url-resolve.js n=100000 path='down' href='javascript'                                                                                       0.49 %       ±1.38%  ±1.84%  ±2.40%
url/url-resolve.js n=100000 path='down' href='long'                                                                                             0.30 %       ±0.49%  ±0.65%  ±0.85%
url/url-resolve.js n=100000 path='down' href='noscheme'                                                                                         0.58 %       ±1.27%  ±1.69%  ±2.20%
url/url-resolve.js n=100000 path='down' href='percent'                                                                                          0.29 %       ±0.43%  ±0.58%  ±0.75%
url/url-resolve.js n=100000 path='down' href='short'                                                                                           -0.11 %       ±0.83%  ±1.11%  ±1.44%
url/url-resolve.js n=100000 path='down' href='ws'                                                                                              -0.15 %       ±0.55%  ±0.73%  ±0.95%
url/url-resolve.js n=100000 path='foo/bar' href='auth'                                                                                         -0.21 %       ±0.76%  ±1.01%  ±1.32%
url/url-resolve.js n=100000 path='foo/bar' href='dot'                                                                                           0.04 %       ±0.98%  ±1.30%  ±1.70%
url/url-resolve.js n=100000 path='foo/bar' href='file'                                                                                         -0.07 %       ±1.01%  ±1.35%  ±1.76%
url/url-resolve.js n=100000 path='foo/bar' href='idn'                                                                                   **     -1.86 %       ±1.09%  ±1.45%  ±1.89%
url/url-resolve.js n=100000 path='foo/bar' href='javascript'                                                                                    0.65 %       ±1.45%  ±1.93%  ±2.51%
url/url-resolve.js n=100000 path='foo/bar' href='long'                                                                                         -0.06 %       ±0.45%  ±0.59%  ±0.77%
url/url-resolve.js n=100000 path='foo/bar' href='noscheme'                                                                                     -0.12 %       ±1.28%  ±1.71%  ±2.22%
url/url-resolve.js n=100000 path='foo/bar' href='percent'                                                                                       0.19 %       ±1.00%  ±1.33%  ±1.74%
url/url-resolve.js n=100000 path='foo/bar' href='short'                                                                                        -0.04 %       ±1.04%  ±1.38%  ±1.80%
url/url-resolve.js n=100000 path='foo/bar' href='ws'                                                                                           -0.16 %       ±0.63%  ±0.84%  ±1.10%
url/url-resolve.js n=100000 path='sibling' href='auth'                                                                                          0.25 %       ±0.63%  ±0.84%  ±1.10%
url/url-resolve.js n=100000 path='sibling' href='dot'                                                                                           0.28 %       ±0.59%  ±0.79%  ±1.03%
url/url-resolve.js n=100000 path='sibling' href='file'                                                                                         -0.27 %       ±0.82%  ±1.09%  ±1.41%
url/url-resolve.js n=100000 path='sibling' href='idn'                                                                                  ***     -1.03 %       ±0.33%  ±0.44%  ±0.57%
url/url-resolve.js n=100000 path='sibling' href='javascript'                                                                                   -0.65 %       ±1.02%  ±1.36%  ±1.77%
url/url-resolve.js n=100000 path='sibling' href='long'                                                                                          0.24 %       ±0.48%  ±0.63%  ±0.83%
url/url-resolve.js n=100000 path='sibling' href='noscheme'                                                                                      0.22 %       ±0.83%  ±1.11%  ±1.44%
url/url-resolve.js n=100000 path='sibling' href='percent'                                                                                      -0.20 %       ±0.83%  ±1.10%  ±1.43%
url/url-resolve.js n=100000 path='sibling' href='short'                                                                                         0.44 %       ±0.77%  ±1.03%  ±1.34%
url/url-resolve.js n=100000 path='sibling' href='ws'                                                                                           -0.45 %       ±0.57%  ±0.76%  ±0.99%
url/url-resolve.js n=100000 path='up' href='auth'                                                                                              -0.13 %       ±0.66%  ±0.87%  ±1.14%
url/url-resolve.js n=100000 path='up' href='dot'                                                                                               -0.46 %       ±0.59%  ±0.78%  ±1.02%
url/url-resolve.js n=100000 path='up' href='file'                                                                                              -0.59 %       ±0.79%  ±1.06%  ±1.38%
url/url-resolve.js n=100000 path='up' href='idn'                                                                                       ***     -1.13 %       ±0.46%  ±0.61%  ±0.79%
url/url-resolve.js n=100000 path='up' href='javascript'                                                                                         0.14 %       ±0.76%  ±1.01%  ±1.32%
url/url-resolve.js n=100000 path='up' href='long'                                                                                              -0.18 %       ±0.34%  ±0.45%  ±0.59%
url/url-resolve.js n=100000 path='up' href='noscheme'                                                                                           0.03 %       ±0.92%  ±1.23%  ±1.60%
url/url-resolve.js n=100000 path='up' href='percent'                                                                                           -0.13 %       ±0.75%  ±1.00%  ±1.30%
url/url-resolve.js n=100000 path='up' href='short'                                                                                             -0.49 %       ±0.77%  ±1.03%  ±1.34%
url/url-resolve.js n=100000 path='up' href='ws'                                                                                                 0.20 %       ±0.68%  ±0.90%  ±1.18%
url/url-resolve.js n=100000 path='withscheme' href='auth'                                                                                      -0.56 %       ±0.83%  ±1.10%  ±1.43%
url/url-resolve.js n=100000 path='withscheme' href='dot'                                                                                       -0.57 %       ±0.97%  ±1.29%  ±1.68%
url/url-resolve.js n=100000 path='withscheme' href='file'                                                                                      -0.53 %       ±1.18%  ±1.57%  ±2.04%
url/url-resolve.js n=100000 path='withscheme' href='idn'                                                                               ***     -1.35 %       ±0.53%  ±0.70%  ±0.92%
url/url-resolve.js n=100000 path='withscheme' href='javascript'                                                                                -0.55 %       ±0.93%  ±1.24%  ±1.61%
url/url-resolve.js n=100000 path='withscheme' href='long'                                                                                       0.01 %       ±0.41%  ±0.55%  ±0.72%
url/url-resolve.js n=100000 path='withscheme' href='noscheme'                                                                                  -0.57 %       ±1.24%  ±1.66%  ±2.16%
url/url-resolve.js n=100000 path='withscheme' href='percent'                                                                                   -0.26 %       ±1.11%  ±1.48%  ±1.94%
url/url-resolve.js n=100000 path='withscheme' href='short'                                                                                     -0.14 %       ±1.00%  ±1.34%  ±1.75%
url/url-resolve.js n=100000 path='withscheme' href='ws'                                                                                        -0.23 %       ±0.83%  ±1.11%  ±1.44%
url/url-searchparams-append.js n=1000 type='URL'                                                                                               -2.28 %       ±2.97%  ±3.95%  ±5.14%
url/url-searchparams-append.js n=1000 type='URLSearchParams'                                                                                   -0.58 %       ±3.44%  ±4.59%  ±6.01%
url/url-searchparams-append.js n=1000000 type='URL'                                                                                             1.44 %       ±2.70%  ±3.60%  ±4.70%
url/url-searchparams-append.js n=1000000 type='URLSearchParams'                                                                          *      2.70 %       ±2.60%  ±3.46%  ±4.51%
url/url-searchparams-creation.js n=1000000 inputType='iterable' type='array'                                                                   -0.28 %       ±1.14%  ±1.52%  ±1.97%
url/url-searchparams-creation.js n=1000000 inputType='iterable' type='encodelast'                                                              -1.42 %       ±1.45%  ±1.94%  ±2.52%
url/url-searchparams-creation.js n=1000000 inputType='iterable' type='encodemany'                                                              -0.33 %       ±1.42%  ±1.89%  ±2.47%
url/url-searchparams-creation.js n=1000000 inputType='iterable' type='multiprimitives'                                                          0.14 %       ±1.52%  ±2.02%  ±2.63%
url/url-searchparams-creation.js n=1000000 inputType='iterable' type='noencode'                                                                -0.20 %       ±1.28%  ±1.71%  ±2.22%
url/url-searchparams-creation.js n=1000000 inputType='object' type='array'                                                                     -0.09 %       ±0.56%  ±0.74%  ±0.96%
url/url-searchparams-creation.js n=1000000 inputType='object' type='encodelast'                                                                -0.31 %       ±0.77%  ±1.02%  ±1.33%
url/url-searchparams-creation.js n=1000000 inputType='object' type='encodemany'                                                                 0.08 %       ±0.80%  ±1.06%  ±1.39%
url/url-searchparams-creation.js n=1000000 inputType='object' type='multiprimitives'                                                           -0.61 %       ±0.67%  ±0.89%  ±1.17%
url/url-searchparams-creation.js n=1000000 inputType='object' type='noencode'                                                                  -0.14 %       ±0.78%  ±1.04%  ±1.36%
url/url-searchparams-creation.js n=1000000 inputType='string' type='array'                                                                      0.42 %       ±0.88%  ±1.17%  ±1.53%
url/url-searchparams-creation.js n=1000000 inputType='string' type='encodelast'                                                                -0.25 %       ±1.30%  ±1.73%  ±2.25%
url/url-searchparams-creation.js n=1000000 inputType='string' type='encodemany'                                                                -0.28 %       ±1.18%  ±1.58%  ±2.05%
url/url-searchparams-creation.js n=1000000 inputType='string' type='multiprimitives'                                                            0.24 %       ±1.56%  ±2.08%  ±2.70%
url/url-searchparams-creation.js n=1000000 inputType='string' type='noencode'                                                                  -0.71 %       ±1.00%  ±1.33%  ±1.74%
url/url-searchparams-inspect.js n=100000 kind='iterator-entries' variant='empty'                                                               -0.14 %       ±1.61%  ±2.15%  ±2.80%
url/url-searchparams-inspect.js n=100000 kind='iterator-entries' variant='large'                                                         *      0.78 %       ±0.70%  ±0.94%  ±1.24%
url/url-searchparams-inspect.js n=100000 kind='iterator-entries' variant='medium'                                                               0.08 %       ±0.70%  ±0.92%  ±1.20%
url/url-searchparams-inspect.js n=100000 kind='iterator-entries' variant='small'                                                                0.24 %       ±0.66%  ±0.88%  ±1.14%
url/url-searchparams-inspect.js n=100000 kind='iterator-keys' variant='empty'                                                                  -0.44 %       ±1.81%  ±2.40%  ±3.13%
url/url-searchparams-inspect.js n=100000 kind='iterator-keys' variant='large'                                                                  -0.14 %       ±1.38%  ±1.83%  ±2.39%
url/url-searchparams-inspect.js n=100000 kind='iterator-keys' variant='medium'                                                                  0.00 %       ±0.63%  ±0.84%  ±1.10%
url/url-searchparams-inspect.js n=100000 kind='iterator-keys' variant='small'                                                                  -0.32 %       ±0.74%  ±0.99%  ±1.29%
url/url-searchparams-inspect.js n=100000 kind='iterator-values' variant='empty'                                                                -0.71 %       ±1.68%  ±2.23%  ±2.91%
url/url-searchparams-inspect.js n=100000 kind='iterator-values' variant='large'                                                                -0.49 %       ±1.18%  ±1.58%  ±2.05%
url/url-searchparams-inspect.js n=100000 kind='iterator-values' variant='medium'                                                               -0.29 %       ±0.58%  ±0.77%  ±1.00%
url/url-searchparams-inspect.js n=100000 kind='iterator-values' variant='small'                                                                 0.26 %       ±0.85%  ±1.13%  ±1.48%
url/url-searchparams-inspect.js n=100000 kind='params' variant='empty'                                                                         -0.30 %       ±3.73%  ±4.97%  ±6.47%
url/url-searchparams-inspect.js n=100000 kind='params' variant='large'                                                                         -0.13 %       ±1.05%  ±1.40%  ±1.83%
url/url-searchparams-inspect.js n=100000 kind='params' variant='medium'                                                                         0.00 %       ±0.67%  ±0.89%  ±1.15%
url/url-searchparams-inspect.js n=100000 kind='params' variant='small'                                                                         -0.14 %       ±0.73%  ±0.97%  ±1.26%
url/url-searchparams-iteration.js n=1000000 loopMethod='forEach'                                                                               -1.72 %       ±2.99%  ±3.98%  ±5.18%
url/url-searchparams-iteration.js n=1000000 loopMethod='iterator'                                                                              -1.03 %       ±1.50%  ±1.99%  ±2.59%
url/url-searchparams-read.js n=20000000 param='nonexistent' accessMethod='get'                                                                 -0.74 %       ±1.33%  ±1.79%  ±2.36%
url/url-searchparams-read.js n=20000000 param='nonexistent' accessMethod='getAll'                                                               0.24 %       ±0.59%  ±0.78%  ±1.01%
url/url-searchparams-read.js n=20000000 param='nonexistent' accessMethod='has'                                                                 -0.61 %       ±1.03%  ±1.37%  ±1.79%
url/url-searchparams-read.js n=20000000 param='one' accessMethod='get'                                                                          1.13 %       ±3.28%  ±4.37%  ±5.69%
url/url-searchparams-read.js n=20000000 param='one' accessMethod='getAll'                                                                      -0.03 %       ±1.37%  ±1.82%  ±2.38%
url/url-searchparams-read.js n=20000000 param='one' accessMethod='has'                                                                          0.87 %       ±3.16%  ±4.21%  ±5.48%
url/url-searchparams-read.js n=20000000 param='three' accessMethod='get'                                                                        2.02 %       ±2.81%  ±3.74%  ±4.86%
url/url-searchparams-read.js n=20000000 param='three' accessMethod='getAll'                                                                    -0.12 %       ±1.85%  ±2.47%  ±3.21%
url/url-searchparams-read.js n=20000000 param='three' accessMethod='has'                                                                       -1.29 %       ±3.15%  ±4.19%  ±5.45%
url/url-searchparams-read.js n=20000000 param='two' accessMethod='get'                                                                         -0.96 %       ±2.67%  ±3.55%  ±4.62%
url/url-searchparams-read.js n=20000000 param='two' accessMethod='getAll'                                                                       0.44 %       ±1.03%  ±1.37%  ±1.78%
url/url-searchparams-read.js n=20000000 param='two' accessMethod='has'                                                                          0.77 %       ±2.28%  ±3.04%  ±3.95%
url/url-searchparams-sort.js n=1000000 type='almostsorted'                                                                                      1.03 %       ±2.78%  ±3.71%  ±4.83%
url/url-searchparams-sort.js n=1000000 type='empty'                                                                                             0.61 %       ±4.11%  ±5.48%  ±7.15%
url/url-searchparams-sort.js n=1000000 type='long'                                                                                             -0.87 %       ±1.00%  ±1.33%  ±1.74%
url/url-searchparams-sort.js n=1000000 type='random'                                                                                           -0.67 %       ±2.97%  ±3.95%  ±5.17%
url/url-searchparams-sort.js n=1000000 type='reversed'                                                                                         -0.53 %       ±2.71%  ±3.61%  ±4.71%
url/url-searchparams-sort.js n=1000000 type='short'                                                                                            -2.98 %       ±4.37%  ±5.82%  ±7.58%
url/url-searchparams-sort.js n=1000000 type='sorted'                                                                                           -0.79 %       ±2.19%  ±2.91%  ±3.79%
url/url-searchparams-sort.js n=1000000 type='wpt'                                                                                               3.97 %       ±5.86%  ±7.80% ±10.17%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='array'                                                                    0.38 %       ±0.73%  ±0.97%  ±1.27%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='encodelast'                                                               0.07 %       ±0.94%  ±1.26%  ±1.64%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='encodemany'                                                              -0.70 %       ±1.19%  ±1.58%  ±2.06%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='multiprimitives'                                                          0.42 %       ±0.88%  ±1.18%  ±1.54%
url/url-searchparams-toString.js n=1000000 inputType='iterable' type='noencode'                                                                -0.21 %       ±0.66%  ±0.87%  ±1.14%
url/url-searchparams-toString.js n=1000000 inputType='object' type='array'                                                                     -0.28 %       ±0.86%  ±1.14%  ±1.49%
url/url-searchparams-toString.js n=1000000 inputType='object' type='encodelast'                                                                -0.43 %       ±1.00%  ±1.33%  ±1.72%
url/url-searchparams-toString.js n=1000000 inputType='object' type='encodemany'                                                                 0.23 %       ±0.95%  ±1.26%  ±1.64%
url/url-searchparams-toString.js n=1000000 inputType='object' type='multiprimitives'                                                           -0.53 %       ±0.74%  ±0.99%  ±1.30%
url/url-searchparams-toString.js n=1000000 inputType='object' type='noencode'                                                                  -0.08 %       ±0.61%  ±0.81%  ±1.05%
url/url-searchparams-toString.js n=1000000 inputType='string' type='array'                                                                      0.50 %       ±0.67%  ±0.89%  ±1.16%
url/url-searchparams-toString.js n=1000000 inputType='string' type='encodelast'                                                                 0.77 %       ±1.03%  ±1.38%  ±1.80%
url/url-searchparams-toString.js n=1000000 inputType='string' type='encodemany'                                                                 0.15 %       ±1.07%  ±1.42%  ±1.85%
url/url-searchparams-toString.js n=1000000 inputType='string' type='multiprimitives'                                                            0.72 %       ±1.06%  ±1.41%  ±1.84%
url/url-searchparams-toString.js n=1000000 inputType='string' type='noencode'                                                                   0.03 %       ±0.61%  ±0.81%  ±1.05%
url/url-searchparams-update.js n=1000000 property='hash' searchParams='false'                                                          ***     -2.19 %       ±0.44%  ±0.59%  ±0.77%
url/url-searchparams-update.js n=1000000 property='hash' searchParams='true'                                                           ***     -2.55 %       ±0.56%  ±0.74%  ±0.98%
url/url-searchparams-update.js n=1000000 property='pathname' searchParams='false'                                                      ***     -2.53 %       ±0.43%  ±0.57%  ±0.74%
url/url-searchparams-update.js n=1000000 property='pathname' searchParams='true'                                                       ***     -2.60 %       ±0.55%  ±0.73%  ±0.96%
url/url-searchparams-update.js n=1000000 property='search' searchParams='false'                                                        ***     -3.32 %       ±0.35%  ±0.47%  ±0.62%
url/url-searchparams-update.js n=1000000 property='search' searchParams='true'                                                         ***     -2.91 %       ±0.51%  ±0.68%  ±0.88%
url/urlpattern-parse.js n=100000 pattern='"[https://(sub.)?example(.com/)foo](https://(sub.)/?example(.com/)foo)"'                                                                   0.15 %       ±0.77%  ±1.04%  ±1.37%
url/urlpattern-parse.js n=100000 pattern='{"hostname":"xn--caf-dma.com"}'                                                                      -0.26 %       ±0.37%  ±0.49%  ±0.64%
url/urlpattern-parse.js n=100000 pattern='{"pathname":"/([[a-z]--a])"}'                                                                 **     -0.70 %       ±0.49%  ±0.66%  ±0.86%
url/urlpattern-parse.js n=100000 pattern='{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080/"}'                -0.17 %       ±0.32%  ±0.42%  ±0.55%
url/urlpattern-test.js n=100000 pattern='"[https://(sub.)?example(.com/)foo](https://(sub.)/?example(.com/)foo)"'                                                           ***     -4.33 %       ±2.22%  ±2.96%  ±3.86%
url/urlpattern-test.js n=100000 pattern='{"hostname":"xn--caf-dma.com"}'                                                                       -1.83 %       ±1.97%  ±2.62%  ±3.41%
url/urlpattern-test.js n=100000 pattern='{"pathname":"/([[a-z]--a])"}'                                                                  **     -3.55 %       ±2.31%  ±3.08%  ±4.02%
url/urlpattern-test.js n=100000 pattern='{"pathname":"/foo","search":"bar","hash":"baz","baseURL":"https://example.com:8080/"}'                 -1.42 %       ±2.17%  ±2.88%  ±3.75%
url/whatwg-url-canParse.js n=1000000 type='auth'                                                                                       ***     -3.09 %       ±0.96%  ±1.28%  ±1.66%
url/whatwg-url-canParse.js n=1000000 type='dot'                                                                                                -0.27 %       ±1.43%  ±1.90%  ±2.47%
url/whatwg-url-canParse.js n=1000000 type='file'                                                                                        **     -2.10 %       ±1.43%  ±1.91%  ±2.48%
url/whatwg-url-canParse.js n=1000000 type='idn'                                                                                        ***     -2.45 %       ±0.17%  ±0.23%  ±0.30%
url/whatwg-url-canParse.js n=1000000 type='javascript'                                                                                  **     -1.55 %       ±1.04%  ±1.39%  ±1.81%
url/whatwg-url-canParse.js n=1000000 type='long'                                                                                                0.31 %       ±0.58%  ±0.77%  ±1.00%
url/whatwg-url-canParse.js n=1000000 type='percent'                                                                                    ***     -6.24 %       ±0.48%  ±0.64%  ±0.83%
url/whatwg-url-canParse.js n=1000000 type='short'                                                                                              -0.15 %       ±1.33%  ±1.78%  ±2.31%
url/whatwg-url-canParse.js n=1000000 type='ws'                                                                                                  0.24 %       ±0.99%  ±1.32%  ±1.72%
url/whatwg-url-get-prop.js e=1 type='auth'                                                                                                     11.20 %      ±45.27% ±60.25% ±78.43%
url/whatwg-url-get-prop.js e=1 type='dot'                                                                                                       0.31 %       ±1.94%  ±2.58%  ±3.36%
url/whatwg-url-get-prop.js e=1 type='file'                                                                                                     -0.82 %       ±1.43%  ±1.91%  ±2.48%
url/whatwg-url-get-prop.js e=1 type='idn'                                                                                                       0.08 %       ±1.69%  ±2.25%  ±2.93%
url/whatwg-url-get-prop.js e=1 type='javascript'                                                                                               -0.45 %       ±1.75%  ±2.33%  ±3.05%
url/whatwg-url-get-prop.js e=1 type='long'                                                                                                     28.19 %      ±55.61% ±74.04% ±96.44%
url/whatwg-url-get-prop.js e=1 type='percent'                                                                                                  -0.14 %       ±1.95%  ±2.60%  ±3.39%
url/whatwg-url-get-prop.js e=1 type='short'                                                                                                     1.18 %       ±1.85%  ±2.47%  ±3.21%
url/whatwg-url-get-prop.js e=1 type='wpt'                                                                                                      -9.34 %      ±16.83% ±22.41% ±29.21%
url/whatwg-url-get-prop.js e=1 type='ws'                                                                                                       -1.39 %       ±1.44%  ±1.91%  ±2.49%
url/whatwg-url-idna.js n=5000000 to='ascii' domain='all'                                                                               ***     -3.90 %       ±0.38%  ±0.51%  ±0.68%
url/whatwg-url-idna.js n=5000000 to='ascii' domain='empty'                                                                                     -0.41 %       ±0.92%  ±1.22%  ±1.59%
url/whatwg-url-idna.js n=5000000 to='ascii' domain='none'                                                                              ***     -1.93 %       ±0.18%  ±0.24%  ±0.32%
url/whatwg-url-idna.js n=5000000 to='ascii' domain='nonstring'                                                                           *      1.41 %       ±1.08%  ±1.43%  ±1.87%
url/whatwg-url-idna.js n=5000000 to='ascii' domain='some'                                                                              ***     -2.07 %       ±0.17%  ±0.23%  ±0.31%
url/whatwg-url-idna.js n=5000000 to='unicode' domain='all'                                                                             ***     -1.89 %       ±0.16%  ±0.22%  ±0.29%
url/whatwg-url-idna.js n=5000000 to='unicode' domain='empty'                                                                                   -0.19 %       ±1.09%  ±1.45%  ±1.89%
url/whatwg-url-idna.js n=5000000 to='unicode' domain='none'                                                                                    -0.28 %       ±0.29%  ±0.39%  ±0.51%
url/whatwg-url-idna.js n=5000000 to='unicode' domain='nonstring'                                                                                0.66 %       ±1.33%  ±1.77%  ±2.30%
url/whatwg-url-idna.js n=5000000 to='unicode' domain='some'                                                                            ***     -1.48 %       ±0.24%  ±0.32%  ±0.42%
url/whatwg-url-parse.js e=1 type='auth' withBase='false'                                                                                       -0.88 %       ±1.14%  ±1.52%  ±1.99%
url/whatwg-url-parse.js e=1 type='auth' withBase='true'                                                                                        -0.77 %       ±1.00%  ±1.33%  ±1.73%
url/whatwg-url-parse.js e=1 type='dot' withBase='false'                                                                                 **     -1.30 %       ±0.95%  ±1.28%  ±1.67%
url/whatwg-url-parse.js e=1 type='dot' withBase='true'                                                                                         -0.30 %       ±1.71%  ±2.28%  ±2.98%
url/whatwg-url-parse.js e=1 type='file' withBase='false'                                                                                        0.62 %       ±2.07%  ±2.75%  ±3.58%
url/whatwg-url-parse.js e=1 type='file' withBase='true'                                                                                        -0.22 %       ±1.38%  ±1.84%  ±2.40%
url/whatwg-url-parse.js e=1 type='idn' withBase='false'                                                                                  *     -1.73 %       ±1.51%  ±2.02%  ±2.64%
url/whatwg-url-parse.js e=1 type='idn' withBase='true'                                                                                 ***     -2.20 %       ±0.80%  ±1.07%  ±1.39%
url/whatwg-url-parse.js e=1 type='javascript' withBase='false'                                                                                 -1.06 %       ±1.93%  ±2.57%  ±3.35%
url/whatwg-url-parse.js e=1 type='javascript' withBase='true'                                                                                  -0.97 %       ±1.37%  ±1.82%  ±2.37%
url/whatwg-url-parse.js e=1 type='long' withBase='false'                                                                                       -1.29 %       ±1.48%  ±1.98%  ±2.61%
url/whatwg-url-parse.js e=1 type='long' withBase='true'                                                                                  *     -1.91 %       ±1.75%  ±2.33%  ±3.04%
url/whatwg-url-parse.js e=1 type='percent' withBase='false'                                                                              *     -1.61 %       ±1.31%  ±1.75%  ±2.29%
url/whatwg-url-parse.js e=1 type='percent' withBase='true'                                                                             ***     -2.10 %       ±1.01%  ±1.35%  ±1.76%
url/whatwg-url-parse.js e=1 type='short' withBase='false'                                                                              ***     -2.60 %       ±1.46%  ±1.97%  ±2.60%
url/whatwg-url-parse.js e=1 type='short' withBase='true'                                                                                       -0.31 %       ±1.25%  ±1.67%  ±2.19%
url/whatwg-url-parse.js e=1 type='wpt' withBase='false'                                                                                         1.11 %       ±4.88%  ±6.50%  ±8.48%
url/whatwg-url-parse.js e=1 type='wpt' withBase='true'                                                                                         -3.22 %       ±6.53%  ±8.69% ±11.32%
url/whatwg-url-parse.js e=1 type='ws' withBase='false'                                                                                         -0.48 %       ±1.51%  ±2.01%  ±2.61%
url/whatwg-url-parse.js e=1 type='ws' withBase='true'                                                                                          -1.38 %       ±1.46%  ±1.94%  ±2.52%
url/whatwg-url-properties.js prop='hash' e=1 type='wpt' withBase='false'                                                                       -2.75 %       ±3.77%  ±5.07%  ±6.70%
url/whatwg-url-properties.js prop='hash' e=1 type='wpt' withBase='true'                                                                        -1.33 %       ±5.17%  ±6.89%  ±8.96%
url/whatwg-url-properties.js prop='host' e=1 type='wpt' withBase='false'                                                                       -0.40 %       ±6.06%  ±8.10% ±10.63%
url/whatwg-url-properties.js prop='host' e=1 type='wpt' withBase='true'                                                                         2.08 %       ±5.56%  ±7.40%  ±9.65%
url/whatwg-url-properties.js prop='hostname' e=1 type='wpt' withBase='false'                                                                   -2.06 %       ±3.72%  ±4.96%  ±6.48%
url/whatwg-url-properties.js prop='hostname' e=1 type='wpt' withBase='true'                                                                    -0.11 %       ±4.22%  ±5.62%  ±7.35%
url/whatwg-url-properties.js prop='href' e=1 type='wpt' withBase='false'                                                                        1.18 %       ±3.69%  ±4.92%  ±6.41%
url/whatwg-url-properties.js prop='href' e=1 type='wpt' withBase='true'                                                                         0.17 %       ±5.81%  ±7.73% ±10.08%
url/whatwg-url-properties.js prop='origin' e=1 type='wpt' withBase='false'                                                                      1.94 %       ±7.38%  ±9.90% ±13.05%
url/whatwg-url-properties.js prop='origin' e=1 type='wpt' withBase='true'                                                                      -0.96 %       ±1.93%  ±2.57%  ±3.35%
url/whatwg-url-properties.js prop='password' e=1 type='wpt' withBase='false'                                                            **     -3.69 %       ±2.75%  ±3.68%  ±4.82%
url/whatwg-url-properties.js prop='password' e=1 type='wpt' withBase='true'                                                                    -0.97 %       ±3.56%  ±4.74%  ±6.18%
url/whatwg-url-properties.js prop='pathname' e=1 type='wpt' withBase='false'                                                                   -4.63 %       ±6.69%  ±8.97% ±11.84%
url/whatwg-url-properties.js prop='pathname' e=1 type='wpt' withBase='true'                                                                     2.30 %       ±5.91%  ±7.87% ±10.26%
url/whatwg-url-properties.js prop='port' e=1 type='wpt' withBase='false'                                                                        1.99 %       ±6.51%  ±8.73% ±11.53%
url/whatwg-url-properties.js prop='port' e=1 type='wpt' withBase='true'                                                                         0.51 %       ±4.26%  ±5.67%  ±7.38%
url/whatwg-url-properties.js prop='protocol' e=1 type='wpt' withBase='false'                                                                    0.77 %       ±4.36%  ±5.80%  ±7.56%
url/whatwg-url-properties.js prop='protocol' e=1 type='wpt' withBase='true'                                                                    -2.58 %       ±3.82%  ±5.09%  ±6.66%
url/whatwg-url-properties.js prop='search' e=1 type='wpt' withBase='false'                                                                     -1.47 %       ±3.63%  ±4.83%  ±6.30%
url/whatwg-url-properties.js prop='search' e=1 type='wpt' withBase='true'                                                                      -0.23 %       ±5.42%  ±7.22%  ±9.40%
url/whatwg-url-properties.js prop='searchParams' e=1 type='wpt' withBase='false'                                                                5.64 %       ±9.95% ±13.24% ±17.23%
url/whatwg-url-properties.js prop='searchParams' e=1 type='wpt' withBase='true'                                                                 2.66 %       ±6.52%  ±8.68% ±11.30%
url/whatwg-url-properties.js prop='username' e=1 type='wpt' withBase='false'                                                                   -1.86 %       ±2.53%  ±3.37%  ±4.38%
url/whatwg-url-properties.js prop='username' e=1 type='wpt' withBase='true'                                                                    -0.70 %       ±3.75%  ±4.99%  ±6.49%
url/whatwg-url-to-and-from-path.js n=5000000 input='/dev/null?key=param&bool' method='pathToFileURL'                                            0.58 %       ±0.82%  ±1.09%  ±1.42%
url/whatwg-url-to-and-from-path.js n=5000000 input='/dev/null?key=param&bool#hash' method='pathToFileURL'                                *      0.81 %       ±0.61%  ±0.82%  ±1.07%
url/whatwg-url-to-and-from-path.js n=5000000 input='/dev/null' method='pathToFileURL'                                                           0.24 %       ±0.68%  ±0.90%  ±1.18%
url/whatwg-url-to-and-from-path.js n=5000000 input='file:///dev/null?key=param&bool' method='fileURLToPath'                            ***     -1.69 %       ±0.94%  ±1.25%  ±1.64%
url/whatwg-url-to-and-from-path.js n=5000000 input='file:///dev/null?key=param&bool' method='pathToFileURL'                              *     -0.36 %       ±0.34%  ±0.45%  ±0.59%
url/whatwg-url-to-and-from-path.js n=5000000 input='file:///dev/null?key=param&bool#hash' method='fileURLToPath'                                0.07 %       ±0.60%  ±0.81%  ±1.06%
url/whatwg-url-to-and-from-path.js n=5000000 input='file:///dev/null?key=param&bool#hash' method='pathToFileURL'                                0.91 %       ±1.07%  ±1.43%  ±1.88%
url/whatwg-url-to-and-from-path.js n=5000000 input='file:///dev/null' method='fileURLToPath'                                             *     -0.73 %       ±0.56%  ±0.74%  ±0.96%
url/whatwg-url-to-and-from-path.js n=5000000 input='file:///dev/null' method='pathToFileURL'                                                    0.43 %       ±0.47%  ±0.63%  ±0.82%
url/whatwg-url-validity.js e=100000 type='invalid'                                                                                       *      0.61 %       ±0.54%  ±0.72%  ±0.94%
url/whatwg-url-validity.js e=100000 type='valid'                                                                                               -1.97 %       ±5.25%  ±6.99%  ±9.10%
```

</details>
