### PR TITLE
build,win: fix vs2022 compilation

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -270,7 +270,7 @@ if %target_arch%==%msvs_host_arch% set vcvarsall_arg=%target_arch%
 
 @rem Look for Visual Studio 2026
 :vs-set-2026
-if defined target_env if "%target_env%" NEQ "vs2026" goto msbuild-not-found
+if defined target_env if "%target_env%" NEQ "vs2026" goto vs-set-2022
 echo Looking for Visual Studio 2026
 @rem VCINSTALLDIR may be set if run from a VS Command Prompt and needs to be
 @rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to


### PR DESCRIPTION
When we added VS2026 support, by accident we broke VS2022 compilation if you have both VS2026 and VS2022 installed (eg, you had to provide the `vs2022` parameter). This PR fixes that bug.