### PR TITLE
doc: clarify status of feature request issues

### DIFF
--- a/doc/contributing/feature-request-management.md
+++ b/doc/contributing/feature-request-management.md
@@ -1,13 +1,15 @@
 # Feature request management
 
-Feature requests are a valuable source of input to the project.
-They help our maintainers understand what additions will be of
-value to users of the Node.js runtime.
+Feature requests are not a valuable source of input for the project.
+It is usually more productive to first send the Pull Request implementing the
+feature, even imperfectly, and let the discussion happen during code review.
+That being said, the project still welcomes feature request issues, either for
+features you cannot and/or won't implement yourself, or if you need more input
+from the community before starting the work.
 
-At the same time, the project is volunteer run and does not
-have the ability to direct resources toward specific work. The
-features which are implemented are those for which volunteers
-are individually motivated to work on. The best way to ensure
+The project is volunteer run and does not have the ability to direct resources
+toward specific work. The features which are implemented are those for which
+volunteers are individually motivated to work on. The best way to ensure
 a feature gets implemented is to create a PR to add it.
 The project strives to support people who do that.
 


### PR DESCRIPTION
The discussion in https://github.com/nodejs/node/issues/61487 made me realize we lack a statement saying "you don't need to open an issue, actually we'd prefer if you open a PR directly if you already know what you want". In fact, we were kinda hinting the opposite, which does not reflect the reality of the issue tracker in my experience, resulting in frustrating experience for both reporters and triagers.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
