### PR TITLE
test: fix flaky test-http2-close-while-writing

### DIFF
--- a/test/parallel/test-http2-close-while-writing.js
+++ b/test/parallel/test-http2-close-while-writing.js
@@ -24,7 +24,7 @@ let client_stream;
 server.on('session', common.mustCall(function(session) {
   session.on('stream', common.mustCall(function(stream) {
     stream.resume();
-    stream.on('data', function() {
+    stream.once('data', function() {
       this.write(Buffer.alloc(1));
       process.nextTick(() => client_stream.destroy());
     });


### PR DESCRIPTION
## Summary

Fixes flaky test `test/parallel/test-http2-close-while-writing.js` which was timing out on macOS.

## Problem

The test uses `stream.on('data', ...)` which can fire multiple times when receiving the 64KB data chunk sent by the client. Each `data` event triggers `client_stream.destroy()` via `process.nextTick()`, leading to multiple destroy calls and intermittent timeouts.

## Solution

Changed `stream.on('data', ...)` to `stream.once('data', ...)` to ensure the callback only fires once, regardless of how many data chunks arrive. This pattern is consistent with similar tests like `test-http2-many-writes-and-destroy.js`.

## Verification

Verified with `python3 tools/test.py --repeat 100` without failures.

Refs: nodejs/reliability#1459