### PR TITLE
src: elide heap allocation in structured clone implementation

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -1619,11 +1619,11 @@ static void StructuredClone(const FunctionCallbackInfo<Value>& args) {
     }
   }
 
-  std::shared_ptr<Message> msg = std::make_shared<Message>();
+  Message msg;
   Local<Value> result;
-  if (msg->Serialize(env, context, value, transfer_list, Local<Object>())
+  if (msg.Serialize(env, context, value, transfer_list, Local<Object>())
           .IsNothing() ||
-      !msg->Deserialize(env, context, nullptr).ToLocal(&result)) {
+      !msg.Deserialize(env, context, nullptr).ToLocal(&result)) {
     return;
   }
   args.GetReturnValue().Set(result);


### PR DESCRIPTION
Small perf improvement:

```
$ node benchmark/compare.js --runs 100 \
>   --old ./node-0da120f879 --new ./node \
>   --filter structured-clone misc > comparison.csv && \
>   npx node-benchmark-compare comparison.csv

[00:02:15|% 100| 1/1 files | 200/200 runs | 3/3 configs]: Done
                                                    confidence improvement accuracy (*)   (**)  (***)
misc/structured-clone.js n=10000 type='arraybuffer'         **      1.81 %       ±1.28% ±1.68% ±2.16%
misc/structured-clone.js n=10000 type='object'               *      0.62 %       ±0.55% ±0.73% ±0.93%
misc/structured-clone.js n=10000 type='string'             ***      8.30 %       ±1.46% ±1.92% ±2.47%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 3 comparisons, you can thus expect the following amount of false-positive results:
  0.15 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.03 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
