### PR TITLE
deps: V8: cherry-pick 64b36b441179

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.40',
+    'v8_embedder_string': '-node.41',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/strings/unicode-inl.h
+++ b/deps/v8/src/strings/unicode-inl.h
@@ -10,6 +10,7 @@
 
 #include "src/base/logging.h"
 #include "src/utils/utils.h"
+#include "third_party/simdutf/simdutf.h"
 
 namespace unibrow {
 
@@ -219,6 +220,16 @@ bool Utf8::IsValidCharacter(uchar c) {
           c != kBadChar);
 }
 
+template <>
+bool Utf8::IsAsciiOneByteString<uint8_t>(const uint8_t* buffer, size_t size) {
+  return simdutf::validate_ascii(reinterpret_cast<const char*>(buffer), size);
+}
+
+template <>
+bool Utf8::IsAsciiOneByteString<uint16_t>(const uint16_t* buffer, size_t size) {
+  return false;
+}
+
 template <typename Char>
 Utf8::EncodingResult Utf8::Encode(v8::base::Vector<const Char> string,
                                   char* buffer, size_t capacity,
@@ -234,8 +245,17 @@ Utf8::EncodingResult Utf8::Encode(v8::base::Vector<const Char> string,
   const Char* characters = string.begin();
   size_t content_capacity = capacity - write_null;
   CHECK_LE(content_capacity, capacity);
-  uint16_t last = Utf16::kNoPreviousCharacter;
   size_t read_index = 0;
+  if (kSourceIsOneByte) {
+    size_t writeable = std::min(string.size(), content_capacity);
+    // Just memcpy when possible.
+    if (writeable > 0 && Utf8::IsAsciiOneByteString(characters, writeable)) {
+      memcpy(buffer, characters, writeable);
+      read_index = writeable;
+      write_index = writeable;
+    }
+  }
+  uint16_t last = Utf16::kNoPreviousCharacter;
   for (; read_index < string.size(); read_index++) {
     Char character = characters[read_index];
 

--- a/deps/v8/src/strings/unicode.h
+++ b/deps/v8/src/strings/unicode.h
@@ -212,6 +212,16 @@ class V8_EXPORT_PRIVATE Utf8 {
   // - valid code point range.
   static bool ValidateEncoding(const uint8_t* str, size_t length);
 
+  template <typename Char>
+  static bool IsAsciiOneByteString(const Char* buffer, size_t size);
+
+  template <>
+  inline bool IsAsciiOneByteString<uint8_t>(const uint8_t* buffer, size_t size);
+
+  template <>
+  inline bool IsAsciiOneByteString<uint16_t>(const uint16_t* buffer,
+                                             size_t size);
+
   // Encode the given characters as Utf8 into the provided output buffer.
   struct EncodingResult {
     size_t bytes_written;


### PR DESCRIPTION
## Summary

- Cherry-picks V8 commit 64b36b44117949fe03df33d077117e7bd6257669 (ASCII fast path optimization in `WriteUtf8V2`)
- Adds SIMD-accelerated ASCII validation using `simdutf::validate_ascii`
- Uses `memcpy` for pure-ASCII strings instead of byte-by-byte UTF-8 encoding
- Bumps `v8_embedder_string` from `-node.40` to `-node.41`

## Changes

**Files modified:**
- `deps/v8/src/strings/unicode-inl.h` — Added `IsAsciiOneByteString` template specializations and ASCII fast path in `Encode`
- `deps/v8/src/strings/unicode.h` — Added `IsAsciiOneByteString` declarations
- `common.gypi` — Incremented embedder string

## Note on Manual Fix

The cherry-pick required a manual addition of `#include "third_party/simdutf/simdutf.h"` to `unicode-inl.h`. The upstream V8 commit relies on this include being present, but the git-node backport tool did not pick it up (the include may have been added in a separate commit or already present in newer V8 versions).

## References

- V8 commit: https://github.com/v8/v8/commit/64b36b44117949fe03df33d077117e7bd6257669
- Chromium review: https://chromium-review.googlesource.com/c/v8/v8/+/7124103

## Test Plan

- [x] `make cctest` — 176/176 tests passed
- [x] `python3 tools/test.py -J --mode=release v8` — 25/25 tests passed  
- [x] `python3 tools/test.py -J --mode=release` — 4795/4796 tests passed (1 unrelated SEA test failure)
- [x] Manual correctness checks for Buffer.from with ASCII and UTF-8 strings