### PR TITLE
http2: validate non-link headers in writeEarlyHints

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -921,7 +921,11 @@ class Http2ServerResponse extends Stream {
 
     for (const key of ObjectKeys(hints)) {
       if (key !== 'link') {
-        headers[key] = hints[key];
+        const name = key.trim().toLowerCase();
+        assertValidHeader(name, hints[key]);
+        if (!checkIsHttpToken(name))
+          throw new ERR_INVALID_HTTP_TOKEN('Header name', name);
+        headers[name] = hints[key];
       }
     }
 

--- a/test/parallel/test-http2-compat-write-early-hints-invalid-header.js
+++ b/test/parallel/test-http2-compat-write-early-hints-invalid-header.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+
+const assert = require('node:assert');
+const http2 = require('node:http2');
+const debug = require('node:util').debuglog('test');
+
+const testResBody = 'response content';
+
+{
+  const server = http2.createServer();
+
+  server.on('request', common.mustCall((req, res) => {
+    debug('Server sending early hints...');
+
+    assert.throws(() => {
+      res.writeEarlyHints({
+        'link': '</styles.css>; rel=preload; as=style',
+        'x\rbad': 'value',
+      });
+    }, (err) => err.code === 'ERR_INVALID_HTTP_TOKEN');
+
+    assert.throws(() => {
+      res.writeEarlyHints({
+        'link': '</styles.css>; rel=preload; as=style',
+        'x-custom': undefined,
+      });
+    }, (err) => err.code === 'ERR_HTTP2_INVALID_HEADER_VALUE');
+
+    debug('Server sending full response...');
+    res.end(testResBody);
+  }));
+
+  server.listen(0);
+
+  server.on('listening', common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+
+    debug('Client sending request...');
+
+    req.on('headers', common.mustNotCall());
+
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[':status'], 200);
+    }));
+
+    let data = '';
+    req.on('data', common.mustCallAtLeast((d) => data += d));
+
+    req.on('end', common.mustCall(() => {
+      debug('Got full response.');
+      assert.strictEqual(data, testResBody);
+      client.close();
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
## Summary

The HTTP/1.1 portion of the original PR landed separately in #61897. This PR now contains only the HTTP/2 compat layer counterpart.

- Validate header names and values for non-link hints in `Http2ServerResponse.prototype.writeEarlyHints()` using `assertValidHeader()` and `checkIsHttpToken()`
- Throws a clear error at the call site instead of forwarding invalid header names/values deeper into the HTTP/2 stack

## Test plan

- [x] `test/parallel/test-http2-compat-write-early-hints-invalid-header.js` — verifies `ERR_INVALID_HTTP_TOKEN` for bad header names and `ERR_HTTP2_INVALID_HEADER_VALUE` for bad values
- [x] Existing early hints tests still pass