### PR TITLE
build: show cc outputs when version detection failed

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1280,10 +1280,16 @@ def try_check_compiler(cc, lang):
                      b'__clang_major__ __clang_minor__ __clang_patchlevel__ '
                      b'__APPLE__')
 
+    cc_out = proc.communicate()
+    cc_stdout = to_utf8(cc_out[0])
     if sys.platform == 'zos':
-      values = (to_utf8(proc.communicate()[0]).split('\n')[-2].split() + ['0'] * 7)[0:8]
+      values = (cc_stdout.split('\n')[-2].split() + ['0'] * 7)[0:8]
     else:
-      values = (to_utf8(proc.communicate()[0]).split() + ['0'] * 7)[0:8]
+      values = (cc_stdout.split() + ['0'] * 7)[0:8]
+
+  if len(values) < 8:
+    cc_stderr = to_utf8(cc_out[1]) if cc_out[1] else ''
+    raise Exception(f'Could not determine compiler version info. \nstdout:\n{cc_stdout}\nstderr:\n{cc_stderr}')
 
   is_clang = values[0] == '1'
   gcc_version = tuple(map(int, values[1:1+3]))


### PR DESCRIPTION
There are chances that `./configure` fails on GitHub Actions.
Print the output of the command to see if there is any way to
improve it.

Example: https://github.com/nodejs/node/actions/runs/21730375777/job/62683227640?pr=61699

```
make: Entering directory '/home/runner/work/node/node/node'
python3 ./configure --verbose --error-on-warn --v8-enable-temporal-support
sccache: error: Timed out waiting for server startup. Maybe the remote service is unreachable?
Run with SCCACHE_LOG=debug SCCACHE_NO_DAEMON=1 to get more information
Node.js configure: Found Python 3.14.2...
Traceback (most recent call last):
  File "/home/runner/work/node/node/node/./configure", line 27, in <module>
    import configure
  File "/home/runner/work/node/node/node/configure.py", line 2587, in <module>
    check_compiler(output)
    ~~~~~~~~~~~~~~^^^^^^^^
  File "/home/runner/work/node/node/node/configure.py", line 1510, in check_compiler
    ok, is_clang, clang_version, gcc_version, is_apple = try_check_compiler(CXX, 'c++')
                                                         ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
  File "/home/runner/work/node/node/node/configure.py", line 1291, in try_check_compiler
    is_apple = values[7] == '1'
               ~~~~~~^^^
IndexError: list index out of range
make: *** [Makefile:626: build-ci] Error 1
make: Leaving directory '/home/runner/work/node/node/node'

```