### PR TITLE
doc: clarify sqlite bare named parameter default

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -943,13 +943,13 @@ added: v22.5.0
   without the prefix character.
 
 The names of SQLite parameters begin with a prefix character. By default,
-`node:sqlite` requires that this prefix character is present when binding
-parameters. However, with the exception of dollar sign character, these
-prefix characters also require extra quoting when used in object keys.
+`node:sqlite` allows binding named parameters without this prefix character in
+the parameter object. With the exception of the dollar sign character, these
+prefix characters require extra quoting when used in object keys.
 
-To improve ergonomics, this method can be used to also allow bare named
-parameters, which do not require the prefix character in JavaScript code. There
-are several caveats to be aware of when enabling bare named parameters:
+This method enables or disables support for bare named parameters, which do not
+require the prefix character in JavaScript code. There are several caveats to
+be aware of when bare named parameters are enabled:
 
 * The prefix character is still required in SQL.
 * The prefix character is still allowed in JavaScript. In fact, prefixed names


### PR DESCRIPTION
Fixes #61823

## Summary

Updates `statement.setAllowBareNamedParameters()` documentation to match the actual default behavior.

- Replaced wording that implied prefixed named parameters are required by default.
- Clarified that bare named parameters are allowed by default.
- Clarified that this API toggles the behavior (enable/disable), and caveats apply when bare names are enabled.

## Validation

Ran markdown lint on the changed file:

```bash
node tools/lint-md/lint-md.mjs doc/api/sqlite.md
```

Result: exit code `0`.