### PR TITLE
test: avoid flaky debugger restart waits

### DIFF
--- a/test/parallel/test-debugger-restart-message.js
+++ b/test/parallel/test-debugger-restart-message.js
@@ -25,7 +25,11 @@ const startCLI = require('../common/debugger');
       assert.strictEqual(cli.output.match(listeningRegExp).length, 1);
 
       for (let i = 0; i < RESTARTS; i++) {
-        await cli.stepCommand('restart');
+        // For `restart`, sync on attach/prompt instead of BREAK_MESSAGE to avoid flaky races.
+        // https://github.com/nodejs/node/issues/61762
+        await cli.command('restart');
+        await cli.waitFor(/Debugger attached\./);
+        await cli.waitForPrompt();
         assert.strictEqual(cli.output.match(listeningRegExp).length, 1);
       }
     } finally {

--- a/test/parallel/test-debugger-run-after-quit-restart.js
+++ b/test/parallel/test-debugger-run-after-quit-restart.js
@@ -57,7 +57,7 @@ const path = require('path');
         { filename: script, line: 2 },
       );
     })
-    .then(() => cli.stepCommand('restart'))
+    .then(() => cli.command('restart'))
     .then(() => cli.waitForInitialBreak())
     .then(() => {
       assert.deepStrictEqual(


### PR DESCRIPTION
## Summary

- replace `stepCommand('restart')` with `command('restart')` in:
  - `test/parallel/test-debugger-restart-message.js`
  - `test/parallel/test-debugger-run-after-quit-restart.js`
- in `test-debugger-restart-message`, wait for `Debugger attached.` and prompt before asserting the listening message count
- in `test-debugger-run-after-quit-restart`, continue to assert behavior via `waitForInitialBreak()` and `breakInfo`

## Context

`test-macOS` has shown intermittent timeouts while waiting for `BREAK_MESSAGE` in restart-related debugger tests.
In failing logs, reconnect succeeds (`Debugger attached.` is printed), but the expected `break ... in` line is not observed before timeout.

## Hypothesis

The flake is likely caused by a timing race in CLI output ordering around restart/reconnect:
- `stepCommand()` requires `BREAK_MESSAGE` to appear
- under some timing conditions (seen on macOS unusual-path runs), attach/prompt output arrives, but `break ... in` output is delayed or missed by this wait pattern

This change does not claim to prove a single root cause. It may be related to timing behavior in `test/common/debugger.js`, but this PR only narrows these two tests to a less fragile synchronization path aligned with what each test is actually verifying.

## Why this approach

- keep test intent intact
- reduce dependence on a brittle `BREAK_MESSAGE` wait specifically for `restart`
- minimize blast radius by changing only the affected tests

## Testing

- [x] `out/Release/node test/parallel/test-debugger-restart-message.js` (passes locally)
- [x] `out/Release/node test/parallel/test-debugger-run-after-quit-restart.js` (passes locally)
- [x] Additional local stress runs were executed from an unusual-character path on both this PR branch and main. (https://github.com/nodejs/node/pull/61773#issuecomment-3940188387)
- [x] CI passes on macOS

Refs: https://github.com/nodejs/node/issues/61762
