### PR TITLE
[v22.x] src: use std::sort in node_metadata for libc++13 compatibility

### DIFF
--- a/src/node_metadata.cc
+++ b/src/node_metadata.cc
@@ -1,4 +1,5 @@
 #include "node_metadata.h"
+#include <algorithm>
 #include "acorn_version.h"
 #include "ada.h"
 #include "amaro_version.h"
@@ -177,8 +178,9 @@ Metadata::Versions::pairs() const {
   NODE_VERSIONS_KEYS(V)
 #undef V
 
-  std::ranges::sort(versions_array,
-                    [](auto& a, auto& b) { return a.first < b.first; });
+  std::sort(versions_array.begin(),
+            versions_array.end(),
+            [](auto& a, auto& b) { return a.first < b.first; });
 
   return versions_array;
 }


### PR DESCRIPTION
### Summary
This replaces `std::ranges::sort()` with `std::sort(begin, end, ...)` in `src/node_metadata.cc`.

### Motivation
On armhf + clang-13/libc++13, `std::ranges::sort` is unavailable, causing Node v22 build failure.

### Testing
- Built on armhf (Raspberry Pi 3, 32-bit userspace)
- Command: `make -j2`

### Notes
- No behavior change intended; sorting semantics are unchanged.