### PR TITLE
meta: fix GHA sccache reporting

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -105,6 +105,7 @@ jobs:
       CC: sccache clang-19
       CXX: sccache clang++-19
       SCCACHE_GHA_ENABLED: 'true'
+      SCCACHE_IDLE_TIMEOUT: '0'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -40,6 +40,7 @@ env:
   CC: sccache clang-19
   CXX: sccache clang++-19
   SCCACHE_GHA_ENABLED: 'true'
+  SCCACHE_IDLE_TIMEOUT: '0'
 
 permissions:
   contents: read

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -40,6 +40,7 @@ env:
   CC: sccache clang-19
   CXX: sccache clang++-19
   SCCACHE_GHA_ENABLED: 'true'
+  SCCACHE_IDLE_TIMEOUT: '0'
 
 permissions:
   contents: read

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -37,6 +37,7 @@ env:
   CC: sccache clang-19
   CXX: sccache clang++-19
   SCCACHE_GHA_ENABLED: 'true'
+  SCCACHE_IDLE_TIMEOUT: '0'
 
 permissions:
   contents: read

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -37,6 +37,7 @@ env:
   CC: sccache clang-19
   CXX: sccache clang++-19
   SCCACHE_GHA_ENABLED: 'true'
+  SCCACHE_IDLE_TIMEOUT: '0'
   RUSTC_VERSION: '1.82'
 
 permissions:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -82,6 +82,7 @@ jobs:
       CC: sccache gcc
       CXX: sccache g++
       SCCACHE_GHA_ENABLED: 'true'
+      SCCACHE_IDLE_TIMEOUT: '0'
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:


### PR DESCRIPTION
#### meta: persist sccache daemon until end of build workflows

sccache stores its stats in process memory, and the daemon shuts down after 10 minutes of inactivity by default, which is longer than the test phase of our GHA builds. As a result, our sccache stats reported by GHA at the end of the workflows are [all zeroes](https://github.com/nodejs/node/actions/runs/21591806388).

Setting `SCCACHE_IDLE_TIMEOUT=0` will cause the sccache daemon to persist for the lifetime of the runner.

<!--
#### meta: use SCCACHE_GHA_ENABLED for shared builds

The test-shared workflow currently sets `SCCACHE_GHA_VERSION=on`; while this (non-canonically) enables the GHA cache, it also prevents any cache entries from being shared with the non-shared workflows, which do not set version strings on their cache entries. Using the canonical `SCCACHE_GHA_ENABLED` means that shared and non-shared builds can share cache hits where available.
-->