### PR TITLE
doc: clarify limitations of path.isAbsolute

### DIFF
--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -322,7 +322,8 @@ added: v0.11.2
 * Returns: {boolean}
 
 The `path.isAbsolute()` method determines if the literal `path` is absolute.
-Therefore, it’s not safe for mitigating path traversals attacks.
+Therefore, it’s not safe for mitigating path traversals attacks. This method only checks whether a path is absolute and does not validate whether it is safe to use.
+
 
 If the given `path` is a zero-length string, `false` will be returned.
 

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -322,7 +322,9 @@ added: v0.11.2
 * Returns: {boolean}
 
 The `path.isAbsolute()` method determines if the literal `path` is absolute.
-Therefore, it’s not safe for mitigating path traversals attacks. This method only checks whether a path is absolute and does not validate whether it is safe to use.
+Therefore, it’s not safe for mitigating path traversal attacks. This method
+only checks whether a path is absolute and does not validate whether it
+is safe to use.
 
 
 If the given `path` is a zero-length string, `false` will be returned.

--- a/doc/api/path.md
+++ b/doc/api/path.md
@@ -60,9 +60,9 @@ path.posix.basename('/tmp/myfile.html');
 // Returns: 'myfile.html'
 ```
 
-On Windows Node.js follows the concept of per-drive working directory.
+On Windows, Node.js follows the concept of per-drive working directory.
 This behavior can be observed when using a drive path without a backslash. For
-example, `path.resolve('C:\\')` can potentially return a different result than
+example, `path.resolve('C:\\')` can return a different result than
 `path.resolve('C:')`. For more information, see
 [this MSDN page][MSDN-Rel-Path].
 
@@ -322,7 +322,7 @@ added: v0.11.2
 * Returns: {boolean}
 
 The `path.isAbsolute()` method determines if the literal `path` is absolute.
-Therefore, it’s not safe for mitigating path traversals.
+Therefore, it’s not safe for mitigating path traversals attacks.
 
 If the given `path` is a zero-length string, `false` will be returned.
 


### PR DESCRIPTION
This PR clarifies the documentation for `path.isAbsolute()` by explicitly stating
that it only checks whether a path is absolute and does not validate whether the
path is safe to use.