### PR TITLE
build: aix: deoptimise implementation-visitor to avoid segfault

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -1429,6 +1429,15 @@
           'ExceptionHandling': 1,
         },
       },
+      # Reduce optimisation of one file on AIX - it causes torque
+      # to segfault if you build node with "--shared"
+      'conditions': [
+        ['OS=="aix" and node_shared=="true"', {
+          'cflags': ['-O1'],
+          'cflags!': ['-O3'],
+          'sources': ['<(V8_ROOT)/src/torque/implementation-visitor.cc'],
+        }],
+      ],
     },  # torque_base
     {
       'target_name': 'torque_ls_base',


### PR DESCRIPTION
When building node.js with `--shared` on AIX the `torque` execution consistently fails with a segmentation fault. This has been tracked down by a change in the v20 timeframe when [V8 was updated to 11.3.244.4](https://github.com/nodejs/node/pull/47251) but at an initial cursory glance it's not immediately clear which change caused it.

By experimentation (by other teams I have spoken to and extra work by myself) it has also been observed that dropping the optimisation level from `-O3` to `-O1` on one source file reliably prevents the crash from occurring. Just to be clear, this problem does not occur on the non-shared library build therefore this change reduces the optimisation only for the shared build and only on AIX.

It is hoped that with this change we can reactivate the [node-test-commit-aix-shared-lib](https://ci.nodejs.org/job/node-test-commit-aix-shared-lib) job and maybe even add in the additional testing being proposed under https://github.com/nodejs/node/pull/61463 in the future.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
