### PR TITLE
src: optimize utf-8 byte length calculation using simdutf

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -764,16 +764,10 @@ void SlowByteLengthUtf8(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   Local<String> source = args[0].As<String>();
 
+  static constexpr int kSmallStringThreshold = 128;
   int length = source->Length();
 
-  if (source->IsOneByte()) {
-    args.GetReturnValue().Set(
-        static_cast<uint64_t>(source->Utf8LengthV2(isolate)));
-    return;
-  }
-
-  static constexpr int kSmallStringThreshold = 128;
-  if (length <= kSmallStringThreshold) {
+  if (length <= kSmallStringThreshold || source->IsOneByte()) {
     args.GetReturnValue().Set(
         static_cast<uint64_t>(source->Utf8LengthV2(isolate)));
     return;
@@ -800,14 +794,10 @@ uint32_t FastByteLengthUtf8(
   CHECK(sourceValue->IsString());
   Local<String> sourceStr = sourceValue.As<String>();
 
+  static constexpr int kSmallStringThreshold = 128;
   int length = sourceStr->Length();
 
-  if (sourceStr->IsOneByte()) {
-    return sourceStr->Utf8LengthV2(isolate);
-  }
-
-  static constexpr int kSmallStringThreshold = 128;
-  if (length <= kSmallStringThreshold) {
+  if (length <= kSmallStringThreshold || sourceStr->IsOneByte()) {
     return sourceStr->Utf8LengthV2(isolate);
   }
 


### PR DESCRIPTION
I used stringView in simdutf for large strings, small strings continue as they are

The benchmark result for buffers is very long, so I created a gist for this benchmark result
all results:

```
➜  node git:(mert/stringView/buffer) ✗ node-benchmark-compare ./result.csv
                                                                                              confidence improvement accuracy (*)    (**)   (***)
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='base64' type='four_bytes'                    1.49 %       ±2.19%  ±2.95%  ±3.93%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='base64' type='latin1'                        0.71 %       ±2.58%  ±3.51%  ±4.72%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='base64' type='one_byte'                      0.12 %       ±2.68%  ±3.62%  ±4.83%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='base64' type='three_bytes'            *      2.57 %       ±2.24%  ±3.03%  ±4.03%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='base64' type='two_bytes'                    -0.03 %       ±2.96%  ±4.00%  ±5.35%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='utf8' type='four_bytes'                      1.25 %       ±1.81%  ±2.44%  ±3.24%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='utf8' type='latin1'                          0.29 %       ±1.89%  ±2.55%  ±3.39%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='utf8' type='one_byte'                        0.92 %       ±2.08%  ±2.80%  ±3.73%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='utf8' type='three_bytes'                     0.63 %       ±1.63%  ±2.19%  ±2.92%
buffers/buffer-bytelength-string.js n=4000000 repeat=1 encoding='utf8' type='two_bytes'                       2.27 %       ±2.71%  ±3.66%  ±4.88%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='base64' type='four_bytes'                  -0.01 %       ±2.29%  ±3.09%  ±4.12%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='base64' type='latin1'                       1.14 %       ±2.18%  ±2.94%  ±3.91%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='base64' type='one_byte'                     1.15 %       ±2.48%  ±3.35%  ±4.46%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='base64' type='three_bytes'                  1.55 %       ±2.14%  ±2.89%  ±3.84%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='base64' type='two_bytes'                    0.29 %       ±2.24%  ±3.03%  ±4.03%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='utf8' type='four_bytes'            ***    216.82 %      ±15.57% ±21.51% ±29.69%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='utf8' type='latin1'                        -0.06 %       ±1.68%  ±2.27%  ±3.02%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='utf8' type='one_byte'               **      2.48 %       ±1.54%  ±2.09%  ±2.78%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='utf8' type='three_bytes'           ***    207.83 %       ±4.55%  ±6.26%  ±8.59%
buffers/buffer-bytelength-string.js n=4000000 repeat=16 encoding='utf8' type='two_bytes'             ***    210.70 %       ±5.83%  ±8.06% ±11.15%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='base64' type='four_bytes'                   -0.84 %       ±2.18%  ±2.97%  ±3.98%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='base64' type='latin1'                        0.65 %       ±2.09%  ±2.83%  ±3.76%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='base64' type='one_byte'                      2.12 %       ±2.26%  ±3.08%  ±4.15%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='base64' type='three_bytes'                   0.85 %       ±2.35%  ±3.17%  ±4.21%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='base64' type='two_bytes'                     0.56 %       ±2.32%  ±3.14%  ±4.21%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='utf8' type='four_bytes'                     -0.01 %       ±1.83%  ±2.46%  ±3.28%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='utf8' type='latin1'                          0.21 %       ±1.93%  ±2.61%  ±3.48%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='utf8' type='one_byte'                        1.56 %       ±1.82%  ±2.46%  ±3.27%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='utf8' type='three_bytes'                     0.20 %       ±1.48%  ±2.00%  ±2.66%
buffers/buffer-bytelength-string.js n=4000000 repeat=2 encoding='utf8' type='two_bytes'                       1.10 %       ±1.85%  ±2.49%  ±3.32%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='base64' type='four_bytes'                 -1.46 %       ±2.05%  ±2.77%  ±3.68%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='base64' type='latin1'               *     -4.38 %       ±4.22%  ±5.73%  ±7.68%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='base64' type='one_byte'                    1.62 %       ±3.54%  ±4.85%  ±6.62%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='base64' type='three_bytes'                -0.72 %       ±1.49%  ±2.01%  ±2.67%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='base64' type='two_bytes'                   1.30 %       ±2.01%  ±2.71%  ±3.61%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='utf8' type='four_bytes'           ***    241.57 %      ±16.03% ±21.83% ±29.44%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='utf8' type='latin1'                       -0.11 %       ±1.49%  ±2.01%  ±2.67%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='utf8' type='one_byte'                      1.09 %       ±1.55%  ±2.09%  ±2.78%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='utf8' type='three_bytes'          ***    345.77 %      ±19.42% ±26.39% ±35.52%
buffers/buffer-bytelength-string.js n=4000000 repeat=256 encoding='utf8' type='two_bytes'            ***    320.12 %      ±13.94% ±18.83% ±25.06%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 40 comparisons, you can thus expect the following amount of false-positive results:
  2.00 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.40 false positives, when considering a   1% risk acceptance (**, ***),
  0.04 false positives, when considering a 0.1% risk acceptance (***)
➜  node git:(mert/stringView/buffer) ✗ 
```
