### PR TITLE
test_runner: avoid reading process.argv and process.cwd() in run()

### DIFF
--- a/lib/internal/main/test_runner.js
+++ b/lib/internal/main/test_runner.js
@@ -30,6 +30,8 @@ if (isUsingInspector() && options.isolation === 'process') {
   options.inspectPort = process.debugPort;
 }
 
+// Capture process state before passing to run() to avoid reading from process.cwd() inside run()
+options.cwd = process.cwd();
 options.globPatterns = ArrayPrototypeSlice(process.argv, 1);
 
 debug('test runner configuration:', options);

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -888,11 +888,7 @@ function run(options = kEmptyObject) {
       await root.harness.bootstrapPromise;
     }
     if (typeof setup === 'function') {
-<<<<<<< HEAD
-      await setup(root.reporter);
-=======
       await setup(root.reporter, cwd);
->>>>>>> af2db6ac72 (test_runner: avoid reading process.argv and process.cwd() in run())
     }
 
     await runFiles();

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -12,7 +12,6 @@ const {
   ArrayPrototypePush,
   ArrayPrototypePushApply,
   ArrayPrototypeShift,
-  ArrayPrototypeSlice,
   ArrayPrototypeSome,
   ArrayPrototypeSort,
   ObjectAssign,
@@ -151,7 +150,8 @@ function getRunArgs(path, { forceExit,
                             execArgv,
                             rerunFailuresFilePath,
                             root: { timeout },
-                            cwd }) {
+                            cwd,
+                            globPatterns }) {
   const processNodeOptions = getOptionsAsFlagsFromBinding();
   const runArgs = ArrayPrototypeFilter(processNodeOptions, filterExecArgv);
 
@@ -196,7 +196,7 @@ function getRunArgs(path, { forceExit,
 
   if (path === kIsolatedProcessName) {
     ArrayPrototypePush(runArgs, '--test');
-    ArrayPrototypePushApply(runArgs, ArrayPrototypeSlice(process.argv, 1));
+    ArrayPrototypePushApply(runArgs, globPatterns);
   } else {
     ArrayPrototypePush(runArgs, path);
   }
@@ -888,7 +888,11 @@ function run(options = kEmptyObject) {
       await root.harness.bootstrapPromise;
     }
     if (typeof setup === 'function') {
+<<<<<<< HEAD
       await setup(root.reporter);
+=======
+      await setup(root.reporter, cwd);
+>>>>>>> af2db6ac72 (test_runner: avoid reading process.argv and process.cwd() in run())
     }
 
     await runFiles();

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -165,7 +165,7 @@ function parsePreviousRuns(rerunFailuresFilePath) {
   return JSONParse(data);
 }
 
-async function getReportersMap(reporters, destinations) {
+async function getReportersMap(reporters, destinations, cwd) {
   return SafePromiseAllReturnArrayLike(reporters, async (name, i) => {
     const destination = kBuiltinDestinations.get(destinations[i]) ??
       createWriteStream(destinations[i], { __proto__: null, flush: true });
@@ -177,7 +177,7 @@ async function getReportersMap(reporters, destinations) {
       let parentURL;
 
       try {
-        parentURL = pathToFileURL(process.cwd() + '/').href;
+        parentURL = pathToFileURL((cwd ?? process.cwd()) + '/').href;
       } catch {
         parentURL = 'file:///';
       }
@@ -328,8 +328,8 @@ function parseCommandLine() {
     validatePath(rerunFailuresFilePath, '--test-rerun-failures');
   }
 
-  const setup = reporterScope.bind(async (rootReporter) => {
-    const reportersMap = await getReportersMap(reporters, destinations);
+  const setup = reporterScope.bind(async (rootReporter, cwd) => {
+    const reportersMap = await getReportersMap(reporters, destinations, cwd);
     for (let i = 0; i < reportersMap.length; i++) {
       const { reporter, destination } = reportersMap[i];
       compose(rootReporter, reporter).pipe(destination);


### PR DESCRIPTION
Captures process state in `main/test_runner.js` and passes it to `run()` as options, so the public API doesn't read from process during execution.

- Uses `globPatterns` instead of `process.argv` in `getRunArgs()`
- Passes `cwd` through the call chain to `getReportersMap()`
- Preserves defaults for programmatic API users

Fixes: https://github.com/nodejs/node/issues/53867