### PR TITLE
doc: mention constructor check in deepStrictEqual

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -612,6 +612,7 @@ are recursively evaluated also by the following rules.
 * [`[[Prototype]]`][prototype-spec] of objects are compared using
   the [`===` operator][].
 * Only [enumerable "own" properties][] are considered.
+* Object constructors are compared when available.
 * {Error} names, messages, causes, and errors are always compared,
   even if these are not enumerable properties.
   `errors` is also compared.


### PR DESCRIPTION
Fixes #60239

## Summary

Adds missing comparison detail to `assert.deepStrictEqual()` docs:

- Documented that object constructors are compared as part of deep strict equality.

This aligns the `assert` docs with current behavior and existing `util.isDeepStrictEqual()` documentation.

## Validation

Ran markdown lint on the changed file:

```bash
node tools/lint-md/lint-md.mjs doc/api/assert.md
```

Result: exit code `0`.