### PR TITLE
tools: add ncrypto updater script

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -64,7 +64,6 @@
 /lib/tls.js @nodejs/crypto @nodejs/net
 /src/crypto/* @nodejs/crypto
 /src/node_crypto* @nodejs/crypto
-/deps/ncrypto/* @nodejs/crypto
 
 # http
 

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -30,6 +30,7 @@ on:
           - llhttp
           - minimatch
           - nbytes
+          - ncrypto
           - nixpkgs-unstable
           - nghttp2
           - nghttp3
@@ -188,6 +189,14 @@ jobs:
             label: dependencies
             run: |
               ./tools/dep_updaters/update-nbytes.sh > temp-output
+              cat temp-output
+              tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
+              rm temp-output
+          - id: ncrypto
+            subsystem: deps
+            label: dependencies
+            run: |
+              ./tools/dep_updaters/update-ncrypto.sh > temp-output
               cat temp-output
               tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
               rm temp-output

--- a/Makefile
+++ b/Makefile
@@ -1491,10 +1491,7 @@ LINT_CPP_EXCLUDE += $(LINT_CPP_ADDON_DOC_FILES)
 # These files were copied more or less verbatim from V8.
 LINT_CPP_EXCLUDE += src/tracing/trace_event.h src/tracing/trace_event_common.h
 
-# deps/ncrypto is included in this list, as it is maintained in
-# this repository, and should be linted. Eventually it should move
-# to its own repo, at which point we should remove it from this list.
-LINT_CPP_DEPS = deps/ncrypto/*.cc deps/ncrypto/*.h
+LINT_CPP_DEPS =
 
 LINT_CPP_FILES = $(filter-out $(LINT_CPP_EXCLUDE), $(wildcard \
 	benchmark/napi/*/*.cc \

--- a/tools/dep_updaters/update-ncrypto.sh
+++ b/tools/dep_updaters/update-ncrypto.sh
@@ -41,7 +41,6 @@ cleanup () {
 trap cleanup INT TERM EXIT
 
 echo "Fetching ncrypto source archive..."
-NCRYPTO_TARBALL="ncrypto-v$NEW_VERSION.tar.gz"
 curl -sL "https://api.github.com/repos/nodejs/ncrypto/tarball/v$NEW_VERSION" \
 | tar xz --strip-components=1 -C "$WORKSPACE" --wildcards \
     '*/README.md' \
@@ -54,8 +53,6 @@ mv "$WORKSPACE/README.md" "$DEPS_DIR/ncrypto/."
 mv "$WORKSPACE/src/engine.cpp" "$DEPS_DIR/ncrypto/engine.cc"
 mv "$WORKSPACE/src/ncrypto.cpp" "$DEPS_DIR/ncrypto/ncrypto.cc"
 mv "$WORKSPACE/include/"* "$DEPS_DIR/ncrypto/."
-
-cleanup
 
 # Update the version number on maintaining-dependencies.md
 # and print the new version as the last line of the script as we need

--- a/tools/dep_updaters/update-ncrypto.sh
+++ b/tools/dep_updaters/update-ncrypto.sh
@@ -1,0 +1,63 @@
+#!/bin/sh
+set -ex
+# Shell script to update ncrypto in the source tree to a specific version
+
+BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+DEPS_DIR="$BASE_DIR/deps"
+[ -z "$NODE" ] && NODE="$BASE_DIR/out/Release/node"
+[ -x "$NODE" ] || NODE=$(command -v node)
+
+# shellcheck disable=SC1091
+. "$BASE_DIR/tools/dep_updaters/utils.sh"
+
+NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
+const res = await fetch('https://api.github.com/repos/nodejs/ncrypto/releases/latest',
+  process.env.GITHUB_TOKEN && {
+    headers: {
+      "Authorization": `Bearer ${process.env.GITHUB_TOKEN}`
+    },
+  });
+if (!res.ok) throw new Error(`FetchError: ${res.status} ${res.statusText}`, { cause: res });
+const { tag_name } = await res.json();
+console.log(tag_name.replace('v', ''));
+EOF
+)"
+
+CURRENT_VERSION=$(awk -F'"' '/^#define NCRYPTO_VERSION /{ print $2 }' "$DEPS_DIR/ncrypto/ncrypto/version.h" || true)
+
+# This function exit with 0 if new version and current version are the same
+compare_dependency_version "ncrypto" "$NEW_VERSION" "$CURRENT_VERSION"
+
+echo "Making temporary workspace..."
+
+WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
+
+cleanup () {
+  EXIT_CODE=$?
+  [ -d "$WORKSPACE" ] && rm -rf "$WORKSPACE"
+  exit $EXIT_CODE
+}
+
+trap cleanup INT TERM EXIT
+
+echo "Fetching ncrypto source archive..."
+NCRYPTO_TARBALL="ncrypto-v$NEW_VERSION.tar.gz"
+curl -sL "https://api.github.com/repos/nodejs/ncrypto/tarball/v$NEW_VERSION" \
+| tar xz --strip-components=1 -C "$WORKSPACE" --wildcards \
+    '*/README.md' \
+    '*/src/engine.cpp' \
+    '*/src/ncrypto.cpp' \
+    '*/include/ncrypto.h' \
+    '*/include/ncrypto/version.h'
+
+mv "$WORKSPACE/README.md" "$DEPS_DIR/ncrypto/."
+mv "$WORKSPACE/src/engine.cpp" "$DEPS_DIR/ncrypto/engine.cc"
+mv "$WORKSPACE/src/ncrypto.cpp" "$DEPS_DIR/ncrypto/ncrypto.cc"
+mv "$WORKSPACE/include/"* "$DEPS_DIR/ncrypto/."
+
+cleanup
+
+# Update the version number on maintaining-dependencies.md
+# and print the new version as the last line of the script as we need
+# to add it to $GITHUB_ENV variable
+finalize_version_update "ncrypto" "$NEW_VERSION"


### PR DESCRIPTION
With https://github.com/nodejs/ncrypto/pull/17 in a release, I think there's no reason to keep maintaining a separate copy of ncrypto in this repo.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
