### PR TITLE
test: use the skipIfNoWatch() utility function

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -94,7 +94,6 @@ test-esm-loader-hooks-inspect-wait: PASS, FLAKY
 test-child-process-fork-net-server: SKIP
 test-cli-node-options: SKIP
 test-cluster-shared-leak: SKIP
-test-fs-promises-watch-iterator: SKIP
 test-http-writable-true-after-close: SKIP
 test-http2-connect-method: SKIP
 test-net-error-twice: SKIP

--- a/test/parallel/test-fs-promises-watch-iterator.js
+++ b/test/parallel/test-fs-promises-watch-iterator.js
@@ -9,7 +9,10 @@ const fs = require('fs');
 const assert = require('assert');
 const { join } = require('path');
 const { setTimeout } = require('timers/promises');
+const { skipIfNoWatch } = require('../common/watch');
 const tmpdir = require('../common/tmpdir');
+
+skipIfNoWatch();
 
 class WatchTestCase {
   constructor(dirName, files) {


### PR DESCRIPTION
Use the `skipIfNoWatch()` utility function in
`test/parallel/test-fs-promises-watch-iterator.js`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
