### PR TITLE
doc: improve stream.compose documentation clarity

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -2981,6 +2981,11 @@ first stream and reads from the last. Each provided stream is piped into
 the next, using `stream.pipeline`. If any of the streams error then all
 are destroyed, including the outer `Duplex` stream.
 
+When composing multiple streams, all must be `Duplex` streams (e.g. transforms).
+Each stream is piped to the next: the first receives writes, the last provides
+reads. When combining a write-only stream with a read-only stream (without
+piping them), use [`stream.Duplex.from({ writable, readable })`][] instead.
+
 Because `stream.compose` returns a new stream that in turn can (and
 should) be piped into other streams, it enables composition. In contrast,
 when passing streams to `stream.pipeline`, typically the first stream is
@@ -3014,15 +3019,17 @@ console.log(res); // prints 'HELLOWORLD'
 ```
 
 `stream.compose` can be used to convert async iterables, generators and
-functions into streams.
+functions into streams. The resulting streams are `Duplex` instances with
+configurable `readable` and `writable` options; when only one side is used,
+they are described as "readable Duplex" or "writable Duplex" accordingly.
 
-* `AsyncIterable` converts into a readable `Duplex`. Cannot yield
-  `null`.
+* `AsyncIterable` converts into a readable `Duplex` (readable side only).
+  Cannot yield `null`.
 * `AsyncGeneratorFunction` converts into a readable/writable transform `Duplex`.
   Must take a source `AsyncIterable` as first parameter. Cannot yield
   `null`.
-* `AsyncFunction` converts into a writable `Duplex`. Must return
-  either `null` or `undefined`.
+* `AsyncFunction` converts into a writable `Duplex` (writable side only).
+  Must return either `null` or `undefined`.
 
 ```mjs
 import { compose } from 'node:stream';
@@ -5016,6 +5023,7 @@ contain multi-byte characters.
 [`stream.Readable.from()`]: #streamreadablefromiterable-options
 [`stream.addAbortSignal()`]: #streamaddabortsignalsignal-stream
 [`stream.compose(...streams)`]: #streamcomposestreams
+[`stream.Duplex.from({ writable, readable })`]: #streamduplexfromsrc
 [`stream.cork()`]: #writablecork
 [`stream.duplexPair()`]: #streamduplexpairoptions
 [`stream.finished()`]: #streamfinishedstream-options-callback


### PR DESCRIPTION
Improves the `stream.compose` documentation to address confusion raised in #40812:

1. **Clarify Duplex vs Duplex.from**: When composing multiple streams, all must be Duplex streams (e.g. transforms) that get piped together. For combining a write-only stream with a read-only stream without piping, use `stream.Duplex.from({ writable, readable })` instead.

2. **Explain readable/writable Duplex terminology**: The terms "readable Duplex" and "writable Duplex" refer to Duplex instances with configurable `readable` and `writable` options where only one side is used. This addresses the confusion about how a "readable Duplex" or "writable Duplex" can exist when Duplex implies both directions.

Refs: https://github.com/nodejs/node/issues/40812

Made with [Cursor](https://cursor.com)