### PR TITLE
doc,test: clarify --eval syntax for leading '-' scripts

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -997,6 +997,9 @@ changes:
 Evaluate the following argument as JavaScript. The modules which are
 predefined in the REPL can also be used in `script`.
 
+If `script` starts with `-`, pass it using `=` (for example,
+`node --print --eval=-42`) so it is parsed as the value of `--eval`.
+
 On Windows, using `cmd.exe` a single quote will not work correctly because it
 only recognizes double `"` for quoting. In Powershell or Git bash, both `'`
 and `"` are usable.

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -467,36 +467,7 @@ void OptionsParser<Options>::Parse(
 
         value = args.pop_first();
 
-        bool is_eval_expression = false;
-        if (name == "--eval" && !value.empty() && value[0] == '-') {
-          std::string eval_value_name = value;
-          const size_t equals_index = value.find('=');
-          if (equals_index != std::string::npos) {
-            eval_value_name = value.substr(0, equals_index);
-          }
-
-          bool is_option_name =
-              options_.contains(eval_value_name) ||
-              aliases_.contains(eval_value_name) ||
-              aliases_.contains(eval_value_name + "=") ||
-              aliases_.contains(eval_value_name + " <arg>");
-
-          if (!is_option_name && eval_value_name.starts_with("--no-")) {
-            const std::string non_negated_name =
-                "--" + eval_value_name.substr(5);
-            is_option_name =
-                options_.contains(non_negated_name) ||
-                aliases_.contains(non_negated_name) ||
-                aliases_.contains(non_negated_name + "=") ||
-                aliases_.contains(non_negated_name + " <arg>");
-          }
-
-          is_eval_expression = !is_option_name;
-        }
-
-        if (!value.empty() &&
-            value[0] == '-' &&
-            !is_eval_expression) {
+        if (!value.empty() && value[0] == '-') {
           missing_argument();
           break;
         } else {

--- a/test/parallel/test-cli-eval.js
+++ b/test/parallel/test-cli-eval.js
@@ -115,32 +115,19 @@ child.exec(...common.escapePOSIXShell`"${process.execPath}" -p "\\-42"`, common.
   assert.strictEqual(stderr, '');
 }));
 
-// Unary-negative eval expressions should not be rejected as missing arguments.
-child.exec(...common.escapePOSIXShell`"${process.execPath}" -pe -42`, common.mustSucceed((stdout, stderr) => {
+// Eval expressions that start with '-' can be passed with '='.
+child.exec(...common.escapePOSIXShell`"${process.execPath}" --print --eval=-42`, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout, '-42\n');
   assert.strictEqual(stderr, '');
 }));
 
 // Edge case: negative zero should preserve its sign when printed.
-child.exec(...common.escapePOSIXShell`"${process.execPath}" -pe -0`, common.mustSucceed((stdout, stderr) => {
+child.exec(...common.escapePOSIXShell`"${process.execPath}" --print --eval=-0`, common.mustSucceed((stdout, stderr) => {
   assert.strictEqual(stdout, '-0\n');
   assert.strictEqual(stderr, '');
 }));
 
-// Expressions like -NaN should be treated as eval input, not options.
-child.exec(...common.escapePOSIXShell`"${process.execPath}" -pe -NaN`, common.mustSucceed((stdout, stderr) => {
-  assert.strictEqual(stdout, 'NaN\n');
-  assert.strictEqual(stderr, '');
-}));
-
-// A bare '-' should be passed to eval and fail with a syntax error.
-child.exec(...common.escapePOSIXShell`"${process.execPath}" -pe -`, common.mustCall((err, stdout, stderr) => {
-  assert.notStrictEqual(err.code, 9);
-  assert.strictEqual(stdout, '');
-  assert.match(stderr, /SyntaxError/);
-}));
-
-// Nearby-path safety: option-looking values should still be rejected.
+// Nearby-path safety: option-looking values should still be rejected with -e.
 child.exec(...common.escapePOSIXShell`"${process.execPath}" -e -p`, common.mustCall((err, stdout, stderr) => {
   assert.strictEqual(err.code, 9);
   assert.strictEqual(stdout, '');


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/43397

## Summary
- remove the parser heuristic added in the previous revision for `-e -<text>`
- document the supported form for leading-hyphen eval expressions: `--eval=<script>` (for example `--eval=-42`)
- add/adjust tests in `test/parallel/test-cli-eval.js` to cover `--eval=-42`, `--eval=-0`, and keep `-e -p` as a missing-argument error

## Testing
- python3 tools/test.py test/parallel/test-cli-eval.js
- python3 tools/test.py --repeat=5 test/parallel/test-cli-eval.js
- python3 tools/test.py test/parallel/test-cli-bad-options.js
- make lint-js NODE=/opt/homebrew/bin/node
- make doc-only NODE=/opt/homebrew/bin/node
- make lint-md LINT_MD_TARGETS=doc/api/cli.md NODE=/opt/homebrew/bin/node