### PR TITLE
build,win: add WinGet Visual Studio 2022 Build Tools Edition config

### DIFF
--- a/.configurations/configuration.vsBuildTools.dsc.yaml
+++ b/.configurations/configuration.vsBuildTools.dsc.yaml
@@ -1,0 +1,54 @@
+# yaml-language-server: $schema=https://aka.ms/configuration-dsc-schema/0.2
+# Reference: https://github.com/nodejs/node/blob/main/BUILDING.md#windows
+properties:
+  resources:
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: pythonPackage
+      directives:
+        description: Install Python 3.14
+        module: Microsoft.WinGet.DSC
+        allowPrerelease: true
+      settings:
+        id: Python.Python.3.14
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: vsPackage
+      directives:
+        description: Install Visual Studio 2022 Build Tools
+        allowPrerelease: true
+      settings:
+        id: Microsoft.VisualStudio.2022.BuildTools
+        source: winget
+        useLatest: true
+    - resource: Microsoft.VisualStudio.DSC/VSComponents
+      id: vsComponents
+      dependsOn:
+        - vsPackage
+      directives:
+        description: Install required VS workloads and components
+        allowPrerelease: true
+      settings:
+        productId: Microsoft.VisualStudio.Product.BuildTools
+        channelId: VisualStudio.17.Release
+        includeRecommended: true
+        components:
+          - Microsoft.VisualStudio.Workload.VCTools
+          - Microsoft.VisualStudio.Component.VC.Llvm.Clang
+          - Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: gitPackage
+      directives:
+        description: Install Git
+        allowPrerelease: true
+      settings:
+        id: Git.Git
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: nasmPackage
+      directives:
+        description: Install NetWide Assembler (NASM)
+        allowPrerelease: true
+      settings:
+        id: Nasm.Nasm
+        source: winget
+  configurationVersion: 0.1.1

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -774,22 +774,36 @@ first and then reinstalling them again.
 
 ##### Option 2: Automated install with WinGet
 
-[WinGet configuration files](https://github.com/nodejs/node/tree/main/.configurations)
+[WinGet configuration files](./.configurations)
 can be used to install all the required prerequisites for Node.js development
 easily. These files will install the following
 [WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/) packages:
 
 * Git for Windows with the `git` and Unix tools added to the `PATH`
 * `Python 3.14`
-* `Visual Studio 2022` (Community, Enterprise or Professional)
-* `Visual Studio 2022 Build Tools` with Visual C++ workload, Clang and ClangToolset
+* `Visual Studio 2022` (Build Tools, Community, Professional or Enterprise Edition) and
+  "Desktop development with C++" workload, Clang and ClangToolset optional components
 * `NetWide Assembler`
 
-To install Node.js prerequisites from PowerShell Terminal:
+The following Desired State Configuration (DSC) files are available:
+
+| Edition      | DSC Configuration                                                                                |
+| ------------ | ------------------------------------------------------------------------------------------------ |
+| Build Tools  | [configuration.vsBuildTools.dsc.yaml](./.configurations/configuration.vsBuildTools.dsc.yaml)     |
+| Community    | [configuration.dsc.yaml](./.configurations/configuration.dsc.yaml)                               |
+| Professional | [configuration.vsProfessional.dsc.yaml](./.configurations/configuration.vsProfessional.dsc.yaml) |
+| Enterprise   | [configuration.vsEnterprise.dsc.yaml](./.configurations/configuration.vsEnterprise.dsc.yaml)     |
+
+Use one of the above DSC files with
+[winget configure](https://learn.microsoft.com/en-us/windows/package-manager/winget/configure#configure-subcommands)
+in a PowerShell Terminal to install Node.js prerequisites.
+For example, using the DSC file for Visual Studio Community Edition, execute the following command line:
 
 ```powershell
 winget configure .\.configurations\configuration.dsc.yaml
 ```
+
+To add optional components for MSI or ARM64 builds, refer to [Option 1: Manual install](#option-1-manual-install).
 
 ##### Option 3: Automated install with Boxstarter
 


### PR DESCRIPTION
## Current situation

[BUILDING > Windows > Option 2: Automated install with WinGet](https://github.com/nodejs/node/blob/main/BUILDING.md#option-2-automated-install-with-winget) contains instructions to install Node.js build prerequisites using predefined [.configurations](https://github.com/nodejs/node/tree/main/.configurations) for Visual Studio 2022 on Windows:

| Edition      | Configuration                                                                                                                           |
| ------------ | --------------------------------------------------------------------------------------------------------------------------------------- |
| Community    | [configuration.dsc.yaml](https://github.com/nodejs/node/blob/main/.configurations/configuration.dsc.yaml)                               |
| Professional | [configuration.vsProfessional.dsc.yaml](https://github.com/nodejs/node/blob/main/.configurations/configuration.vsProfessional.dsc.yaml) |
| Enterprise   | [configuration.vsEnterprise.dsc.yaml](https://github.com/nodejs/node/blob/main/.configurations/configuration.vsEnterprise.dsc.yaml)     |

Compared to both the sections [Option 1: Manual install](https://github.com/nodejs/node/blob/main/BUILDING.md#option-1-manual-install) and [Option 3: Automated install with Boxstarter](https://github.com/nodejs/node/blob/main/BUILDING.md#option-3-automated-install-with-boxstarter), a WinGet configuration for the Visual Studio 2022 Build Tools Edition for Option 2 is missing. The documentation is also slightly misleading, since it lists "Visual Studio 2022 Build Tools" as being installed, although this edition is not installed.

## Change

- Add a Build Tools 2022 Edition configuration to the [.configurations](https://github.com/nodejs/node/tree/main/.configurations) directory:

    | Edition     | Configuration                         |
    | ----------- | ------------------------------------- |
    | Build Tools | `configuration.vsBuildTools.dsc.yaml` |

    The required [Desktop develop development with C++](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-build-tools?view=visualstudio&preserve-view=true#desktop-development-with-c) workload has `ID: Microsoft.VisualStudio.Workload.VCTools`, differing from other editions such as the Community Edition which uses instead [ID: Microsoft.VisualStudio.Workload.NativeDesktop](https://learn.microsoft.com/en-us/visualstudio/install/workload-component-id-vs-community?view=visualstudio&preserve-view=true#desktop-development-with-c).

- Align workload naming to the Visual Studio Installer UI and documentation, changing "Visual C++" to "Desktop development with C++" workload.
- Use relative links to ensure the document points to its own branch and not just the `main` branch
