### PR TITLE
src: avoid JS callback for deprecated Promise resolve-after-resolved events

### DIFF
--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -77,10 +77,14 @@ void PromiseRejectCallback(PromiseRejectMessage message) {
                   "rejections",
                   "unhandled", unhandledRejections,
                   "handledAfter", rejectionsHandledAfter);
-  } else if (event == kPromiseResolveAfterResolved) {
-    value = message.GetValue();
-  } else if (event == kPromiseRejectAfterResolved) {
-    value = message.GetValue();
+  } else if (event == kPromiseResolveAfterResolved ||
+             event == kPromiseRejectAfterResolved) {
+    // Do not notify JS land about these events. These events are triggered
+    // when a promise is resolved/rejected after already being resolved.
+    // Notifying JS land would cause memory leaks in tight loops with
+    // immediately-resolving promises (e.g., Promise.race).
+    // See: https://github.com/nodejs/node/issues/51452
+    return;
   } else {
     return;
   }

--- a/test/parallel/test-promise-race-memory-leak.js
+++ b/test/parallel/test-promise-race-memory-leak.js
@@ -1,0 +1,102 @@
+// Copyright Node.js contributors. All rights reserved.
+'use strict';
+
+// Tests for memory leak in Promise.race with immediately-resolving promises.
+// See: https://github.com/nodejs/node/issues/51452
+
+const common = require('../common');
+const assert = require('node:assert');
+
+// Test 1: Promise.race with immediately-resolving promises should not leak
+{
+  async function promiseValue(value) {
+    return value;
+  }
+
+  async function run() {
+    let count = 0;
+    const maxIterations = 1000;
+
+    for (let i = 0; i < maxIterations; i++) {
+      await Promise.race([promiseValue("foo"), promiseValue("bar")]);
+      count++;
+    }
+
+    assert.strictEqual(count, maxIterations);
+  }
+
+  run().then(common.mustCall());
+}
+
+// Test 2: Promise.any with immediately-resolving promises should not leak
+{
+  async function promiseValue(value) {
+    return value;
+  }
+
+  async function run() {
+    let count = 0;
+    const maxIterations = 1000;
+
+    for (let i = 0; i < maxIterations; i++) {
+      await Promise.any([promiseValue("foo"), promiseValue("bar")]);
+      count++;
+    }
+
+    assert.strictEqual(count, maxIterations);
+  }
+
+  run().then(common.mustCall());
+}
+
+// Test 3: Mixed immediately-resolving and delayed promises should work correctly
+{
+  async function immediateValue(value) {
+    return value;
+  }
+
+  function delayedValue(value, delay) {
+    return new Promise((resolve) => {
+      setTimeout(() => resolve(value), delay);
+    });
+  }
+
+  async function run() {
+    let count = 0;
+    const maxIterations = 100;
+
+    for (let i = 0; i < maxIterations; i++) {
+      await Promise.race([
+        immediateValue("immediate"),
+        delayedValue("delayed", 10)
+      ]);
+      count++;
+    }
+
+    assert.strictEqual(count, maxIterations);
+  }
+
+  run().then(common.mustCall());
+}
+
+// Test 4: Verify that Promise.race still resolves correctly with immediate values
+{
+  async function promiseValue(value) {
+    return value;
+  }
+
+  Promise.race([promiseValue("first"), promiseValue("second")]).then(common.mustCall((result) => {
+    assert.strictEqual(result, "first");
+  }));
+}
+
+// Test 5: Verify that Promise.any still resolves correctly with immediate values
+{
+  async function promiseValue(value) {
+    return value;
+  }
+
+  Promise.any([promiseValue("first"), promiseValue("second")]).then(common.mustCall((result) => {
+    assert.strictEqual(result, "first");
+  }));
+}


### PR DESCRIPTION
## Summary
- return early in `src/node_task_queue.cc` for `kPromiseResolveAfterResolved` and `kPromiseRejectAfterResolved`
- avoid invoking the JS promise reject callback for event types that JS-side logic already ignores
- add `test/parallel/test-promise-race-memory-leak.js` to cover immediate-resolution Promise.race/Promise.any behavior and nearby safety checks
## Context
Issue: https://github.com/nodejs/node/issues/51452
The original report was against older Node versions (`v21.5.0`). On current `main`, reproduction is less direct, but this change keeps C++ behavior aligned with existing JS semantics (deprecated `multipleResolves` path is ignored) and removes unnecessary callback/context handling for these events.
## Testing
- `python3 tools/test.py test/parallel/test-promise-race-memory-leak.js`
- `python3 tools/test.py --repeat=5 test/parallel/test-promise-race-memory-leak.js`
- `python3 tools/test.py test/parallel/test-promise*`
- `python3 tools/test.py test/parallel/test-promise-reject-callback-exception.js`
- `make lint-cpp`
- `make lint-js` (skipped in this environment due local binary resolution: `/Users/jorgitin/Documents/projects/node/node` is a directory)