### PR TITLE
util: move TextEncoder class to C++

### DIFF
--- a/lib/internal/encoding.js
+++ b/lib/internal/encoding.js
@@ -46,23 +46,16 @@ const {
 const {
   isAnyArrayBuffer,
   isArrayBufferView,
-  isUint8Array,
 } = require('internal/util/types');
 
 const {
-  validateString,
   validateObject,
   kValidateObjectAllowObjectsAndNull,
 } = require('internal/validators');
 
 const { hasIntl } = internalBinding('config');
 const binding = internalBinding('encoding_binding');
-const {
-  encodeInto,
-  encodeIntoResults,
-  encodeUtf8String,
-  decodeUTF8,
-} = binding;
+const { decodeUTF8, TextEncoder } = binding;
 
 function validateDecoder(obj) {
   if (obj == null || obj[kDecoder] !== true)
@@ -335,61 +328,6 @@ function getEncodingFromLabel(label) {
   if (enc !== undefined) return enc;
   return encodings.get(trimAsciiWhitespace(label.toLowerCase()));
 }
-
-let lazyInspect;
-
-class TextEncoder {
-  #encoding = 'utf-8';
-
-  #encode(input) {
-    return encodeUtf8String(`${input}`);
-  }
-
-  #encodeInto(input, dest) {
-    encodeInto(input, dest);
-    // We need to read from the binding here since the buffer gets refreshed
-    // from the snapshot.
-    const { 0: read, 1: written } = encodeIntoResults;
-    return { read, written };
-  }
-
-  get encoding() {
-    return this.#encoding;
-  }
-
-  encode(input = '') {
-    return this.#encode(input);
-  }
-
-  encodeInto(src, dest) {
-    validateString(src, 'src');
-    if (!dest || !isUint8Array(dest))
-      throw new ERR_INVALID_ARG_TYPE('dest', 'Uint8Array', dest);
-
-    return this.#encodeInto(src, dest);
-  }
-
-  [inspect](depth, opts) {
-    if (typeof depth === 'number' && depth < 0)
-      return this;
-    const ctor = getConstructorOf(this);
-    const obj = { __proto__: {
-      constructor: ctor === null ? TextEncoder : ctor,
-    } };
-    obj.encoding = this.#encoding;
-    // Lazy to avoid circular dependency
-    lazyInspect ??= require('internal/util/inspect').inspect;
-    return lazyInspect(obj, opts);
-  }
-}
-
-ObjectDefineProperties(
-  TextEncoder.prototype, {
-    'encode': kEnumerableProperty,
-    'encodeInto': kEnumerableProperty,
-    'encoding': kEnumerableProperty,
-    [SymbolToStringTag]: { __proto__: null, configurable: true, value: 'TextEncoder' },
-  });
 
 function parseInput(input) {
   if (isAnyArrayBuffer(input)) {

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -305,6 +305,7 @@
   V(psk_string, "psk")                                                         \
   V(public_exponent_string, "publicExponent")                                  \
   V(rate_string, "rate")                                                       \
+  V(read_string, "read")                                                       \
   V(read_host_object_string, "_readHostObject")                                \
   V(readable_string, "readable")                                               \
   V(read_bigints_string, "readBigInts")                                        \
@@ -374,6 +375,7 @@
   V(windows_verbatim_arguments_string, "windowsVerbatimArguments")             \
   V(wrap_string, "wrap")                                                       \
   V(writable_string, "writable")                                               \
+  V(written_string, "written")                                                 \
   V(write_host_object_string, "_writeHostObject")                              \
   V(write_queue_size_string, "writeQueueSize")
 
@@ -442,6 +444,7 @@
   V(srv_record_template, v8::DictionaryTemplate)                               \
   V(streambaseoutputstream_constructor_template, v8::ObjectTemplate)           \
   V(tcp_constructor_template, v8::FunctionTemplate)                            \
+  V(text_encoder_encode_into_result_template, v8::ObjectTemplate)              \
   V(tlsa_record_template, v8::DictionaryTemplate)                              \
   V(tty_constructor_template, v8::FunctionTemplate)                            \
   V(txt_record_template, v8::DictionaryTemplate)                               \

--- a/test/parallel/test-whatwg-encoding-custom-interop.js
+++ b/test/parallel/test-whatwg-encoding-custom-interop.js
@@ -47,7 +47,7 @@ assert(TextEncoder);
 
   const expectedError = {
     name: 'TypeError',
-    message: /from an object whose class did not declare it/,
+    message: /Illegal invocation/,
   };
 
   inspectFn.call(instance, Infinity, {});
@@ -62,7 +62,7 @@ assert(TextEncoder);
   for (const i of invalidThisArgs) {
     assert.throws(() => encodeFn.call(i), {
       name: 'TypeError',
-      message: 'Receiver must be an instance of class TextEncoder',
+      message: /Illegal invocation/,
     });
   }
 }


### PR DESCRIPTION
In an attempt to improve performance, and reduce the code bloat in internal/util.js... Pending benchmark CI. 

Benchmark CI: https://ci.nodejs.org/view/Node.js%20benchmark/job/benchmark-node-micro-benchmarks/1798/