### PR TITLE
[v22.x backport] build: support Python 3.14

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -28,7 +28,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
 
 permissions:

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
   CC: sccache clang
   CXX: sccache clang++

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
   CC: sccache clang
   CXX: sccache clang++

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -34,7 +34,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
 
 permissions:

--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -13,7 +13,7 @@ on:
     - cron: 30 0 * * *
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
 
 permissions:
   contents: read

--- a/.github/workflows/lint-release-proposal.yml
+++ b/.github/workflows/lint-release-proposal.yml
@@ -10,7 +10,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   NODE_VERSION: lts/*
 
 permissions:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,7 +14,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   NODE_VERSION: lts/*
 
 permissions:

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -31,7 +31,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
   CC: sccache clang
   CXX: sccache clang++

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -25,7 +25,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   FLAKY_TESTS: keep_retrying
   CC: sccache clang
   CXX: sccache clang++

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -29,7 +29,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
   XCODE_VERSION: '16.1'
   FLAKY_TESTS: keep_retrying
 

--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -43,7 +43,7 @@ on:
           - zstd
 
 env:
-  PYTHON_VERSION: '3.12'
+  PYTHON_VERSION: '3.14'
 
 permissions:
   contents: read

--- a/android-configure
+++ b/android-configure
@@ -4,6 +4,7 @@
 # Note that the mix of single and double quotes is intentional,
 # as is the fact that the ] goes on a new line.
 _=[ 'exec' '/bin/sh' '-c' '''
+command -v python3.14 >/dev/null && exec python3.14 "$0" "$@"
 command -v python3.13 >/dev/null && exec python3.13 "$0" "$@"
 command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
 command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
@@ -23,7 +24,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js android configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
+acceptable_pythons = ((3, 14), (3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
 if sys.version_info[:2] in acceptable_pythons:
   import android_configure
 else:

--- a/configure
+++ b/configure
@@ -4,6 +4,7 @@
 # Note that the mix of single and double quotes is intentional,
 # as is the fact that the ] goes on a new line.
 _=[ 'exec' '/bin/sh' '-c' '''
+command -v python3.14 >/dev/null && exec python3.14 "$0" "$@"
 command -v python3.13 >/dev/null && exec python3.13 "$0" "$@"
 command -v python3.12 >/dev/null && exec python3.12 "$0" "$@"
 command -v python3.11 >/dev/null && exec python3.11 "$0" "$@"
@@ -23,7 +24,7 @@ except ImportError:
   from distutils.spawn import find_executable as which
 
 print('Node.js configure: Found Python {}.{}.{}...'.format(*sys.version_info))
-acceptable_pythons = ((3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
+acceptable_pythons = ((3, 14), (3, 13), (3, 12), (3, 11), (3, 10), (3, 9), (3, 8))
 if sys.version_info[:2] in acceptable_pythons:
   import configure
 else:


### PR DESCRIPTION
Python v3.14 -- October 7th
* https://www.python.org/download/pre-releases
* https://www.python.org/downloads/release/python-3140rc3

PR-URL: https://github.com/nodejs/node/pull/59983
Reviewed-By: Marco Ippolito <marcoippolito54@gmail.com>a
Reviewed-By: Stefan Stojanovic <stefan.stojanovic@janeasystems.com>
Reviewed-By: Stewart X Addison <sxa@redhat.com>

---

Refs: https://github.com/nodejs/node/issues/60874
Refs: https://github.com/nodejs/node/pull/61370

## Situation

Node.js 22.x (Maintenance LTS) build fails with Python 3.14.

Python 3.14 is:

- the current highest [supported Python version](https://devguide.python.org/versions/)
- the version installed on Windows using `py install default`
- the system-default on Fedora 43

On Windows 11 25H2 with prerequisites including Python 3.14.x installed:

```shell
git switch v22.x
.\vcbuild
```

fails with:

```text
Node.js configure: Found Python 3.14.3...
Please use python3.13 or python3.12 or python3.11 or python3.10 or python3.9 or python3.8.
Failed to create vc project files.
```

## Change

Backports https://github.com/nodejs/node/pull/59983 as modified through the backport PR for v24.x https://github.com/nodejs/node/pull/61370 and commit https://github.com/nodejs/node/commit/1f64d6841e1c6b61c76d3015e6cccabf4bec9827 in the v24.x branch, resolving merge conflicts.

The commit message from the backport needs to be modified. The original message "build: test on Python 3.14 release candidate 3" was not entirely accurate, as the commit not only tested on Python 3.14, it also provided support for Python 3.14. Additionally, by the time the PR was merged, Python 3.14 was in GA status, and no longer a release candidate.

The changed commit message is:

> build: support Python 3.14

## Verification

For both Windows and Fedora confirm
- there is no error concerning the version of Python
- the build completes successfully

### Windows

On Windows 11 25H2 manually install prerequisites according to [Windows - Option 1: Manual install](https://github.com/nodejs/node/blob/main/BUILDING.md#option-1-manual-install) and using Visual Studio 2022 Build Tools Edition.

Only Python 3.14.x should be shown installed by:

```shell
py list
```

In a PowerShell 7 terminal, execute:

```powershell
.\vcbuild
```

### Fedora

On Fedora 43, install prerequisites according to [Unix prerequisites](https://github.com/nodejs/node/blob/main/BUILDING.md#unix-prerequisites):

```shell
sudo dnf update
sudo dnf install python3 gcc-c++ make python3-pip
```

Execute:

```shell
./configure
make -j4
```
