### PR TITLE
test: adapt buffer test for v8 sandbox

### DIFF
--- a/test/parallel/test-buffer-concat.js
+++ b/test/parallel/test-buffer-concat.js
@@ -22,6 +22,7 @@
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+const { kMaxLength } = require('buffer');
 
 const zero = [];
 const one = [ Buffer.from('asdf') ];
@@ -84,8 +85,8 @@ assert.throws(() => {
   Buffer.concat([Buffer.from('hello')], -2);
 }, {
   code: 'ERR_OUT_OF_RANGE',
-  message: 'The value of "length" is out of range. It must be >= 0 && <= 9007199254740991. ' +
-           'Received -2'
+  message: 'The value of "length" is out of range. It must be >= 0 && <= ' +
+    `${kMaxLength}. Received -2`
 });
 
 // eslint-disable-next-line node-core/crypto-check


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/60405

This test will fail for V8 sandboxed builds, where the upper bound will be 2³⁵ - 1 instead of `Number.MAX_SAFE_INTEGER`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
