### PR TITLE
sqlite: reserve local vectors space

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -321,7 +321,8 @@ class CustomAggregate {
     }
 
     auto recv = Undefined(isolate);
-    LocalVector<Value> js_argv(isolate, argc + 1);
+    LocalVector<Value> js_argv(isolate);
+    js_argv.reserve(argc + 1);
 
     js_argv.emplace_back(Local<Value>::New(isolate, agg->value));
 
@@ -625,7 +626,8 @@ void UserDefinedFunction::xFunc(sqlite3_context* ctx,
   Isolate* isolate = env->isolate();
   auto recv = Undefined(isolate);
   auto fn = self->fn_.Get(isolate);
-  LocalVector<Value> js_argv(isolate, argc);
+  LocalVector<Value> js_argv(isolate);
+  js_argv.reserve(argc);
 
   for (int i = 0; i < argc; ++i) {
     sqlite3_value* value = argv[i];
@@ -2064,18 +2066,16 @@ int DatabaseSync::AuthorizerCallback(void* user_data,
   CHECK(cb->IsFunction());
 
   Local<Function> callback = cb.As<Function>();
-  LocalVector<Value> js_argv(isolate, 5);
 
-  // Convert SQLite authorizer parameters to JavaScript values
-  js_argv.emplace_back(Integer::New(isolate, action_code));
-  js_argv.emplace_back(
-      NullableSQLiteStringToValue(isolate, param1).ToLocalChecked());
-  js_argv.emplace_back(
-      NullableSQLiteStringToValue(isolate, param2).ToLocalChecked());
-  js_argv.emplace_back(
-      NullableSQLiteStringToValue(isolate, param3).ToLocalChecked());
-  js_argv.emplace_back(
-      NullableSQLiteStringToValue(isolate, param4).ToLocalChecked());
+  LocalVector<Value> js_argv(
+      isolate,
+      {
+          Integer::New(isolate, action_code),
+          NullableSQLiteStringToValue(isolate, param1).ToLocalChecked(),
+          NullableSQLiteStringToValue(isolate, param2).ToLocalChecked(),
+          NullableSQLiteStringToValue(isolate, param3).ToLocalChecked(),
+          NullableSQLiteStringToValue(isolate, param4).ToLocalChecked(),
+      });
 
   MaybeLocal<Value> retval = callback->Call(
       context, Undefined(isolate), js_argv.size(), js_argv.data());


### PR DESCRIPTION
Reserve local vectors to prevent reallocations