### PR TITLE
inspector: unwrap internal/debugger/inspect imports

### DIFF
--- a/lib/internal/debugger/inspect.js
+++ b/lib/internal/debugger/inspect.js
@@ -32,11 +32,8 @@ const {
   AbortController,
 } = require('internal/abort_controller');
 
-const { 0: InspectClient, 1: createRepl } =
-    [
-      require('internal/debugger/inspect_client'),
-      require('internal/debugger/inspect_repl'),
-    ];
+const InspectClient = require('internal/debugger/inspect_client');
+const createRepl = require('internal/debugger/inspect_repl');
 
 const debuglog = util.debuglog('inspect');
 


### PR DESCRIPTION
Artifact left over from the inspector adoption.

Refs: #38161