### PR TITLE
lib: normalize . and .. in path before rm/rmSync

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -149,6 +149,10 @@ const {
 
 const permission = require('internal/process/permission');
 
+// Matches a dotdot path component (e.g. `..`, `/../`, `../`) but not
+// filenames with consecutive dots like `a..b`.
+const dotdotRe = /(^|[\\/])\.\.(?:[\\/]|$)/;
+
 let fs;
 
 // Lazy loaded
@@ -1179,6 +1183,14 @@ function rm(path, options, callback) {
     options = undefined;
   }
   path = getValidatedPath(path);
+  if (typeof path === 'string') {
+    if (SideEffectFreeRegExpPrototypeExec(dotdotRe, path) !== null)
+      path = pathModule.normalize(path);
+  } else if (isArrayBufferView(path)) {
+    const str = BufferToString(path, 'utf8');
+    if (SideEffectFreeRegExpPrototypeExec(dotdotRe, str) !== null)
+      path = pathModule.normalize(str);
+  }
 
   validateRmOptions(path, options, false, (err, options) => {
     if (err) {
@@ -1202,8 +1214,17 @@ function rm(path, options, callback) {
  * @returns {void}
  */
 function rmSync(path, options) {
+  path = getValidatedPath(path);
+  if (typeof path === 'string') {
+    if (SideEffectFreeRegExpPrototypeExec(dotdotRe, path) !== null)
+      path = pathModule.normalize(path);
+  } else if (isArrayBufferView(path)) {
+    const str = BufferToString(path, 'utf8');
+    if (SideEffectFreeRegExpPrototypeExec(dotdotRe, str) !== null)
+      path = pathModule.normalize(str);
+  }
   const opts = validateRmOptionsSync(path, options, false);
-  return binding.rmSync(getValidatedPath(path), opts.maxRetries, opts.recursive, opts.retryDelay);
+  return binding.rmSync(path, opts.maxRetries, opts.recursive, opts.retryDelay);
 }
 
 /**

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -17,6 +17,7 @@ const {
   Symbol,
   SymbolAsyncDispose,
   Uint8Array,
+  uncurryThis,
 } = primordials;
 
 const { fs: constants } = internalBinding('constants');
@@ -30,6 +31,7 @@ const {
 
 const binding = internalBinding('fs');
 const { Buffer } = require('buffer');
+const BufferToString = uncurryThis(Buffer.prototype.toString);
 
 const {
   AbortError,
@@ -92,6 +94,7 @@ const {
   promisify,
   isWindows,
   isMacOS,
+  SideEffectFreeRegExpPrototypeExec,
 } = require('internal/util');
 const EventEmitter = require('events');
 const { StringDecoder } = require('string_decoder');
@@ -101,6 +104,10 @@ const { isIterable } = require('internal/streams/utils');
 const assert = require('internal/assert');
 
 const permission = require('internal/process/permission');
+
+// Matches a dotdot path component (e.g. `..`, `/../`, `../`) but not
+// filenames with consecutive dots like `a..b`.
+const dotdotRe = /(^|[\\/])\.\.(?:[\\/]|$)/;
 
 const kHandle = Symbol('kHandle');
 const kFd = Symbol('kFd');
@@ -802,6 +809,14 @@ async function ftruncate(handle, len = 0) {
 
 async function rm(path, options) {
   path = getValidatedPath(path);
+  if (typeof path === 'string') {
+    if (SideEffectFreeRegExpPrototypeExec(dotdotRe, path) !== null)
+      path = pathModule.normalize(path);
+  } else if (isArrayBufferView(path)) {
+    const str = BufferToString(path, 'utf8');
+    if (SideEffectFreeRegExpPrototypeExec(dotdotRe, str) !== null)
+      path = pathModule.normalize(str);
+  }
   options = await validateRmOptionsPromise(path, options, false);
   return lazyRimRaf()(path, options);
 }

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -569,3 +569,38 @@ if (isGitPresent) {
     }
   }
 }
+
+// Test that rm/rmSync normalize '.' and '..' in paths before processing.
+// Regression test for https://github.com/nodejs/node/issues/61958
+//
+// Each variant gets its own base directory to avoid async/sync races.
+// The weird path is constructed by joining components with path.sep so that
+// the '..' and '.' are preserved and not pre-normalized by path.join.
+{
+  // --- rmSync: <base>/a/b/../. should remove <base>/a entirely ---
+  const base = nextDirPath('dotdot-sync');
+  fs.mkdirSync(path.join(base, 'a', 'b', 'c', 'd'), common.mustNotMutateObjectDeep({ recursive: true }));
+  const weirdPath = [base, 'a', 'b', '..', '.'].join(path.sep);
+  fs.rmSync(weirdPath, common.mustNotMutateObjectDeep({ recursive: true }));
+  assert.strictEqual(fs.existsSync(path.join(base, 'a')), false);
+}
+
+{
+  // --- fs.rm (callback): same path construction ---
+  const base = nextDirPath('dotdot-cb');
+  fs.mkdirSync(path.join(base, 'a', 'b', 'c', 'd'), common.mustNotMutateObjectDeep({ recursive: true }));
+  const weirdPath = [base, 'a', 'b', '..', '.'].join(path.sep);
+  fs.rm(weirdPath, common.mustNotMutateObjectDeep({ recursive: true }), common.mustSucceed(() => {
+    assert.strictEqual(fs.existsSync(path.join(base, 'a')), false);
+  }));
+}
+
+{
+  // --- fs.promises.rm: same path construction ---
+  const base = nextDirPath('dotdot-prom');
+  fs.mkdirSync(path.join(base, 'a', 'b', 'c', 'd'), common.mustNotMutateObjectDeep({ recursive: true }));
+  const weirdPath = [base, 'a', 'b', '..', '.'].join(path.sep);
+  fs.promises.rm(weirdPath, common.mustNotMutateObjectDeep({ recursive: true })).then(common.mustCall(() => {
+    assert.strictEqual(fs.existsSync(path.join(base, 'a')), false);
+  }));
+}


### PR DESCRIPTION
## Summary
- `fs.rmSync`, `fs.rm`, and `fs.promises.rm` now call `path.normalize()` on string paths before passing them to either the C++ binding (`rmSync`) or the JS rimraf implementation (`rm`/`promises.rm`)
- This makes all three variants behave consistently when the path contains `.` or `..` components

## Root cause

Two different code paths handle `rm` in Node.js:

- **`rmSync`** (C++ — `src/node_file.cc:1661`): calls `std::filesystem::remove_all(file_path)`.  
  With `file_path = "a/b/../."`, C++ deletes the *contents* of `a` (by resolving the path through the kernel), but when it then tries to `rmdir("a/b/../.")` to remove the top-level entry, the `b` component was already deleted, so the path can't be resolved → ENOENT → treated as success → `a/` is left behind.

- **`rm` / `promises.rm`** (JS rimraf — `lib/internal/fs/rimraf.js`): calls `rmdir(2)` on the original path first.  
  On POSIX, `rmdir("a/b/../.")` returns `EINVAL` (trailing `.` is an invalid argument for rmdir). EINVAL is not handled by rimraf's retry logic → the operation fails immediately without removing anything.

Neither behaviour is correct, and they disagree with each other.

## Fix

Apply `path.normalize()` to string paths right after `getValidatedPath()` in all three entry points:

| File | Line | Change |
|------|------|--------|
| `lib/fs.js` | `rm()` | `if (typeof path === 'string') path = pathModule.normalize(path)` |
| `lib/fs.js` | `rmSync()` | same, before both validation and binding call |
| `lib/internal/fs/promises.js` | `rm()` | same |

`path.normalize('a/b/../.')` → `'a'`, which both rimraf and the C++ binding handle without issue. Buffer paths are left unchanged (they are an edge case and `path.normalize` only accepts strings).

## Test

Three new test cases added to `test/parallel/test-fs-rm.js`:
- `fs.rmSync` with a `../. `path removes the target directory completely
- `fs.rm` (callback) with the same path
- `fs.promises.rm` with the same path

Each case creates `<base>/a/b/c/d`, applies rm to `<base>/a/b/../.` (which should resolve to `<base>/a`), and asserts that `<base>/a` no longer exists.

## Related
- Ref: [isaacs/rimraf](https://github.com/isaacs/rimraf) — reporter notes a matching fix can also be applied upstream

Fixes: https://github.com/nodejs/node/issues/61958