### PR TITLE
tools: avoid building twice in coverage jobs

### DIFF
--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -71,11 +71,11 @@ jobs:
         run: npx envinfo
       - name: Install gcovr
         run: pip install gcovr==7.2
-      - name: Build
-        run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn --coverage --without-intl"
+      - name: Configure
+        run: ./configure -v --error-on-warn --coverage --without-intl
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
-      - name: Test
+      - name: Build and test
         run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots  --measure-flakiness 9" || exit 0
       - name: Report JS
         run: npx c8 report --check-coverage

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install gcovr
         run: pip install gcovr==7.2
       - name: Configure
-        run: ./configure -v --error-on-warn --coverage --without-intl
+        run: ./configure --verbose --error-on-warn --coverage --without-intl
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Build and test

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -71,11 +71,11 @@ jobs:
         run: npx envinfo
       - name: Install gcovr
         run: pip install gcovr==7.2
-      - name: Build
-        run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn --coverage"
+      - name: Configure
+        run: ./configure -v --error-on-warn --coverage
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
-      - name: Test
+      - name: Build and test
         run: NODE_V8_COVERAGE=coverage/tmp make test-cov -j4 V=1 TEST_CI_ARGS="-p dots  --measure-flakiness 9" || exit 0
       - name: Report JS
         run: npx c8 report --check-coverage

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -72,7 +72,7 @@ jobs:
       - name: Install gcovr
         run: pip install gcovr==7.2
       - name: Configure
-        run: ./configure -v --error-on-warn --coverage
+        run: ./configure --verbose --error-on-warn --coverage
       # TODO(bcoe): fix the couple tests that fail with the inspector enabled.
       # The cause is most likely coverage's use of the inspector.
       - name: Build and test


### PR DESCRIPTION
I've noticed in https://github.com/nodejs/node/actions/runs/22221357240/job/64277318487 that the workflow builds `node` twice, it seems that we could simply skip the first build and get the result faster.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
