### PR TITLE
readline: initialize input before history manager

### DIFF
--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -215,7 +215,6 @@ function InterfaceConstructor(input, output, completer, terminal) {
     input.removeHistoryDuplicates = removeHistoryDuplicates;
   }
 
-  this.setupHistoryManager(input);
 
   if (completer !== undefined && typeof completer !== 'function') {
     throw new ERR_INVALID_ARG_VALUE('completer', completer);
@@ -234,6 +233,7 @@ function InterfaceConstructor(input, output, completer, terminal) {
   this[kSubstringSearch] = null;
   this.output = output;
   this.input = input;
+  this.setupHistoryManager(input);
   this[kUndoStack] = [];
   this[kRedoStack] = [];
   this[kPreviousCursorCols] = -1;
@@ -384,9 +384,13 @@ class Interface extends InterfaceConstructor {
   setupHistoryManager(options) {
     this.historyManager = new ReplHistory(this, options);
 
-    if (options.onHistoryFileLoaded) {
-      this.historyManager.initialize(options.onHistoryFileLoaded);
-    }
+    // Only initialize REPL history when createInterface()
+  // was called with an options object (options.input).
+  // This prevents accidental REPL history init when
+  // createInterface(input) is used.
+  if (options?.input && typeof options.onHistoryFileLoaded === 'function') {
+    this.historyManager.initialize(options.onHistoryFileLoaded);
+  }
 
     ObjectDefineProperty(this, 'history', {
       __proto__: null, configurable: true, enumerable: true,

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -172,9 +172,11 @@ function InterfaceConstructor(input, output, completer, terminal) {
   let crlfDelay;
   let prompt = '> ';
   let signal;
+  let inputOptions;
 
   if (input?.input) {
     // An options object was given
+    inputOptions = input;
     output = input.output;
     completer = input.completer;
     terminal = input.terminal;
@@ -233,7 +235,7 @@ function InterfaceConstructor(input, output, completer, terminal) {
   this[kSubstringSearch] = null;
   this.output = output;
   this.input = input;
-  this.setupHistoryManager(input);
+  this.setupHistoryManager(inputOptions || input);
   this[kUndoStack] = [];
   this[kRedoStack] = [];
   this[kPreviousCursorCols] = -1;
@@ -384,13 +386,20 @@ class Interface extends InterfaceConstructor {
   setupHistoryManager(options) {
     this.historyManager = new ReplHistory(this, options);
 
-    // Only initialize REPL history when createInterface()
-  // was called with an options object (options.input).
-  // This prevents accidental REPL history init when
-  // createInterface(input) is used.
-  if (options?.input && typeof options.onHistoryFileLoaded === 'function') {
-    this.historyManager.initialize(options.onHistoryFileLoaded);
-  }
+    // Only initialize REPL history when called from REPL.setupHistory(),
+    // not from the readline constructor. 
+    // Constructor passes: stream OR { input: stream, output: stream, ... }
+    // setupHistory passes: { filePath: ..., size: ..., onHistoryFileLoaded: ... }
+    // Detect constructor calls by checking for stream.on() or options.input
+    if (options && typeof options === 'object') {
+      const isStream = typeof options.on === 'function';
+      const hasInputProperty = options.input !== undefined;
+      const isFromConstructor = isStream || hasInputProperty;
+      
+      if (!isFromConstructor && typeof options.onHistoryFileLoaded === 'function') {
+        this.historyManager.initialize(options.onHistoryFileLoaded);
+      }
+    }
 
     ObjectDefineProperty(this, 'history', {
       __proto__: null, configurable: true, enumerable: true,

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -235,7 +235,24 @@ function InterfaceConstructor(input, output, completer, terminal) {
   this[kSubstringSearch] = null;
   this.output = output;
   this.input = input;
-  this.setupHistoryManager(inputOptions || input);
+
+  // If inputOptions was provided (constructor with options object),
+  // copy the stream's size/history properties back to it for setupHistoryManager
+  let historyOptions = inputOptions || input;
+  if (inputOptions !== undefined && input !== undefined &&
+      inputOptions !== input) {
+    if (input.size !== undefined && historyOptions.size === undefined) {
+      historyOptions.size = input.size;
+    }
+    if (input.history !== undefined && historyOptions.history === undefined) {
+      historyOptions.history = input.history;
+    }
+    if (input.removeHistoryDuplicates !== undefined &&
+        historyOptions.removeHistoryDuplicates === undefined) {
+      historyOptions.removeHistoryDuplicates = input.removeHistoryDuplicates;
+    }
+  }
+  this.setupHistoryManager(historyOptions);
   this[kUndoStack] = [];
   this[kRedoStack] = [];
   this[kPreviousCursorCols] = -1;
@@ -387,7 +404,7 @@ class Interface extends InterfaceConstructor {
     this.historyManager = new ReplHistory(this, options);
 
     // Only initialize REPL history when called from REPL.setupHistory(),
-    // not from the readline constructor. 
+    // not from the readline constructor.
     // Constructor passes: stream OR { input: stream, output: stream, ... }
     // setupHistory passes: { filePath: ..., size: ..., onHistoryFileLoaded: ... }
     // Detect constructor calls by checking for stream.on() or options.input
@@ -395,7 +412,7 @@ class Interface extends InterfaceConstructor {
       const isStream = typeof options.on === 'function';
       const hasInputProperty = options.input !== undefined;
       const isFromConstructor = isStream || hasInputProperty;
-      
+
       if (!isFromConstructor && typeof options.onHistoryFileLoaded === 'function') {
         this.historyManager.initialize(options.onHistoryFileLoaded);
       }

--- a/test/parallel/test-readline-history-init-order.js
+++ b/test/parallel/test-readline-history-init-order.js
@@ -1,18 +1,48 @@
 'use strict';
 
-const assert = require('assert');
+const common = require('../common');
 const readline = require('readline');
 const { PassThrough } = require('stream');
 
-assert.doesNotThrow(() => {
-  const input = new PassThrough();
+// Regression test for https://github.com/nodejs/node/issues/61526
+// This test ensures that createInterface() doesn't crash when input
+// has an onHistoryFileLoaded property (e.g., from a Proxy or jest.mock)
 
-  // This simulates the condition that previously caused
-  // accidental REPL history initialization.
+// Test case 1: options object with onHistoryFileLoaded as function
+{
+  const input = new PassThrough();
   input.onHistoryFileLoaded = () => {};
 
   readline.createInterface({
     input,
     output: new PassThrough()
   });
-});
+}
+
+// Test case 2: options object without onHistoryFileLoaded
+{
+  const input = new PassThrough();
+  readline.createInterface({
+    input,
+    output: new PassThrough()
+  });
+}
+
+// Test case 3: options object with onHistoryFileLoaded as non-function
+{
+  const input = new PassThrough();
+  input.onHistoryFileLoaded = { some: 'object' };
+
+  readline.createInterface({
+    input,
+    output: new PassThrough()
+  });
+}
+
+// Test case 4: direct stream with onHistoryFileLoaded (original bug scenario)
+{
+  const input = new PassThrough();
+  input.onHistoryFileLoaded = () => {};
+
+  readline.createInterface(input, new PassThrough());
+}

--- a/test/parallel/test-readline-history-init-order.js
+++ b/test/parallel/test-readline-history-init-order.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const assert = require('assert');
+const readline = require('readline');
+const { PassThrough } = require('stream');
+
+assert.doesNotThrow(() => {
+  const input = new PassThrough();
+
+  // This simulates the condition that previously caused
+  // accidental REPL history initialization.
+  input.onHistoryFileLoaded = () => {};
+
+  readline.createInterface({
+    input,
+    output: new PassThrough()
+  });
+});

--- a/test/parallel/test-readline-history-init-order.js
+++ b/test/parallel/test-readline-history-init-order.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const common = require('../common');
 const readline = require('readline');
 const { PassThrough } = require('stream');
 

--- a/test/parallel/test-repl-persistent-history.js
+++ b/test/parallel/test-repl-persistent-history.js
@@ -183,8 +183,10 @@ function cleanupTmpFile() {
 }
 
 // Copy our fixture to the tmp directory
+const writeStream = fs.createWriteStream(historyPath);
 fs.createReadStream(historyFixturePath)
-  .pipe(fs.createWriteStream(historyPath)).on('unpipe', () => runTest());
+  .pipe(writeStream);
+writeStream.on('finish', () => runTest());
 
 const runTestWrap = common.mustCall(runTest, numtests);
 


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->


Fixes a regression where `setupHistoryManager()` could run before
`this.input` was assigned, causing a crash when `onHistoryFileLoaded`
is present (for example, Proxy or `jest.mock()` inputs).

This change ensures `this.input` is initialized before history setup
and adds a regression test to cover the scenario.

Fixes: #61526

Testing:
- Added regression test
- Unable to run tests locally due to Windows build issues; CI should validate

