### PR TITLE
src: throw RangeError on failed ArrayBuffer BackingStore allocation

### DIFF
--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -17,6 +17,7 @@ namespace encoding_binding {
 using v8::ArrayBuffer;
 using v8::BackingStore;
 using v8::BackingStoreInitializationMode;
+using v8::BackingStoreOnFailureMode;
 using v8::Context;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
@@ -317,9 +318,15 @@ void BindingData::EncodeUtf8String(const FunctionCallbackInfo<Value>& args) {
   Local<ArrayBuffer> ab;
   {
     std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
-        isolate, length, BackingStoreInitializationMode::kUninitialized);
+        isolate,
+        length,
+        BackingStoreInitializationMode::kUninitialized,
+        BackingStoreOnFailureMode::kReturnNull);
 
-    CHECK(bs);
+    if (!bs) [[unlikely]] {
+      THROW_ERR_MEMORY_ALLOCATION_FAILED(isolate);
+      return;
+    }
 
     // We are certain that `data` is sufficiently large
     str->WriteUtf8V2(isolate,

--- a/src/node_blob.cc
+++ b/src/node_blob.cc
@@ -22,6 +22,7 @@ using v8::ArrayBuffer;
 using v8::ArrayBufferView;
 using v8::BackingStore;
 using v8::BackingStoreInitializationMode;
+using v8::BackingStoreOnFailureMode;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -83,7 +84,14 @@ void Concat(const FunctionCallbackInfo<Value>& args) {
   }
 
   std::shared_ptr<BackingStore> store = ArrayBuffer::NewBackingStore(
-      isolate, total, BackingStoreInitializationMode::kUninitialized);
+      isolate,
+      total,
+      BackingStoreInitializationMode::kUninitialized,
+      BackingStoreOnFailureMode::kReturnNull);
+  if (!store) [[unlikely]] {
+    THROW_ERR_MEMORY_ALLOCATION_FAILED(isolate);
+    return;
+  }
   uint8_t* ptr = static_cast<uint8_t*>(store->Data());
   for (size_t n = 0; n < views.size(); n++) {
     uint8_t* from =

--- a/src/node_errors.h
+++ b/src/node_errors.h
@@ -106,7 +106,7 @@ void OOMErrorHandler(const char* location, const v8::OOMDetails& details);
   V(ERR_INVALID_URL_PATTERN, TypeError)                                        \
   V(ERR_INVALID_URL_SCHEME, TypeError)                                         \
   V(ERR_LOAD_SQLITE_EXTENSION, Error)                                          \
-  V(ERR_MEMORY_ALLOCATION_FAILED, Error)                                       \
+  V(ERR_MEMORY_ALLOCATION_FAILED, RangeError)                                  \
   V(ERR_MESSAGE_TARGET_CONTEXT_UNAVAILABLE, Error)                             \
   V(ERR_MISSING_ARGS, TypeError)                                               \
   V(ERR_MISSING_PASSPHRASE, TypeError)                                         \


### PR DESCRIPTION
This also updates `ERR_MEMORY_ALLOCATION_FAILED` to be a RangeError,
aligning with V8's OutOfMemory error type and ECMAScript's OutOfMemory
error type.

There are still many call sites in crypto, tls and quic need to be reviewed
to properly handle the failed ArrayBuffer BackingStore allocation. This
PR updates call sites not in these modules.

Refs: https://github.com/nodejs/node/blob/c755b0113ce0cb6d83baf2cf070ba381a5673db2/deps/v8/src/builtins/builtins-typed-array.cc#L584
Refs: https://tc39.es/ecma262/#sec-sharedarraybuffer.prototype.grow
Refs: https://github.com/nodejs/node/pull/61403#discussion_r2712909264