### PR TITLE
path: match Windows reserved names by component boundary

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -83,6 +83,32 @@ function isWindowsReservedName(path, colonIndex) {
   return ArrayPrototypeIncludes(WINDOWS_RESERVED_NAMES, devicePart);
 }
 
+function hasWindowsReservedNamePrefix(path) {
+  // Windows resolves a reserved device name to the device itself when the name
+  // is followed by a colon or by a dot: `NUL.txt` and `NUL.tar.gz` are both
+  // equivalent to `NUL`. Test the leading path component up to its first `.`
+  // or `:` instead of relying on `isWindowsReservedName()` being called with a
+  // colon index of -1, which merely sliced off the last character and so
+  // matched unrelated names such as `CONx` while missing `NUL.txt`.
+  //
+  // A bare reserved name carrying neither `.` nor `:` is deliberately left
+  // alone, preserving `normalize('CON') === 'CON'`.
+  const len = path.length;
+  let i = 0;
+  while (i < len && !isPathSeparator(StringPrototypeCharCodeAt(path, i))) {
+    i++;
+  }
+  let j = 0;
+  while (j < i) {
+    const code = StringPrototypeCharCodeAt(path, j);
+    if (code === CHAR_DOT || code === CHAR_COLON) {
+      return isWindowsReservedName(path, j);
+    }
+    j++;
+  }
+  return false;
+}
+
 function isWindowsDeviceRoot(code) {
   return (code >= CHAR_UPPERCASE_A && code <= CHAR_UPPERCASE_Z) ||
          (code >= CHAR_LOWERCASE_A && code <= CHAR_LOWERCASE_Z);
@@ -470,8 +496,7 @@ const win32 = {
         }
       } while ((index = StringPrototypeIndexOf(path, ':', index + 1)) !== -1);
     }
