### PR TITLE
doc: update DEP0040 (punycode) to application type deprecation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -946,7 +946,7 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Application
+Type: Application (non-`node_modules` code only)
 
 The [`punycode`][] module is deprecated. Please use a userland alternative
 instead.


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/61901#issuecomment-3934754672

## Situation

[DEP0040: node:punycode module](https://nodejs.org/docs/latest/api/deprecations.html#DEP0040) is listed as [Runtime deprecation](https://nodejs.org/docs/latest/api/deprecations.html#deprecated-apis) since v21.0.0.

This is missing the change applied by PR https://github.com/nodejs/node/pull/56632 to [v23.7.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V23.md#2025-01-30-version-2370-current-aduh95), backported also to [v22.14.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#2025-02-11-version-22140-jod-lts-aduh95), which changed to [Application deprecation](https://nodejs.org/docs/latest/api/deprecations.html#deprecated-api) (non-`node_modules` code only).

## Change

Update [DEP0040](https://nodejs.org/docs/latest/api/deprecations.html#DEP0040) to

Type: Application (non-`node_modules` code only)

with History change in

- [v23.7.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V23.md#2025-01-30-version-2370-current-aduh95)
- [v22.14.0](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V22.md#2025-02-11-version-22140-jod-lts-aduh95)

through PR https://github.com/nodejs/node/pull/56632