### PR TITLE
build: use path-ignore in GHA coverage-windows.yml

### DIFF
--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -3,31 +3,55 @@ name: Coverage Windows
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - lib/**/*.js
-      - vcbuild.bat
-      - src/**/*.cc
-      - src/**/*.h
-      - test/**
-      - tools/gyp/**
-      - tools/test.py
-      - .github/workflows/coverage-windows.yml
-      - codecov.yml
-      - .nycrc
+    paths-ignore:
+      - '**.md'
+      - '**.nix'
+      - eslint.config.mjs
+      - '**/eslint.config_partial.mjs'
+      - android-configure
+      - android-configure.py
+      - android-patches/**
+      - benchmarks/**
+      - doc/**
+      - pyproject.yml
+      - tsconfig.json
+      - test/internet/**
+      - tools/actions/**
+      - tools/bootstrap/**
+      - tools/dep_updaters/**
+      - tools/doc/**
+      - tools/eslint-rules/**
+      - tools/eslint/**
+      - tools/lint-md/**
+      - typings/**
+      - .**
+      - '!.github/workflows/coverage-windows.yml'
   push:
     branches:
       - main
-    paths:
-      - lib/**/*.js
-      - vcbuild.bat
-      - src/**/*.cc
-      - src/**/*.h
-      - test/**
-      - tools/gyp/**
-      - tools/test.py
-      - .github/workflows/coverage-windows.yml
-      - codecov.yml
-      - .nycrc
+    paths-ignore:
+      - '**.md'
+      - '**.nix'
+      - eslint.config.mjs
+      - '**/eslint.config_partial.mjs'
+      - android-configure
+      - android-configure.py
+      - android-patches/**
+      - benchmarks/**
+      - doc/**
+      - pyproject.yml
+      - tsconfig.json
+      - test/internet/**
+      - tools/actions/**
+      - tools/bootstrap/**
+      - tools/dep_updaters/**
+      - tools/doc/**
+      - tools/eslint-rules/**
+      - tools/eslint/**
+      - tools/lint-md/**
+      - typings/**
+      - .**
+      - '!.github/workflows/coverage-windows.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
Use similar `paths-ignore` in other GHA jobs like `.github/workflows/test-macos.yml` to ignore certain changes that do not have effect on builds.

This allows changes to `configure.py`, `node.gyp`, or `src/inspector/node_protocol.pdl`, etc, to be tested on GHA windows.

For example, windows GHA was not triggered on https://github.com/nodejs/node/pull/61806.