### PR TITLE
doc: clarify keepAlive and keepAliveTimeout semantics

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2013,10 +2013,12 @@ socketTimeout = keepAliveTimeout + keepAliveTimeoutBuffer
 If the server receives new data before the keep-alive timeout has fired, it
 will reset the regular inactivity timeout, i.e., [`server.timeout`][].
 
-A value of `0` will disable the keep-alive timeout behavior on incoming
-connections.
-A value of `0` makes the HTTP server behave similarly to Node.js versions prior
-to 8.0.0, which did not have a keep-alive timeout.
+A value of `0` disables the keep-alive timeout. HTTP persistent
+connections remain enabled and will stay open until closed by the
+client or the server.
+
+Disabling the timeout may increase resource usage, as idle connections
+can remain open indefinitely.
 
 The socket timeout logic is set up on connection, so changing this value only
 affects new connections to the server, not any existing connections.

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -767,9 +767,10 @@ changes:
     access to specific IP addresses, IP ranges, or IP subnets.
   * `fd` {number} If specified, wrap around an existing socket with
     the given file descriptor, otherwise a new socket will be created.
-  * `keepAlive` {boolean} If set to `true`, it enables keep-alive functionality on
-    the socket immediately after the connection is established, similarly on what
-    is done in [`socket.setKeepAlive()`][]. **Default:** `false`.
+  * `keepAlive` {boolean} If set to `true`, TCP keepalive is enabled on the
+    socket immediately after the connection is established, equivalent to
+    calling [`socket.setKeepAlive()`][]. If set to `false`, TCP keepalive is
+    not enabled automatically. **Default:** `false`.
   * `keepAliveInitialDelay` {number} If set to a positive number, it sets the
     initial delay before the first keepalive probe is sent on an idle socket. **Default:** `0`.
   * `noDelay` {boolean} If set to `true`, it disables the use of Nagle's algorithm


### PR DESCRIPTION
Clarify that the keepAlive option enables TCP keepalive and does not control HTTP persistent connections. Also clarify that keepAliveTimeout = 0 disables the timeout rather than HTTP keep-alive itself.

Refs: #61850

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
