### PR TITLE
doc: move describe/it aliases section before expectFailure

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -125,34 +125,6 @@ Any subtests that are still outstanding when their parent finishes
 are cancelled and treated as failures. Any subtest failures cause the parent
 test to fail.
 
-## Skipping tests
-
-Individual tests can be skipped by passing the `skip` option to the test, or by
-calling the test context's `skip()` method as shown in the
-following example.
-
-```js
-// The skip option is used, but no message is provided.
-test('skip option', { skip: true }, (t) => {
-  // This code is never executed.
-});
-
-// The skip option is used, and a message is provided.
-test('skip option with message', { skip: 'this is skipped' }, (t) => {
-  // This code is never executed.
-});
-
-test('skip() method', (t) => {
-  // Make sure to return here as well if the test contains additional logic.
-  t.skip();
-});
-
-test('skip() method with message', (t) => {
-  // Make sure to return here as well if the test contains additional logic.
-  t.skip('this is skipped');
-});
-```
-
 ## Rerunning failed tests
 
 The test runner supports persisting the state of the run to a file, allowing
@@ -193,37 +165,6 @@ When the `--test-rerun-failures` option is used, the test runner will only run t
 node --test-rerun-failures /path/to/state/file
 ```
 
-## TODO tests
-
-Individual tests can be marked as flaky or incomplete by passing the `todo`
-option to the test, or by calling the test context's `todo()` method, as shown
-in the following example. These tests represent a pending implementation or bug
-that needs to be fixed. TODO tests are executed, but are not treated as test
-failures, and therefore do not affect the process exit code. If a test is marked
-as both TODO and skipped, the TODO option is ignored.
-
-```js
-// The todo option is used, but no message is provided.
-test('todo option', { todo: true }, (t) => {
-  // This code is executed, but not treated as a failure.
-  throw new Error('this does not fail the test');
-});
-
-// The todo option is used, and a message is provided.
-test('todo option with message', { todo: 'this is a todo test' }, (t) => {
-  // This code is executed.
-});
-
-test('todo() method', (t) => {
-  t.todo();
-});
-
-test('todo() method with message', (t) => {
-  t.todo('this is a todo test and is not treated as a failure');
-  throw new Error('this does not fail the test');
-});
-```
-
 ## `describe()` and `it()` aliases
 
 Suites and tests can also be written using the `describe()` and `it()`
@@ -256,6 +197,65 @@ import { describe, it } from 'node:test';
 
 ```cjs
 const { describe, it } = require('node:test');
+```
+
+## Skipping tests
+
+Individual tests can be skipped by passing the `skip` option to the test, or by
+calling the test context's `skip()` method as shown in the
+following example.
+
+```js
+// The skip option is used, but no message is provided.
+test('skip option', { skip: true }, (t) => {
+  // This code is never executed.
+});
+
+// The skip option is used, and a message is provided.
+test('skip option with message', { skip: 'this is skipped' }, (t) => {
+  // This code is never executed.
+});
+
+test('skip() method', (t) => {
+  // Make sure to return here as well if the test contains additional logic.
+  t.skip();
+});
+
+test('skip() method with message', (t) => {
+  // Make sure to return here as well if the test contains additional logic.
+  t.skip('this is skipped');
+});
+```
+
+## TODO tests
+
+Individual tests can be marked as flaky or incomplete by passing the `todo`
+option to the test, or by calling the test context's `todo()` method, as shown
+in the following example. These tests represent a pending implementation or bug
+that needs to be fixed. TODO tests are executed, but are not treated as test
+failures, and therefore do not affect the process exit code. If a test is marked
+as both TODO and skipped, the TODO option is ignored.
+
+```js
+// The todo option is used, but no message is provided.
+test('todo option', { todo: true }, (t) => {
+  // This code is executed, but not treated as a failure.
+  throw new Error('this does not fail the test');
+});
+
+// The todo option is used, and a message is provided.
+test('todo option with message', { todo: 'this is a todo test' }, (t) => {
+  // This code is executed.
+});
+
+test('todo() method', (t) => {
+  t.todo();
+});
+
+test('todo() method with message', (t) => {
+  t.todo('this is a todo test and is not treated as a failure');
+  throw new Error('this does not fail the test');
+});
 ```
 
 ## Expecting tests to fail


### PR DESCRIPTION
The “Expecting tests to fail” section uses it() before the documentation explains that it() is an alias of test().

This reorders the relevant documentation sections so that the describe() / it() aliases are introduced before being used, improving readability for first-time readers.