### PR TITLE
test: fix case-insensitive path matching on Windows

### DIFF
--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -64,12 +64,18 @@ function transformProjectRoot(replacement = '<project-root>') {
   const winPath = replaceWindowsPaths(projectRoot);
   // Handles URL encoded project root in file URL strings as well.
   const urlEncoded = pathToFileURL(projectRoot).pathname;
+  // On Windows, paths are case-insensitive, so we need to use case-insensitive
+  // regex replacement to handle cases where the drive letter case differs.
+  const flags = common.isWindows ? 'gi' : 'g';
+  const urlEncodedRegex = new RegExp(RegExp.escape(urlEncoded), flags);
+  const projectRootRegex = new RegExp(RegExp.escape(projectRoot), flags);
+  const winPathRegex = new RegExp(RegExp.escape(winPath), flags);
   return (str) => {
     return str.replaceAll('\\\'', "'")
       // Replace fileUrl first as `winPath` could be a substring of the fileUrl.
-      .replaceAll(urlEncoded, replacement)
-      .replaceAll(projectRoot, replacement)
-      .replaceAll(winPath, replacement);
+      .replaceAll(urlEncodedRegex, replacement)
+      .replaceAll(projectRootRegex, replacement)
+      .replaceAll(winPathRegex, replacement);
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes flaky `test-node-output-sourcemaps` test on Windows CI.

## Problem

On Windows, file paths are case-insensitive but JavaScript string comparison is case-sensitive. When the drive letter case differs between the computed project root (e.g., `C:/workspace/...`) and the actual output from child processes (e.g., `c:/workspace/...`), the path replacement in `transformProjectRoot()` would fail.

This causes snapshot tests to fail with errors like:
```
Expected values to be strictly equal
actual: 'c:/workspace/node-test-binary.../test/fixtures/...'
expected: '<project-root>/test/fixtures/...'
```

## Solution

Use case-insensitive regex replacement (`gi` flag) on Windows to ensure paths are correctly normalized regardless of drive letter casing.

## Verification

Tested locally with `python3 tools/test.py --repeat 20 test/parallel/test-node-output-sourcemaps.mjs` - all passed.

Refs: https://github.com/nodejs/reliability/issues/1453