### PR TITLE
doc: update supported Windows SDK version to 11

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -154,11 +154,11 @@ platforms. This is true regardless of entries in the table below.
 
 Depending on the host platform, the selection of toolchains may vary.
 
-| Operating System | Compiler Versions                                                         |
-| ---------------- | ------------------------------------------------------------------------- |
-| Linux            | GCC >= 12.2 or Clang >= 19.1                                              |
-| Windows          | Visual Studio 2022 or 2026 with the Windows 10 or 11 SDK on a 64-bit host |
-| macOS            | Xcode >= 16.4 (Apple LLVM >= 19)                                          |
+| Operating System | Compiler Versions                                                   |
+| ---------------- | ------------------------------------------------------------------- |
+| Linux            | GCC >= 12.2 or Clang >= 19.1                                        |
+| Windows          | Visual Studio 2022 or 2026 with the Windows 11 SDK on a 64-bit host |
+| macOS            | Xcode >= 16.4 (Apple LLVM >= 19)                                    |
 
 ### Official binary platforms and toolchains
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/61864

## Situation

The [Supported toolchains](https://github.com/nodejs/node/blob/main/BUILDING.md#supported-toolchains) section of the `BUILDING.md` document specifies:

| Operating System | Compiler Versions                                                         |
| ---------------- | ------------------------------------------------------------------------- |
| Windows          | Visual Studio 2022 or 2026 with the Windows 10 or 11 SDK on a 64-bit host |

and this includes the Windows 10 SDK (10.0.19041.0) which is [out of support](https://learn.microsoft.com/en-us/windows/apps/windows-sdk/#support-and-servicing) since 2025-10-14.

- Visual Studio 2022 (17.14.27) also shows Windows 10 SDK as out of support
- Visual Studio 2026 (18.3.1) no longer offers Windows 10 SDK for installation

## Change

Update the [Supported toolchains](https://github.com/nodejs/node/blob/main/BUILDING.md#supported-toolchains) section of the `BUILDING.md` document to remove the Windows 10 SDK:

| Operating System | Compiler Versions                                                   |
| ---------------- | ------------------------------------------------------------------- |
| Windows          | Visual Studio 2022 or 2026 with the Windows 11 SDK on a 64-bit host |

Impact should be minimal, since the Windows 11 SDK "can target Windows 11, version 25H2, in addition to previous Windows releases." See also [Windows SDK System requirements](https://learn.microsoft.com/en-us/windows/apps/windows-sdk/#system-requirements).

This is however a `semver-major` change that applies only to the `main` branch and may not be backported to existing release lines. It is intended for use in the upcoming Node.js 26.x release only.

(PR https://github.com/nodejs/node/pull/61864 is the non-`semver-major` PR to flow into v25.x and be backported to v24.x.)
