### PR TITLE
test: skip strace test with shared openssl

### DIFF
--- a/test/parallel/test-strace-openat-openssl.js
+++ b/test/parallel/test-strace-openat-openssl.js
@@ -11,6 +11,9 @@ if (!common.isLinux)
   common.skip('linux only');
 if (common.isASan)
   common.skip('strace does not work well with address sanitizer builds');
+if (process.config.variables.node_shared_openssl) {
+  common.skip('external shared openssl may open other files');
+}
 if (spawnSync('strace').error !== undefined) {
   common.skip('missing strace');
 }


### PR DESCRIPTION
`parallel/test-strace-openat-openssl` was [added](https://github.com/nodejs/node/pull/46150) to [check explicitly for a list of known files](https://github.com/nodejs/security-wg/issues/827) that would be opened for a set workload (`require("crypto")`). This is not reliable when Node.js is linked to an external/shared OpenSSL library (e.g. it might be configured to load configuration files from a different default location and/or load more than one configuration file) so skip this test when Node.js is built in that way.

Fixes: https://github.com/nodejs/node/issues/61966

---

Test is failing for `v20.x-staging` and `v22.x-staging` (although as of https://github.com/nodejs/node/pull/61921 it has been skipped there) due to `strace` being installed as part of gcc 10 (only used on those older release lines) cc @nodejs/releasers .

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
