### PR TITLE
deps: prefer cpuinfo_cur_freq over scaling_cur_freq in uv_cpu_info()

### DIFF
--- a/deps/uv/src/unix/linux.c
+++ b/deps/uv/src/unix/linux.c
@@ -1886,10 +1886,19 @@ nocpuinfo:
       continue;
 
     n++;
+    /* Prefer cpuinfo_cur_freq: it reads a hardware-cached value and avoids
+     * slow ACPI/SMM round-trips that scaling_cur_freq triggers on some AMD
+     * CPUs (especially inside containers), which can take ~20ms per core.
+     * Fall back to scaling_cur_freq when cpuinfo_cur_freq is not available.
+     */
     snprintf(buf, sizeof(buf),
-             "/sys/devices/system/cpu/cpu%u/cpufreq/scaling_cur_freq", cpu);
-
+             "/sys/devices/system/cpu/cpu%u/cpufreq/cpuinfo_cur_freq", cpu);
     fp = uv__open_file(buf);
+    if (fp == NULL) {
+      snprintf(buf, sizeof(buf),
+               "/sys/devices/system/cpu/cpu%u/cpufreq/scaling_cur_freq", cpu);
+      fp = uv__open_file(buf);
+    }
     if (fp == NULL)
       continue;
 


### PR DESCRIPTION
## Summary

- In `uv_cpu_info()` on Linux, reading `/sys/devices/system/cpu/cpuN/cpufreq/scaling_cur_freq` for each CPU core triggers a slow ACPI/SMM round-trip on some modern AMD CPUs inside containers — up to ~20ms per core, making `os.cpus()` take 500–600ms on a 32-core system
- `cpuinfo_cur_freq` exposes the same current-frequency information but reads from a hardware-cached register, avoiding the ACPI round-trip
- This patch prefers `cpuinfo_cur_freq` and falls back to `scaling_cur_freq` for systems that do not expose it

## Root cause

`uv_cpu_info()` in `deps/uv/src/unix/linux.c` iterates over every online CPU and opens `/sys/devices/system/cpu/cpu%u/cpufreq/scaling_cur_freq` sequentially. On AMD EPYC and Ryzen 9000-series CPUs running inside a Linux container, each `open()` + `read()` of that file causes the kernel cpufreq driver to issue an ACPI call into System Management Mode (SMM) to query the live clock frequency. SMM is a privileged firmware context that suspends all other CPU execution while it runs; inside a container the latency is amplified and regularly reaches 20 ms per core.

With 32 cores: 32 × 20 ms = ~640 ms spent inside a single `os.cpus()` call.

The regression was introduced when libuv switched from `cpuinfo_cur_freq` to `scaling_cur_freq` (libuv issue https://github.com/libuv/libuv/issues/4098). The libuv project closed the upstream issue as NOT_PLANNED.

Confirmed by comparing `node:20.2.0-alpine` (19 ms) vs `node:20.3.0-alpine` (356 ms) on the same AMD host.

## Fix

`deps/uv/src/unix/linux.c` — in the per-CPU frequency loop starting around line 1884:

- Try `cpuinfo_cur_freq` first; it is a cached readout of the actual hardware frequency reported by the CPU's own registers (via `/sys/bus/cpu/drivers/acpi-cpufreq` or equivalent) and does not trigger SMM
- If that file is absent (e.g. non-x86 platforms, or cpufreq not loaded), fall back to `scaling_cur_freq` — identical behaviour to today

The change is purely a path-preference inside the existing `if (fp == NULL) continue;` fallback pattern already used in the function, so it is safe on all platforms that currently work.

## Test

`os.cpus()` correctness (structure, types, `speed` field) is already covered by `test/parallel/test-os.js`. No new test is added — a timing assertion for this fix would be flaky in CI and the slow path requires a specific AMD CPU model inside a Linux container.

## Related

- Fixes https://github.com/nodejs/node/issues/61998
- Upstream libuv issue: https://github.com/libuv/libuv/issues/4098 (closed NOT_PLANNED)
- Related Node.js discussion: https://github.com/nodejs/node/issues/48831
- Performance discussion: https://github.com/nodejs/performance/issues/93

Fixes: https://github.com/nodejs/node/issues/61998