### PR TITLE
src: enable X509sToArrayOfStrings to skip errors

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -1111,7 +1111,7 @@ MaybeLocal<Array> X509sToArrayOfStrings(Environment* env,
         per_process::Debug(DebugCategory::CRYPTO,
                            "Skipping system certificate with subject "
                            "'%s' because X509 to PEM conversion failed\n",
-                           subject_str.c_str());
+                           subject_str);
         skipped++;
         continue;
       }


### PR DESCRIPTION
As suggested in the linked issue, this PR relaxes the X509 to PEM conversion by skipping failures for system certs. If conversion fails, Node.js will try to give info about the failed certs if it can. This new behavior is used only on system certs, since for others, the user has control. AFAIK, there is no way to add a reliable test for this, but if someone has an idea, feel free to share it with me.

Fixes: https://github.com/nodejs/node/issues/61636