### PR TITLE
test: add describe abort signal tests

### DIFF
--- a/test/parallel/test-runner-misc.js
+++ b/test/parallel/test-runner-misc.js
@@ -22,20 +22,43 @@ if (process.argv[2] === 'child') {
       test(() => assert.strictEqual(testSignal.aborted, true));
     }));
 
-    // TODO(benjamingr) add more tests to describe + AbortSignal
-    // this just tests the parameter is passed
     test.describe('Abort Signal in describe', common.mustCall(({ signal }) => {
       test.it('Supports AbortSignal', common.mustCall(() => {
         assert.strictEqual(signal.aborted, false);
       }));
     }));
+
+    let describeSignal;
+    test.describe('describe signal timeout', { timeout: 10 }, common.mustCall(async ({ signal }) => {
+      await test.it('nested it timeout', common.mustCall(async (t) => {
+        assert.strictEqual(t.signal.aborted, false);
+        describeSignal = t.signal;
+        await setTimeout(50);
+      }));
+    }));
+
+    test(() => assert.strictEqual(describeSignal.aborted, true));
+
+    let manualAbortSignal;
+    test.describe('describe signal manual abort', common.mustCall((t) => {
+      const controller = new AbortController();
+      t.signal.addEventListener('abort', () => controller.abort());
+
+      return test.it('nested manual abort', { signal: controller.signal }, common.mustCall(async (t) => {
+        assert.strictEqual(t.signal.aborted, false);
+        manualAbortSignal = t.signal;
+        controller.abort();
+        await setTimeout(50);
+      }));
+    }));
+    test(() => assert.strictEqual(manualAbortSignal.aborted, true));
   } else assert.fail('unreachable');
 } else {
   const child = spawnSync(process.execPath, [__filename, 'child', 'abortSignal']);
   const stdout = child.stdout.toString();
-  assert.match(stdout, /pass 2$/m);
+  assert.match(stdout, /pass 4$/m);
   assert.match(stdout, /fail 0$/m);
-  assert.match(stdout, /cancelled 1$/m);
+  assert.match(stdout, /cancelled 3$/m);
   assert.strictEqual(child.status, 1);
   assert.strictEqual(child.signal, null);
 }


### PR DESCRIPTION
## Summary
@benjamingr
Adds tests to `test/parallel/test-runner-misc.js` to verify `AbortSignal` behavior in `describe` blocks.
This addresses the TODO comment: `// TODO(benjamingr) add more tests to describe + AbortSignal`.

## Changes
- Added test case for `describe` timeout triggering signal abort.
- Added test case for manual abort in `describe`.
- Verified signal propagation to nested tests.
- Updated child process output assertions to match new test results (3 cancelled tests).

## Verification
- Run `tools/test.py test/parallel/test-runner-misc.js`