### PR TITLE
http: include Content-Length in HEAD responses for keep-alive

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -493,6 +493,12 @@ function _storeHeader(firstLine, headers) {
     if (!this._hasBody) {
       // Make sure we don't end the 0\r\n\r\n at the end of the message.
       this.chunkedEncoding = false;
+      // For HEAD responses, include Content-Length if known so that
+      // the client can determine message boundaries for keep-alive.
+      if (!this._removedContLen &&
+          typeof this._contentLength === 'number') {
+        header += 'Content-Length: ' + this._contentLength + '\r\n';
+      }
     } else if (!this.useChunkedEncodingByDefault) {
       this._last = true;
     } else if (!state.trailer &&

--- a/test/parallel/test-http-head-response-content-length-keep-alive.js
+++ b/test/parallel/test-http-head-response-content-length-keep-alive.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// This test ensures that HEAD responses include a Content-Length header
+// when the server calls res.end() without explicit headers, so that
+// HTTP keep-alive works correctly for HEAD requests.
+// Ref: https://github.com/nodejs/node/issues/28438
+
+const server = http.createServer(common.mustCall(function(req, res) {
+  res.end();
+}, 2));
+
+server.listen(0, common.mustCall(function() {
+  const port = this.address().port;
+  const agent = new http.Agent({ keepAlive: true });
+
+  // First: verify GET response includes Content-Length
+  const getReq = http.request({ port, method: 'GET', agent }, common.mustCall(function(res) {
+    assert.strictEqual(res.headers['content-length'], '0');
+
+    // Second: verify HEAD response also includes Content-Length
+    const headReq = http.request({ port, method: 'HEAD', agent }, common.mustCall(function(res) {
+      assert.strictEqual(res.headers['content-length'], '0',
+        'HEAD response should include Content-Length for keep-alive');
+      agent.destroy();
+      server.close();
+    }));
+    headReq.end();
+
+    res.resume();
+  }));
+  getReq.end();
+}));


### PR DESCRIPTION
## Summary

HEAD responses from `http.createServer` do not include a `Content-Length` header by default when `res.end()` is called without explicit headers. This breaks HTTP keep-alive for HEAD requests because the client-side HTTP parser cannot determine message boundaries.

GET responses already include `Content-Length: 0` by default. This change applies the same behavior to HEAD (and other bodyless) responses.

### Before
```
GET / → headers: { 'content-length': '0', connection: 'keep-alive', ... }
HEAD / → headers: { connection: 'keep-alive', ... }  // missing content-length!
```

### After
```
GET / → headers: { 'content-length': '0', connection: 'keep-alive', ... }
HEAD / → headers: { 'content-length': '0', connection: 'keep-alive', ... }
```

## Changes

- `lib/_http_outgoing.js`: In `_storeHeader()`, when the response has no body (`!this._hasBody`), also emit `Content-Length` header if the content length is known and was not explicitly removed by the user.
- `test/parallel/test-http-head-response-content-length-keep-alive.js`: New test verifying that both GET and HEAD responses include `Content-Length: 0` when `res.end()` is called.

## Reproduction

```js
const http = require('http');
const server = http.createServer((req, res) => res.end());
server.listen(2333);
```

```js
const agent = new http.Agent({ keepAlive: true });
http.request({ port: 2333, method: 'HEAD', agent }, (res) => {
  console.log(res.headers); // no content-length → keep-alive broken
}).end();
```

Fixes: https://github.com/nodejs/node/issues/28438