### PR TITLE
deps: V8: cherry-pick 64b36b441179

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.11',
+    'v8_embedder_string': '-node.12',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/strings/unicode.h
+++ b/deps/v8/src/strings/unicode.h
@@ -212,6 +212,9 @@ class V8_EXPORT_PRIVATE Utf8 {
   // - valid code point range.
   static bool ValidateEncoding(const uint8_t* str, size_t length);
 
+  template <typename Char>
+  static bool IsAsciiOneByteString(const Char* buffer, size_t size);
+
   // Encode the given characters as Utf8 into the provided output buffer.
   struct EncodingResult {
     size_t bytes_written;
@@ -222,6 +225,14 @@ class V8_EXPORT_PRIVATE Utf8 {
                                char* buffer, size_t capacity, bool write_null,
                                bool replace_invalid_utf8);
 };
+
+template <>
+inline bool Utf8::IsAsciiOneByteString<uint8_t>(const uint8_t* buffer,
+                                                 size_t size);
+
+template <>
+inline bool Utf8::IsAsciiOneByteString<uint16_t>(const uint16_t* buffer,
+                                                  size_t size);
 
 #if V8_ENABLE_WEBASSEMBLY
 class V8_EXPORT_PRIVATE Wtf8 {


### PR DESCRIPTION
Cherry-picks V8 commit [`64b36b441179`](https://github.com/v8/v8/commit/64b36b44117949fe03df33d077117e7bd6257669) (ASCII fast path optimization in `WriteUtf8V2`).

This optimizes the `WriteUtf8V2` path for ASCII-only one-byte strings by using SIMD-accelerated validation (`simdutf::validate_ascii`) followed by a bulk `memcpy`, instead of encoding byte-by-byte through the generic UTF-8 path.

**Changes:**
- `deps/v8/src/strings/unicode-inl.h` — Added `IsAsciiOneByteString` template specializations and ASCII fast path in `Encode`
- `deps/v8/src/strings/unicode.h` — Added `IsAsciiOneByteString` declarations
- `common.gypi` — Incremented embedder string (`-node.11` → `-node.12`)

**References:**
- V8 commit: https://github.com/v8/v8/commit/64b36b44117949fe03df33d077117e7bd6257669
- Chromium review: https://chromium-review.googlesource.com/c/v8/v8/+/7124103
- Supersedes: https://github.com/nodejs/node/pull/61698 (was against `v24.x-staging`, maintainers requested rebase to `main`)