### PR TITLE
doc: fix typo in --disable-wasm-trap-handler description

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -758,7 +758,7 @@ added:
 
 By default, Node.js enables trap-handler-based WebAssembly bound
 checks. As a result, V8 does not need to insert inline bound checks
-int the code compiled from WebAssembly which may speedup WebAssembly
+in the code compiled from WebAssembly which may speed up WebAssembly
 execution significantly, but this optimization requires allocating
 a big virtual memory cage (currently 10GB). If the Node.js process
 does not have access to a large enough virtual memory address space

--- a/doc/node.1
+++ b/doc/node.1
@@ -460,7 +460,7 @@ vm.measureMemory();
 .It Fl -disable-wasm-trap-handler
 By default, Node.js enables trap-handler-based WebAssembly bound
 checks. As a result, V8 does not need to insert inline bound checks
-int the code compiled from WebAssembly which may speedup WebAssembly
+in the code compiled from WebAssembly which may speed up WebAssembly
 execution significantly, but this optimization requires allocating
 a big virtual memory cage (currently 10GB). If the Node.js process
 does not have access to a large enough virtual memory address space


### PR DESCRIPTION
This PR fixes a typo in the `--disable-wasm-trap-handler` documentation.

Changes:
- `doc/api/cli.md`: `int the` -> `in the`, `may speedup` -> `may speed up`
- `doc/node.1`: applied the same fix to keep the man page in sync

This is a docs-only change and does not affect runtime behavior.

### Testing
No runtime tests were run (docs-only change).
