### PR TITLE
test_runner: preserve user flags in argv

### DIFF
--- a/lib/internal/main/test_runner.js
+++ b/lib/internal/main/test_runner.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const {
-  ArrayPrototypeSlice,
+  ArrayPrototypePush,
+  StringPrototypeStartsWith,
 } = primordials;
 
 const {
@@ -30,7 +31,26 @@ if (isUsingInspector() && options.isolation === 'process') {
   options.inspectPort = process.debugPort;
 }
 
-options.globPatterns = ArrayPrototypeSlice(process.argv, 1);
+const userArgs = [];
+const globPatterns = [];
+let isArg = false;
+
+for (let i = 1; i < process.argv.length; i++) {
+  const arg = process.argv[i];
+  if (isArg) {
+    ArrayPrototypePush(userArgs, arg);
+  } else if (arg === '--') {
+    isArg = true;
+    ArrayPrototypePush(userArgs, arg);
+  } else if (StringPrototypeStartsWith(arg, '-')) {
+    ArrayPrototypePush(userArgs, arg);
+  } else {
+    ArrayPrototypePush(globPatterns, arg);
+  }
+}
+
+options.globPatterns = globPatterns;
+options.argv = userArgs;
 
 debug('test runner configuration:', options);
 run(options).on('test:summary', (data) => {

--- a/test/fixtures/test-runner/argv.js
+++ b/test/fixtures/test-runner/argv.js
@@ -1,0 +1,1 @@
+console.log(JSON.stringify(process.argv));

--- a/test/parallel/test-runner-cli-args.js
+++ b/test/parallel/test-runner-cli-args.js
@@ -1,0 +1,47 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+const fixtures = require('../common/fixtures');
+
+const testFixture = fixtures.path('test-runner/argv.js');
+
+{
+  const args = ['--test', testFixture, '--hello'];
+  const child = spawnSync(process.execPath, args);
+
+  assert.strictEqual(child.stderr.toString(), '');
+  const stdout = child.stdout.toString();
+  assert.match(stdout, /"--hello"\]/);
+  assert.strictEqual(child.status, 0);
+}
+
+{
+  const args = ['--test', testFixture, '--', '--hello', '--world'];
+  const child = spawnSync(process.execPath, args);
+
+  assert.strictEqual(child.stderr.toString(), '');
+  const stdout = child.stdout.toString();
+  assert.match(stdout, /"--","--hello","--world"\]/);
+  assert.strictEqual(child.status, 0);
+}
+
+{
+  const args = ['--test', testFixture, '--', 'foo.js'];
+  const child = spawnSync(process.execPath, args);
+
+  assert.strictEqual(child.stderr.toString(), '');
+  const stdout = child.stdout.toString();
+  assert.match(stdout, /"--","foo\.js"\]/);
+  assert.strictEqual(child.status, 0);
+}
+
+{
+  const args = ['--test', testFixture, '--hello', '--', 'world'];
+  const child = spawnSync(process.execPath, args);
+
+  assert.strictEqual(child.stderr.toString(), '');
+  const stdout = child.stdout.toString();
+  assert.match(stdout, /"--hello","--","world"\]/);
+  assert.strictEqual(child.status, 0);
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/61852

This PR fixes an issue where user-specified flags were being stripped from `process.argv` when running with the `--test` flag.

Previously, the test runner treated all arguments as potential file patterns, ignoring flags that weren't specific to the test runner. This made it impossible to pass custom flags (e.g., `--hello`) to test files.

This change ensures that:
1. Arguments following `--` are correctly treated as user arguments.
2. Arguments starting with `-` (that are not consumed by Node.js or the test runner) are preserved and passed to the test process.

Added new tests in `test/parallel/test-runner-cli-args.js` to verify:
- Implicit flag passing: `node --test fixture.js --hello`
- Explicit flag passing: `node --test fixture.js -- --hello`
- Mixed usage: `node --test fixture.js --hello -- world`