### PR TITLE
errors: fix incorrect argument label for array elements

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1404,7 +1404,8 @@ E('ERR_INVALID_ARG_TYPE',
       // For cases like 'first argument'
       msg += `${name} `;
     } else {
-      const type = StringPrototypeIncludes(name, '.') ? 'property' : 'argument';
+      const type = (StringPrototypeIncludes(name, '.') ||
+                    StringPrototypeIncludes(name, '[')) ? 'property' : 'argument';
       msg += `"${name}" ${type} `;
     }
     msg += 'must be ';
@@ -1468,7 +1469,8 @@ E('ERR_INVALID_ARG_VALUE', (name, value, reason = 'is invalid') => {
   if (inspected.length > 128) {
     inspected = `${StringPrototypeSlice(inspected, 0, 128)}...`;
   }
-  const type = StringPrototypeIncludes(name, '.') ? 'property' : 'argument';
+  const type = (StringPrototypeIncludes(name, '.') ||
+                StringPrototypeIncludes(name, '[')) ? 'property' : 'argument';
   return `The ${type} '${name}' ${reason}. Received ${inspected}`;
 }, TypeError, RangeError, HideStackFramesError);
 E('ERR_INVALID_ASYNC_ID', 'Invalid %s value: %s', RangeError);

--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -59,7 +59,7 @@ assert.strictEqual(flatLongLen.toString(), check);
     Buffer.concat(value);
   }, {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: 'The "list[0]" argument must be an instance of Buffer ' +
+    message: 'The "list[0]" property must be an instance of Buffer ' +
              `or Uint8Array.${common.invalidArgTypeHelper(value[0])}`
   });
 });
@@ -68,7 +68,7 @@ assert.throws(() => {
   Buffer.concat([Buffer.from('hello'), 3]);
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "list[1]" argument must be an instance of Buffer ' +
+  message: 'The "list[1]" property must be an instance of Buffer ' +
            'or Uint8Array. Received type number (3)'
 });
 

--- a/test/parallel/test-diff.js
+++ b/test/parallel/test-diff.js
@@ -31,7 +31,7 @@ describe('diff', () => {
     const expected = ['1', '2'];
 
     assert.throws(() => diff(actual, expected), {
-      message: 'The "actual[1]" argument must be of type string. Received an instance of Object'
+      message: 'The "actual[1]" property must be of type string. Received an instance of Object'
     });
   });
 

--- a/test/parallel/test-dns-setservers-type-check.js
+++ b/test/parallel/test-dns-setservers-type-check.js
@@ -60,7 +60,7 @@ const promiseResolver = new dns.promises.Resolver();
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "servers[0]" argument must be of type string.' +
+      message: 'The "servers[0]" property must be of type string.' +
                common.invalidArgTypeHelper(val[0])
     };
     assert.throws(
@@ -110,7 +110,7 @@ const promiseResolver = new dns.promises.Resolver();
     const errObj = {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "servers[0]" argument must be of type string.' +
+      message: 'The "servers[0]" property must be of type string.' +
               common.invalidArgTypeHelper(val[0])
     };
     assert.throws(() => {

--- a/test/parallel/test-process-setgroups.js
+++ b/test/parallel/test-process-setgroups.js
@@ -42,7 +42,7 @@ assert.throws(
     {
       code: 'ERR_INVALID_ARG_TYPE',
       name: 'TypeError',
-      message: 'The "groups[0]" argument must be ' +
+      message: 'The "groups[0]" property must be ' +
                'one of type number or string.' +
                common.invalidArgTypeHelper(val)
     }

--- a/test/parallel/test-tls-set-default-ca-certificates-error.js
+++ b/test/parallel/test-tls-set-default-ca-certificates-error.js
@@ -27,14 +27,14 @@ for (const invalid of [null, undefined, 42, {}, true]) {
   // Test input validation - should throw when passed an array with invalid elements
   assert.throws(() => tls.setDefaultCACertificates([invalid]), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "certs\[0\]" argument must be of type string or an instance of ArrayBufferView/
+    message: /The "certs\[0\]" property must be of type string or an instance of ArrayBufferView/
   });
   // Verify that default certificates remain unchanged after error.
   assertEqualCerts(tls.getCACertificates('default'), defaultCerts);
 
   assert.throws(() => tls.setDefaultCACertificates([fixtureCert, invalid]), {
     code: 'ERR_INVALID_ARG_TYPE',
-    message: /The "certs\[1\]" argument must be of type string or an instance of ArrayBufferView/
+    message: /The "certs\[1\]" property must be of type string or an instance of ArrayBufferView/
   });
   // Verify that default certificates remain unchanged after error.
   assertEqualCerts(tls.getCACertificates('default'), defaultCerts);


### PR DESCRIPTION
This PR fixes array elements being incorrectly classified as "argument" in `ERR_INVALID_ARG_TYPE` and                                                                                               
  `ERR_INVALID_ARG_VALUE` error messages.        

for example:
  
```js
Buffer.concat([1]);     
```                                                                                                         
                                                                                                                                                                                                                                                                                                                                                                                                                     
  **Before:**                                                                                                                                                  
  The "list[0]" argument must be an instance of Buffer or Uint8Array.                                                                                          
                                                                                                                                                               
  **After:**                                                                                                                                                   
  The "list[0]" property must be an instance of Buffer or Uint8Array.                                                                                          
                                                                                                                                                               
  Updated related test expectations in:                                                                                                                        
  - `test-buffer-concat.js`                                                                                                                                    
  - `test-diff.js`                                                                                                                                             
  - `test-dns-setservers-type-check.js`                                                                                                                        
  - `test-process-setgroups.js`                                                                                                                                
  - `test-tls-set-default-ca-certificates-error.js`     

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
