### PR TITLE
sea: support ESM entry point in SEA

### DIFF
--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -11,6 +11,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "node.h"
 #include "node_exit_code.h"
 
 namespace node {
@@ -43,6 +44,7 @@ struct SeaConfig {
   std::string executable_path;
   SeaFlags flags = SeaFlags::kDefault;
   SeaExecArgvExtension exec_argv_extension = SeaExecArgvExtension::kEnv;
+  ModuleFormat main_format = ModuleFormat::kCommonJS;
   std::unordered_map<std::string, std::string> assets;
   std::vector<std::string> exec_argv;
 };
@@ -52,6 +54,7 @@ struct SeaResource {
   SeaExecArgvExtension exec_argv_extension = SeaExecArgvExtension::kEnv;
   std::string_view code_path;
   std::string_view main_code_or_snapshot;
+  ModuleFormat main_code_format = ModuleFormat::kCommonJS;
   std::optional<std::string_view> code_cache;
   std::unordered_map<std::string_view, std::string_view> assets;
   std::vector<std::string_view> exec_argv;
@@ -59,8 +62,9 @@ struct SeaResource {
   bool use_snapshot() const;
   bool use_code_cache() const;
 
-  static constexpr size_t kHeaderSize =
-      sizeof(kMagic) + sizeof(SeaFlags) + sizeof(SeaExecArgvExtension);
+  static constexpr size_t kHeaderSize = sizeof(kMagic) + sizeof(SeaFlags) +
+                                        sizeof(SeaExecArgvExtension) +
+                                        sizeof(ModuleFormat);
 };
 
 bool IsSingleExecutable();

--- a/test/fixtures/sea/esm/sea-config.json
+++ b/test/fixtures/sea/esm/sea-config.json
@@ -1,0 +1,6 @@
+{
+  "main": "sea.mjs",
+  "output": "sea",
+  "mainFormat": "module",
+  "disableExperimentalSEAWarning": true
+}

--- a/test/fixtures/sea/esm/sea.mjs
+++ b/test/fixtures/sea/esm/sea.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert';
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+import { dirname } from 'node:path';
+
+// Test createRequire with process.execPath.
+const assert2 = createRequire(process.execPath)('node:assert');
+assert.strictEqual(assert2.strict, assert.strict);
+
+// Test import.meta properties. This should be in sync with the CommonJS entry
+// point's corresponding values.
+assert.strictEqual(import.meta.url, pathToFileURL(process.execPath).href);
+assert.strictEqual(import.meta.filename, process.execPath);
+assert.strictEqual(import.meta.dirname, dirname(process.execPath));
+assert.strictEqual(import.meta.main, true);
+// TODO(joyeecheung): support import.meta.resolve when we also support
+// require.resolve in CommonJS entry points, the behavior of the two
+// should be in sync.
+
+// Test import() with a built-in module.
+const { strict } = await import('node:assert');
+assert.strictEqual(strict, assert.strict);
+
+console.log('ESM SEA executed successfully');

--- a/test/sea/test-single-executable-application-esm.js
+++ b/test/sea/test-single-executable-application-esm.js
@@ -1,0 +1,33 @@
+'use strict';
+
+require('../common');
+
+const {
+  buildSEA,
+  skipIfBuildSEAIsNotSupported,
+} = require('../common/sea');
+
+skipIfBuildSEAIsNotSupported();
+
+// This tests the creation of a single executable application with an ESM
+// entry point using the "mainFormat": "module" configuration.
+
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+
+tmpdir.refresh();
+
+const outputFile = buildSEA(fixtures.path('sea', 'esm'));
+
+spawnSyncAndExitWithoutError(
+  outputFile,
+  {
+    env: {
+      NODE_DEBUG_NATIVE: 'SEA',
+      ...process.env,
+    },
+  },
+  {
+    stdout: /ESM SEA executed successfully/,
+  });


### PR DESCRIPTION
This uses the new StartExecutionCallbackWithModule embedder API added in https://github.com/nodejs/node/pull/61548 to support ESM entrypoint in SEA via a new configuration field `"mainFormat"`. The behavior currently aligns with the embedder API and is mostly in sync with the CommonJS entry point behavior, except that support for code caching and snapshot is left for follow-ups.

Similar to CommonJS entrypoints, non-builtin access is currently not supported - though the WIP VFS would unlock that. This PR would allow users that are bundling their apps for SEA building to target ESM instead of CommonJS for the bundle output.

Build with: `node --build-sea sea-config.json`

```json
{
  "main": "sea.mjs",
  "output": "sea",
  "mainFormat": "module",
}
```

```js
// sea.mjs
// Static import for builtins is supported.
import assert from 'node:assert';
import { pathToFileURL } from 'node:url';

// Dynamic import() for builtins and top-level await are supported
const { strict } = await import('node:assert');
assert.strictEqual(strict, assert.strict);

// import.meta is supported (mostly)
assert.strictEqual(import.meta.url, pathToFileURL(process.execPath).href);
assert.strictEqual(import.meta.filename, process.execPath);
assert.strictEqual(import.meta.dirname, dirname(process.execPath));
assert.strictEqual(import.meta.main, true);

// import.meta.resolve is currently unsupported - will depend on something like VFS.
```

Note: for follow-ups:

- Snapshot support will rely on https://github.com/nodejs/node/pull/61769
- non-built-in access will rely on https://github.com/nodejs/node/pull/61478

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
