### PR TITLE
deps: V8: cherry-pick 67507b2a88f4

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/strings/unicode.h
+++ b/deps/v8/src/strings/unicode.h
@@ -213,7 +213,7 @@ class V8_EXPORT_PRIVATE Utf8 {
   static bool ValidateEncoding(const uint8_t* str, size_t length);
 
   template <typename Char>
-  static bool IsAsciiOneByteString(const Char* buffer, size_t size);
+  static size_t WriteLeadingAscii(const Char* src, char* dest, size_t size);
 
   // Encode the given characters as Utf8 into the provided output buffer.
   struct EncodingResult {
@@ -227,12 +227,12 @@ class V8_EXPORT_PRIVATE Utf8 {
 };
 
 template <>
-inline bool Utf8::IsAsciiOneByteString<uint8_t>(const uint8_t* buffer,
+size_t unibrow::Utf8::WriteLeadingAscii<uint8_t>(const uint8_t* src, char* dest,
                                                  size_t size);
 
 template <>
-inline bool Utf8::IsAsciiOneByteString<uint16_t>(const uint16_t* buffer,
-                                                  size_t size);
+size_t unibrow::Utf8::WriteLeadingAscii<uint16_t>(const uint16_t* src,
+                                                  char* dest, size_t size);
 
 #if V8_ENABLE_WEBASSEMBLY
 class V8_EXPORT_PRIVATE Wtf8 {


### PR DESCRIPTION
## Summary

Cherry-picks two V8 commits (squashed) to add Highway-based `WriteLeadingAscii` and fix its GCC build:

- [`67507b2a88f4`](https://github.com/v8/v8/commit/67507b2a88f4cf6eb18ed351661d218e498fa3e7) — **Reland "use highway to check and copy leading ascii"** (Dan Carney)
  Replaces `IsAsciiOneByteString` + `memcpy` with Highway `WriteLeadingAscii` in `Utf8::Encode`, providing a faster ASCII fast path for `WriteUtf8V2`.
  CL: https://chromium-review.googlesource.com/c/v8/v8/+/7184338

- [`ee2873a6303d`](https://github.com/v8/v8/commit/ee2873a6303da9116d2b4a87caf8e1e7da50ea3e) — **Fix GCC Build** (Abdirahim Musse)
  Moves `WriteLeadingAscii` explicit template specializations to namespace scope — C++ forbids them inside class scope, and GCC rejects it.
  CL: https://chromium-review.googlesource.com/c/v8/v8/+/7138905

  Note: only the `unicode.h` portion of this commit is included; the test file changes (`heap-unittest.cc`, `module-decoder-unittest.cc`) do not apply cleanly to Node.js's V8 copy and are unrelated to the `WriteLeadingAscii` fix.

This patch addresses part of the remaining ~30-40% performance gap in `WriteUtf8V2` vs v22 after #61712 landed the initial `simdutf` + `memcpy` fast path.

Refs: https://github.com/nodejs/node/issues/60719

## Test plan

- [ ] CI: V8 CI + Node.js CI