### PR TITLE
fs: fix globSync traverse on allowed directory

### DIFF
--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -408,7 +408,7 @@ class Glob {
       this.#results.add(path);
     }
 
-    if (!isDirectory) {
+    if (!isDirectory && stat !== null) {
       return;
     }
 

--- a/test/parallel/test-fs-glob-permission.js
+++ b/test/parallel/test-fs-glob-permission.js
@@ -1,0 +1,71 @@
+'use strict';
+
+require('../common');
+
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { spawnSyncAndAssert } = require('../common/child_process');
+const tmpdir = require('../common/tmpdir');
+
+// This test verifies that fs.globSync() works correctly udner permission model
+// when --allow-fs-read is granted only to the certain directory
+
+// Example:
+// Directory structure:
+//   somedir/
+//     file1.js
+//   sample.js
+//
+// Command:
+//   node --permission --allow-fs-read=somedir/ sample.js
+//
+// Code:
+//   fs.globSync('somedir/*') <- sould find file1.js
+
+tmpdir.refresh();
+
+const someDir = tmpdir.resolve('somedir');
+const script = tmpdir.resolve('sample.js');
+
+fs.mkdirSync(someDir);
+fs.writeFileSync(
+  path.join(someDir, 'file1.js'),
+  'console.log("test");'
+);
+
+fs.writeFileSync(
+  script,
+  `
+'use strict';
+const fs = require('fs');
+const matches = fs.globSync('somedir/*');
+console.log(JSON.stringify(matches));
+`
+);
+
+spawnSyncAndAssert(
+  process.execPath,
+  [
+    '--permission',
+    `--allow-fs-read=${someDir}`,
+    script,
+  ],
+  {
+    cwd: tmpdir.path,
+  },
+  {
+    stdout(output) {
+      assert.deepStrictEqual(
+        JSON.parse(output),
+        ['somedir/file1.js']
+      );
+      return true;
+    },
+    stderr(output) {
+      assert.doesNotMatch(output, /ERR_ACCESS_DENIED/);
+      return true;
+    },
+  }
+);


### PR DESCRIPTION
Fix an issue where fs.globSync failed to find files when read access was granted only for a certain directory via the --allow-fs-read flag.

Fixes: https://github.com/nodejs/node/issues/61499

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
