### PR TITLE
doc: move Security-Team from TSC to SECURITY

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -399,8 +399,6 @@ includes a fix, documentation, an informational CVE or blog post.
 * [@vdeturckheim](https://github.com/vdeturckheim) - Vladimir de Turckheim
 * [@BethGriggs](https://github.com/BethGriggs) - Beth Griggs
 
-<!-- ncu-team-sync end -->
-
 ## Team with access to private security reports against Node.js
 
 [TSC voting members](https://github.com/nodejs/node#tsc-voting-members)


### PR DESCRIPTION
This has been quite out-of-date on TSC repository - possibly because fewer people take a look at it.

This commit moves it to Node.js core repository and updates the list according to HackerOne and nodejs-private.