### PR TITLE
doc: simplify addAbortListener example

### DIFF
--- a/doc/api/events.md
+++ b/doc/api/events.md
@@ -1909,6 +1909,8 @@ const { addAbortListener } = require('node:events');
 
 function example(signal) {
   signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+  // addAbortListener() returns a disposable, so the `using` keyword ensures
+  // the abort listener is automatically removed when this scope exits.
   using _ = addAbortListener(signal, (e) => {
     // Do something when signal is aborted.
   });
@@ -1920,6 +1922,8 @@ import { addAbortListener } from 'node:events';
 
 function example(signal) {
   signal.addEventListener('abort', (e) => e.stopImmediatePropagation());
+  // addAbortListener() returns a disposable, so the `using` keyword ensures
+  // the abort listener is automatically removed when this scope exits.
   using _ = addAbortListener(signal, (e) => {
     // Do something when signal is aborted.
   });


### PR DESCRIPTION
The example was written before v8 supported the using keyword and hence explicitly called `Symbol.dispose`.

Since now the keyword is supported, the example can be simplified.