### PR TITLE
test: reduce waitForInitialBreak() flakiness in debugger tests

### DIFF
--- a/test/parallel/test-debugger-auto-resume.mjs
+++ b/test/parallel/test-debugger-auto-resume.mjs
@@ -23,7 +23,9 @@ addLibraryPath(process.env);
 
   const cli = startCLI([script], [], { env });
 
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
+  await cli.waitForPrompt();
   assert.deepStrictEqual(cli.breakInfo, {
     filename: script,
     line: 10,

--- a/test/parallel/test-debugger-backtrace.js
+++ b/test/parallel/test-debugger-backtrace.js
@@ -17,6 +17,7 @@ const path = require('path');
 
   async function runTest() {
     try {
+      await cli.waitForPrompt();
       await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       await cli.stepCommand('c');

--- a/test/parallel/test-debugger-break.js
+++ b/test/parallel/test-debugger-break.js
@@ -14,6 +14,7 @@ const script = path.relative(process.cwd(), scriptFullPath);
 const cli = startCLI([script]);
 
 (async () => {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   assert.deepStrictEqual(

--- a/test/parallel/test-debugger-breakpoint-exists.js
+++ b/test/parallel/test-debugger-breakpoint-exists.js
@@ -13,6 +13,7 @@ const cli = startCLI([script]);
 
 (async () => {
   try {
+    await cli.waitForPrompt();
     await cli.waitForInitialBreak();
     await cli.waitForPrompt();
     await cli.command('setBreakpoint(1)');

--- a/test/parallel/test-debugger-clear-breakpoints.js
+++ b/test/parallel/test-debugger-clear-breakpoints.js
@@ -20,7 +20,8 @@ const path = require('path');
     throw error;
   }
 
-  return cli.waitForInitialBreak()
+  return cli.waitForPrompt()
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('sb("break.js", 3)'))
     .then(() => cli.command('sb("break.js", 9)'))

--- a/test/parallel/test-debugger-exceptions.js
+++ b/test/parallel/test-debugger-exceptions.js
@@ -17,8 +17,8 @@ const path = require('path');
 
   (async () => {
     try {
-      await cli.waitForInitialBreak();
       await cli.waitForPrompt();
+      await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 1 });
 

--- a/test/parallel/test-debugger-exec-scope.mjs
+++ b/test/parallel/test-debugger-exec-scope.mjs
@@ -10,6 +10,7 @@ import assert from 'assert';
 const cli = startCLI([fixtures.path('debugger/backtrace.js')]);
 
 try {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.stepCommand('c');

--- a/test/parallel/test-debugger-exec.js
+++ b/test/parallel/test-debugger-exec.js
@@ -12,6 +12,7 @@ const cli = startCLI([fixtures.path('debugger/alive.js')]);
 
 async function waitInitialBreak() {
   try {
+    await cli.waitForPrompt();
     await cli.waitForInitialBreak();
     await cli.waitForPrompt();
     await cli.command('exec [typeof heartbeat, typeof process.exit]');

--- a/test/parallel/test-debugger-extract-function-name.mjs
+++ b/test/parallel/test-debugger-extract-function-name.mjs
@@ -10,6 +10,7 @@ import assert from 'assert';
 const cli = startCLI([fixtures.path('debugger', 'three-lines.js')]);
 
 try {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('exec a = function func() {}; a;');

--- a/test/parallel/test-debugger-heap-profiler.js
+++ b/test/parallel/test-debugger-heap-profiler.js
@@ -20,6 +20,7 @@ const filename = tmpdir.resolve('node.heapsnapshot');
 
   async function waitInitialBreak() {
     try {
+      await cli.waitForPrompt();
       await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       await cli.command('takeHeapSnapshot()');

--- a/test/parallel/test-debugger-help.mjs
+++ b/test/parallel/test-debugger-help.mjs
@@ -10,6 +10,7 @@ import assert from 'assert';
 const cli = startCLI([fixtures.path('debugger', 'empty.js')]);
 
 try {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('help');

--- a/test/parallel/test-debugger-list.js
+++ b/test/parallel/test-debugger-list.js
@@ -11,6 +11,7 @@ const assert = require('assert');
 const cli = startCLI([fixtures.path('debugger/three-lines.js')]);
 
 (async () => {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('list(0)');

--- a/test/parallel/test-debugger-low-level.js
+++ b/test/parallel/test-debugger-low-level.js
@@ -14,6 +14,7 @@ const assert = require('assert');
 
   async function testDebuggerLowLevel() {
     try {
+      await cli.waitForPrompt();
       await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       await cli.command('scripts');

--- a/test/parallel/test-debugger-object-type-remote-object.js
+++ b/test/parallel/test-debugger-object-type-remote-object.js
@@ -11,6 +11,7 @@ const assert = require('assert');
 const cli = startCLI([fixtures.path('debugger/empty.js')]);
 
 (async () => {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('exec new Date(0)');

--- a/test/parallel/test-debugger-preserve-breaks.js
+++ b/test/parallel/test-debugger-preserve-breaks.js
@@ -16,6 +16,7 @@ const script = path.relative(process.cwd(), scriptFullPath);
 (async () => {
   const cli = startCLI([script]);
   try {
+    await cli.waitForPrompt();
     await cli.waitForInitialBreak();
     await cli.waitForPrompt();
     await cli.command('breakpoints');
@@ -29,7 +30,9 @@ const script = path.relative(process.cwd(), scriptFullPath);
     await cli.stepCommand('c'); // hit line 3
     assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 3 });
     await cli.command('restart');
+    await cli.waitForPrompt();
     await cli.waitForInitialBreak();
+    await cli.waitForPrompt();
     assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 1 });
     await cli.stepCommand('c');
     assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 2 });

--- a/test/parallel/test-debugger-profile-command.js
+++ b/test/parallel/test-debugger-profile-command.js
@@ -15,6 +15,7 @@ const cli = startCLI([fixtures.path('debugger/empty.js')]);
 const rootDir = path.resolve(__dirname, '..', '..');
 
 (async () => {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('profile');

--- a/test/parallel/test-debugger-profile.js
+++ b/test/parallel/test-debugger-profile.js
@@ -30,6 +30,7 @@ function delay(ms) {
 
   try {
     (async () => {
+      await cli.waitForPrompt();
       await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       await cli.command('exec console.profile()');

--- a/test/parallel/test-debugger-random-port-with-inspect-port.js
+++ b/test/parallel/test-debugger-random-port-with-inspect-port.js
@@ -13,7 +13,7 @@ const script = fixtures.path('debugger', 'three-lines.js');
 const cli = startCLI(['--inspect-port=0', script], [], {}, { randomPort: false });
 
 (async () => {
-  await cli.waitForInitialBreak();
+  await cli.waitFor(/Debugger attached\./);
   await cli.waitForPrompt();
   assert.match(cli.output, /debug>/, 'prints a prompt');
   assert.match(

--- a/test/parallel/test-debugger-random-port.js
+++ b/test/parallel/test-debugger-random-port.js
@@ -14,7 +14,8 @@ const assert = require('assert');
 
   const cli = startCLI([script]);
 
-  cli.waitForInitialBreak()
+  cli.waitForPrompt()
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
       assert.match(cli.output, /debug>/, 'prints a prompt');

--- a/test/parallel/test-debugger-restart-message.js
+++ b/test/parallel/test-debugger-restart-message.js
@@ -20,6 +20,7 @@ const startCLI = require('../common/debugger');
 
   async function onWaitForInitialBreak() {
     try {
+      await cli.waitForPrompt();
       await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       assert.strictEqual(cli.output.match(listeningRegExp).length, 1);

--- a/test/parallel/test-debugger-run-after-quit-restart.js
+++ b/test/parallel/test-debugger-run-after-quit-restart.js
@@ -15,7 +15,8 @@ const path = require('path');
   const script = path.relative(process.cwd(), scriptFullPath);
   const cli = startCLI([script]);
 
-  cli.waitForInitialBreak()
+  cli.waitForPrompt()
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => cli.stepCommand('n'))
     .then(() => {

--- a/test/parallel/test-debugger-sb-before-load.js
+++ b/test/parallel/test-debugger-sb-before-load.js
@@ -20,6 +20,7 @@ const otherScript = path.relative(process.cwd(), otherScriptFullPath);
 const cli = startCLI([script]);
 
 (async () => {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('sb("other.js", 2)');

--- a/test/parallel/test-debugger-scripts.js
+++ b/test/parallel/test-debugger-scripts.js
@@ -15,6 +15,7 @@ const assert = require('assert');
 
   (async () => {
     try {
+      await cli.waitForPrompt();
       await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       await cli.command('scripts');

--- a/test/parallel/test-debugger-set-context-line-number.mjs
+++ b/test/parallel/test-debugger-set-context-line-number.mjs
@@ -21,6 +21,7 @@ function getLastLine(output) {
 
 // Stepping through breakpoints.
 try {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
 

--- a/test/parallel/test-debugger-use-strict.js
+++ b/test/parallel/test-debugger-use-strict.js
@@ -18,7 +18,8 @@ const assert = require('assert');
     throw error;
   }
 
-  return cli.waitForInitialBreak()
+  return cli.waitForPrompt()
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
       const brk = cli.breakInfo;

--- a/test/parallel/test-debugger-watch-validation.js
+++ b/test/parallel/test-debugger-watch-validation.js
@@ -11,7 +11,8 @@ const assert = require('assert');
 const cli = startCLI([fixtures.path('debugger/break.js')]);
 
 (async () => {
-  await cli.waitForInitialBreak();
+  await cli.waitFor(/Debugger attached\./);
+  await cli.waitForPrompt();
   await cli.command('watch()');
   await cli.waitFor(/ERR_INVALID_ARG_TYPE/);
   assert.match(cli.output, /TypeError \[ERR_INVALID_ARG_TYPE\]: The "expression" argument must be of type string\. Received undefined/);

--- a/test/parallel/test-debugger-watchers.mjs
+++ b/test/parallel/test-debugger-watchers.mjs
@@ -16,6 +16,7 @@ function onFatal(error) {
 
 // Stepping through breakpoints.
 try {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('watch("x")');

--- a/test/sequential/test-debugger-custom-port.js
+++ b/test/sequential/test-debugger-custom-port.js
@@ -14,7 +14,7 @@ const script = fixtures.path('debugger', 'three-lines.js');
 const cli = startCLI([`--port=${common.PORT}`, script], [], {}, { randomPort: false });
 (async function() {
   try {
-    await cli.waitForInitialBreak();
+    await cli.waitFor(/Debugger attached\./);
     await cli.waitForPrompt();
     assert.match(cli.output, /debug>/, 'prints a prompt');
     assert.match(

--- a/test/sequential/test-debugger-launch.mjs
+++ b/test/sequential/test-debugger-launch.mjs
@@ -10,6 +10,7 @@ import assert from 'assert';
 const script = fixtures.path('debugger', 'three-lines.js');
 const cli = startCLI([script], [], {}, { randomPort: false });
 try {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   assert.match(cli.output, /debug>/, 'prints a prompt');


### PR DESCRIPTION
This fixes flakiness around `waitForInitialBreak()` in debugger tests.

`waitForInitialBreak()` can be flaky during startup because the CLI may already attach and print `debug>` before the initial `break ... in` output arrives. In some CI runs, tests end up waiting on that break message while startup output is still racing.

This change takes two approaches:

- Tests that do not depend on `waitForInitialBreak()` no longer use it.
- Tests that still need `waitForInitialBreak()` now wait for `debug>` first. This synchronizes with the CLI becoming interactive and reduces the startup race before waiting for the initial break.

<details>
<summary>CI failed logs on main branch (Nov 27, 2025 ~ Mar 8, 2026)</summary>

- `test-debugger-help.mjs`
  - https://github.com/nodejs/node/actions/runs/22783998746 (line 13)

- `test-debugger-break.js`
  - https://github.com/nodejs/node/actions/runs/22641591280 (line 17)

- `test-debugger-preserve-breaks.js`
  - https://github.com/nodejs/node/actions/runs/21915213108 (line 32)

- `test-debugger-backtrace.js`
  - https://github.com/nodejs/node/actions/runs/22250826545 (line 20)

- `test-debugger-random-port-with-inspect-port.js`
  - https://github.com/nodejs/node/actions/runs/21785139333 (line 16)

- `test-debugger-watch-validation.js`
  - https://github.com/nodejs/node/actions/runs/21772762644 (line 14)

- `test-debugger-profile.js`
  - https://github.com/nodejs/node/actions/runs/21589980783 (line 33)

- `test-debugger-object-type-remote-object.js`
  - https://github.com/nodejs/node/actions/runs/21568369570 (line 14)

- `test-debugger-low-level.js`
  - https://github.com/nodejs/node/actions/runs/21441860169 (line 17)

- `test-debugger-exec.js`
  - https://github.com/nodejs/node/actions/runs/21359022841 (line 15)

- `test-debugger-set-context-line-number.mjs`
  - https://github.com/nodejs/node/actions/runs/21336641272 (line 24)

- `test-debugger-scripts.js`
  - https://github.com/nodejs/node/actions/runs/20887752808 (line 18)

- `test-debugger-sb-before-load.js`
  - https://github.com/nodejs/node/actions/runs/22055336538 (line 23)

- `test-debugger-exceptions.js`
  - https://github.com/nodejs/node/actions/runs/22050359911 (line 20)

- `test-debugger-clear-breakpoints.js`
  - https://github.com/nodejs/node/actions/runs/22026231669 (line 23)

- `test-debugger-auto-resume.mjs`
  - https://github.com/nodejs/node/actions/runs/22474577256/attempts/1 (line 26)

</details>

Refs: https://github.com/nodejs/node/issues/61762