### PR TITLE
sqlite: optimize column name creation and text value encoding

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -66,7 +66,7 @@ using v8::Value;
 
 inline MaybeLocal<String> Utf8StringMaybeOneByte(Isolate* isolate,
                                                  std::string_view input) {
-  int len = static_cast<int>(input.size());
+  const int len = static_cast<int>(input.size());
   if (simdutf::validate_ascii(input.data(), input.size())) {
     return String::NewFromOneByte(
         isolate,
@@ -120,7 +120,7 @@ inline MaybeLocal<String> Utf8StringMaybeOneByte(Isolate* isolate,
       case SQLITE_TEXT: {                                                      \
         const char* v =                                                        \
             reinterpret_cast<const char*>(sqlite3_##from##_text(__VA_ARGS__)); \
-        int v_len = sqlite3_##from##_bytes(__VA_ARGS__);                       \
+        const int v_len = sqlite3_##from##_bytes(__VA_ARGS__);                 \
         (result) =                                                             \
             Utf8StringMaybeOneByte((isolate), std::string_view(v, v_len))      \
                 .As<Value>();                                                  \
@@ -2434,6 +2434,10 @@ StatementSync::~StatementSync() {
 void StatementSync::Finalize() {
   sqlite3_finalize(statement_);
   statement_ = nullptr;
+  InvalidateColumnNameCache();
+}
+
+void StatementSync::InvalidateColumnNameCache() {
   cached_column_names_.clear();
 }
 
@@ -2623,17 +2627,16 @@ MaybeLocal<Name> StatementSync::ColumnNameToName(const int column) {
       .As<Name>();
 }
 
-// Returns cached internalized column name strings for this statement,
-// invalidating the cache when SQLite re-prepares the statement (e.g. after
-// schema changes like ALTER TABLE) detected via SQLITE_STMTSTATUS_REPREPARE.
+// Populates `keys` with cached column names, rebuilding the cache if the
+// statement was re-prepared.
 bool StatementSync::GetCachedColumnNames(LocalVector<Name>* keys) {
   Isolate* isolate = env()->isolate();
 
-  int reprepare_count =
-      sqlite3_stmt_status(statement_, SQLITE_STMTSTATUS_REPREPARE, 0);
+  const int reprepare_count =
+      sqlite3_stmt_status(statement_, SQLITE_STMTSTATUS_REPREPARE, false);
   if (reprepare_count != cached_column_names_reprepare_count_) {
     cached_column_names_.clear();
-    int num_cols = sqlite3_column_count(statement_);
+    const int num_cols = sqlite3_column_count(statement_);
     if (num_cols == 0) {
       cached_column_names_reprepare_count_ = reprepare_count;
       return true;
@@ -2642,7 +2645,7 @@ bool StatementSync::GetCachedColumnNames(LocalVector<Name>* keys) {
     for (int i = 0; i < num_cols; ++i) {
       Local<Name> key;
       if (!ColumnNameToName(i).ToLocal(&key)) {
-        cached_column_names_.clear();
+        InvalidateColumnNameCache();
         return false;
       }
       cached_column_names_.emplace_back(Global<Name>(isolate, key));

--- a/src/node_sqlite.h
+++ b/src/node_sqlite.h
@@ -298,6 +298,7 @@ class StatementSync : public BaseObject {
   inline int ResetStatement();
   std::vector<v8::Global<v8::Name>> cached_column_names_;
   int cached_column_names_reprepare_count_ = -1;
+  void InvalidateColumnNameCache();
   bool BindParams(const v8::FunctionCallbackInfo<v8::Value>& args);
   bool BindValue(const v8::Local<v8::Value>& value, const int index);
 


### PR DESCRIPTION
Skip the full `UTF-8` decode path for text values that are pure ASCII by validating with `simdutf` and creating `OneByte` V8 strings, halving memory.`Internalize` column name strings so V8 shares hidden classes across row objects. Cache column names in the `iterate()` hot loop, invalidating on schema changes via `SQLITE_STMTSTATUS_REPREPARE`.

Benchmark: 30-run
<img width="2100" height="1800" alt="sqlite-benchmark" src="https://github.com/user-attachments/assets/d1349fe0-d7af-4dde-a87d-52936158adf9" />


Refs: https://github.com/nodejs/performance/issues/181

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
