### PR TITLE
repl: fix flaky test-repl-programmatic-history

### DIFF
--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -58,6 +58,7 @@ const kResolveHistoryPath = Symbol('_kResolveHistoryPath');
 const kReplHistoryMessage = Symbol('_kReplHistoryMessage');
 const kFlushHistory = Symbol('_kFlushHistory');
 const kGetHistoryPath = Symbol('_kGetHistoryPath');
+const kCloseHandle = Symbol('_kCloseHandle');
 
 class ReplHistory {
   constructor(context, options) {
@@ -393,13 +394,27 @@ class ReplHistory {
     }
     this[kContext].off('line', this[kOnLine].bind(this));
 
+    await this[kCloseHandle]();
+  }
+
+  async [kCloseHandle]() {
     if (this[kHistoryHandle] !== null) {
+      const handle = this[kHistoryHandle];
+      this[kHistoryHandle] = null;
       try {
-        await this[kHistoryHandle].close();
+        await handle.close();
       } catch (err) {
         debug('Error closing history file:', err);
       }
     }
+  }
+
+  /**
+   * Closes the history file handle.
+   * @returns {Promise<void>}
+   */
+  closeHandle() {
+    return this[kCloseHandle]();
   }
 
   [kReplHistoryMessage]() {

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1039,10 +1039,16 @@ class REPLServer extends Interface {
     this[kBufferedCommandSymbol] = '';
   }
   close() {
-    if (this.terminal && this.historyManager.isFlushing && !this._closingOnFlush) {
+    if (this.terminal && this.historyManager?.isFlushing && !this._closingOnFlush) {
       this._closingOnFlush = true;
-      this.once('flushHistory', () => super.close());
+      this.once('flushHistory', () => this.close());
 
+      return;
+    }
+    // Ensure the history file handle is closed before completing
+    if (this.terminal && this.historyManager?.closeHandle && !this._historyHandleClosed) {
+      this._historyHandleClosed = true;
+      this.historyManager.closeHandle().then(() => super.close());
       return;
     }
     process.nextTick(() => super.close());


### PR DESCRIPTION
## Summary

Fixes flaky test `test/parallel/test-repl-programmatic-history.js`.

## Problem

The test was flaky because the FileHandle for the history file could be garbage collected before being explicitly closed, causing `ERR_INVALID_STATE` errors when the handle was already closed by the GC finalizer.

## Solution

- Added an explicit `closeHandle()` method to `ReplHistory` class
- Modified `REPLServer.close()` to wait for the history file handle to be properly closed before completing the close operation
- This ensures deterministic cleanup regardless of GC timing

## Verification

Verified with `python3 tools/test.py --repeat 1000 test/parallel/test-repl-programmatic-history.js` - all 1000 runs passed with 0 failures.

Refs: https://github.com/nodejs/reliability/issues/1450