### PR TITLE
test_runner: skip branches entirely on ignored lines

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -193,18 +193,20 @@ class TestCoverage {
           ObjectAssign(range, mapRangeToLines(range, lines));
 
           if (isBlockCoverage) {
-            ArrayPrototypePush(branchReports, {
-              __proto__: null,
-              line: range.lines[0]?.line,
-              count: range.count,
-            });
+            // Skip branches that are entirely on ignored lines
+            if (range.ignoredLines !== range.lines.length) {
+              ArrayPrototypePush(branchReports, {
+                __proto__: null,
+                line: range.lines[0]?.line,
+                count: range.count,
+              });
 
-            if (range.count !== 0 ||
-                range.ignoredLines === range.lines.length) {
-              branchesCovered++;
+              if (range.count !== 0) {
+                branchesCovered++;
+              }
+
+              totalBranches++;
             }
-
-            totalBranches++;
           }
         }
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/61586

## Summary
When a branch is entirely on ignored lines (via c8 ignore comments), it should not appear in the BRDA output at all, rather than appearing with 0 coverage.

## Changes
Modified the branch coverage logic in `lib/internal/test_runner/coverage.js` to check if all lines in the branch are ignored before:
- Adding to `branchReports` array
- Incrementing `totalBranches` counter

This ensures ignored branches don't pollute coverage reports.

## Testing
Requires building Node.js and running the test suite:
```bash
./configure && make -j4
make test-only
```