### PR TITLE
tools: update sccache to v0.13.0

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.13.0
       - name: Environment Information
         run: npx envinfo
       - name: Download tarball

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.13.0
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.13.0
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.13.0
       - name: Environment Information
         run: npx envinfo
       - name: Build

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.13.0
       - name: Environment Information
         run: npx envinfo
       - name: Build

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Set up sccache
         uses: Mozilla-Actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad  # v0.0.9
         with:
-          version: v0.12.0
+          version: v0.13.0
       - name: Environment Information
         run: npx envinfo
       # The `npm ci` for this step fails a lot as part of the Test step. Run it


### PR DESCRIPTION
## Summary

Updates `sccache` version to `v0.13.0` in GitHub Actions workflows.

This update addresses the recent GitHub Actions Cache rate limit changes (200 uploads/minute) that were causing cache thrashing and 429 errors as reported in #61436.

The `v0.13.0` release of sccache (released Jan 13, 2026) likely contains the necessary adjustments for the rate limit policy enforced on Jan 16, 2026.

References:
- Refs: nodejs/node#61436
- sccache release: https://github.com/mozilla/sccache/releases/tag/v0.13.0

## Checklist

- [x] I have read the [Node.js Contributing Guide](https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md).
- [x] My changes follow the [Node.js Code of Conduct](https://github.com/nodejs/node/blob/HEAD/CODE_OF_CONDUCT.md).
- [x] I have updated the relevant workflows.