### PR TITLE
esm: avoid super-linear data URL MIME regex

### DIFF
--- a/benchmark/esm/get-data-protocol-format.js
+++ b/benchmark/esm/get-data-protocol-format.js
@@ -1,0 +1,30 @@
+// Benchmarks defaultGetFormat() on `data:` URLs. The MIME-matching regex used
+// to be susceptible to catastrophic backtracking on malformed input lacking a
+// `,` separator (https://github.com/nodejs/node/issues/61904); `pathLength`
+// scales the malformed path so a regression shows up as a sharp drop in ops/sec
+// rather than a hang.
+'use strict';
+
+const common = require('../common.js');
+
+const configs = {
+  n: [1e4],
+  pathLength: [1e2, 1e3, 1e4],
+};
+
+const options = {
+  flags: ['--expose-internals'],
+};
+
+const bench = common.createBenchmark(main, configs, options);
+
+function main({ n, pathLength }) {
+  const { defaultGetFormat } = require('internal/modules/esm/get_format');
+  const url = new URL(`data:a/${'a'.repeat(pathLength)}B`);
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    defaultGetFormat(url, { parentURL: undefined });
+  }
+  bench.end(n);
+}

--- a/lib/internal/modules/esm/get_format.js
+++ b/lib/internal/modules/esm/get_format.js
@@ -97,7 +97,7 @@ function detectModuleFormat(source, url) {
  */
 function getDataProtocolModuleFormat(parsed) {
   const { 1: mime } = RegExpPrototypeExec(
-    /^([^/]+\/[^;,]+)(?:[^,]*?)(;base64)?,/,
+    /^([^/]+\/[^;,]+)(?:;[^,]*)?,/,
     parsed.pathname,
   ) || [ null, null, null ];
 

--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -205,7 +205,7 @@ function throwIfUnsupportedURLScheme(parsed) {
  */
 function throwUnknownModuleFormat(url, format) {
   const dataUrl = RegExpPrototypeExec(
-    /^data:([^/]+\/[^;,]+)(?:[^,]*?)(;base64)?,/,
+    /^data:([^/]+\/[^;,]+)(?:;[^,]*)?,/,
     url,
   );
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/61904

This updates ESM data URL MIME extraction regexes to remove overlapping quantifiers that allow super-linear backtracking.

- Replaced `(?:[^,]*?)(;base64)?,` with `(?:;[^,]*)?,` in:
  - `lib/internal/modules/esm/get_format.js`
  - `lib/internal/modules/esm/load.js`

Behavior is preserved for existing valid/invalid `data:` URL shapes while avoiding pathological backtracking on crafted inputs.