### PR TITLE
doc: correct tools README Boxstarter link

### DIFF
--- a/tools/bootstrap/README.md
+++ b/tools/bootstrap/README.md
@@ -1,2 +1,2 @@
-Refer to [BUILDING.md](../../BUILDING.md#option-2-automated-install-with-boxstarter) for
+Refer to [BUILDING.md](../../BUILDING.md#option-3-automated-install-with-boxstarter) for
 instructions on how to build Node.js with boxstarter.


### PR DESCRIPTION
## Current documentation

The [tools/bootstrap/README.md](https://github.com/nodejs/node/blob/main/tools/bootstrap/README.md) links back to the bookmark https://github.com/nodejs/node/blob/main/BUILDING.md#option-2-automated-install-with-boxstarter.

This section was however moved by the addition of WinGet through PR https://github.com/nodejs/node/pull/55356 and option 2 became option 3.

## Change

Update the [tools/bootstrap/README.md](https://github.com/nodejs/node/blob/main/tools/bootstrap/README.md) to link to https://github.com/nodejs/node/blob/main/BUILDING.md#option-3-automated-install-with-boxstarter.

## Branch applicability

The link is incorrect in branches v25.x & v24.x & v22.x

Since the WinGet installation method was not added to the [v20.x/BUILDING.md](https://github.com/nodejs/node/blob/v20.x/BUILDING.md), this PR should not be backported to the v20.x branch. The [v20.x/tools/bootstrap/README.md](https://github.com/nodejs/node/blob/v20.x/tools/bootstrap/README.md) contains a correct link.