### PR TITLE
test: print stack immediately avoiding GC interleaving

### DIFF
--- a/lib/internal/source_map/source_map_cache_map.js
+++ b/lib/internal/source_map/source_map_cache_map.js
@@ -13,6 +13,9 @@ const {
     source_map_data_private_symbol,
   },
 } = internalBinding('util');
+let debug = require('internal/util/debuglog').debuglog('source_map', (fn) => {
+  debug = fn;
+});
 
 /**
  * Specialized map of WeakRefs to module instances that caches source map
@@ -46,6 +49,7 @@ class SourceMapCacheMap {
     ArrayPrototypeForEach(keys, (key) => {
       const ref = this.#weakModuleMap.get(key);
       if (ref && ref.deref() === undefined) {
+        debug(`Cleanup obsolete source map cache entry with key: ${key}`);
         this.#weakModuleMap.delete(key);
       }
     });

--- a/test/fixtures/source-map/output/source_map_sourcemapping_url_string.js
+++ b/test/fixtures/source-map/output/source_map_sourcemapping_url_string.js
@@ -7,7 +7,5 @@ Error.stackTraceLimit = 2;
 try {
   require('../typescript-sourcemapping_url_string');
 } catch (err) {
-  setTimeout(() => {
-    console.info(err);
-  }, 10);
+  console.info(err);
 }

--- a/test/fixtures/source-map/output/source_map_throw_catch.js
+++ b/test/fixtures/source-map/output/source_map_throw_catch.js
@@ -7,7 +7,5 @@ Error.stackTraceLimit = 2;
 try {
   require('../typescript-throw');
 } catch (err) {
-  setTimeout(() => {
-    console.info(err);
-  }, 10);
+  console.info(err);
 }


### PR DESCRIPTION
`require(mod)` does not keep the mod in require cache if mod throws synchronously.
This fixes the tests to print the stack immediately in case that source map cache
could be cleaned up when the CJS module is reclaimed by GC in the next event loop
tick.

Refs: https://github.com/nodejs/node/pull/61002#issuecomment-3846108521