### PR TITLE
deps: update nbytes to 0.1.3 for HexEncode perf

### DIFF
--- a/deps/nbytes/src/nbytes.cpp
+++ b/deps/nbytes/src/nbytes.cpp
@@ -157,6 +157,11 @@ const int8_t unhex_table[256] = {
     -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
     -1, -1, -1, -1, -1, -1, -1, -1, -1};
 
+inline constexpr char nibble(uint8_t x) {
+  uint8_t add = (x >= 10) ? ('a' - 10) : '0';
+  return x + add;
+}
+
 size_t HexEncode(const char *src, size_t slen, char *dst, size_t dlen) {
   // We know how much we'll write, just make sure that there's space.
   NBYTES_ASSERT_TRUE(dlen >= MultiplyWithOverflowCheck<size_t>(slen, 2u) &&
@@ -164,10 +169,9 @@ size_t HexEncode(const char *src, size_t slen, char *dst, size_t dlen) {
 
   dlen = slen * 2;
   for (size_t i = 0, k = 0; k < dlen; i += 1, k += 2) {
-    static const char hex[] = "0123456789abcdef";
     uint8_t val = static_cast<uint8_t>(src[i]);
-    dst[k + 0] = hex[val >> 4];
-    dst[k + 1] = hex[val & 15];
+    dst[k + 0] = nibble(val >> 4);
+    dst[k + 1] = nibble(val & 15);
   }
 
   return dlen;


### PR DESCRIPTION
Refs: https://github.com/nodejs/nbytes/pull/12
Refs: https://github.com/nodejs/nbytes/pull/13

Fixes the hex part of #60249 and improves `Buffer#toString('hex')`  2-4x

In local tests on a MacBook, this improves `.toString('hex')` throughput from ~`2.24 GiB/s` to ~`9.53 GiB/s` on ~80 KiB chunks
For comparison, `Uint8Array#toHex()` shows `3.28 GiB/s`.

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1790/console

```
10:57:55                                                 confidence improvement accuracy (*)   (**)  (***)
10:57:55 buffers/buffer-hex-decode.js n=1000000 len=1024        ***    170.96 %       ±1.02% ±1.38% ±1.82%
10:57:55 buffers/buffer-hex-decode.js n=1000000 len=64          ***     53.49 %       ±1.65% ±2.20% ±2.88%
10:57:55 buffers/buffer-hex-encode.js n=1000000 len=1024                 0.13 %       ±0.19% ±0.25% ±0.32%
10:57:55 buffers/buffer-hex-encode.js n=1000000 len=64                  -0.14 %       ±0.85% ±1.13% ±1.47%
```