### PR TITLE
doc: fix dropdown menu being obscured at <600px due to transparency issue

### DIFF
--- a/doc/api_assets/style.css
+++ b/doc/api_assets/style.css
@@ -240,6 +240,7 @@ li.picker-header a span {
   max-width: 75vw;
   max-height: min(600px, 60vh);
   overflow-y: auto;
+  z-index: 10;
 }
 
 .picker > ul, .picker > ol {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/59282

The documentation header dropdown was being obscured by its parent header
on screens smaller than 600px due to stacking context.

Adjusted z-index values so the dropdown appears above surrounding elements.
Verified locally using Chrome on macOS.
