### PR TITLE
tls: forward keepAlive, keepAliveInitialDelay, noDelay to socket

### DIFF
--- a/lib/internal/net.js
+++ b/lib/internal/net.js
@@ -100,6 +100,9 @@ function isLoopback(host) {
 
 module.exports = {
   kReinitializeHandle: Symbol('kReinitializeHandle'),
+  kSetNoDelay: Symbol('kSetNoDelay'),
+  kSetKeepAlive: Symbol('kSetKeepAlive'),
+  kSetKeepAliveInitialDelay: Symbol('kSetKeepAliveInitialDelay'),
   isIP,
   isIPv4,
   isIPv6,

--- a/lib/internal/tls/wrap.js
+++ b/lib/internal/tls/wrap.js
@@ -590,6 +590,9 @@ function TLSSocket(socket, opts) {
     highWaterMark: tlsOptions.highWaterMark,
     onread: !socket ? tlsOptions.onread : null,
     signal: tlsOptions.signal,
+    noDelay: tlsOptions.noDelay,
+    keepAlive: tlsOptions.keepAlive,
+    keepAliveInitialDelay: tlsOptions.keepAliveInitialDelay,
   });
 
   // Proxy for API compatibility
@@ -1755,6 +1758,9 @@ exports.connect = function connect(...args) {
     highWaterMark: options.highWaterMark,
     onread: options.onread,
     signal: options.signal,
+    noDelay: options.noDelay,
+    keepAlive: options.keepAlive,
+    keepAliveInitialDelay: options.keepAliveInitialDelay,
   });
 
   // rejectUnauthorized property can be explicitly defined as `undefined`

--- a/lib/net.js
+++ b/lib/net.js
@@ -48,6 +48,9 @@ let debug = require('internal/util/debuglog').debuglog('net', (fn) => {
 });
 const {
   kReinitializeHandle,
+  kSetNoDelay,
+  kSetKeepAlive,
+  kSetKeepAliveInitialDelay,
   isIP,
   isIPv4,
   isIPv6,
@@ -356,9 +359,6 @@ function closeSocketHandle(self, isException, isCleanupPending = false) {
 
 const kBytesRead = Symbol('kBytesRead');
 const kBytesWritten = Symbol('kBytesWritten');
-const kSetNoDelay = Symbol('kSetNoDelay');
-const kSetKeepAlive = Symbol('kSetKeepAlive');
-const kSetKeepAliveInitialDelay = Symbol('kSetKeepAliveInitialDelay');
 const kSetTOS = Symbol('kSetTOS');
 
 function Socket(options) {

--- a/test/parallel/test-tls-connect-keepalive-nodelay.js
+++ b/test/parallel/test-tls-connect-keepalive-nodelay.js
@@ -1,0 +1,65 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+// This test verifies that tls.connect() forwards keepAlive,
+// keepAliveInitialDelay, and noDelay options to the underlying socket.
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+const {
+  kSetNoDelay,
+  kSetKeepAlive,
+  kSetKeepAliveInitialDelay,
+} = require('internal/net');
+
+const key = fixtures.readKey('agent1-key.pem');
+const cert = fixtures.readKey('agent1-cert.pem');
+
+// Test: keepAlive, keepAliveInitialDelay, and noDelay
+{
+  const server = tls.createServer({ key, cert }, (socket) => {
+    socket.end();
+  });
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false,
+      keepAlive: true,
+      keepAliveInitialDelay: 1000,
+      noDelay: true,
+    }, common.mustCall(() => {
+      assert.strictEqual(socket[kSetKeepAlive], true);
+      assert.strictEqual(socket[kSetKeepAliveInitialDelay], 1);
+      assert.strictEqual(socket[kSetNoDelay], true);
+      socket.destroy();
+      server.close();
+    }));
+  }));
+}
+
+// Test: defaults (options not set)
+{
+  const server = tls.createServer({ key, cert }, (socket) => {
+    socket.end();
+  });
+
+  server.listen(0, common.mustCall(() => {
+    const socket = tls.connect({
+      port: server.address().port,
+      rejectUnauthorized: false,
+    }, common.mustCall(() => {
+      assert.strictEqual(socket[kSetKeepAlive], false);
+      assert.strictEqual(socket[kSetKeepAliveInitialDelay], 0);
+      assert.strictEqual(socket[kSetNoDelay], false);
+      socket.destroy();
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## Summary

`tls.connect()` silently ignores `keepAlive`, `keepAliveInitialDelay`, and `noDelay` options. The documentation states it accepts any `socket.connect()` option, and `net.createConnection()` with the same options works correctly.

This forwards the options through both points so `net.Socket`'s constructor stores them on the internal symbols (`kSetNoDelay`, `kSetKeepAlive`, `kSetKeepAliveInitialDelay`), which `afterConnect()` then applies to the handle.

Fixes: https://github.com/nodejs/node/issues/62003

I believe this is a good candidate for backport, as it fixes a silent options-dropping bug in `tls.connect()` that affects `keepAlive/noDelay` behavior (in particular with AWS Lambda on 20.x runtime).