### PR TITLE
fs: fix process crash in fs.promises.writeFile

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -1240,7 +1240,35 @@ async function writeFile(path, data, options) {
 
   checkAborted(options.signal);
 
-  const fd = await open(path, flag, options.mode);
+
+  let fd;
+  if (isCustomIterable(data) && typeof data.on === 'function') {
+    fd = await new Promise((resolve, reject) => {
+      let isRejected = false;
+      const onStreamError = (err) => {
+        isRejected = true;
+        reject(err);
+      };
+      data.on('error', onStreamError);
+      open(path, flag, options.mode).then((fd) => {
+        data.removeListener('error', onStreamError);
+        if (isRejected) {
+          // If the stream emitted an error while opening the file, close the file.
+          // Ignore any errors from closing the file since the promise is already
+          // rejected with the stream error.
+          fd.close().then(undefined, () => {});
+        } else {
+          resolve(fd);
+        }
+      }, (err) => {
+        data.removeListener('error', onStreamError);
+        reject(err);
+      });
+    });
+  } else {
+    fd = await open(path, flag, options.mode);
+  }
+
   let writeOp = writeFileHandle(fd, data, options.signal, options.encoding);
 
   if (flush) {

--- a/test/parallel/test-fs-promises-writefile.js
+++ b/test/parallel/test-fs-promises-writefile.js
@@ -161,6 +161,21 @@ async function doReadWithEncoding() {
   assert.deepStrictEqual(data, syncData);
 }
 
+async function doWriteStreamWithError() {
+  const s1 = new Readable({
+    read() {}
+  });
+
+  process.nextTick(() => {
+    s1.emit('error', new Error('Boom'));
+  });
+
+  await assert.rejects(
+    fsPromises.writeFile(otherDest, s1),
+    { message: 'Boom' }
+  );
+}
+
 (async () => {
   await doWrite();
   await doWriteWithCancel();
@@ -169,6 +184,7 @@ async function doReadWithEncoding() {
   await doReadWithEncoding();
   await doWriteStream();
   await doWriteStreamWithCancel();
+  await doWriteStreamWithError();
   await doWriteIterable();
   await doWriteInvalidIterable();
   await doWriteIterableWithEncoding();


### PR DESCRIPTION
This commit fixes an issue where the process would crash if the input stream emitted an error while the file was being opened.

The issue was caused by a race condition where the stream would emit an 'error' event before the file handle was returned from `open()`. Since there were no error listeners attached to the stream at that point, the process would crash with an "Unhandled 'error' event".

This fix attaches a temporary error listener to the stream before calling `open()`. If the stream emits an error, the promise is rejected immediately. When `open()` completes (even if the stream already errored), the file handle is safely closed to prevent resource leaks.

Fixes: https://github.com/nodejs/node/issues/58742