### PR TITLE
test: restraint version replacement pattern in snapshots

### DIFF
--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -14,7 +14,7 @@ const windowNewlineRegexp = /\r/g;
 // placeholder. This could commonly present in an unhandled exception
 // output.
 function replaceNodeVersion(str) {
-  return str.replaceAll(process.version, '<node-version>');
+  return str.replaceAll(`Node.js ${process.version}`, 'Node.js <node-version>');
 }
 
 function replaceStackTrace(str, replacement = '$1*$7$8\n') {


### PR DESCRIPTION
In release workflows, the project root may contain the version of the binary. This restrains the replacement pattern of Node.js version to be more specific to the version in error outputs.

Refs: https://github.com/nodejs/node/pull/61739#issuecomment-3868591475