### PR TITLE
test_runner: show interrupted test on SIGINT

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -3347,6 +3347,32 @@ This event is guaranteed to be emitted in the same order as the tests are
 defined.
 The corresponding execution ordered event is `'test:complete'`.
 
+### Event: `'test:interrupted'`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `data` {Object}
+  * `tests` {Array} An array of objects containing information about the
+    interrupted tests.
+    * `column` {number|undefined} The column number where the test is defined,
+      or `undefined` if the test was run through the REPL.
+    * `file` {string|undefined} The path of the test file,
+      `undefined` if test was run through the REPL.
+    * `line` {number|undefined} The line number where the test is defined, or
+      `undefined` if the test was run through the REPL.
+    * `name` {string} The test name.
+    * `nesting` {number} The nesting level of the test.
+
+Emitted when the test runner is interrupted by a `SIGINT` signal (e.g., when
+pressing <kbd>Ctrl</kbd>+<kbd>C</kbd>). The event contains information about
+the tests that were running at the time of interruption.
+
+When using process isolation (the default), the test name will be the file path
+since the parent runner only knows about file-level tests. When using
+`--test-isolation=none`, the actual test name is shown.
+
 ### Event: `'test:pass'`
 
 * `data` {Object}

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -3,6 +3,7 @@ const {
   ArrayPrototypeForEach,
   ArrayPrototypePush,
   FunctionPrototypeBind,
+  Promise,
   PromiseResolve,
   PromiseWithResolvers,
   SafeMap,
@@ -32,7 +33,7 @@ const { PassThrough, compose } = require('stream');
 const { reportReruns } = require('internal/test_runner/reporter/rerun');
 const { queueMicrotask } = require('internal/process/task_queues');
 const { TIMEOUT_MAX } = require('internal/timers');
-const { clearInterval, setInterval } = require('timers');
+const { clearInterval, setImmediate, setInterval } = require('timers');
 const { bigint: hrtime } = process.hrtime;
 const testResources = new SafeMap();
 let globalRoot;
@@ -289,7 +290,33 @@ function setupProcessState(root, globalOptions) {
     }
   };
 
+  const findRunningTests = (test, running = []) => {
+    if (test.startTime !== null && !test.finished) {
+      for (let i = 0; i < test.subtests.length; i++) {
+        findRunningTests(test.subtests[i], running);
+      }
+      // Only add leaf tests (innermost running tests)
+      if (test.activeSubtests === 0 && test.name !== '<root>') {
+        ArrayPrototypePush(running, {
+          __proto__: null,
+          name: test.name,
+          nesting: test.nesting,
+          file: test.loc?.file,
+          line: test.loc?.line,
+          column: test.loc?.column,
+        });
+      }
+    }
+    return running;
+  };
+
   const terminationHandler = async () => {
+    const runningTests = findRunningTests(root);
+    if (runningTests.length > 0) {
+      root.reporter.interrupted(runningTests);
+      // Allow the reporter stream to process the interrupted event
+      await new Promise((resolve) => setImmediate(resolve));
+    }
     await exitHandler(true);
     process.exit();
   };

--- a/lib/internal/test_runner/reporter/spec.js
+++ b/lib/internal/test_runner/reporter/spec.js
@@ -106,7 +106,30 @@ class SpecReporter extends Transform {
         break;
       case 'test:watch:restarted':
         return `\nRestarted at ${DatePrototypeToLocaleString(new Date())}\n`;
+      case 'test:interrupted':
+        return this.#formatInterruptedTests(data.tests);
     }
+  }
+  #formatInterruptedTests(tests) {
+    if (tests.length === 0) {
+      return '';
+    }
+
+    const results = [
+      `\n${colors.yellow}Interrupted while running:${colors.white}\n`,
+    ];
+
+    for (let i = 0; i < tests.length; i++) {
+      const test = tests[i];
+      let msg = `${indent(test.nesting)}${reporterUnicodeSymbolMap['warning:alert']}${test.name}`;
+      if (test.file) {
+        const relPath = relative(this.#cwd, test.file);
+        msg += ` ${colors.gray}(${relPath}:${test.line}:${test.column})${colors.white}`;
+      }
+      ArrayPrototypePush(results, msg);
+    }
+
+    return ArrayPrototypeJoin(results, '\n') + '\n';
   }
   _transform({ type, data }, encoding, callback) {
     callback(null, this.#handleEvent({ __proto__: null, type, data }));

--- a/lib/internal/test_runner/reporter/tap.js
+++ b/lib/internal/test_runner/reporter/tap.js
@@ -61,6 +61,16 @@ async function * tapReporter(source) {
       case 'test:coverage':
         yield getCoverageReport(indent(data.nesting), data.summary, '# ', '', true);
         break;
+      case 'test:interrupted':
+        for (let i = 0; i < data.tests.length; i++) {
+          const test = data.tests[i];
+          let msg = `Interrupted while running: ${test.name}`;
+          if (test.file) {
+            msg += ` at ${test.file}:${test.line}:${test.column}`;
+          }
+          yield `# ${tapEscape(msg)}\n`;
+        }
+        break;
     }
   }
 }

--- a/lib/internal/test_runner/tests_stream.js
+++ b/lib/internal/test_runner/tests_stream.js
@@ -149,6 +149,13 @@ class TestsStream extends Readable {
     });
   }
 
+  interrupted(tests) {
+    this[kEmitMessage]('test:interrupted', {
+      __proto__: null,
+      tests,
+    });
+  }
+
   end() {
     this.#tryPush(null);
   }


### PR DESCRIPTION
## Summary

When the test runner process is killed with SIGINT (Ctrl+C), display which test was running at the time of interruption. This makes it easier to identify tests that hang or take too long.

### Changes
- Add `test:interrupted` event emitted when SIGINT is received
- Add `interrupted()` method to TestsStream  
- Handle the event in both TAP and spec reporters
- TAP outputs: `# Interrupted while running: <test>`
- Spec outputs with yellow header and warning symbol
- Use setImmediate to allow reporter stream to flush before exit

### Behavior
- With process isolation (default): shows the file path since the parent runner only knows about file-level tests
- With `--test-isolation=none`: shows the actual test name and location

### Example output (TAP)
```
TAP version 13
# Interrupted while running: never ending test at /path/to/test.js:6:1
```

### Example output (spec)
```
Interrupted while running:
⚠ never ending test (test.js:6:1)
```