### PR TITLE
worker: fix TOCTOU race in CWD caching

### DIFF
--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -112,8 +112,8 @@ if (isMainThread) {
   cwdCounter = new Uint32Array(constructSharedArrayBuffer(4));
   const originalChdir = process.chdir;
   process.chdir = function(path) {
-    AtomicsAdd(cwdCounter, 0, 1);
     originalChdir(path);
+    AtomicsAdd(cwdCounter, 0, 1);
   };
 }
 

--- a/test/parallel/test-worker-cwd-no-stale-cache.js
+++ b/test/parallel/test-worker-cwd-no-stale-cache.js
@@ -1,0 +1,73 @@
+'use strict';
+
+// This test verifies that worker threads do not cache stale CWD values
+// after process.chdir() has completed in the main thread.
+//
+// Regression test for a TOCTOU race condition where the atomic counter
+// was incremented before chdir() completed, allowing workers to cache
+// stale directory paths.
+
+const common = require('../common');
+const assert = require('assert');
+const path = require('path');
+const { Worker, isMainThread, parentPort } = require('worker_threads');
+
+if (!isMainThread) {
+  // Worker: respond to 'check' messages with current cwd
+  parentPort.on('message', (msg) => {
+    if (msg.type === 'check') {
+      parentPort.postMessage({
+        type: 'cwd',
+        cwd: process.cwd(),
+        expected: msg.expected,
+      });
+    }
+  });
+  return;
+}
+
+// Main thread
+const testDir = __dirname;
+const parentDir = path.dirname(testDir);
+
+// Ensure we start in a known directory
+process.chdir(testDir);
+
+const worker = new Worker(__filename);
+
+let checksCompleted = 0;
+const totalChecks = 100;
+
+worker.on('message', common.mustCall((msg) => {
+  if (msg.type === 'cwd') {
+    // After chdir() has returned in the main thread, the worker
+    // must see the new directory, not a stale cached value
+    assert.strictEqual(
+      msg.cwd,
+      msg.expected,
+      `Worker returned stale CWD: got "${msg.cwd}", expected "${msg.expected}"`
+    );
+    checksCompleted++;
+
+    if (checksCompleted < totalChecks) {
+      // Alternate between directories
+      const newDir = checksCompleted % 2 === 0 ? testDir : parentDir;
+      process.chdir(newDir);
+      // Immediately after chdir returns, ask worker for cwd
+      worker.postMessage({ type: 'check', expected: newDir });
+    } else {
+      worker.terminate();
+    }
+  }
+}, totalChecks));
+
+worker.on('online', common.mustCall(() => {
+  // Start the test cycle
+  process.chdir(parentDir);
+  worker.postMessage({ type: 'check', expected: parentDir });
+}));
+
+worker.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 1); // terminated
+  assert.strictEqual(checksCompleted, totalChecks);
+}));


### PR DESCRIPTION
The atomic counter used to signal CWD changes to worker threads was
being incremented before chdir() completed, creating a race window
where workers could cache stale directory paths with the new counter
value. This caused process.cwd() in workers to return incorrect values
until the next chdir() call.

Fix by reordering operations: call originalChdir() first, then
increment the counter. This ensures workers never cache stale data
while believing it is current.

A unit test for this fix is not feasible as it would be too flaky due to the timing-dependent nature of the race condition.

Reported-by: Giulio Comi
Reported-by: Caleb Everett