### PR TITLE
tools,win: upgrade install additional tools to Visual Studio 2026

### DIFF
--- a/tools/msvs/install_tools/install_tools.bat
+++ b/tools/msvs/install_tools/install_tools.bat
@@ -39,7 +39,7 @@ echo license terms or not. Read and understand the license terms of the packages
 echo being installed and their dependencies prior to installation:
 echo - https://chocolatey.org/packages/chocolatey
 echo - https://chocolatey.org/packages/python
-echo - https://chocolatey.org/packages/visualstudio2022-workload-vctools
+echo - https://chocolatey.org/packages/visualstudio2026-workload-vctools
 echo.
 echo This script is provided AS-IS without any warranties of any kind
 echo ----------------------------------------------------------------
@@ -61,6 +61,6 @@ cls
     -ArgumentList '-NoProfile -InputFormat None -ExecutionPolicy Bypass -Command ^
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; ^
     iex ((New-Object System.Net.WebClient).DownloadString(''https://chocolatey.org/install.ps1'')); ^
-    choco upgrade -y python visualstudio2022-workload-vctools; ^
+    choco upgrade -y python visualstudio2026-workload-vctools; ^
     Read-Host ''Type ENTER to exit'' ' ^
     -Verb RunAs


### PR DESCRIPTION
## Situation

- [tools/msvs/install_tools/install_tools.bat](https://github.com/nodejs/node/blob/main/tools/msvs/install_tools/install_tools.bat) installs Visual Studio 2022 (v17)

- The current version of [Visual Studio](https://visualstudio.microsoft.com) is 2026 (v18), one version above.

Minimum versions for Visual Studio 2026 to run with `node-gyp` are:

- [node-gyp@12.1.0](https://github.com/nodejs/node-gyp/releases/tag/v12.1.0) adds detection and support for Visual Studio 2026
- [npm@11.6.3](https://github.com/npm/cli/blob/latest/CHANGELOG.md#1163-2025-11-19) includes [node-gyp@12.1.0](https://github.com/nodejs/node-gyp/releases/tag/v12.1.0)

These are currently given in the branches main, v25.x and expected in the next v24.x release. Branches v22.x and v20.x would be expected to remain on npm 10.x and so will not be eligible.

| Branch        | npm    | Minimum versions available |
| ------------- | ------ | -------------------------- |
| main          | 11.8.0 | YES                        |
| v25.x         | 11.8.0 | YES                        |
| v24.x         | 11.6.2 | NO                         |
| v24.x-staging | 11.8.0 | YES                        |
| v22.x         | 10.9.4 | NO                         |
| v20.x         | 10.8.2 | NO                         |

## Change

Update [tools/msvs/install_tools/install_tools.bat](https://github.com/nodejs/node/blob/main/tools/msvs/install_tools/install_tools.bat) from Visual Studio 2022 to 2026,

from Chocolatey package:

- https://chocolatey.org/packages/visualstudio2022-workload-vctools (Visual C++ build tools workload for Visual Studio 2022 Build Tools 1.0.0)

to

- https://chocolatey.org/packages/visualstudio2026-workload-vctools (Visual C++ build tools workload for Visual Studio 2026 Build Tools 1.0.0)

## Logs

```text
Upgraded:
 - chocolatey-compatibility.extension v1.0.0
 - chocolatey-core.extension v1.4.0
 - chocolatey-dotnetfx.extension v1.0.1
 - chocolatey-visualstudio.extension v1.13.0
 - chocolatey-windowsupdate.extension v1.0.5
 - dotnetfx v4.8.0.20220524
 - KB2919355 v1.0.20160915
 - KB2919442 v1.0.20160915
 - KB2999226 v1.0.20181019
 - KB3033929 v1.0.5
 - KB3035131 v1.0.3
 - python v3.14.2
 - python3 v3.14.2
 - python314 v3.14.2
 - vcredist140 v14.44.35211
 - vcredist2015 v14.0.24215.20170201
 - visualstudio2026buildtools v118.2.0
 - visualstudio2026-workload-vctools v1.0.0
 - visualstudio-installer v2.0.7
```

## Size requirements

The current statement in the script is still accurate:

> This will require about 7 GiB of free disk space, plus any space necessary to install Windows updates.

cc: @StefanStojanovic