### PR TITLE
src: fix libuv assertion on windows

### DIFF
--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -117,6 +117,8 @@ class WorkerThreadsTaskRunner::DelayedTaskScheduler {
                        double delay_in_seconds) {
     auto locked = tasks_.Lock();
 
+    if (has_shut_down_) return;
+
     auto entry = std::make_unique<TaskQueueEntry>(std::move(task), priority);
     auto delayed = std::make_unique<ScheduleTask>(
         this, std::move(entry), delay_in_seconds);
@@ -132,6 +134,7 @@ class WorkerThreadsTaskRunner::DelayedTaskScheduler {
 
   void Stop() {
     auto locked = tasks_.Lock();
+    has_shut_down_ = true;
     locked.Push(std::make_unique<StopTask>(this));
     uv_async_send(&flush_tasks_);
   }
@@ -241,6 +244,7 @@ class WorkerThreadsTaskRunner::DelayedTaskScheduler {
   uv_loop_t loop_;
   uv_async_t flush_tasks_;
   std::unordered_set<uv_timer_t*> timers_;
+  bool has_shut_down_ = false;
 };
 
 WorkerThreadsTaskRunner::WorkerThreadsTaskRunner(

--- a/test/parallel/test-process-exit-after-fetch-throw.js
+++ b/test/parallel/test-process-exit-after-fetch-throw.js
@@ -1,0 +1,32 @@
+'use strict';
+// Ref: https://github.com/nodejs/node/issues/56645
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+const http = require('http');
+
+if (process.argv[2] === 'child') {
+  http
+    .createServer((_, res) => {
+      res.writeHead(302, { Location: '/' });
+      res.end();
+    })
+    .listen(0, '127.0.0.1', async function() {
+      try {
+        await fetch(`http://127.0.0.1:${this.address().port}/`);
+      } catch {
+        // ignore
+      }
+      process.exit(0);
+    });
+} else {
+  const child = cp.spawn(process.execPath, [__filename, 'child']);
+
+  child.on(
+    'close',
+    common.mustCall((exitCode, signal) => {
+      assert.strictEqual(exitCode, 0);
+      assert.strictEqual(signal, null);
+    }),
+  );
+}


### PR DESCRIPTION
Set the pointer to `nullptr` after calling `uv_close` to avoid assertions.

Fixes: https://github.com/nodejs/node/issues/56645

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
