### PR TITLE
module: fix extensionless entry with explicit type=commonjs

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1929,6 +1929,15 @@ Module._extensions['.js'] = function(module, filename) {
     } else {
       format = 'typescript';
     }
+  } else if (path.extname(filename) === '') {
+    // Extensionless files skip the .js suffix check above. When type is explicit,
+    // follow it so ESM syntax surfaces as SyntaxError for commonjs instead of
+    // silently delegating to ESM.
+    pkg = packageJsonReader.getNearestParentPackageJSON(filename);
+    const typeFromPjson = pkg?.data?.type;
+    if (typeFromPjson === 'commonjs' || typeFromPjson === 'module') {
+      format = typeFromPjson;
+    }
   }
   const { source, format: loadedFormat } = loadSource(module, filename, format);
   // Function require shouldn't be used in ES modules when require(esm) is disabled.

--- a/test/es-module/test-extensionless-esm-type-commonjs.js
+++ b/test/es-module/test-extensionless-esm-type-commonjs.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
+const fixtures = require('../common/fixtures');
+
+spawnSyncAndAssert(process.execPath, [
+  fixtures.path('es-modules', 'extensionless-esm-commonjs', 'script'),
+], {
+  status: 1,
+  stderr: /SyntaxError: Cannot use import statement outside a module/,
+});
+
+spawnSyncAndAssert(process.execPath, [
+  fixtures.path('es-modules', 'extensionless-esm-module', 'script'),
+], {
+  stdout: /script STARTED[\s\S]*v\d+\./,
+  trim: true,
+});

--- a/test/fixtures/es-modules/extensionless-esm-commonjs/package.json
+++ b/test/fixtures/es-modules/extensionless-esm-commonjs/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/test/fixtures/es-modules/extensionless-esm-commonjs/script
+++ b/test/fixtures/es-modules/extensionless-esm-commonjs/script
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+console.log('script STARTED')
+import { version } from 'node:process'
+console.log(version)

--- a/test/fixtures/es-modules/extensionless-esm-module/package.json
+++ b/test/fixtures/es-modules/extensionless-esm-module/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "module"
+}

--- a/test/fixtures/es-modules/extensionless-esm-module/script
+++ b/test/fixtures/es-modules/extensionless-esm-module/script
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+console.log('script STARTED')
+import { version } from 'node:process'
+console.log(version)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

When an extensionless entry point contains ESM syntax but is in a package with "type": "commonjs" in package.json, the module would silently exit with code 0 without executing or showing any error. This happened because extensionless files skip the `.js` suffix check in the CJS loader, so the explicit `type: commonjs` was not being enforced, allowing ESM syntax to be silently delegated to ESM loading which never completed before the process exited.

This change ensures the CJS loader treats extensionless entry points as commonjs when `type` is explicitly set to "commonjs" in package.json, forcing ESM syntax to surface as a SyntaxError instead of silently exiting.

Fixes: #61104

Related: #61171 (alternative approach)