### PR TITLE
meta: do not set a version string for cache entries of shared build workflows

### DIFF
--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -176,7 +176,7 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8.0.0
         with:
           script: |
-            core.exportVariable('SCCACHE_GHA_ENABLED', 'true');
+            core.exportVariable('SCCACHE_GHA_ENABLED', 'on');
             core.exportVariable('ACTIONS_CACHE_SERVICE_V2', 'on');
             core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
             core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');


### PR DESCRIPTION
#### meta: use SCCACHE_GHA_ENABLED for shared build workflows

The test-shared workflow currently sets `SCCACHE_GHA_VERSION=on`; while this (non-canonically) enables the GHA cache, it also appends "-on" to the version tag of every uploaded cache entry, which prevents any cache entries from being shared with the non-shared workflows. Using the canonical `SCCACHE_GHA_ENABLED` doesn't overwrite the version string, which means that shared and non-shared builds can share cache hits where available.