### PR TITLE
[v24.x backport] build: add support for Visual Studio 2026

### DIFF
--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -273,7 +273,7 @@ if %target_arch%==%msvs_host_arch% set vcvarsall_arg=%target_arch%
 
 @rem Look for Visual Studio 2026
 :vs-set-2026
-if defined target_env if "%target_env%" NEQ "vs2026" goto msbuild-not-found
+if defined target_env if "%target_env%" NEQ "vs2026" goto vs-set-2022
 echo Looking for Visual Studio 2026
 @rem VCINSTALLDIR may be set if run from a VS Command Prompt and needs to be
 @rem cleared first as vswhere_usability_wrapper.cmd doesn't when it fails to


### PR DESCRIPTION
Backporting 2 interrelated PRs:

---

commit a4b05c133bed7263ba2ef3b983ebe0a6c4101d12
Author: Michaël Zasso <targos@protonmail.com>
Date:   Wed Nov 19 17:01:37 2025 +0100

    build: add support for Visual Studio 2026

    Backport-PR-URL: https://github.com/nodejs/node/pull/61840
    PR-URL: https://github.com/nodejs/node/pull/60727
    Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
    Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
    Reviewed-By: Yagiz Nizipli <yagiz@nizipli.com>
    Reviewed-By: Stefan Stojanovic <stefan.stojanovic@janeasystems.com>
---

commit 25c5353c475dd29a3e2fd31747b657559f25b182
Author: Stefan Stojanovic <stefan.stojanovic@janeasystems.com>
Date:   Wed Jan 28 15:52:43 2026 +0100

    build,win: fix vs2022 compilation

    Backport-PR-URL: https://github.com/nodejs/node/pull/61840
    PR-URL: https://github.com/nodejs/node/pull/61530
    Reviewed-By: Colin Ihrig <cjihrig@gmail.com>
    Reviewed-By: Luigi Pinca <luigipinca@gmail.com>
    Reviewed-By: Michaël Zasso <targos@protonmail.com>
    Reviewed-By: Richard Lau <richard.lau@ibm.com>
---

## Situation

[BUILDING > Supported toolchains](https://github.com/nodejs/node/blob/v24.x/BUILDING.md#supported-toolchains) for the v24.x branch shows:

| Operating System | Compiler Versions                                              |
| ---------------- | -------------------------------------------------------------- |
| Windows          | Visual Studio >= 2022 with the Windows 10 SDK on a 64-bit host |

With only Visual Studio 2026 Build Tools Edition from https://visualstudio.microsoft.com/downloads/#build-tools-for-visual-studio-2026 installed with necessary prerequisites (no side-by-side Visual Studio 2022 installed), executing `.\vcbuild` in a PowerShell 7 terminal fails, although the "Supported toolchains" suggest that Visual Studio 2026 should be supported.

> Looking for Visual Studio 2022
> Failed to find a suitable Visual Studio installation with Clang compiler/LLVM toolset.

## Change

Cherry-pick https://github.com/nodejs/node/commit/934d90735ae36bc1bd362bf28f901d7b68c1176e from https://github.com/nodejs/node/pull/60727

Preserve the `[nocorepack]` option in `vcbuild.bat` `v24.x`, which was removed for `>=v25.x`, to resolve a cherry-pick conflict.

Also cherry-pick https://github.com/nodejs/node/commit/5a8864de93211434c8cdbdf3d2426bfa8a9b3e81 from https://github.com/nodejs/node/pull/61530 to fix a one line bug in https://github.com/nodejs/node/pull/60727 which prevented selecting Visual Studio 2022 with `.\vcbuild vs2022` in a side-by-side configuration where both Visual Studio 2022 and 2026 were installed.

## Verification

In Windows 11 25H2 with Visual Studio 2022 & 2026 variously installed / not installed, ensure that all valid command combinations of `.\vcbuild` run:

| Command          | Visual Studio 2022 installed | Visual Studio 2026 installed | Studio version selected |
| ---------------- | ---------------------------- | ---------------------------- | ----------------------- |
| .\vcbuild        | YES                          | NO                           | vs2022                  |
| .\vcbuild vs2022 | YES                          | NO                           | vs2022                  |
| .\vcbuild        | YES                          | YES                          | vs2026                  |
| .\vcbuild vs2022 | YES                          | YES                          | vs2022                  |
| .\vcbuild vs2026 | YES                          | YES                          | vs2026                  |
| .\vcbuild        | NO                           | YES                          | vs2026                  |
| .\vcbuild v2026  | NO                           | YES                          | vs2026                  |
