### PR TITLE
buffer: always use _copy for copy

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -268,7 +268,7 @@ function copyImpl(source, target, targetStart, sourceStart, sourceEnd) {
   return _copyActual(source, target, targetStart, sourceStart, sourceEnd);
 }
 
-function _copyActual(source, target, targetStart, sourceStart, sourceEnd, isUint8Copy = false) {
+function _copyActual(source, target, targetStart, sourceStart, sourceEnd) {
   if (sourceEnd - sourceStart > target.byteLength - targetStart)
     sourceEnd = sourceStart + target.byteLength - targetStart;
 
@@ -280,11 +280,7 @@ function _copyActual(source, target, targetStart, sourceStart, sourceEnd, isUint
   if (nb <= 0)
     return 0;
 
-  if (sourceStart === 0 && nb === sourceLen && (isUint8Copy || isUint8Array(target))) {
-    TypedArrayPrototypeSet(target, source, targetStart);
-  } else {
-    _copy(source, target, targetStart, sourceStart, nb);
-  }
+  _copy(source, target, targetStart, sourceStart, nb);
 
   return nb;
 }


### PR DESCRIPTION
This fixes a performance regression for `Buffer.copy(target, 0)` and brings it back inline with Buffer.write.

V8 has a massive `TypedArray.prototype.set` penalty on SharedArrayBuffer

Buffer.set and Buffer.copy are up to 8.4x slower when writing to a SharedArrayBuffer vs a regular ArrayBuffer, while Buffer.write (string encoding) is completely unaffected.
```
256 bytes, varying offset (Apple M3 Pro, Node 25.6.1):
                  ArrayBuffer    SharedArrayBuffer    Slowdown
Buffer.set           13.6 ns             56.1 ns       4.1x
Buffer.copy          17.0 ns             65.1 ns       3.8x
Buffer.write         75.8 ns             74.1 ns       1.0x (unaffected)

4096 bytes, varying offset:
                  ArrayBuffer    SharedArrayBuffer    Slowdown
Buffer.set           80.3 ns            674.2 ns       8.4x
Buffer.copy          78.4 ns            677.7 ns       8.6x
Buffer.write        190.6 ns            186.1 ns       1.0x (unaffected)
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
