### PR TITLE
esm: detect ESM syntax in extensionless files under type:commonjs

### DIFF
--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -162,6 +162,16 @@ function getFileProtocolModuleFormat(url, context = { __proto__: null }, ignoreE
       return getFormatOfExtensionlessFile(url);
     }
     if (packageType !== 'none') {
+      // When source is available, check if an extensionless file in a "type": "commonjs"
+      // package actually contains ES module syntax. Without this, ESM files without an
+      // extension (common for CLI scripts with shebangs) silently fail when loaded as CJS.
+      // See https://github.com/nodejs/node/issues/61104
+      if (source) {
+        const detected = detectModuleFormat(source, url);
+        if (detected === 'module') {
+          return detected;
+        }
+      }
       return packageType; // 'commonjs' or future package types
     }
 

--- a/test/parallel/test-esm-extensionless-commonjs-type.js
+++ b/test/parallel/test-esm-extensionless-commonjs-type.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// Test that extensionless files containing ESM syntax are not silently
+// swallowed when the nearest package.json has "type": "commonjs".
+// Regression test for https://github.com/nodejs/node/issues/61104
+
+const common = require('../common');
+const assert = require('assert');
+const { execFileSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+
+const dir = path.join(tmpdir.path, 'esm-extensionless');
+fs.mkdirSync(dir, { recursive: true });
+
+// Create package.json with "type": "commonjs"
+fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({
+  type: 'commonjs',
+}));
+
+// Create an extensionless script with ESM syntax (simulating a CLI tool with a shebang)
+const script = path.join(dir, 'script');
+fs.writeFileSync(script, `#!/usr/bin/env node
+process.exitCode = 42;
+export {};
+`);
+fs.chmodSync(script, 0o755);
+
+// The script should either run as ESM (exit code 42) or throw an error.
+// It must NOT silently exit with code 0.
+try {
+  const result = execFileSync(process.execPath, [script], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  // If we reach here, the script ran without error.
+  // The exit code should be 42 (set by process.exitCode in the ESM script).
+  assert.fail('Expected the script to either exit with code 42 or throw an error, but it exited with code 0');
+} catch (err) {
+  // execFileSync throws if exit code is non-zero, which is expected.
+  // Either exit code 42 (ESM ran correctly) or an error was thrown (also acceptable).
+  if (err.status !== null) {
+    // The script ran but exited non-zero — ESM was properly detected and executed.
+    assert.strictEqual(err.status, 42,
+      `Expected exit code 42 from ESM script, got ${err.status}. stderr: ${err.stderr}`);
+  }
+  // If there's a stderr message about ESM/CommonJS mismatch, that's also acceptable
+  // as long as it's not a silent success.
+}


### PR DESCRIPTION
## Summary

Fixes a silent failure where extensionless files containing ES module syntax produce no output and exit with code 0 when the nearest `package.json` has `"type": "commonjs"`.

This is a common scenario for CLI tools that use shebangs (`#!/usr/bin/env node`) without a file extension.

### Reproduction

```bash
echo '{ "type": "commonjs" }' > package.json
printf '#!/usr/bin/env node\nconsole.log("started")\nimport { version } from "node:process"\nconsole.log(version)\n' > script
chmod +x script
./script ; echo "exit: $?"
# Output: exit: 0
# Expected: either the script runs, or an error is printed
```

## Root Cause

In `lib/internal/modules/esm/get_format.js`, `getFileProtocolModuleFormat()` handles extensionless files (line 159-177). When `packageType` is `'commonjs'`, it returns `'commonjs'` immediately without checking the file content for ESM syntax (line 164-165).

This causes the ESM loader to treat the file as a CJS module, routing it through `createCJSModuleWrap` in the translators, which wraps the ESM code as CJS — silently producing an empty/non-functional module.

Compare with:
- The `'none'` (no type field) case for extensionless files, which **does** call `detectModuleFormat(source, url)` at line 176
- The `.js` extension case with no type field, which **does** call `detectModuleFormat(source, url)` at line 127

## Fix

For extensionless files when `packageType !== 'none'` (i.e., explicitly `'commonjs'`), check the source content via `detectModuleFormat()` before returning the package type. If the file contains ES module syntax, return `'module'` so it's loaded correctly.

```javascript
if (packageType !== 'none') {
  if (source) {
    const detected = detectModuleFormat(source, url);
    if (detected === 'module') {
      return detected;
    }
  }
  return packageType;
}
```

This is consistent with how ambiguous files are already handled elsewhere in the same function, and relies on the existing `containsModuleSyntax` V8 binding (used by `detectModuleFormat`) which is already enabled by default via `--experimental-detect-module`.

## Test

`test/parallel/test-esm-extensionless-commonjs-type.js` — creates an extensionless ESM file in a `type: commonjs` project, runs it, and asserts it does not silently exit with code 0.

Fixes: https://github.com/nodejs/node/issues/61104

Made with [Cursor](https://cursor.com)