-    const colonIndex = StringPrototypeIndexOf(path, ':');
-    if (isWindowsReservedName(path, colonIndex)) {
+    if (hasWindowsReservedNamePrefix(path)) {
       return `.\\${device ?? ''}${tail}`;
     }
     if (device === undefined) {

--- a/test/parallel/test-path-win32-normalize-device-names.js
+++ b/test/parallel/test-path-win32-normalize-device-names.js
@@ -28,7 +28,7 @@ const normalizeDeviceNameTests = [
   { input: 'con:', expected: '.\\con:.' },
   { input: 'CON:.', expected: '.\\CON:.' },
   { input: 'coN:', expected: '.\\coN:.' },
-  { input: 'LPT9.foo', expected: 'LPT9.foo' },
+  { input: 'LPT9.foo', expected: '.\\LPT9.foo' },
   { input: 'COM9:', expected: '.\\COM9:.' },
   { input: 'COM9.', expected: '.\\COM9.' },
   { input: 'C:COM9', expected: 'C:COM9' },
@@ -76,7 +76,7 @@ const normalizeDeviceNameTests = [
   { input: 'D:bar', expected: 'D:bar' },
 
   { input: 'CON', expected: 'CON' },
-  { input: 'CON.TXT', expected: 'CON.TXT' },
+  { input: 'CON.TXT', expected: '.\\CON.TXT' },
   { input: 'COM10:', expected: '.\\COM10:' },
   { input: 'LPT10:', expected: '.\\LPT10:' },
   { input: 'CONNINGTOWER:', expected: '.\\CONNINGTOWER:' },
@@ -110,6 +110,30 @@ const normalizeDeviceNameTests = [
 ];
 
 for (const { input, expected } of normalizeDeviceNameTests) {
+  const actual = path.win32.normalize(input);
+  assert.strictEqual(actual, expected,
+                     `path.win32.normalize(${JSON.stringify(input)}) === ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);
+}
+
+const reservedNameBoundaryTests = [
+  { input: 'NUL.txt', expected: '.\\NUL.txt' },
+  { input: 'NUL.tar.gz', expected: '.\\NUL.tar.gz' },
+  { input: 'CON.TXT', expected: '.\\CON.TXT' },
+  { input: 'LPT9.foo', expected: '.\\LPT9.foo' },
+  { input: 'COM1.prn', expected: '.\\COM1.prn' },
+  { input: 'COM¹.txt', expected: '.\\COM¹.txt' },
+  { input: 'con.txt', expected: '.\\con.txt' },
+  { input: 'CONx', expected: 'CONx' },
+  { input: 'NULLED.txt', expected: 'NULLED.txt' },
+  { input: 'COM10.txt', expected: 'COM10.txt' },
+  { input: 'LPT10.foo', expected: 'LPT10.foo' },
+  { input: 'PRNINTER.tar', expected: 'PRNINTER.tar' },
+  { input: 'C:file.txt', expected: 'C:file.txt' },
+  { input: 'CON\\path', expected: 'CON\\path' },
+  { input: 'NUL/path', expected: 'NUL\\path' },
+];
+
+for (const { input, expected } of reservedNameBoundaryTests) {
   const actual = path.win32.normalize(input);
   assert.strictEqual(actual, expected,
                      `path.win32.normalize(${JSON.stringify(input)}) === ${JSON.stringify(expected)}, but got ${JSON.stringify(actual)}`);


### PR DESCRIPTION
### What

`win32.normalize()` prefixes a path with `.\` when it starts with a Windows
reserved device name (`CON`, `NUL`, `PRN`, `COM1`, `LPT1`, ...), so the result
cannot be read as a device reference.

The no-colon case was handled by calling `isWindowsReservedName(path, -1)`,
which slices off the last character and compares the remainder against the
reserved list. That is an accident of `String.prototype.slice(0, -1)`, not a
rule, and it is wrong in both directions.

**False positives** — ordinary files rewritten as devices:

    normalize('CONx')   // '.\CONx'   ('CONx'.slice(0,-1) === 'CON')
    normalize('NULs')   // '.\NULs'

**False negatives** — real device references left untouched:

    normalize('NUL.txt')     // 'NUL.txt'
    normalize('COM9.tar.gz') // 'COM9.tar.gz'

Per Microsoft's file-naming documentation, "avoid these names followed
immediately by an extension; NUL.txt and NUL.tar.gz are both equivalent to
NUL", so the second group are device references and the prefix is what they
need.

### How

Take the leading path component, and if the part before its first `.` or `:`
is a reserved name, treat it as a device. A bare reserved name carrying
neither is left alone, so `normalize('CON') === 'CON'` is preserved. One rule
covers both directions.

### What this breaks

Two existing assertions change, both in the false-negative group:

    'LPT9.foo'  'LPT9.foo'  ->  '.\LPT9.foo'
    'CON.TXT'   'CON.TXT'   ->  '.\CON.TXT'

They are updated here. This is user-visible, so the PR should carry
`semver-major`.

Nothing else moves. The CVE-2024-36139 assertions, the UNC cases, the
drive-letter cases and the `\\.\` / `\\?\` cases are unchanged — 80 of the 82
assertions across `test-path-win32-normalize-device-names.js` and
`test-path-normalize.js` produce identical output.

### Verification

I built executable copies of `lib/path.js` — current `main`, the narrowing in
#64266, and this patch — and confirmed the unmodified copy matches
`require('path')` exactly before comparing.

Against #64266 over 297,026 generated inputs: 7,219 inputs differ, every one
of them a reserved name followed by a dot and an extension. Zero differences
of any other kind, so this is a strict superset of that narrowing rather than
a competing rule.

### Refs

- #64159 — guarded the check with `colonIndex !== -1`; landed, then reverted
  in #64216 because it also dropped the `COM9.` case
- #64266 — narrows the no-colon check to a trailing dot; fixes the false
  positives, leaves the false negatives

This PR previously proposed the same `colonIndex !== -1` guard, in January.
See the comment below for why it was rewritten.