### PR TITLE
esm: add import trace for evaluation errors

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -195,6 +195,7 @@ class ModuleLoader {
 
   constructor(asyncLoaderHooks) {
     this.#setAsyncLoaderHooks(asyncLoaderHooks);
+    this.importParents = new Map();
   }
 
   /**

--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -10,6 +10,7 @@ const {
   Promise,
   PromisePrototypeThen,
   RegExpPrototypeSymbolReplace,
+  SafeMap,
   encodeURIComponent,
   hardenRegExp,
 } = primordials;
@@ -195,7 +196,7 @@ class ModuleLoader {
 
   constructor(asyncLoaderHooks) {
     this.#setAsyncLoaderHooks(asyncLoaderHooks);
-    this.importParents = new Map();
+    this.importParents = new SafeMap();
   }
 
   /**

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -24,6 +24,73 @@ let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
 });
 
 const {
+  overrideStackTrace,
+  ErrorPrepareStackTrace,
+  codes,
+} = require('internal/errors');
+
+const { ERR_REQUIRE_ASYNC_MODULE } = codes;
+
+/**
+ * Builds a linear import trace by walking parent modules
+ * from the module that threw during evaluation.
+ */
+function buildImportTrace(importParents, startURL) {
+  const trace = [];
+  let current = startURL;
+  const seen = new Set([current]);
+
+  while (true) {
+    const parent = importParents.get(current);
+    if (!parent || seen.has(parent)) break;
+
+    trace.push({ child: current, parent });
+    seen.add(current);
+    current = parent;
+  }
+
+  return trace.length ? trace : null;
+}
+
+/**
+ * Formats an import trace for inclusion in an error stack.
+ */
+function formatImportTrace(trace) {
+  return trace
+    .map(({ child, parent }) => `  ${child} imported by ${parent}`)
+    .join('\n');
+}
+
+/**
+ * Appends an ESM import trace to an error’s stack output.
+ * Uses a per-error stack override; no global side effects.
+ */
+function decorateErrorWithImportTrace(e, importParents) {
+   if (!importParents || typeof importParents.get !== 'function') return;
+  if (!e || typeof e !== 'object') return;
+
+  overrideStackTrace.set(e, (error, trace) => {
+    let thrownURL;
+    for (const cs of trace) {
+      const getFileName = cs.getFileName;
+      if (typeof getFileName === 'function') {
+        const file = getFileName.call(cs);
+        if (typeof file === 'string' && file.startsWith('file://')) {
+          thrownURL = file;
+          break;
+        }
+      }
+    }
+
+    const importTrace = thrownURL ? buildImportTrace(importParents, thrownURL) : null;
+    const stack = ErrorPrepareStackTrace(error, trace);
+    if (!importTrace) return stack;
+
+    return `${stack}\n\nImport trace:\n${formatImportTrace(importTrace)}`;
+  });
+}
+
+const {
   ModuleWrap,
   kErrored,
   kEvaluated,
@@ -53,9 +120,6 @@ const {
 } = require('internal/modules/helpers');
 const { getOptionValue } = require('internal/options');
 const noop = FunctionPrototype;
-const {
-  ERR_REQUIRE_ASYNC_MODULE,
-} = require('internal/errors').codes;
 let hasPausedEntry = false;
 
 const CJSGlobalLike = [
@@ -159,6 +223,7 @@ class ModuleJobBase {
         // that hooks can pre-fetch sources off-thread.
         const job = this.loader.getOrCreateModuleJob(this.url, request, requestType);
         debug(`ModuleJobBase.syncLink() ${this.url} -> ${request.specifier}`, job);
+        this.loader.importParents.set(job.url, this.url);
         assert(!isPromise(job));
         assert(job.module instanceof ModuleWrap);
         if (request.phase === kEvaluationPhase) {
@@ -430,6 +495,9 @@ class ModuleJob extends ModuleJobBase {
       await this.module.evaluate(timeout, breakOnSigint);
     } catch (e) {
       explainCommonJSGlobalLikeNotDefinedError(e, this.module.url, this.module.hasTopLevelAwait);
+
+      decorateErrorWithImportTrace(e, this.loader.importParents);
+
       throw e;
     }
     return { __proto__: null, module: this.module };

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -247,7 +247,6 @@ class ModuleJobBase {
 
         const line = request.line;
         const column = request.column;
-        // console.log(`Import at ${request.specifier} (line: ${line}, column: ${column})`);
         // Set the parent info with line/column
         let parentInfo = this.url;
         if (typeof line === 'number' && typeof column === 'number') {

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -24,25 +24,28 @@ let debug = require('internal/util/debuglog').debuglog('esm', (fn) => {
 });
 
 const {
-  overrideStackTrace,
   ErrorPrepareStackTrace,
-  codes,
+  codes: {
+    ERR_REQUIRE_ASYNC_MODULE,
+  },
+  overrideStackTrace,
 } = require('internal/errors');
-
-const { ERR_REQUIRE_ASYNC_MODULE } = codes;
 
 /**
  * Builds a linear import trace by walking parent modules
  * from the module that threw during evaluation.
+ * @returns {Array<{child: string, parent: string}>|null}
  */
 function buildImportTrace(importParents, startURL) {
   const trace = [];
   let current = startURL;
-  const seen = new Set([current]);
+  const seen = new SafeSet([current]);
 
   while (true) {
     const parent = importParents.get(current);
-    if (!parent || seen.has(parent)) break;
+    if (!parent || seen.has(parent)) {
+      break;
+    }
 
     trace.push({ child: current, parent });
     seen.add(current);
@@ -54,6 +57,7 @@ function buildImportTrace(importParents, startURL) {
 
 /**
  * Formats an import trace for inclusion in an error stack.
+ * @returns {string}
  */
 function formatImportTrace(trace) {
   return trace
@@ -62,12 +66,13 @@ function formatImportTrace(trace) {
 }
 
 /**
- * Appends an ESM import trace to an error’s stack output.
+ * Appends an ESM import trace to an error's stack output.
  * Uses a per-error stack override; no global side effects.
  */
 function decorateErrorWithImportTrace(e, importParents) {
-   if (!importParents || typeof importParents.get !== 'function') return;
-  if (!e || typeof e !== 'object') return;
+  if (!e || typeof e !== 'object') {
+    return;
+  }
 
   overrideStackTrace.set(e, (error, trace) => {
     let thrownURL;
@@ -84,7 +89,9 @@ function decorateErrorWithImportTrace(e, importParents) {
 
     const importTrace = thrownURL ? buildImportTrace(importParents, thrownURL) : null;
     const stack = ErrorPrepareStackTrace(error, trace);
-    if (!importTrace) return stack;
+    if (!importTrace) {
+      return stack;
+    }
 
     return `${stack}\n\nImport trace:\n${formatImportTrace(importTrace)}`;
   });

--- a/lib/internal/modules/esm/module_job.js
+++ b/lib/internal/modules/esm/module_job.js
@@ -42,14 +42,28 @@ function buildImportTrace(importParents, startURL) {
   const seen = new SafeSet([current]);
 
   while (true) {
-    const parent = importParents.get(current);
-    if (!parent || seen.has(parent)) {
+    const parentInfo = importParents.get(current);
+    let parentURL;
+    if (typeof parentInfo === 'object' && parentInfo !== null && typeof parentInfo.url === 'string') {
+      parentURL = parentInfo.url;
+    } else {
+      parentURL = parentInfo;
+    }
+    if (!parentInfo || seen.has(parentURL)) {
       break;
     }
-
-    trace.push({ child: current, parent });
-    seen.add(current);
-    current = parent;
+    let parentDisplay;
+    if (typeof parentInfo === 'object' && parentInfo !== null && typeof parentInfo.url === 'string') {
+      parentDisplay = parentInfo.url;
+      if (typeof parentInfo.line === 'number' && typeof parentInfo.column === 'number') {
+        parentDisplay += `:${parentInfo.line + 1}:${parentInfo.column + 1}`;
+      }
+    } else {
+      parentDisplay = parentInfo;
+    }
+    trace.push({ child: current, parent: parentDisplay });
+    seen.add(parentURL);
+    current = parentURL;
   }
 
   return trace.length ? trace : null;
@@ -61,7 +75,7 @@ function buildImportTrace(importParents, startURL) {
  */
 function formatImportTrace(trace) {
   return trace
-    .map(({ child, parent }) => `  ${child} imported by ${parent}`)
+    .map(({ child, parent }) => `    ${parent}`)
     .join('\n');
 }
 
@@ -93,7 +107,7 @@ function decorateErrorWithImportTrace(e, importParents) {
       return stack;
     }
 
-    return `${stack}\n\nImport trace:\n${formatImportTrace(importTrace)}`;
+    return `${stack}\n\nImported by:\n${formatImportTrace(importTrace)}`;
   });
 }
 
@@ -230,7 +244,16 @@ class ModuleJobBase {
         // that hooks can pre-fetch sources off-thread.
         const job = this.loader.getOrCreateModuleJob(this.url, request, requestType);
         debug(`ModuleJobBase.syncLink() ${this.url} -> ${request.specifier}`, job);
-        this.loader.importParents.set(job.url, this.url);
+
+        const line = request.line;
+        const column = request.column;
+        // console.log(`Import at ${request.specifier} (line: ${line}, column: ${column})`);
+        // Set the parent info with line/column
+        let parentInfo = this.url;
+        if (typeof line === 'number' && typeof column === 'number') {
+          parentInfo = { url: this.url, line, column };
+        }
+        this.loader.importParents.set(job.url, parentInfo);
         assert(!isPromise(job));
         assert(job.module instanceof ModuleWrap);
         if (request.phase === kEvaluationPhase) {

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -100,6 +100,7 @@
     "transferList")                                                            \
   V(clone_untransferable_str, "Found invalid value in transferList.")          \
   V(code_string, "code")                                                       \
+  V(column_string, "column")                                                   \
   V(config_string, "config")                                                   \
   V(constants_string, "constants")                                             \
   V(crypto_dh_string, "dh")                                                    \
@@ -239,6 +240,7 @@
   V(length_string, "length")                                                   \
   V(limits_string, "limits")                                                   \
   V(library_string, "library")                                                 \
+  V(line_string, "line")                                                       \
   V(loop_count, "loopCount")                                                   \
   V(max_buffer_string, "maxBuffer")                                            \
   V(max_concurrent_streams_string, "maxConcurrentStreams")                     \

--- a/src/module_wrap.cc
+++ b/src/module_wrap.cc
@@ -40,6 +40,7 @@ using v8::Isolate;
 using v8::Just;
 using v8::JustVoid;
 using v8::Local;
+using v8::Location;
 using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
@@ -565,7 +566,7 @@ static Local<Object> createImportAttributesContainer(
 }
 
 static Local<Array> createModuleRequestsContainer(
-    Realm* realm, Isolate* isolate, Local<FixedArray> raw_requests) {
+    Realm* realm, Isolate* isolate, Local<Module> module, Local<FixedArray> raw_requests) {
   EscapableHandleScope scope(isolate);
   Local<Context> context = realm->context();
   LocalVector<Value> requests(isolate, raw_requests->Length());
@@ -584,15 +585,22 @@ static Local<Array> createModuleRequestsContainer(
         createImportAttributesContainer(realm, isolate, raw_attributes, 3);
     ModuleImportPhase phase = module_request->GetPhase();
 
+    int source_offset = module_request->GetSourceOffset();
+    Location loc = module->SourceOffsetToLocation(source_offset);
+
     Local<Name> names[] = {
         realm->isolate_data()->specifier_string(),
         realm->isolate_data()->attributes_string(),
         realm->isolate_data()->phase_string(),
+        realm->isolate_data()->line_string(),
+        realm->isolate_data()->column_string(),
     };
     Local<Value> values[] = {
         specifier,
         attributes,
         Integer::New(isolate, to_phase_constant(phase)),
+        Integer::New(isolate, loc.GetLineNumber()),
+        Integer::New(isolate, loc.GetColumnNumber()),
     };
     DCHECK_EQ(arraysize(names), arraysize(values));
 
@@ -616,7 +624,7 @@ void ModuleWrap::GetModuleRequests(const FunctionCallbackInfo<Value>& args) {
 
   Local<Module> module = obj->module_.Get(isolate);
   args.GetReturnValue().Set(createModuleRequestsContainer(
-      realm, isolate, module->GetModuleRequests()));
+      realm, isolate, module, module->GetModuleRequests()));
 }
 
 // moduleWrap.link(moduleWraps)

--- a/test/es-module/test-esm-import-trace.mjs
+++ b/test/es-module/test-esm-import-trace.mjs
@@ -1,0 +1,26 @@
+import { spawnSync } from 'node:child_process';
+import assert from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { test } from 'node:test';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const fixture = path.join(
+  __dirname,
+  '../fixtures/es-modules/import-trace/entry.mjs'
+);
+
+test('includes import trace for evaluation-time errors', () => {
+  const result = spawnSync(
+    process.execPath,
+    [fixture],
+    { encoding: 'utf8' }
+  );
+
+  assert.notStrictEqual(result.status, 0);
+  assert.match(result.stderr, /Import trace:/);
+  assert.match(result.stderr, /bar\.mjs imported by .*foo\.mjs/);
+  assert.match(result.stderr, /foo\.mjs imported by .*entry\.mjs/);
+});

--- a/test/es-module/test-esm-import-trace.mjs
+++ b/test/es-module/test-esm-import-trace.mjs
@@ -1,14 +1,10 @@
 import { spawnSync } from 'node:child_process';
 import assert from 'node:assert';
-import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import { test } from 'node:test';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-
 const fixture = path.join(
-  __dirname,
+  import.meta.dirname,
   '../fixtures/es-modules/import-trace/entry.mjs'
 );
 
@@ -23,4 +19,33 @@ test('includes import trace for evaluation-time errors', () => {
   assert.match(result.stderr, /Import trace:/);
   assert.match(result.stderr, /bar\.mjs imported by .*foo\.mjs/);
   assert.match(result.stderr, /foo\.mjs imported by .*entry\.mjs/);
+});
+
+const multiFixture = path.join(
+  import.meta.dirname,
+  '../fixtures/es-modules/import-trace-multi/entry.mjs'
+);
+
+test('import trace matches actual code path for multiple parents', () => {
+  const result = spawnSync(
+    process.execPath,
+    [multiFixture],
+    { encoding: 'utf8' }
+  );
+
+  assert.notStrictEqual(result.status, 0);
+  // Should show the actual import chain that led to the error
+  const traceFoo = /bar\.mjs imported by .*foo\.mjs/;
+  const traceAlt = /bar\.mjs imported by .*alt\.mjs/;
+  const entryFoo = /foo\.mjs imported by .*entry\.mjs/;
+  const entryAlt = /alt\.mjs imported by .*entry\.mjs/;
+
+  assert(
+    traceFoo.test(result.stderr) || traceAlt.test(result.stderr),
+    'Import trace should show either foo.mjs or alt.mjs as parent'
+  );
+  assert(
+    entryFoo.test(result.stderr) || entryAlt.test(result.stderr),
+    'Import trace should show either foo.mjs or alt.mjs imported by entry.mjs'
+  );
 });

--- a/test/es-module/test-esm-import-trace.mjs
+++ b/test/es-module/test-esm-import-trace.mjs
@@ -16,9 +16,9 @@ test('includes import trace for evaluation-time errors', () => {
   );
 
   assert.notStrictEqual(result.status, 0);
-  assert.match(result.stderr, /Import trace:/);
-  assert.match(result.stderr, /bar\.mjs imported by .*foo\.mjs/);
-  assert.match(result.stderr, /foo\.mjs imported by .*entry\.mjs/);
+  assert.match(result.stderr, /Imported by:/);
+  assert.match(result.stderr, /.*foo\.mjs:1:8/);
+  assert.match(result.stderr, /.*entry\.mjs:1:8/);
 });
 
 const multiFixture = path.join(
@@ -34,18 +34,21 @@ test('import trace matches actual code path for multiple parents', () => {
   );
 
   assert.notStrictEqual(result.status, 0);
-  // Should show the actual import chain that led to the error
-  const traceFoo = /bar\.mjs imported by .*foo\.mjs/;
-  const traceAlt = /bar\.mjs imported by .*alt\.mjs/;
-  const entryFoo = /foo\.mjs imported by .*entry\.mjs/;
-  const entryAlt = /alt\.mjs imported by .*entry\.mjs/;
+  const traceFoo = /.*foo\.mjs:1:8/;
+  const traceAlt = /.*alt\.mjs:1:8/;
+  const entryFoo = /.*entry\.mjs:1:8/;
+  const entryAlt = /.*entry\.mjs:2:8/;
 
-  assert(
-    traceFoo.test(result.stderr) || traceAlt.test(result.stderr),
-    'Import trace should show either foo.mjs or alt.mjs as parent'
-  );
-  assert(
-    entryFoo.test(result.stderr) || entryAlt.test(result.stderr),
-    'Import trace should show either foo.mjs or alt.mjs imported by entry.mjs'
-  );
+  let parentMatched;
+  if (traceFoo.test(result.stderr)) {
+    parentMatched = 'foo';
+    assert(entryFoo.test(result.stderr),
+      'Import trace should show foo.mjs imported by entry.mjs with line/column');
+  } else if (traceAlt.test(result.stderr)) {
+    parentMatched = 'alt';
+    assert(entryAlt.test(result.stderr),
+      'Import trace should show alt.mjs imported by entry.mjs with line/column');
+  } else {
+    assert.fail('Import trace should show either foo.mjs or alt.mjs as parent with line/column');
+  }
 });

--- a/test/fixtures/es-modules/import-trace-multi/alt.mjs
+++ b/test/fixtures/es-modules/import-trace-multi/alt.mjs
@@ -1,0 +1,1 @@
+import './bar.mjs';

--- a/test/fixtures/es-modules/import-trace-multi/bar.mjs
+++ b/test/fixtures/es-modules/import-trace-multi/bar.mjs
@@ -1,0 +1,1 @@
+throw new Error('fail');

--- a/test/fixtures/es-modules/import-trace-multi/entry.mjs
+++ b/test/fixtures/es-modules/import-trace-multi/entry.mjs
@@ -1,0 +1,2 @@
+import './foo.mjs';
+import './alt.mjs';

--- a/test/fixtures/es-modules/import-trace-multi/foo.mjs
+++ b/test/fixtures/es-modules/import-trace-multi/foo.mjs
@@ -1,0 +1,1 @@
+import './bar.mjs';

--- a/test/fixtures/es-modules/import-trace/bar.mjs
+++ b/test/fixtures/es-modules/import-trace/bar.mjs
@@ -1,0 +1,1 @@
+throw new Error('bar failed');

--- a/test/fixtures/es-modules/import-trace/entry.mjs
+++ b/test/fixtures/es-modules/import-trace/entry.mjs
@@ -1,0 +1,1 @@
+import './foo.mjs';

--- a/test/fixtures/es-modules/import-trace/foo.mjs
+++ b/test/fixtures/es-modules/import-trace/foo.mjs
@@ -1,0 +1,1 @@
+import './bar.mjs';


### PR DESCRIPTION
This PR adds an import trace to error output for errors thrown during ESM module evaluation. The trace shows the chain of modules that led to the failing module, making it easier to understand why a module was loaded.

When an error is thrown during ESM evaluation, the resulting stack trace often lacks information about the importer chain. This makes debugging difficult, especially in cases where a module is imported indirectly.

This change addresses that gap by appending a clearly separated “Import trace” section to the formatted error stack.

- Applies only to errors thrown during ESM module evaluation
- Preserves existing stack formatting and source map handling
- Does not modify V8 stack frames or global error behavior

Adds a new ESM test covering evaluation-time import failures

Fixes: #46992

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
