### PR TITLE
benchmark: add large buffer sizes to buffer-creation

### DIFF
--- a/benchmark/buffers/buffer-creation.js
+++ b/benchmark/buffers/buffer-creation.js
@@ -9,7 +9,7 @@ const bench = common.createBenchmark(main, {
     'fast-allocUnsafe',
     'slow-allocUnsafe',
   ],
-  len: [10, 1024, 4096, 8192],
+  len: [10, 1024, 4096, 8192, 10 * 1024, 51 * 1024, 102 * 1024, 204 * 1024],
   n: [6e5],
 });
 


### PR DESCRIPTION
## Summary

- Adds `10 KiB`, `51 KiB`, `102 KiB`, and `204 KiB` to the `len` parameter of `benchmark/buffers/buffer-creation.js`
- The existing benchmark only covered sizes up to 8192 bytes (8 KiB); performance regressions in the medium-to-large size range were invisible

## Root cause context

Issue #61967 reports significant `Buffer.allocUnsafe()` regressions in v24 vs v20:

| Size   | v20.12.1 | v24.13.0 | Change |
|--------|----------|----------|--------|
| 10 KiB | 1044 ms  | 996 ms   | -5%    |
| 51 KiB | 1230 ms  | 1387 ms  | +13%   |
| 102 KiB | 1339 ms | 2077 ms  | +55%   |
| 204 KiB | 1969 ms | 3349 ms  | +70%   |

The regression is limited to `Buffer.allocUnsafe()` sizes that bypass the small-allocation pool (≥ 4096 bytes), and shows size-dependent scaling. Adding these sizes to the benchmark makes the regression reproducible and trackable via CI benchmark comparisons.

To run with a smaller iteration count suitable for large sizes:
```bash
node benchmark/buffers/buffer-creation.js type=fast-allocUnsafe len=204800 n=10000
```

## Test plan

- [x] `node benchmark/buffers/buffer-creation.js` continues to work for all existing sizes
- [x] New sizes `10240`, `52224`, `104448`, `208896` can be selected via `len=` argument

Refs: https://github.com/nodejs/node/issues/61967