### PR TITLE
stream: fix pipeTo to defer writes per WHATWG spec

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1584,9 +1584,14 @@ class PipeToReadableStreamReadRequest {
   }
 
   [kChunk](chunk) {
-    this.state.currentWrite = writableStreamDefaultWriterWrite(this.writer, chunk);
-    setPromiseHandled(this.state.currentWrite);
-    this.promise.resolve(false);
+    // Per spec, pipeTo must queue a microtask for the write to avoid
+    // synchronous write during enqueue(). See WHATWG Streams spec
+    // "ReadableStreamPipeTo" step 15's "chunk steps".
+    queueMicrotask(() => {
+      this.state.currentWrite = writableStreamDefaultWriterWrite(this.writer, chunk);
+      setPromiseHandled(this.state.currentWrite);
+      this.promise.resolve(false);
+    });
   }
 
   [kClose]() {

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -2,14 +2,6 @@
   "idlharness-shadowrealm.window.js": {
     "skip": "ShadowRealm support is not enabled"
   },
-  "piping/general-addition.any.js": {
-    "fail": {
-      "note": "Blocked on https://github.com/whatwg/streams/issues/1243",
-      "expected": [
-        "enqueue() must not synchronously call write algorithm"
-      ]
-    }
-  },
   "queuing-strategies-size-function-per-global.window.js": {
     "skip": "Browser-specific test"
   },


### PR DESCRIPTION
## Summary

- Fix `PipeToReadableStreamReadRequest[kChunk]` to defer writes via `queueMicrotask()` per the WHATWG Streams spec
- The spec requires that pipeTo's chunk steps must not synchronously call the write algorithm during `enqueue()`
- Remove expected WPT test failure for "enqueue() must not synchronously call write algorithm"

## Details

Previously, `PipeToReadableStreamReadRequest[kChunk]` would synchronously call `writableStreamDefaultWriterWrite()`, which violated the WHATWG Streams spec ([ReadableStreamPipeTo](https://streams.spec.whatwg.org/#readable-stream-pipe-to) step 15's "chunk steps").

This caused the WPT test `piping/general-addition.any.js` → `"enqueue() must not synchronously call write algorithm"` to fail, which was tracked as an expected failure (see https://github.com/whatwg/streams/issues/1243).

Wrapping the write in `queueMicrotask()` defers it to the next microtask, matching the spec's required timing semantics.

Refs: https://github.com/whatwg/streams/issues/1243

## Test plan

- [x] WPT streams tests pass (`test/wpt/test-streams.js`)
- [x] Previously expected failure now passes
- [x] All `test/parallel/test-webstreams-*.js` tests pass