### PR TITLE
readline: add handleSigint to allow disabling SIGINT trap

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -172,6 +172,7 @@ function InterfaceConstructor(input, output, completer, terminal) {
   let crlfDelay;
   let prompt = '> ';
   let signal;
+  let trapSigint = true;
 
   if (input?.input) {
     // An options object was given
@@ -205,6 +206,9 @@ function InterfaceConstructor(input, output, completer, terminal) {
 
     if (signal) {
       validateAbortSignal(signal, 'options.signal');
+    }
+    if (input.trapSigint !== undefined) {
+      trapSigint = input.trapSigint;
     }
 
     crlfDelay = input.crlfDelay;
@@ -254,6 +258,7 @@ function InterfaceConstructor(input, output, completer, terminal) {
   this.setPrompt(prompt);
 
   this.terminal = !!terminal;
+  this.trapSigint = trapSigint;
 
   function onerror(err) {
     self.emit('error', err);
@@ -1330,6 +1335,7 @@ class Interface extends InterfaceConstructor {
             this.close();
             this[kQuestionReject]?.(new AbortError('Aborted with Ctrl+C'));
           }
+          if (!this.trapSigint) process.kill(process.pid, 'SIGINT');
           break;
 
         case 'h': // delete left


### PR DESCRIPTION
Add a `handleSigint` option to `readline.createInterface()` that allows users to disable `SIGINT` signal handling. When set to `false`, pressing Ctrl+C will terminate the process with the appropriate exit code instead of being trapped by readline and treated as EOF.

The option defaults to `true` to maintain backward compatibility.

Fixes #61487.