### PR TITLE
watch: fix --watch-path restart on unrelated file with --env-file

### DIFF
--- a/lib/internal/watch_mode/files_watcher.js
+++ b/lib/internal/watch_mode/files_watcher.js
@@ -128,11 +128,14 @@ class FilesWatcher extends EventEmitter {
 
   filterFile(file, owner) {
     if (!file) return;
-    if (supportsRecursiveWatching) {
+    if (supportsRecursiveWatching && this.#mode === 'filter') {
+      // In filter mode, watch the parent directory with a single recursive
+      // FSWatcher - changes are then filtered by #filteredFiles in #onChange.
       this.watchPath(dirname(file));
     } else {
-      // Having multiple FSWatcher's seems to be slower
-      // than a single recursive FSWatcher
+      // In 'all' mode, watch the specific file directly so that unrelated
+      // files in the same directory do not trigger unnecessary restarts.
+      // Also used on platforms without recursive watching support.
       this.watchPath(file, false);
     }
     this.#filteredFiles.add(file);

--- a/test/parallel/test-watch-mode-files_watcher.mjs
+++ b/test/parallel/test-watch-mode-files_watcher.mjs
@@ -161,6 +161,47 @@ describe('watch mode file watcher', () => {
        assert.strictEqual(changesCount, 1);
      });
 
+  // Regression test for https://github.com/nodejs/node/issues/61906
+  // When --watch-path is used (mode: 'all'), filterFile() is called for
+  // --env-file entries. It must watch only that specific file, not the
+  // entire parent directory, so that touching an unrelated file in the
+  // same directory does not trigger a restart.
+  it('filterFile in "all" mode should not trigger on unrelated files',
+     { skip: !supportsRecursiveWatching }, async () => {
+       watcher = new FilesWatcher({ debounce: 100, mode: 'all' });
+       watcher.on('changed', common.mustNotCall(
+         'unexpected restart triggered by unrelated file change'));
+
+       const envFile = tmpdir.resolve('env-no-trigger.env');
+       const unrelated = tmpdir.resolve('env-unrelated.txt');
+       writeFileSync(envFile, 'FOO=bar');
+       writeFileSync(unrelated, 'initial');
+
+       watcher.filterFile(envFile);
+
+       await setTimeout(common.platformTimeout(100)); // avoid throttling
+       writeFileSync(unrelated, 'changed');
+       // Wait long enough to confirm no restart was triggered
+       await setTimeout(1000);
+     });
+
+  it('filterFile in "all" mode should trigger when the watched file changes',
+     { skip: !supportsRecursiveWatching }, async () => {
+       watcher = new FilesWatcher({ debounce: 100, mode: 'all' });
+       watcher.on('changed', () => changesCount++);
+
+       const envFile = tmpdir.resolve('env-trigger.env');
+       writeFileSync(envFile, 'FOO=bar');
+
+       watcher.filterFile(envFile);
+
+       const changed = once(watcher, 'changed');
+       await setTimeout(common.platformTimeout(100)); // avoid throttling
+       writeFileSync(envFile, 'FOO=newvalue');
+       await changed;
+       assert.strictEqual(changesCount, 1);
+     });
+
   it('should ruse existing watcher if it exists',
      { skip: !supportsRecursiveWatching }, () => {
        assert.deepStrictEqual(watcher.watchedPaths, []);


### PR DESCRIPTION
## Summary
- When using `--watch-path=<dir>` together with `--env-file=<path>`, touching any file in the directory that contains the env file incorrectly triggers a restart — even if the changed file has nothing to do with the watched path
- Fix: `filterFile()` now watches the specific file directly in `'all'` mode, rather than watching its entire parent directory

## Root cause

`FilesWatcher` has two modes:

| Mode | When used | `#onChange` behaviour |
|------|-----------|-----------------------|
| `'filter'` | No `--watch-path` | Only fires for files in `#filteredFiles` |
| `'all'` | `--watch-path` provided | Fires for **any** change in any watched path |

`filterFile()` in `lib/internal/watch_mode/files_watcher.js:131` takes a shortcut on macOS and Windows (platforms with recursive `fs.watch` support): instead of setting up one watcher per file, it calls `watchPath(dirname(file))` to watch the whole parent directory with a single recursive FSWatcher.

In `'filter'` mode this is harmless — `#onChange` checks `#filteredFiles` before emitting `'changed'`, so only the tracked file triggers a restart.

In `'all'` mode the filter check is skipped. So when `watch_mode.js` calls `filterFile(resolve('.env'))` (line 106) to watch the env file, it actually watches `.` (the CWD) recursively. Any `fs.watch` event in the CWD — including `touch unrelated` — then passes straight through and triggers a restart.

## Fix

Add `&& this.#mode === 'filter'` to the condition that selects the parent-directory strategy:

```js
// Before
if (supportsRecursiveWatching) {
  this.watchPath(dirname(file));   // watches the whole directory

// After
if (supportsRecursiveWatching && this.#mode === 'filter') {
  this.watchPath(dirname(file));   // only in filter mode
} else {
  this.watchPath(file, false);     // watch the specific file
}
```

In `'all'` mode the env file is now watched directly (`watchPath(file, false)`), so only changes to that exact file fire the watcher.

## Tests

Two new cases added to `test/parallel/test-watch-mode-files_watcher.mjs`:

1. **No false trigger**: `filterFile()` in `'all'` mode + modify an unrelated file in the same directory → `mustNotCall` asserts no `'changed'` event fires
2. **Correct trigger**: `filterFile()` in `'all'` mode + modify the watched file itself → `'changed'` fires exactly once

## Related

Ref: https://github.com/nodejs/node/issues/61906 (reporter provided a clean minimal repro)

Fixes: https://github.com/nodejs/node/issues/61906