### PR TITLE
tools: lint new WPTRunner() paths for no duplicates

### DIFF
--- a/test/eslint.config_partial.mjs
+++ b/test/eslint.config_partial.mjs
@@ -212,6 +212,14 @@ export default [
   },
   {
     files: [
+      'test/wpt/test-*.js',
+    ],
+    rules: {
+      'node-core/no-duplicate-wpt-runner-paths': 'error',
+    },
+  },
+  {
+    files: [
       'test/es-module/test-esm-example-loader.js',
       'test/es-module/test-esm-type-flag.js',
       'test/es-module/test-esm-type-flag-alias.js',

--- a/tools/eslint-rules/no-duplicate-wpt-runner-paths.js
+++ b/tools/eslint-rules/no-duplicate-wpt-runner-paths.js
@@ -1,0 +1,100 @@
+/**
+ * @file Ensure WPTRunner paths do not overlap across test files.
+ *   Prevents running the same WPT tests multiple times by detecting
+ *   when one WPTRunner path is a parent or subset of another.
+ */
+'use strict';
+
+const { isString } = require('./rules-utils.js');
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+// Module-level state to track paths across all files in a lint run.
+// Map<path, { filename, loc }>
+const registeredPaths = new Map();
+
+/**
+ * Check if pathA contains pathB (i.e., pathB is a subdirectory of pathA)
+ * @param {string} pathA - The potential parent path
+ * @param {string} pathB - The potential child path
+ * @returns {boolean}
+ */
+function isSubdirectory(pathA, pathB) {
+  // Normalize: remove trailing slashes
+  const normalizedA = pathA.replace(/\/+$/, '');
+  const normalizedB = pathB.replace(/\/+$/, '');
+
+  if (normalizedA === normalizedB) {
+    return true;
+  }
+
+  // pathB is a subdirectory of pathA if pathB starts with pathA/
+  return normalizedB.startsWith(normalizedA + '/');
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description: 'Disallow overlapping WPTRunner paths across test files',
+    },
+    schema: [],
+    messages: {
+      overlappingPath:
+        "WPTRunner path '{{ currentPath }}' overlaps with '{{ existingPath }}' in {{ existingFile }}. " +
+        'One path is a subset of the other, which would run the same tests multiple times.',
+    },
+  },
+
+  create(context) {
+    return {
+      NewExpression(node) {
+        // Check if this is a `new WPTRunner(...)` call
+        if (node.callee.type !== 'Identifier' || node.callee.name !== 'WPTRunner') {
+          return;
+        }
+
+        // Get the first argument (the path)
+        const [firstArg] = node.arguments;
+        if (!isString(firstArg)) {
+          return;
+        }
+
+        const currentPath = firstArg.value;
+        const currentFilename = context.filename;
+
+        // Check against all registered paths for overlaps
+        for (const [existingPath, existingInfo] of registeredPaths) {
+          // Skip if same file (could be legitimate multiple runners in same file)
+          if (existingInfo.filename === currentFilename) {
+            continue;
+          }
+
+          // Check if either path is a subdirectory of the other
+          const currentIsSubOfExisting = isSubdirectory(existingPath, currentPath);
+          const existingIsSubOfCurrent = isSubdirectory(currentPath, existingPath);
+
+          if (currentIsSubOfExisting || existingIsSubOfCurrent) {
+            context.report({
+              node: firstArg,
+              messageId: 'overlappingPath',
+              data: {
+                currentPath,
+                existingPath,
+                existingFile: existingInfo.filename,
+              },
+            });
+          }
+        }
+
+        // Register this path
+        registeredPaths.set(currentPath, {
+          filename: currentFilename,
+          loc: firstArg.loc,
+        });
+      },
+    };
+  },
+};


### PR DESCRIPTION
A lint rule to prevent future issues of duplicate wpt tests

Refs: https://github.com/nodejs/node/pull/61617
Refs: https://github.com/nodejs/node/pull/61316#issuecomment-3831252538


Local result:

```
➜  node git:(main) ✗ make lint-js    
Running JS linter...

/node/test/wpt/test-webidl.js
  6:30  error  WPTRunner path 'webidl' overlaps with 'webidl/ecmascript-binding/es-exceptions' in /node/test/wpt/test-domexception.js. One path is a subset of the other, which would run the same tests multiple times  node-core/no-duplicate-wpt-runner-paths

✖ 1 problem (1 error, 0 warnings)
```