### PR TITLE
test_runner: fix lcov BRDA output for ignored branches

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -193,18 +193,24 @@ class TestCoverage {
           ObjectAssign(range, mapRangeToLines(range, lines));
 
           if (isBlockCoverage) {
-            ArrayPrototypePush(branchReports, {
-              __proto__: null,
-              line: range.lines[0]?.line,
-              count: range.count,
-            });
+            // Only add branch to reports if not all lines are ignored
+            if (range.ignoredLines !== range.lines.length) {
+              ArrayPrototypePush(branchReports, {
+                __proto__: null,
+                line: range.lines[0]?.line,
+                count: range.count,
+              });
 
-            if (range.count !== 0 ||
-                range.ignoredLines === range.lines.length) {
+              if (range.count !== 0) {
+                branchesCovered++;
+              }
+
+              totalBranches++;
+            } else {
+              // All lines are ignored - count as covered but don't report
               branchesCovered++;
+              totalBranches++;
             }
-
-            totalBranches++;
           }
         }
 


### PR DESCRIPTION
Fix BRDA entries appearing in lcov output for branches on lines excluded by /* node:coverage ignore next */ comments. Branches with all ignored lines are now excluded from branchReports (matching DA line exclusion behavior). Ignored branches still count toward coverage statistics but don't appear in detailed reports.

Fixes: https://github.com/nodejs/node/issues/61586