### PR TITLE
doc: fix grammar in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Looking for help? Check out the
   each October.
 * **LTS**: Releases that receive Long Term Support, with a focus on stability
   and security. Every even-numbered major version will become an LTS release.
-  LTS releases receive 12 months of _Active a LTS_ support and a further 18 months
+  LTS releases receive 12 months of _Active LTS_ support and a further 18 months
   of _Maintenance_. LTS release lines have alphabetically-ordered code names,
   beginning with v4 Argon. There are no breaking changes or feature additions,
   except in some special circumstances.


### PR DESCRIPTION
Fixes a small typo in the README file in the LTS release description.

The phrase:

> "12 months of _Active a LTS_ support"

has been corrected to:

> "12 months of _Active LTS_ support"

This improves clarity and correctness of the documentation.

