### PR TITLE
build: `generate_config_gypi.py` generates valid JSON

### DIFF
--- a/tools/generate_config_gypi.py
+++ b/tools/generate_config_gypi.py
@@ -58,7 +58,7 @@ def translate_config(out_dir, config, v8_config):
       'llvm_version': 13,
       'napi_build_version': config['napi_build_version'],
       'node_builtin_shareable_builtins':
-          eval(config['node_builtin_shareable_builtins']),
+          json.loads(config['node_builtin_shareable_builtins']),
       'node_module_version': int(config['node_module_version']),
       'node_use_openssl': config['node_use_openssl'],
       'node_use_amaro': config['node_use_amaro'],
@@ -102,7 +102,8 @@ def main():
 
   # Write output.
   with open(args.target, 'w') as f:
-    f.write(repr(translate_config(args.out_dir, config, v8_config)))
+    f.write(json.dumps(translate_config(args.out_dir, config, v8_config),
+                       sort_keys=True))
 
   # Write depfile. Force regenerating config.gypi when GN configs change.
   if args.dep_file:


### PR DESCRIPTION
Refs https://github.com/nodejs/node/pull/60794

`generate_config_gypi.py` needs to generate valid JSON and didn't.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
