### PR TITLE
deps: V8: backport 6a0a25abaed3

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/AUTHORS
+++ b/deps/v8/AUTHORS
@@ -305,6 +305,7 @@ Vadim Gorbachev <bmsdave@gmail.com>
 Varun Varada <varuncvarada@gmail.com>
 Victor Costan <costan@gmail.com>
 Victor Polevoy <fx@thefx.co>
+Vivian Wang <wangruikang@iscas.ac.cn>
 Vlad Burlik <vladbph@gmail.com>
 Vladimir Kempik <vladimir.kempik@syntacore.com>
 Vladimir Krivosheev <develar@gmail.com>

--- a/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
+++ b/deps/v8/src/codegen/riscv/macro-assembler-riscv.cc
@@ -6846,9 +6846,10 @@ void MacroAssembler::EnterFrame(StackFrame::Type type) {
 
 void MacroAssembler::LeaveFrame(StackFrame::Type type) {
   ASM_CODE_COMMENT(this);
-  AddWord(sp, fp, 2 * kSystemPointerSize);
+  Move(sp, fp);
   LoadWord(ra, MemOperand(fp, 1 * kSystemPointerSize));
   LoadWord(fp, MemOperand(fp, 0 * kSystemPointerSize));
+  AddWord(sp, sp, 2 * kSystemPointerSize);
 }
 
 void MacroAssembler::EnterExitFrame(Register scratch, int stack_space,


### PR DESCRIPTION
Original commit message:

    [riscv] Fix sp handling in MacroAssembler::LeaveFrame

    Keep sp <= fp to ensure that data right above fp doesn't get clobbered
    by an inopportune signal and its handler.

    Such clobbering can happen in e.g. Node.js when JIT-compiled code is
    interrupted by a SIGCHLD handler.

    Bug: None
    Change-Id: Ief0836032ada7942e89f081f7605f61632c4d414
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7540554
    Reviewed-by: Ji Qiu <qiuji@iscas.ac.cn>
    Commit-Queue: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
    Reviewed-by: Rezvan Mahdavi Hezaveh <rezvan@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#105069}

Refs: https://github.com/v8/v8/commit/6a0a25abaed397f83eb0d92e4b33a5e18204f8bc

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This V8 backport fixes [a long-standing heisenbug](https://github.com/revyos/revyos/issues/27) that affects riscv64 since at least node.js 16.

CC @RevySR @dramforever @sxa