### PR TITLE
http2: invoke pending write callback on stream destroy

### DIFF
--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -253,6 +253,7 @@ const kOptions = Symbol('options');
 const kOwner = owner_symbol;
 const kOrigin = Symbol('origin');
 const kPendingRequestCalls = Symbol('kPendingRequestCalls');
+const kPendingWriteCb = Symbol('kPendingWriteCb');
 const kProceed = Symbol('proceed');
 const kRemoteSettings = Symbol('remote-settings');
 const kRequestAsyncResource = Symbol('requestAsyncResource');
@@ -2276,10 +2277,13 @@ class Http2Stream extends Duplex {
       cb(err);
     };
     const writeCallback = (err) => {
+      if (!waitingForWriteCallback) return;
+      this[kPendingWriteCb] = null;
       waitingForWriteCallback = false;
       writeCallbackErr = err;
       done();
     };
+    this[kPendingWriteCb] = writeCallback;
     const endCheckCallback = (err) => {
       waitingForEndCheck = false;
       endCheckCallbackErr = err;
@@ -2444,6 +2448,12 @@ class Http2Stream extends Duplex {
     if (!this.closed)
       closeStream(this, code, hasHandle ? kForceRstStream : kNoRstStream);
     this.push(null);
+
+    const pendingWriteCb = this[kPendingWriteCb];
+    if (pendingWriteCb) {
+      this[kPendingWriteCb] = null;
+      pendingWriteCb(err);
+    }
 
     if (hasHandle) {
       handle.destroy();


### PR DESCRIPTION
## Summary

- Track the pending write callback on `Http2Stream` via `kPendingWriteCb` and invoke it in `_destroy()` before calling `handle.destroy()`, ensuring the Writable stream can clean up properly when a stream is destroyed mid-write
- Make the write callback idempotent so duplicate invocations from the C++ side are harmless no-ops

When an HTTP/2 stream is destroyed while a write is in progress, the pending write callback may never be called if the write data has already been consumed by nghttp2 and moved to the session's `outgoing_buffers_`. This leaves the Writable stream's `kWriting` flag set permanently, preventing `errorBuffer` from cleaning up remaining buffered writes and keeping references alive that block event loop exit.

Fixes: https://github.com/nodejs/node/issues/58252
Refs: https://github.com/nodejs/node/pull/58253

## Test plan

- [x] `test-http2-close-while-writing` passes consistently
- [x] Stress tested with 500 repetitions — zero failures
- [x] Full HTTP/2 test suite (`test-http2-*`) passes with no regressions