### PR TITLE
doc: support toolchain Visual Studio 2022 & 2026 + Windows 10 & 11 SDK

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -154,11 +154,11 @@ platforms. This is true regardless of entries in the table below.
 
 Depending on the host platform, the selection of toolchains may vary.
 
-| Operating System | Compiler Versions                                                   |
-| ---------------- | ------------------------------------------------------------------- |
-| Linux            | GCC >= 12.2 or Clang >= 19.1                                        |
-| Windows          | Visual Studio 2022 or 2026 with the Windows 11 SDK on a 64-bit host |
-| macOS            | Xcode >= 16.4 (Apple LLVM >= 19)                                    |
+| Operating System | Compiler Versions                                                         |
+| ---------------- | ------------------------------------------------------------------------- |
+| Linux            | GCC >= 12.2 or Clang >= 19.1                                              |
+| Windows          | Visual Studio 2022 or 2026 with the Windows 10 or 11 SDK on a 64-bit host |
+| macOS            | Xcode >= 16.4 (Apple LLVM >= 19)                                          |
 
 ### Official binary platforms and toolchains
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/61449

## Situation

The [Supported toolchains](https://github.com/nodejs/node/blob/main/BUILDING.md#supported-toolchains) section of the `BUILDING.md` document specifies:

| Operating System | Compiler Versions                                              |
| ---------------- | -------------------------------------------------------------- |
| Windows          | Visual Studio >= 2022 with the Windows 10 SDK on a 64-bit host |

1. The use of only a lower bound for the version of Visual Studio conflicts with the structure of the Windows [vcbuild.bat](https://github.com/nodejs/node/blob/main/vcbuild.bat). Each version of Visual Studio needs to be explicitly supported by the script, which currently includes the ability to work with Visual Studio 2022 and 2026 only. According to [Visual Studio Product Lifecycle and Servicing](https://learn.microsoft.com/en-us/visualstudio/releases/2026/servicing-vs) it can be expected that Microsoft will release Visual Studio 2027 in November 2026 (See also https://learn.microsoft.com/en-us/visualstudio/releases/2026/release-rhythm#annual-releases). The script will not automatically support this version and the statement of compatibility with "Visual Studio >= 2022" will become incorrect.
2. As described in the [Windows > Option 1: Manual install](https://github.com/nodejs/node/blob/main/BUILDING.md#option-1-manual-install) section of the `BUILDING.md` document, the "Desktop development with C++" workload is required. In the older Visual Studio 2019, this installed the Windows 10 SDK. The Visual Studio 2022 & 2026 releases however install the Windows 11 SDK, not the Windows 10 SDK by default, although Visual Studio 2022 does allow optionally installing the (out-of-support) Windows 10 SDK.

## Change

Update the [Supported toolchains](https://github.com/nodejs/node/blob/main/BUILDING.md#supported-toolchains) section of the `BUILDING.md` document to:

| Operating System | Compiler Versions                                                   |
| ---------------- | ------------------------------------------------------------------- |
| Windows          | Visual Studio 2022 or 2026 with the Windows 10 or 11 SDK on a 64-bit host |

This restricts the Visual Studio versions to the working ones, and adds Windows 11 SDK (which is the one currently supported by Microsoft) to the supported toolchain.

## Backporting

- This PR can be backported to v25.x with no restrictions

- Backporting to v24.x ~~requires the landing of PR https://github.com/nodejs/node/pull/61840 for consistency between documentation and capabilities, although backporting without the other PR won't make the documentation any more inaccurate than it currently is~~ Edit: prerequisite now available

- Do not backport to v22.x or v20.x since they are not compatible with Visual Studio 2026 (see https://github.com/nodejs/node/pull/61450 & https://github.com/nodejs/node/pull/61451 instead)
