### PR TITLE
test: fix location object to match Location interface in WPT

### DIFF
--- a/test/common/wpt.js
+++ b/test/common/wpt.js
@@ -596,7 +596,16 @@ class WPTRunner {
     const title = spec.getMeta().title;
     let { initScript } = this;
 
-    initScript = `${initScript}\n\n//===\nglobalThis.location = new URL("${url.href}");`;
+    initScript = `${initScript}\n\n//===\nconst _location = new URL("${url.href}");\n` +
+    `globalThis.location = new Proxy(_location, {\n` +
+    `  has(target, prop) { return prop !== 'searchParams' && prop in target; },\n` +
+    `  get(target, prop) { return prop === 'searchParams' ? undefined : target[prop]; },\n` +
+    `  ownKeys(target) { return Object.keys(target).filter(k => k !== 'searchParams'); },\n` +
+    `  getOwnPropertyDescriptor(target, prop) {\n` +
+    `    if (prop === 'searchParams') return undefined;\n` +
+    `    return Object.getOwnPropertyDescriptor(target, prop);\n` +
+    `  }\n` +
+    `});`;
 
     if (title) {
       initScript = `${initScript}\n\n//===\nglobalThis.META_TITLE = "${title}";`;

--- a/test/wpt/status/url.json
+++ b/test/wpt/status/url.json
@@ -10,13 +10,6 @@
       ]
     }
   },
-  "historical.any.js": {
-    "fail": {
-      "expected": [
-        "searchParams on location object"
-      ]
-    }
-  },
   "javascript-urls.window.js": {
     "skip": "requires document.body reference"
   },


### PR DESCRIPTION
The Location interface should not have a searchParams property according to the WHATWG URL spec. This commit fixes the WPT test runner to hide the searchParams property from the location object using a Proxy, ensuring that WPT tests expecting the Location interface behavior pass correctly.

- Use Proxy to hide searchParams from location object in WPT runner
- Remove historical.any.js from expected failures in url.json

Fixes the 'searchParams on location object' test in historical.any.js

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
