### PR TITLE
fix: exclude branches on ignored lines from coverage reports

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -193,18 +193,21 @@ class TestCoverage {
           ObjectAssign(range, mapRangeToLines(range, lines));
 
           if (isBlockCoverage) {
-            ArrayPrototypePush(branchReports, {
-              __proto__: null,
-              line: range.lines[0]?.line,
-              count: range.count,
-            });
+            // Only include branches that are not entirely on ignored lines
+            if (range.ignoredLines !== range.lines.length) {
+              ArrayPrototypePush(branchReports, {
+                __proto__: null,
+                line: range.lines[0]?.line,
+                count: range.count,
+              });
 
-            if (range.count !== 0 ||
-                range.ignoredLines === range.lines.length) {
-              branchesCovered++;
+              if (range.count !== 0 ||
+                  range.ignoredLines === range.lines.length) {
+                branchesCovered++;
+              }
+
+              totalBranches++;
             }
-
-            totalBranches++;
           }
         }
 


### PR DESCRIPTION
## Issue
When using `/* node:coverage ignore next */` comments, the DA (line coverage) entries are correctly excluded from the LCOV output, but BRDA (branch coverage) entries for branches leading to ignored lines remain as uncovered. This causes false branch coverage failures.

## Problem
- DA entries are excluded
- BRDA entries are NOT excluded
- Results in incorrect branch coverage percentages (e.g., 66.67% instead of 100%)
- Breaks CI/CD pipelines with branch coverage thresholds

## Solution
Modified `lib/internal/test_runner/coverage.js` to exclude branches that are entirely on ignored lines from the branch coverage totals, matching the behavior of line coverage exclusion.

## Changes
- Only include branches in `branchReports` if they are not entirely on ignored lines
- Ensures consistency with c8 and other coverage tools
- Fixes #61586

## Testing
The fix can be verified with the minimal reproduction case from the issue:
https://github.com/tobigumo/node-coverage-brda-bug