### PR TITLE
tools: switch to ARM runners on GHA jobs

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -98,7 +98,7 @@ jobs:
           compression-level: 0
   test-tarball-linux:
     needs: build-tarball
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     env:
       CC: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'sccache' || '' }} clang-19
       CXX: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'sccache' || '' }} clang++-19

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -48,7 +48,7 @@ permissions:
 jobs:
   coverage-linux:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -36,7 +36,7 @@ jobs:
       matrix:
         node-version: ${{ fromJSON(needs.collect-versions.outputs.matrix) }}
       fail-fast: false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-lto:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -226,6 +226,7 @@ jobs:
   lint-codeowners:
     if: github.event.pull_request.draft == false
     # cannot use ubuntu-slim here because mszostok/codeowners-validator is dockerized
+    # cannot use ubuntu-24.04-arm here because the docker image is x86 only
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/notify-on-push.yml
+++ b/.github/workflows/notify-on-push.yml
@@ -12,7 +12,7 @@ jobs:
     name: Notify on Force Push on `main`
     if: github.repository == 'nodejs/node' && github.event.forced
     # cannot use ubuntu-slim here because rtCamp/action-slack-notify is dockerized
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Slack Notification
         uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661  # 2.3.3
@@ -32,7 +32,7 @@ jobs:
     name: Notify on Push on `main` with invalid message
     if: github.repository == 'nodejs/node'
     # cannot use ubuntu-slim here because rtCamp/action-slack-notify is dockerized
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:

--- a/.github/workflows/notify-on-review-wanted.yml
+++ b/.github/workflows/notify-on-review-wanted.yml
@@ -13,7 +13,7 @@ jobs:
     name: Notify on Review Wanted
     if: github.repository == 'nodejs/node' && github.event.label.name == 'review wanted'
     # cannot use ubuntu-slim here because rtCamp/action-slack-notify is dockerized
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Determine PR or Issue
         id: define-message

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     # cannot use ubuntu-slim here because ossf/scorecard-action is dockerized
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -45,7 +45,7 @@ permissions:
 jobs:
   test-internet:
     if: github.event_name == 'schedule' && github.repository == 'nodejs/node' || github.event.pull_request.draft == false
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:


### PR DESCRIPTION
AFAICT those are slightly faster (this can be seen for e.g. `test-linux` and `test-shared` which run both varients, the ARM one always finishes first).
According to https://docs.github.com/en/billing/concepts/product-billing/github-actions#baseline-minute-costs, ARM runners are also cheaper – which is only relevant for the private repo where we prepare the security releases.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
