### PR TITLE
assert: fix loose deepEqual arrays with undefined and null failing

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -998,9 +998,10 @@ function objEquiv(a, b, mode, keys1, keys2, memos, iterationType) {
       if (b[i] === undefined) {
         if (!hasOwn(b, i))
           return sparseArrayEquiv(a, b, mode, memos, i);
-        if (a[i] !== undefined || !hasOwn(a, i))
+        if ((a[i] !== undefined || !hasOwn(a, i)) && (mode !== kLoose || a[i] !== null))
           return false;
-      } else if (a[i] === undefined || !innerDeepEqual(a[i], b[i], mode, memos)) {
+      } else if ((a[i] === undefined || !innerDeepEqual(a[i], b[i], mode, memos)) &&
+                 (mode !== kLoose || b[i] !== null)) {
         return false;
       }
     }

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -126,6 +126,11 @@ test('deepEqual', () => {
   }
 });
 
+test('loose deepEqual', () => {
+  assertOnlyDeepEqual([null, undefined, undefined], [null, undefined, null]);
+  assertNotDeepOrStrict([null, undefined, undefined, 1], [null, undefined, null, 2]);
+});
+
 test('date', () => {
   assertNotDeepOrStrict(date, date2);
   assert.throws(
@@ -246,6 +251,13 @@ function assertOnlyDeepEqual(a, b, err) {
     () => assert.deepStrictEqual(b, a),
     err || { code: 'ERR_ASSERTION' }
   );
+
+  const partial = mustCall(() => {
+    assert.partialDeepStrictEqual(b, a);
+    assert.partialDeepStrictEqual(a, b);
+  });
+
+  assert.throws(partial, err || { code: 'ERR_ASSERTION' });
 }
 
 test('es6 Maps and Sets', () => {


### PR DESCRIPTION
The comparison has to accept these as identical.

Fixes: https://github.com/nodejs/node/issues/61583
