### PR TITLE
doc: regenerate `node.1` using `doc-kit`

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -833,15 +833,6 @@ added: v6.0.0
 Enable FIPS-compliant crypto at startup. (Requires Node.js to be built
 against FIPS-compatible OpenSSL.)
 
-### `--enable-network-family-autoselection`
-
-<!-- YAML
-added: v18.18.0
--->
-
-Enables the family autoselection algorithm unless connection options explicitly
-disables it.
-
 ### `--enable-source-maps`
 
 <!-- YAML
@@ -2294,7 +2285,7 @@ Write reports in a compact format, single-line JSON, more easily consumable
 by log processing systems than the default multi-line format designed for
 human consumption.
 
-### `--report-dir=directory`, `report-directory=directory`
+### `--report-dir=directory`, `--report-directory=directory`
 
 <!-- YAML
 added: v11.8.0

--- a/doc/node.1
+++ b/doc/node.1
@@ -512,10 +512,6 @@ priority than \fB--dns-result-order\fR.
 Enable FIPS-compliant crypto at startup. (Requires Node.js to be built
 against FIPS-compatible OpenSSL.)
 .
-.It Fl -enable-network-family-autoselection
-Enables the family autoselection algorithm unless connection options explicitly
-disables it.
-.
 .It Fl -enable-source-maps
 Enable Source Map support for stack traces.
 When using a transpiler, such as TypeScript, stack traces thrown by an
@@ -1189,7 +1185,7 @@ Write reports in a compact format, single-line JSON, more easily consumable
 by log processing systems than the default multi-line format designed for
 human consumption.
 .
-.It Fl -report-dir Ns = Ns Ar directory , Fl eport-directory Ns = Ns Ar directory
+.It Fl -report-dir Ns = Ns Ar directory , Fl -report-directory Ns = Ns Ar directory
 Location at which the report will be generated.
 .
 .It Fl -report-exclude-env


### PR DESCRIPTION
This file has been generated using `@nodejs/doc-kit`. Once #57343 lands, we will move the generation of this file into an Makefile script, but in the mean time, I've seen _several_ issues opened to update this file, so might as well update it.

You can preview the output of this man-page with `curl "https://raw.githubusercontent.com/nodejs/node/81c1d6f411f750205ba59915983d7d3047eb5f0d/doc/node.1" -s | mandoc` (or locally, `mandoc path/to/doc/node.1`) (**Note**, I suggest using `mandoc -l` to page the output)

Additionally, a [PDF version](https://github.com/user-attachments/files/24865754/node.1.pdf) of the output.

Fixes #60877
Fixes #58895
Fixes #60840
Fixes #60857
Fixes #61148
Fixes #61508
