### PR TITLE
http: align header value validation with Fetch spec

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3680,6 +3680,9 @@ Found'`.
 <!-- YAML
 added: v0.1.13
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/61597
+    description: The `httpValidation` option is supported now.
   - version:
       - v25.1.0
       - v24.12.0
@@ -3736,6 +3739,16 @@ changes:
     `readableHighWaterMark` and `writableHighWaterMark`. This affects
     `highWaterMark` property of both `IncomingMessage` and `ServerResponse`.
     **Default:** See [`stream.getDefaultHighWaterMark()`][].
+  * `httpValidation` {string} Controls HTTP header value validation strictness
+    for incoming requests. Accepted values are:
+    * `'strict'`: Strictest validation; rejects any non-ASCII or control
+      characters in header values.
+    * `'relaxed'`: Allows a limited set of non-ASCII characters in header
+      values, aligning with the
+      [Fetch specification](https://fetch.spec.whatwg.org/).
+    * `'insecure'`: Disables all header value validation (equivalent to
+      `insecureHTTPParser: true`).
+      Cannot be used together with `insecureHTTPParser`. **Default:** `'strict'`.
   * `insecureHTTPParser` {boolean} If set to `true`, it will use an HTTP parser
     with leniency flags enabled. Using the insecure parser should be avoided.
     See [`--insecure-http-parser`][] for more information.
@@ -3992,6 +4005,9 @@ This can be overridden for servers and client requests by passing the
 <!-- YAML
 added: v0.3.6
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/61597
+    description: The `httpValidation` option is supported now.
   - version:
       - v16.7.0
       - v14.18.0
@@ -4047,6 +4063,16 @@ changes:
     request to. **Default:** `'localhost'`.
   * `hostname` {string} Alias for `host`. To support [`url.parse()`][],
     `hostname` will be used if both `host` and `hostname` are specified.
+  * `httpValidation` {string} Controls HTTP header value validation strictness
+    for outgoing requests. Accepted values are:
+    * `'strict'`: Strictest validation; rejects any non-ASCII or control
+      characters in header values.
+    * `'relaxed'`: Allows a limited set of non-ASCII characters in header
+      values, aligning with the
+      [Fetch specification](https://fetch.spec.whatwg.org/).
+    * `'insecure'`: Disables all header value validation (equivalent to
+      `insecureHTTPParser: true`).
+      Cannot be used together with `insecureHTTPParser`. **Default:** `'strict'`.
   * `insecureHTTPParser` {boolean} If set to `true`, it will use an HTTP parser
     with leniency flags enabled. Using the insecure parser should be avoided.
     See [`--insecure-http-parser`][] for more information.

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -46,7 +46,7 @@ const {
   freeParser,
   parsers,
   HTTPParser,
-  isLenient,
+  calculateLenientFlags,
   prepareError,
   kSkipPendingData,
 } = require('_http_common');
@@ -74,6 +74,7 @@ const {
   codes: {
     ERR_HTTP_HEADERS_SENT,
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_ARG_VALUE,
     ERR_INVALID_HTTP_TOKEN,
     ERR_INVALID_PROTOCOL,
     ERR_UNESCAPED_CHARACTERS,
@@ -82,6 +83,7 @@ const {
 const {
   validateInteger,
   validateBoolean,
+  validateOneOf,
   validateString,
 } = require('internal/validators');
 const { getTimerDuration } = require('internal/timers');
@@ -118,9 +120,6 @@ let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
 const INVALID_PATH_REGEX = /[^\u0021-\u00ff]/;
 const kError = Symbol('kError');
 const kPath = Symbol('kPath');
-
-const kLenientAll = HTTPParser.kLenientAll | 0;
-const kLenientNone = HTTPParser.kLenientNone | 0;
 
 const HTTP_CLIENT_TRACE_EVENT_NAME = 'http.client.request';
 
@@ -298,6 +297,21 @@ function ClientRequest(input, options, cb) {
   }
 
   this.insecureHTTPParser = insecureHTTPParser;
+
+  const httpValidation = options.httpValidation;
+  if (httpValidation !== undefined) {
+    validateOneOf(httpValidation, 'options.httpValidation',
+                  ['strict', 'relaxed', 'insecure']);
+    if (insecureHTTPParser !== undefined) {
+      throw new ERR_INVALID_ARG_VALUE(
+        'options.httpValidation',
+        httpValidation,
+        'cannot be used together with options.insecureHTTPParser',
+      );
+    }
+  }
+
+  this.httpValidation = httpValidation;
 
   if (options.joinDuplicateHeaders !== undefined) {
     validateBoolean(options.joinDuplicateHeaders, 'options.joinDuplicateHeaders');
@@ -907,12 +921,11 @@ function emitFreeNT(req) {
 function tickOnSocket(req, socket) {
   const parser = parsers.alloc();
   req.socket = socket;
-  const lenient = req.insecureHTTPParser === undefined ?
-    isLenient() : req.insecureHTTPParser;
+  const lenientFlags = calculateLenientFlags(req.httpValidation, req.insecureHTTPParser);
   parser.initialize(HTTPParser.RESPONSE,
                     new HTTPClientAsyncResource('HTTPINCOMINGMESSAGE', req),
                     req.maxHeaderSize || 0,
-                    lenient ? kLenientAll : kLenientNone);
+                    lenientFlags);
   parser.socket = socket;
   parser.outgoing = req;
   req.parser = parser;

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -256,17 +256,31 @@ function checkIsHttpToken(val) {
   return true;
 }
 
-const headerCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
+// Strict header value regex per RFC 7230 (original/default behavior):
+// field-value = *( field-content / obs-fold )
+// field-content = field-vchar [ 1*( SP / HTAB ) field-vchar ]
+// field-vchar = VCHAR / obs-text
+// This rejects control characters (0x00-0x1f except HTAB) and DEL (0x7f).
+const strictHeaderCharRegex = /[^\t\x20-\x7e\x80-\xff]/;
+
+// Lenient header value regex per Fetch spec (https://fetch.spec.whatwg.org/#header-value):
+// - Must contain no 0x00 (NUL) or HTTP newline bytes (0x0a LF, 0x0d CR)
+// - Must be byte sequences (0x00-0xff), not arbitrary unicode
+// This allows most control characters except NUL, CR, and LF.
+// eslint-disable-next-line no-control-regex
+const lenientHeaderCharRegex = /[\x00\x0a\x0d]|[^\x00-\xff]/;
+
 /**
- * True if val contains an invalid field-vchar
- *  field-value    = *( field-content / obs-fold )
- *  field-content  = field-vchar [ 1*( SP / HTAB ) field-vchar ]
- *  field-vchar    = VCHAR / obs-text
+ * True if val contains an invalid header value character.
+ * By default uses strict validation per RFC 7230.
+ * When lenient=true, uses relaxed validation per Fetch spec.
  * @param {string} val
+ * @param {boolean} [lenient] - Use lenient validation (Fetch spec rules)
  * @returns {boolean}
  */
-function checkInvalidHeaderChar(val) {
-  return headerCharRegex.test(val);
+function checkInvalidHeaderChar(val, lenient = false) {
+  const regex = lenient ? lenientHeaderCharRegex : strictHeaderCharRegex;
+  return regex.test(val);
 }
 
 function cleanParser(parser) {
@@ -300,6 +314,19 @@ function isLenient() {
   return insecureHTTPParser;
 }
 
+function calculateLenientFlags(httpValidation, insecureHTTPParserOption) {
+  if (httpValidation === 'strict') {
+    return HTTPParser.kLenientNone | 0;
+  } else if (httpValidation === 'relaxed') {
+    return HTTPParser.kLenientHeaderValueRelaxed | 0;
+  } else if (httpValidation === 'insecure') {
+    return HTTPParser.kLenientAll | 0;
+  }
+  const lenient = insecureHTTPParserOption === undefined ?
+    isLenient() : insecureHTTPParserOption;
+  return lenient ? HTTPParser.kLenientAll | 0 : HTTPParser.kLenientNone | 0;
+}
+
 module.exports = {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   _checkIsHttpToken: checkIsHttpToken,
@@ -312,6 +339,7 @@ module.exports = {
   kIncomingMessage,
   HTTPParser,
   isLenient,
+  calculateLenientFlags,
   prepareError,
   kSkipPendingData,
 };

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -44,6 +44,7 @@ const {
   _checkIsHttpToken: checkIsHttpToken,
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   chunkExpression: RE_TE_CHUNKED,
+  isLenient,
 } = require('_http_common');
 const {
   defaultTriggerAsyncIdScope,
@@ -157,6 +158,33 @@ function OutgoingMessage(options) {
 }
 ObjectSetPrototypeOf(OutgoingMessage.prototype, Stream.prototype);
 ObjectSetPrototypeOf(OutgoingMessage, Stream);
+
+// Check if lenient header validation should be used.
+// For ClientRequest: checks this.httpValidation or this.insecureHTTPParser
+// For ServerResponse: checks the server's httpValidation or insecureHTTPParser
+// Falls back to global --insecure-http-parser flag.
+OutgoingMessage.prototype._isLenientHeaderValidation = function() {
+  // New httpValidation option takes priority (ClientRequest case)
+  if (this.httpValidation !== undefined) {
+    return this.httpValidation !== 'strict';
+  }
+  // ServerResponse: check server's httpValidation option
+  const serverHttpValidation = this.req?.socket?.server?.httpValidation;
+  if (serverHttpValidation !== undefined) {
+    return serverHttpValidation !== 'strict';
+  }
+  // Legacy insecureHTTPParser - ClientRequest has it directly
+  if (typeof this.insecureHTTPParser === 'boolean') {
+    return this.insecureHTTPParser;
+  }
+  // ServerResponse can access via req.socket.server
+  const serverOption = this.req?.socket?.server?.insecureHTTPParser;
+  if (typeof serverOption === 'boolean') {
+    return serverOption;
+  }
+  // Fall back to global option
+  return isLenient();
+};
 
 ObjectDefineProperty(OutgoingMessage.prototype, 'errored', {
   __proto__: null,
@@ -411,18 +439,19 @@ function _storeHeader(firstLine, headers) {
     trailer: false,
     header: firstLine,
   };
+  const lenient = this._isLenientHeaderValidation();
 
   if (headers) {
     if (headers === this[kOutHeaders]) {
       for (const key in headers) {
         const entry = headers[key];
-        processHeader(this, state, entry[0], entry[1], false);
+        processHeader(this, state, entry[0], entry[1], false, lenient);
       }
     } else if (ArrayIsArray(headers)) {
       if (headers.length && ArrayIsArray(headers[0])) {
         for (let i = 0; i < headers.length; i++) {
           const entry = headers[i];
-          processHeader(this, state, entry[0], entry[1], true);
+          processHeader(this, state, entry[0], entry[1], true, lenient);
         }
       } else {
         if (headers.length % 2 !== 0) {
@@ -430,13 +459,13 @@ function _storeHeader(firstLine, headers) {
         }
 
         for (let n = 0; n < headers.length; n += 2) {
-          processHeader(this, state, headers[n + 0], headers[n + 1], true);
+          processHeader(this, state, headers[n + 0], headers[n + 1], true, lenient);
         }
       }
     } else {
       for (const key in headers) {
         if (ObjectHasOwn(headers, key)) {
-          processHeader(this, state, key, headers[key], true);
+          processHeader(this, state, key, headers[key], true, lenient);
         }
       }
     }
@@ -535,7 +564,7 @@ function _storeHeader(firstLine, headers) {
   if (state.expect) this._send('');
 }
 
-function processHeader(self, state, key, value, validate) {
+function processHeader(self, state, key, value, validate, lenient) {
   if (validate)
     validateHeaderName(key);
 
@@ -562,17 +591,17 @@ function processHeader(self, state, key, value, validate) {
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
       for (let i = 0; i < value.length; i++)
-        storeHeader(self, state, key, value[i], validate);
+        storeHeader(self, state, key, value[i], validate, lenient);
       return;
     }
     value = value.join('; ');
   }
-  storeHeader(self, state, key, value, validate);
+  storeHeader(self, state, key, value, validate, lenient);
 }
 
-function storeHeader(self, state, key, value, validate) {
+function storeHeader(self, state, key, value, validate, lenient) {
   if (validate)
-    validateHeaderValue(key, value);
+    validateHeaderValue(key, value, lenient);
   state.header += key + ': ' + value + '\r\n';
   matchHeader(self, state, key, value);
 }
@@ -618,11 +647,11 @@ const validateHeaderName = assignFunctionName('validateHeaderName', hideStackFra
   }
 }));
 
-const validateHeaderValue = assignFunctionName('validateHeaderValue', hideStackFrames((name, value) => {
+const validateHeaderValue = assignFunctionName('validateHeaderValue', hideStackFrames((name, value, lenient) => {
   if (value === undefined) {
     throw new ERR_HTTP_INVALID_HEADER_VALUE.HideStackFramesError(value, name);
   }
-  if (checkInvalidHeaderChar(value)) {
+  if (checkInvalidHeaderChar(value, lenient)) {
     debug('Header "%s" contains invalid characters', name);
     throw new ERR_INVALID_CHAR.HideStackFramesError('header content', name);
   }
@@ -647,7 +676,13 @@ OutgoingMessage.prototype.setHeader = function setHeader(name, value) {
     throw new ERR_HTTP_HEADERS_SENT('set');
   }
   validateHeaderName(name);
-  validateHeaderValue(name, value);
+  if (value === undefined) {
+    throw new ERR_HTTP_INVALID_HEADER_VALUE(value, name);
+  }
+  if (checkInvalidHeaderChar(value, this._isLenientHeaderValidation())) {
+    debug('Header "%s" contains invalid characters', name);
+    throw new ERR_INVALID_CHAR('header content', name);
+  }
 
   let headers = this[kOutHeaders];
   if (headers === null)
@@ -705,7 +740,13 @@ OutgoingMessage.prototype.appendHeader = function appendHeader(name, value) {
     throw new ERR_HTTP_HEADERS_SENT('append');
   }
   validateHeaderName(name);
-  validateHeaderValue(name, value);
+  if (value === undefined) {
+    throw new ERR_HTTP_INVALID_HEADER_VALUE(value, name);
+  }
+  if (checkInvalidHeaderChar(value, this._isLenientHeaderValidation())) {
+    debug('Header "%s" contains invalid characters', name);
+    throw new ERR_INVALID_CHAR('header content', name);
+  }
 
   const field = name.toLowerCase();
   const headers = this[kOutHeaders];
@@ -1005,12 +1046,13 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
 
     // Check if the field must be sent several times
     const isArrayValue = ArrayIsArray(value);
+    const lenient = this._isLenientHeaderValidation();
     if (
       isArrayValue && value.length > 1 &&
       (!this[kUniqueHeaders] || !this[kUniqueHeaders].has(field.toLowerCase()))
     ) {
       for (let j = 0, l = value.length; j < l; j++) {
-        if (checkInvalidHeaderChar(value[j])) {
+        if (checkInvalidHeaderChar(value[j], lenient)) {
           debug('Trailer "%s"[%d] contains invalid characters', field, j);
           throw new ERR_INVALID_CHAR('trailer content', field);
         }
@@ -1021,7 +1063,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
         value = value.join('; ');
       }
 
-      if (checkInvalidHeaderChar(value)) {
+      if (checkInvalidHeaderChar(value, lenient)) {
         debug('Trailer "%s" contains invalid characters', field);
         throw new ERR_INVALID_CHAR('trailer content', field);
       }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -46,7 +46,7 @@ const {
   kIncomingMessage,
   kSocket,
   HTTPParser,
-  isLenient,
+  calculateLenientFlags,
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   prepareError,
 } = require('_http_common');
@@ -92,6 +92,7 @@ const {
 const {
   validateInteger,
   validateBoolean,
+  validateOneOf,
   validateLinkHeaderValue,
   validateObject,
   validateFunction,
@@ -187,8 +188,7 @@ const STATUS_CODES = {
 
 const kOnExecute = HTTPParser.kOnExecute | 0;
 const kOnTimeout = HTTPParser.kOnTimeout | 0;
-const kLenientAll = HTTPParser.kLenientAll | 0;
-const kLenientNone = HTTPParser.kLenientNone | 0;
+
 const kConnections = Symbol('http.server.connections');
 const kConnectionsCheckingInterval = Symbol('http.server.connectionsCheckingInterval');
 
@@ -325,19 +325,20 @@ ServerResponse.prototype.writeInformation = function writeInformation(
   const statusMessage = STATUS_CODES[statusCode] || 'unknown';
   let head = `HTTP/1.1 ${statusCode} ${statusMessage}\r\n`;
 
+  const lenient = this._isLenientHeaderValidation();
   if (headers !== undefined && headers !== null) {
     if (ArrayIsArray(headers)) {
       if (headers.length && ArrayIsArray(headers[0])) {
         for (let i = 0; i < headers.length; i++) {
           const entry = headers[i];
-          head += processInformationHeader(entry[0], entry[1]);
+          head += processInformationHeader(entry[0], entry[1], lenient);
         }
       } else {
         if (headers.length % 2 !== 0) {
           throw new ERR_INVALID_ARG_VALUE('headers', headers);
         }
         for (let i = 0; i < headers.length; i += 2) {
-          head += processInformationHeader(headers[i], headers[i + 1]);
+          head += processInformationHeader(headers[i], headers[i + 1], lenient);
         }
       }
     } else {
@@ -345,7 +346,7 @@ ServerResponse.prototype.writeInformation = function writeInformation(
       const keys = ObjectKeys(headers);
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i];
-        head += processInformationHeader(key, headers[key]);
+        head += processInformationHeader(key, headers[key], lenient);
       }
     }
   }
@@ -355,9 +356,9 @@ ServerResponse.prototype.writeInformation = function writeInformation(
   return this._writeRaw(head, 'ascii', cb);
 };
 
-function processInformationHeader(name, value) {
+function processInformationHeader(name, value, lenient) {
   validateHeaderName(name);
-  validateHeaderValue(name, value);
+  validateHeaderValue(name, value, lenient);
   return `${name}: ${value}\r\n`;
 }
 
@@ -515,6 +516,20 @@ function storeHTTPOptions(options) {
   if (insecureHTTPParser !== undefined)
     validateBoolean(insecureHTTPParser, 'options.insecureHTTPParser');
   this.insecureHTTPParser = insecureHTTPParser;
+
+  const httpValidation = options.httpValidation;
+  if (httpValidation !== undefined) {
+    validateOneOf(httpValidation, 'options.httpValidation',
+                  ['strict', 'relaxed', 'insecure']);
+    if (insecureHTTPParser !== undefined) {
+      throw new ERR_INVALID_ARG_VALUE(
+        'options.httpValidation',
+        httpValidation,
+        'cannot be used together with options.insecureHTTPParser',
+      );
+    }
+  }
+  this.httpValidation = httpValidation;
 
   const requestTimeout = options.requestTimeout;
   if (requestTimeout !== undefined) {
@@ -761,8 +776,7 @@ function connectionListenerInternal(server, socket) {
 
   const parser = parsers.alloc();
 
-  const lenient = server.insecureHTTPParser === undefined ?
-    isLenient() : server.insecureHTTPParser;
+  const lenientFlags = calculateLenientFlags(server.httpValidation, server.insecureHTTPParser);
 
   // TODO(addaleax): This doesn't play well with the
   // `async_hooks.currentResource()` proposal, see
@@ -771,7 +785,7 @@ function connectionListenerInternal(server, socket) {
     HTTPParser.REQUEST,
     new HTTPServerAsyncResource('HTTPINCOMINGMESSAGE', socket),
     server.maxHeaderSize || 0,
-    lenient ? kLenientAll : kLenientNone,
+    lenientFlags,
     server[kConnections],
   );
   parser.socket = socket;

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -96,6 +96,7 @@ const uint32_t kLenientOptionalLFAfterCR = 1 << 6;
 const uint32_t kLenientOptionalCRLFAfterChunk = 1 << 7;
 const uint32_t kLenientOptionalCRBeforeLF = 1 << 8;
 const uint32_t kLenientSpacesAfterChunkSize = 1 << 9;
+const uint32_t kLenientHeaderValueRelaxed = 1 << 10;
 const uint32_t kLenientAll =
     kLenientHeaders | kLenientChunkedLength | kLenientKeepAlive |
     kLenientTransferEncoding | kLenientVersion | kLenientDataAfterClose |
@@ -1006,6 +1007,11 @@ class Parser : public AsyncWrap, public StreamListener {
     if (lenient_flags & kLenientSpacesAfterChunkSize) {
       llhttp_set_lenient_spaces_after_chunk_size(&parser_, 1);
     }
+#if LLHTTP_VERSION_MAJOR * 1000 + LLHTTP_VERSION_MINOR >= 9004
+    if (lenient_flags & kLenientHeaderValueRelaxed) {
+      llhttp_set_lenient_header_value_relaxed(&parser_, 1);
+    }
+#endif
 
     header_nread_ = 0;
     url_.Reset();
@@ -1332,6 +1338,16 @@ void CreatePerIsolateProperties(IsolateData* isolate_data,
          Integer::NewFromUnsigned(isolate, kLenientOptionalCRBeforeLF));
   t->Set(FIXED_ONE_BYTE_STRING(isolate, "kLenientSpacesAfterChunkSize"),
          Integer::NewFromUnsigned(isolate, kLenientSpacesAfterChunkSize));
+  // kLenientHeaderValueRelaxed requires llhttp >= 9.4.0 for the
+  // llhttp_set_lenient_header_value_relaxed() API. Export 0 on older
+  // shared-library builds so JS can detect feature availability.
+#if LLHTTP_VERSION_MAJOR * 1000 + LLHTTP_VERSION_MINOR >= 9004
+  t->Set(FIXED_ONE_BYTE_STRING(isolate, "kLenientHeaderValueRelaxed"),
+         Integer::NewFromUnsigned(isolate, kLenientHeaderValueRelaxed));
+#else
+  t->Set(FIXED_ONE_BYTE_STRING(isolate, "kLenientHeaderValueRelaxed"),
+         Integer::NewFromUnsigned(isolate, 0));
+#endif
 
   t->Set(FIXED_ONE_BYTE_STRING(isolate, "kLenientAll"),
          Integer::NewFromUnsigned(isolate, kLenientAll));

--- a/test/parallel/test-http-header-value-relaxed.js
+++ b/test/parallel/test-http-header-value-relaxed.js
@@ -1,0 +1,429 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+const { duplexPair } = require('stream');
+const { HTTPParser } = require('_http_common');
+// llhttp_set_lenient_header_value_relaxed() was added in llhttp 9.4.0.
+// On shared-library builds using an older system llhttp the constant is
+// exported as 0, so inbound-parsing tests must be skipped there.
+const kRelaxedInboundSupported = HTTPParser.kLenientHeaderValueRelaxed > 0;
+
+// Integration tests for relaxed header value validation.
+// When httpValidation is 'relaxed' or 'insecure', outgoing headers with control
+// characters (0x01-0x1f except HTAB, and DEL 0x7f) are allowed per Fetch spec.
+// NUL (0x00), CR (0x0d), and LF (0x0a) are always rejected.
+// httpValidation: 'relaxed' - only enables relaxed header value parsing, not
+//   other insecure lenient behaviours (e.g. duplicate Transfer-Encoding).
+// httpValidation: 'insecure' - enables all lenient parsing (same as insecureHTTPParser).
+// httpValidation and insecureHTTPParser are mutually exclusive.
+
+// Helper: create a request that won't actually connect (for setHeader tests)
+function dummyRequest(opts) {
+  const req = http.request({ host: '127.0.0.1', port: 1, ...opts });
+  req.on('error', () => {});  // Suppress connection errors
+  return req;
+}
+
+// ============================================================================
+// Test 1: Client setHeader with control chars in strict mode (default) - throws
+// ============================================================================
+{
+  const req = dummyRequest();
+  assert.throws(() => {
+    req.setHeader('X-Test', 'value\x01here');
+  }, { code: 'ERR_INVALID_CHAR' });
+  req.destroy();
+}
+
+// ============================================================================
+// Test 2: Client setHeader with control chars in relaxed mode - allowed
+// ============================================================================
+{
+  const req = dummyRequest({ httpValidation: 'relaxed' });
+  // Should not throw - control chars allowed in relaxed mode
+  req.setHeader('X-Test', 'value\x01here');
+  req.setHeader('X-Bel', 'ding\x07');
+  req.setHeader('X-Esc', 'esc\x1b');
+  req.setHeader('X-Del', 'del\x7f');
+  req.destroy();
+}
+
+// ============================================================================
+// Test 3: NUL, CR, LF always rejected even in relaxed mode (client)
+// ============================================================================
+{
+  const req = dummyRequest({ httpValidation: 'relaxed' });
+  assert.throws(() => {
+    req.setHeader('X-Test', 'value\x00here');
+  }, { code: 'ERR_INVALID_CHAR' });
+  assert.throws(() => {
+    req.setHeader('X-Test', 'value\rhere');
+  }, { code: 'ERR_INVALID_CHAR' });
+  assert.throws(() => {
+    req.setHeader('X-Test', 'value\nhere');
+  }, { code: 'ERR_INVALID_CHAR' });
+  req.destroy();
+}
+
+// ============================================================================
+// Test 4: Server response setHeader with control chars in relaxed mode
+// ============================================================================
+{
+  const server = http.createServer({
+    httpValidation: 'relaxed',
+  }, common.mustCall((req, res) => {
+    // Should not throw - control chars allowed in relaxed mode
+    res.setHeader('X-Custom', 'value\x01here');
+    res.end('ok');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    // Use a raw TCP connection to read the response headers directly,
+    // since http.get would fail to parse the control char in the header.
+    const client = net.connect(port, common.mustCall(() => {
+      client.write('GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n');
+    }));
+    let data = '';
+    client.on('data', (chunk) => { data += chunk; });
+    client.on('end', common.mustCall(() => {
+      // eslint-disable-next-line no-control-regex
+      assert.match(data, /X-Custom: value\x01here/);
+      server.close();
+    }));
+  }));
+}
+
+// ============================================================================
+// Test 5: Server response NUL/CR/LF always rejected in relaxed mode
+// ============================================================================
+{
+  const server = http.createServer({
+    httpValidation: 'relaxed',
+  }, common.mustCall((req, res) => {
+    assert.throws(() => {
+      res.setHeader('X-Test', 'value\x00here');
+    }, { code: 'ERR_INVALID_CHAR' });
+    assert.throws(() => {
+      res.setHeader('X-Test', 'value\rhere');
+    }, { code: 'ERR_INVALID_CHAR' });
+    assert.throws(() => {
+      res.setHeader('X-Test', 'value\nhere');
+    }, { code: 'ERR_INVALID_CHAR' });
+    res.end('ok');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      res.resume();
+      res.on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}
+
+// ============================================================================
+// Test 6: Server response strict mode (default) rejects control chars
+// ============================================================================
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    assert.throws(() => {
+      res.setHeader('X-Test', 'value\x01here');
+    }, { code: 'ERR_INVALID_CHAR' });
+    res.end('ok');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      res.resume();
+      res.on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}
+
+// ============================================================================
+// Test 7: appendHeader also respects relaxed mode
+// ============================================================================
+{
+  const req = dummyRequest({ httpValidation: 'relaxed' });
+  // Should not throw in relaxed mode
+  req.appendHeader('X-Test', 'value\x01here');
+  req.destroy();
+}
+
+// ============================================================================
+// Test 8: appendHeader strict mode rejects control chars
+// ============================================================================
+{
+  const req = dummyRequest();
+  assert.throws(() => {
+    req.appendHeader('X-Test', 'value\x01here');
+  }, { code: 'ERR_INVALID_CHAR' });
+  req.destroy();
+}
+
+// ============================================================================
+// Test 9: Explicit insecureHTTPParser: false overrides global flag
+// ============================================================================
+{
+  const req = dummyRequest({ insecureHTTPParser: false });
+  assert.throws(() => {
+    req.setHeader('X-Test', 'value\x01here');
+  }, { code: 'ERR_INVALID_CHAR' });
+  req.destroy();
+}
+
+// ============================================================================
+// Test 10: Inbound response header with control char accepted in lenient mode
+//          (exercises the new llhttp_set_lenient_header_value_relaxed path)
+// Only runs on builds with llhttp >= 9.4 (kLenientHeaderValueRelaxed > 0).
+// ============================================================================
+if (kRelaxedInboundSupported) {
+  const [clientSide, serverSide] = duplexPair();
+
+  const req = http.request({
+    createConnection: common.mustCall(() => clientSide),
+    httpValidation: 'relaxed',
+  }, common.mustCall((res) => {
+    assert.strictEqual(res.headers['x-ctrl'], 'value\x01here');
+    res.resume();
+    res.on('end', common.mustCall());
+  }));
+  req.end();
+
+  serverSide.resume();
+  serverSide.end(
+    'HTTP/1.1 200 OK\r\n' +
+    'X-Ctrl: value\x01here\r\n' +
+    'Content-Length: 0\r\n' +
+    '\r\n',
+  );
+}
+
+// Test 10b: Same inbound header without insecureHTTPParser — parser must error
+{
+  const [clientSide, serverSide] = duplexPair();
+
+  const req = http.request({
+    createConnection: common.mustCall(() => clientSide),
+  }, common.mustNotCall());
+  req.end();
+  req.on('error', common.mustCall());
+
+  serverSide.resume();
+  serverSide.end(
+    'HTTP/1.1 200 OK\r\n' +
+    'X-Ctrl: value\x01here\r\n' +
+    'Content-Length: 0\r\n' +
+    '\r\n',
+  );
+}
+
+// ============================================================================
+// Test 11: httpValidation: 'insecure' outbound - same as insecureHTTPParser
+// ============================================================================
+{
+  const req = dummyRequest({ httpValidation: 'insecure' });
+  // Should not throw - control chars allowed in insecure mode
+  req.setHeader('X-Test', 'value\x01here');
+  req.setHeader('X-Bel', 'ding\x07');
+  req.destroy();
+}
+
+// ============================================================================
+// Test 12: Mutual exclusion - client throws when both options are set
+// ============================================================================
+{
+  assert.throws(() => {
+    dummyRequest({ httpValidation: 'relaxed', insecureHTTPParser: true });
+  }, { code: 'ERR_INVALID_ARG_VALUE' });
+}
+
+// ============================================================================
+// Test 13: Mutual exclusion - server throws when both options are set
+// ============================================================================
+{
+  assert.throws(() => {
+    http.createServer({ httpValidation: 'relaxed', insecureHTTPParser: true });
+  }, { code: 'ERR_INVALID_ARG_VALUE' });
+}
+
+// ============================================================================
+// Test 14: httpValidation: 'relaxed' accepts inbound REQUEST headers with
+//          control chars (server side - exercises kLenientHeaderValueRelaxed)
+// Only runs on builds with llhttp >= 9.4 (kLenientHeaderValueRelaxed > 0).
+// ============================================================================
+if (kRelaxedInboundSupported) {
+  const server = http.createServer({
+    httpValidation: 'relaxed',
+  }, common.mustCall((req, res) => {
+    assert.strictEqual(req.headers['x-ctrl'], 'value\x01here');
+    res.end('ok');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    // Use a raw TCP connection to send a request with a control char header.
+    const client = net.connect(port, common.mustCall(() => {
+      client.write('GET / HTTP/1.1\r\nHost: localhost\r\nX-Ctrl: value\x01here\r\nConnection: close\r\n\r\n');
+    }));
+    let data = '';
+    client.on('data', (chunk) => { data += chunk; });
+    client.on('end', common.mustCall(() => {
+      assert.match(data, /^HTTP\/1\.1 200/);
+      server.close();
+    }));
+  }));
+}
+
+// ============================================================================
+// Test 15: httpValidation: 'relaxed' inbound REQUEST - strict mode (default)
+//          rejects request with control char in header value
+// ============================================================================
+{
+  const server = http.createServer(
+    common.mustNotCall(),
+  );
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const client = net.connect(port, common.mustCall(() => {
+      client.write('GET / HTTP/1.1\r\nHost: localhost\r\nX-Ctrl: value\x01here\r\nConnection: close\r\n\r\n');
+    }));
+    let data = '';
+    client.on('data', (chunk) => { data += chunk; });
+    client.on('end', common.mustCall(() => {
+      // Server should respond with 400 Bad Request or close the connection
+      assert.match(data, /^HTTP\/1\.1 400|^$/);
+      server.close();
+    }));
+  }));
+}
+
+// ============================================================================
+// Test 16: httpValidation: 'relaxed' does NOT enable all insecure lenient
+//          flags - duplicate Transfer-Encoding is still rejected in relaxed
+//          mode but accepted in insecure mode.
+// (kLenientTransferEncoding is only in kLenientAll, not kLenientHeaderValueRelaxed)
+// ============================================================================
+{
+  // A request where Transfer-Encoding: chunked appears twice (joined internally
+  // as "chunked, chunked"), which llhttp rejects without kLenientTransferEncoding.
+  const doubleTE =
+    'GET / HTTP/1.1\r\n' +
+    'Host: localhost\r\n' +
+    'Connection: close\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    '\r\n' +
+    '0\r\n\r\n';
+
+  // With httpValidation: 'relaxed', duplicate T-E should be rejected (400).
+  {
+    const server = http.createServer({
+      httpValidation: 'relaxed',
+    }, common.mustNotCall());
+
+    server.listen(0, common.mustCall(() => {
+      const port = server.address().port;
+      const client = net.connect(port, common.mustCall(() => {
+        client.write(doubleTE);
+      }));
+      client.resume();
+      client.on('close', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }
+
+  // With httpValidation: 'insecure', duplicate T-E is accepted (kLenientAll
+  // includes kLenientTransferEncoding).
+  {
+    const server = http.createServer({
+      httpValidation: 'insecure',
+    }, common.mustCall((req, res) => {
+      res.end('ok');
+    }));
+
+    server.listen(0, common.mustCall(() => {
+      const port = server.address().port;
+      const client = net.connect(port, common.mustCall(() => {
+        client.write(doubleTE);
+      }));
+      let data = '';
+      client.on('data', (chunk) => { data += chunk; });
+      client.on('end', common.mustCall(() => {
+        assert.match(data, /^HTTP\/1\.1 200/);
+        server.close();
+      }));
+    }));
+  }
+}
+
+// ============================================================================
+// Test 17: writeHead respects httpValidation: 'relaxed'
+//          (exercises the storeHeader/validateHeaderValue path, not setHeader)
+// ============================================================================
+{
+  const server = http.createServer({
+    httpValidation: 'relaxed',
+  }, common.mustCall((req, res) => {
+    // writeHead calls _storeHeader which calls storeHeader/validateHeaderValue.
+    // With httpValidation: 'relaxed', control chars should be allowed.
+    res.writeHead(200, { 'X-Custom': 'value\x01here' });
+    res.end('ok');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+    const client = net.connect(port, common.mustCall(() => {
+      client.write('GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n');
+    }));
+    let data = '';
+    client.on('data', (chunk) => { data += chunk; });
+    client.on('end', common.mustCall(() => {
+      // eslint-disable-next-line no-control-regex
+      assert.match(data, /X-Custom: value\x01here/);
+      server.close();
+    }));
+  }));
+}
+
+// ============================================================================
+// Test 18: writeHead strict mode (default) rejects control chars
+// ============================================================================
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    assert.throws(() => {
+      res.writeHead(200, { 'X-Custom': 'value\x01here' });
+    }, { code: 'ERR_INVALID_CHAR' });
+    res.end('ok');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      res.resume();
+      res.on('end', common.mustCall(() => {
+        server.close();
+      }));
+    }));
+  }));
+}
+
+// ============================================================================
+// Test 19: httpValidation: 'strict' (explicit) rejects control chars even
+//          when insecureHTTPParser would otherwise be lenient
+// ============================================================================
+{
+  const req = dummyRequest({ httpValidation: 'strict' });
+  // 'strict' must always reject control chars, regardless of any global setting
+  assert.throws(() => {
+    req.setHeader('X-Test', 'value\x01here');
+  }, { code: 'ERR_INVALID_CHAR' });
+  req.destroy();
+}

--- a/test/parallel/test-http-invalidheaderfield2.js
+++ b/test/parallel/test-http-invalidheaderfield2.js
@@ -59,30 +59,77 @@ const { _checkIsHttpToken, _checkInvalidHeaderChar } = require('_http_common');
 });
 
 
-// Good header field values
+// ============================================================================
+// Strict header value validation (default) - per RFC 7230
+// Rejects control characters (0x00-0x1f except HTAB) and DEL (0x7f)
+// ============================================================================
+
+// Good header field values in strict mode
+[
+  'foo bar',
+  'foo\tbar',  // HTAB is allowed
+  '0123456789ABCdef',
+  '!@#$%^&*()-_=+\\;\':"[]{}<>,./?|~`',
+  '\x80\x81\xff',  // obs-text (0x80-0xff) is allowed
+].forEach(function(str) {
+  assert.strictEqual(
+    _checkInvalidHeaderChar(str), false,
+    `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly failed in strict mode`);
+});
+
+// Bad header field values in strict mode
+// Control characters (except HTAB) and DEL are rejected
+[
+  'foo\x00bar',     // NUL
+  'foo\x01bar',     // SOH
+  'foo\rbar',       // CR
+  'foo\nbar',       // LF
+  'foo\r\nbar',     // CRLF
+  'foo\x7Fbar',     // DEL
+  '中文呢',          // unicode > 0xff
+].forEach(function(str) {
+  assert.strictEqual(
+    _checkInvalidHeaderChar(str), true,
+    `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly succeeded in strict mode`);
+});
+
+
+// ============================================================================
+// Lenient header value validation (with insecureHTTPParser) - per Fetch spec
+// Only NUL (0x00), CR (0x0d), LF (0x0a), and chars > 0xff are rejected
+// ============================================================================
+
+// Good header field values in lenient mode
+// CTL characters (except NUL, LF, CR) are valid per Fetch spec
 [
   'foo bar',
   'foo\tbar',
   '0123456789ABCdef',
   '!@#$%^&*()-_=+\\;\':"[]{}<>,./?|~`',
+  '\x01\x02\x03\x04\x05\x06\x07\x08',  // 0x01-0x08
+  'foo\x0bbar',                         // VT (0x0b)
+  'foo\x0cbar',                         // FF (0x0c)
+  '\x0e\x0f\x10\x11\x12\x13\x14\x15',  // 0x0e-0x15
+  '\x16\x17\x18\x19\x1a\x1b\x1c\x1d',  // 0x16-0x1d
+  '\x1e\x1f',                           // 0x1e-0x1f
+  '\x7FMe!',                            // DEL (0x7f)
+  '\x80\x81\xff',                       // obs-text (0x80-0xff)
 ].forEach(function(str) {
   assert.strictEqual(
-    _checkInvalidHeaderChar(str), false,
-    `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly failed`);
+    _checkInvalidHeaderChar(str, true), false,
+    `_checkInvalidHeaderChar(${inspect(str)}, true) unexpectedly failed in lenient mode`);
 });
 
-// Bad header field values
+// Bad header field values in lenient mode
+// Only NUL (0x00), LF (0x0a), CR (0x0d), and characters > 0xff are invalid
 [
-  'foo\rbar',
-  'foo\nbar',
-  'foo\r\nbar',
-  '中文呢', // unicode
-  '\x7FMe!',
-  'Testing 123\x00',
-  'foo\vbar',
-  'Ding!\x07',
+  'foo\rbar',         // CR (0x0d)
+  'foo\nbar',         // LF (0x0a)
+  'foo\r\nbar',       // CRLF
+  '中文呢',           // unicode > 0xff
+  'Testing 123\x00',  // NUL (0x00)
 ].forEach(function(str) {
   assert.strictEqual(
-    _checkInvalidHeaderChar(str), true,
-    `_checkInvalidHeaderChar(${inspect(str)}) unexpectedly succeeded`);
+    _checkInvalidHeaderChar(str, true), true,
+    `_checkInvalidHeaderChar(${inspect(str)}, true) unexpectedly succeeded in lenient mode`);
 });


### PR DESCRIPTION
This PR adds support for relaxed HTTP header value validation via the existing `insecureHTTPParser` option. This addresses the use case where Node.js needs to interoperate with servers/clients that use control characters in header values (per Fetch spec).

## Behavior

### Default (Strict) - per RFC 7230/9110
Header values are validated strictly, rejecting:
- Control characters `0x00-0x1f` (except HTAB `0x09`)
- DEL `0x7f`
- Characters > `0xff`

### With `insecureHTTPParser: true` (Lenient) - per Fetch spec
Header values are validated leniently, only rejecting:
- `0x00` (NUL)
- `0x0a` (LF)
- `0x0d` (CR)
- Characters > `0xff`

This allows control characters like `0x01-0x08`, `0x0b-0x0c`, `0x0e-0x1f`, and `0x7f` when the option is enabled.

## Usage

```javascript
// Client request with relaxed validation
const req = http.request({
  host: 'example.com',
  port: 80,
  insecureHTTPParser: true  // Enables lenient header validation
});
req.setHeader('X-Custom', 'value\x01with-control-char');  // Now allowed

// Server with relaxed validation
const server = http.createServer({ insecureHTTPParser: true }, (req, res) => {
  res.setHeader('X-Custom', 'value\x01with-control-char');  // Now allowed
  res.end();
});

// Or globally via CLI flag
// node --insecure-http-parser app.js
```

## What stays strict (regardless of option)

Per @pimterry's feedback:
- `http.validateHeaderValue()` - The public API remains strict
- Status message validation - Always strict per RFC

## Security Consideration

This change is safe because:
1. **Response splitting requires CRLF injection** - CR (`0x0d`) and LF (`0x0a`) are **always rejected**, even in lenient mode
2. **NUL is always rejected** - `0x00` is rejected in both modes
3. **Opt-in only** - Users must explicitly enable `insecureHTTPParser` to get lenient behavior

## Changes

- `lib/_http_common.js`: Added strict and lenient regex patterns, `checkInvalidHeaderChar` now accepts optional `lenient` parameter
- `lib/_http_outgoing.js`: Added `_isLenientHeaderValidation()` method, updated `setHeader`, `appendHeader`, `addTrailers` to use lenient validation when enabled
- `test/parallel/test-http-invalidheaderfield2.js`: Updated to test both strict and lenient modes

Refs: https://github.com/nodejs/node/issues/61582
Refs: https://fetch.spec.whatwg.org/#header-value