### PR TITLE
doc: Clarify supported Visual Studio versions for windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -156,7 +156,7 @@ Depending on the host platform, the selection of toolchains may vary.
 | Operating System | Compiler Versions                                              |
 | ---------------- | -------------------------------------------------------------- |
 | Linux            | GCC >= 12.2 or Clang >= 19.1                                   |
-| Windows          | Visual Studio >= 2022 with the Windows 10 SDK on a 64-bit host |
+| Windows          | Visual Studio 2022 or 2026 with the Windows 10 SDK on a 64-bit host |
 | macOS            | Xcode >= 16.4 (Apple LLVM >= 19)                               |
 
 ### Official binary platforms and toolchains


### PR DESCRIPTION
The current documentation uses ">=" which implies that any future version of Visual Studio will work. However, VS 2026 has been shown to cause build failures on certain branches. This change explicitly lists 2022 and 2026 as the supported versions to prevent user confusion.

Fixes: https://github.com/nodejs/node/issues/61449