### PR TITLE
doc: clarify fs.copyFile() symlink behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -923,3 +923,5 @@ additions comply with the project’s license guidelines.
 [Strategic initiatives]: doc/contributing/strategic-initiatives.md
 [Technical values and prioritization]: doc/contributing/technical-values.md
 [Working Groups]: https://github.com/nodejs/TSC/blob/HEAD/WORKING_GROUPS.md
+
+

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -540,6 +540,10 @@ The `error.syscall` property is a string describing the [syscall][] that failed.
 This is a list of system errors commonly-encountered when writing a Node.js
 program. For a comprehensive list, see the [`errno`(3) man page][].
 
+Some file system operations such as `fs.copyFile()` operate on the resolved
+target of symbolic links rather than the link itself. As a result, any errors
+raised may originate from the target file rather than the symbolic link.
+
 * `EACCES` (Permission denied): An attempt was made to access a file in a way
   forbidden by its file access permissions.
 
@@ -595,6 +599,7 @@ program. For a comprehensive list, see the [`errno`(3) man page][].
   the connected party did not properly respond after a period of time. Usually
   encountered by [`http`][] or [`net`][]. Often a sign that a `socket.end()`
   was not properly called.
+
 
 ## Class: `TypeError`
 

--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1003,6 +1003,10 @@ changes:
 Asynchronously copies `src` to `dest`. By default, `dest` is overwritten if it
 already exists.
 
+If `src` is a symbolic link, the link is dereferenced and the contents of the
+target file are copied, rather than creating a new symbolic link.
+
+
 No guarantees are made about the atomicity of the copy operation. If an
 error occurs after the destination file has been opened for writing, an attempt
 will be made to remove the destination.
@@ -2466,6 +2470,10 @@ already exists. No arguments other than a possible exception are given to the
 callback function. Node.js makes no guarantees about the atomicity of the copy
 operation. If an error occurs after the destination file has been opened for
 writing, Node.js will attempt to remove the destination.
+
+If `src` is a symbolic link, the link is dereferenced and the contents of the
+target file are copied, rather than creating a new symbolic link.
+
 
 `mode` is an optional integer that specifies the behavior
 of the copy operation. It is possible to create a mask consisting of the bitwise
@@ -5537,6 +5545,10 @@ Synchronously copies `src` to `dest`. By default, `dest` is overwritten if it
 already exists. Returns `undefined`. Node.js makes no guarantees about the
 atomicity of the copy operation. If an error occurs after the destination file
 has been opened for writing, Node.js will attempt to remove the destination.
+
+If `src` is a symbolic link, the link is dereferenced and the contents of the
+target file are copied.
+
 
 `mode` is an optional integer that specifies the behavior
 of the copy operation. It is possible to create a mask consisting of the bitwise

--- a/doc/changelogs/CHANGELOG_V24.md
+++ b/doc/changelogs/CHANGELOG_V24.md
@@ -1812,6 +1812,10 @@ Several APIs have been deprecated or removed in this release:
 * Deprecation of using Zlib classes without `new` ([#55718](https://github.com/nodejs/node/pull/55718))
 * Deprecation of passing `args` to `spawn` and `execFile` in child\_process ([#57199](https://github.com/nodejs/node/pull/57199))
 
+### Documentation
+
+* Documented that `fs.copyFile()` dereferences symbolic links when copying files.
+
 ### Semver-Major Commits
 
 * \[[`c6b934380a`](https://github.com/nodejs/node/commit/c6b934380a)] - **(SEMVER-MAJOR)** **src**: enable `Float16Array` on global object (Michaël Zasso) [#58154](https://github.com/nodejs/node/pull/58154)


### PR DESCRIPTION
This PR documents that fs.copyFile() dereferences symbolic links and copies the contents of the target file.

Changes:

Update fs.md to clarify symlink behavior

Add a brief note in errors.md

Add a changelog entry

Scope: Documentation only; no runtime or API changes.