### PR TITLE
test: fix flaky test-http2-close-while-writing

### DIFF
--- a/test/parallel/test-http2-close-while-writing.js
+++ b/test/parallel/test-http2-close-while-writing.js
@@ -38,7 +38,7 @@ server.listen(0, common.mustCall(() => {
   });
   client_stream = client.request({ ':method': 'POST' });
   client_stream.on('close', common.mustCall(() => {
-    client.close();
+    client.destroy();
     server.close();
   }));
   client_stream.resume();


### PR DESCRIPTION
The test was flaky due to a race condition where `client.close()` would
wait for a graceful shutdown while the server had already destroyed the
session/stream, leading to a timeout.

Changes:
- Replace `client.close()` with `client.destroy()` in the `close` event
  handler of the client stream.
- Add `common.mustNotCall()` error handlers to the client, client stream,
  and server session to catch unexpected errors.
- Add check `if (!client_stream.destroyed)` before destroying client
  stream in the server's data handler.

Refs: https://github.com/nodejs/node/issues/33156