### PR TITLE
repl: fix FileHandle leak in history initialization

### DIFF
--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -327,6 +327,7 @@ class ReplHistory {
 
       await this[kFlushHistory]();
     } catch (err) {
+      await this[kCloseHandle]();
       return this[kHandleHistoryInitError](err, onReadyCallback);
     }
   }

--- a/test/parallel/test-repl-history-init-fail-leak.js
+++ b/test/parallel/test-repl-history-init-fail-leak.js
@@ -1,0 +1,56 @@
+'use strict';
+// Flags: --expose-internals
+
+const common = require('../common');
+const fs = require('fs');
+const path = require('path');
+const { ReplHistory } = require('internal/repl/history');
+const assert = require('assert');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+const historyPath = path.join(tmpdir.path, '.node_repl_history');
+
+fs.writeFileSync(historyPath, 'dummy\n');
+
+const originalOpen = fs.promises.open;
+let closeCalled = false;
+
+fs.promises.open = async (filepath, flags, mode) => {
+  const handle = await originalOpen(filepath, flags, mode);
+
+  if (flags === 'r+' && filepath === historyPath) {
+    handle.truncate = async (len) => {
+      throw new Error('Mock truncate error');
+    };
+
+    const originalClose = handle.close;
+    handle.close = async () => {
+      closeCalled = true;
+      return originalClose.call(handle);
+    };
+  }
+
+  return handle;
+};
+
+const context = {
+  historySize: 30,
+  on: () => {},
+  once: () => {},
+  emit: () => {},
+  pause: () => {},
+  resume: () => {},
+  off: () => {},
+  line: '',
+  _historyPrev: () => {},
+  _writeToOutput: () => {}
+};
+
+const history = new ReplHistory(context, { filePath: historyPath });
+
+history.initialize(common.mustCall((err) => {
+  assert.strictEqual(err, null);
+  assert.strictEqual(closeCalled, true);
+}));


### PR DESCRIPTION
## Summary

This PR fixes a `FileHandle` leak in `lib/internal/repl/history.js` that causes `ERR_INVALID_STATE` when garbage collection occurs.

If an error occurs during `kInitializeHistory` (specifically within the `try` block that includes `kFlushHistory`), the open `FileHandle` (`this[kHistoryHandle]`) was not being explicitly closed before delegating to `kHandleHistoryInitError`. This led to the handle being closed by the garbage collector, triggering the error.

This fixes the regression observed in `test-repl-programmatic-history`.

## References

- CI Failure: https://ci.nodejs.org/job/node-test-commit-linux-containered/nodes=ubuntu2404_sharedlibs_shared_x64/54482/testReport/junit/(root)/parallel/test_repl_programmatic_history/


Fixes #61578