### PR TITLE
docs: Remove incorrect mention of `module`

### DIFF
--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -146,11 +146,10 @@ The most prominent features that require transformation are:
 
 * `Enum` declarations
 * `namespace` with runtime code
-* legacy `module` with runtime code
 * parameter properties
 * import aliases
 
-`namespaces` and `module` that do not contain runtime code are supported.
+`namespace`s that do not contain runtime code are supported.
 This example will work correctly:
 
 ```ts


### PR DESCRIPTION
Node/Amaro has never supported `module`-keyword namespaces.  Even with `transform-types` on.

This removes the incorrect mention.