### PR TITLE
[v22.x] test: mark `test-strace-openat-openssl` as flaky

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -49,6 +49,7 @@ test-worker-nearheaplimit-deadlock: PASS, FLAKY
 [$system==win32 && $arch==arm64]
 
 [$system==linux]
+test-strace-openat-openssl: PASS, FLAKY
 # https://github.com/nodejs/node/issues/54803
 test-performance-function: PASS, FLAKY
 # https://github.com/nodejs/node/issues/54346


### PR DESCRIPTION
We have a test that started failing overnight on `ubi81_sharedlibs_openssl111fips_x64`:

- for v20.x-staging, passes on Feb 3 (https://ci.nodejs.org/job/node-test-commit-linux-containered/54624/nodes=ubi81_sharedlibs_openssl111fips_x64/), fails on Feb 4 (https://ci.nodejs.org/job/node-test-commit-linux-containered/54638/nodes=ubi81_sharedlibs_openssl111fips_x64/)
- for v22.x-staging, passes on Feb 3 (https://ci.nodejs.org/job/node-test-commit-linux-containered/54623/nodes=ubi81_sharedlibs_openssl111fips_x64/), fails on Feb 5 (https://ci.nodejs.org/job/node-test-commit-linux-containered/54646/nodes=ubi81_sharedlibs_openssl111fips_x64/)

It's unclear what's causing it, v24.x-staging does not seem to be affected. Let's mark the test as flaky so it doesn't block backports and release.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
