### PR TITLE
test: increase debugger waitFor timeout on macOS and Windows

### DIFF
--- a/test/common/debugger.js
+++ b/test/common/debugger.js
@@ -8,10 +8,12 @@ const BREAK_MESSAGE = new RegExp('(?:' + [
 ].join('|') + ') in', 'i');
 
 let TIMEOUT = common.platformTimeout(10000);
-// Some macOS and Windows machines require more time to receive the outputs from the client.
+// Some macOS and Windows machines require more time to receive the outputs from the
+// client, especially under CI load where the async Debugger.getScriptSource CDP
+// round-trip in the initial break handler can be slow.
 // https://github.com/nodejs/build/issues/3014
 if (common.isWindows || common.isMacOS) {
-  TIMEOUT = common.platformTimeout(15000);
+  TIMEOUT = common.platformTimeout(30000);
 }
 
 function isPreBreak(output) {


### PR DESCRIPTION
## Summary

- Increase the macOS/Windows debugger test timeout from 15s to 30s

The `test-debugger-restart-message` test is flaky on macOS CI. The `Debugger.on('paused')` handler in the inspect REPL prints the "break in" message only after an async `Debugger.getScriptSource` CDP round-trip to V8 completes. On loaded macOS CI machines, this round-trip can exceed the 15s timeout.

The timeout has already been bumped twice (5s→10s in #56970, 10s→15s for macOS in #60367). `platformTimeout()` applies no multiplier for macOS, so the raw ms value is the actual timeout. Doubling to 30s provides adequate headroom.

## Test plan

- [x] `test-debugger-restart-message` passes locally
- [ ] CI passes on macOS