### PR TITLE
test_runner: fix wrong signal exit codes

### DIFF
--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -285,8 +285,8 @@ function setupProcessState(root, globalOptions) {
     process.removeListener('unhandledRejection', rejectionHandler);
     process.removeListener('beforeExit', exitHandler);
     if (globalOptions.isTestRunner) {
-      process.removeListener('SIGINT', () => terminationHandler(kSigInt));
-      process.removeListener('SIGTERM', () => terminationHandler(kSigTerm));
+      process.removeListener('SIGINT', sigIntHandler);
+      process.removeListener('SIGTERM', sigTermHandler);
     }
   };
 
@@ -321,13 +321,16 @@ function setupProcessState(root, globalOptions) {
     process.exit(exitCode);
   };
 
+  const sigIntHandler = () => terminationHandler(kSigInt);
+  const sigTermHandler = () => terminationHandler(kSigTerm);
+
   process.on('uncaughtException', exceptionHandler);
   process.on('unhandledRejection', rejectionHandler);
   process.on('beforeExit', exitHandler);
   // TODO(MoLow): Make it configurable to hook when isTestRunner === false.
   if (globalOptions.isTestRunner) {
-    process.on('SIGINT', () => terminationHandler(kSigInt));
-    process.on('SIGTERM', () => terminationHandler(kSigTerm));
+    process.on('SIGINT', sigIntHandler);
+    process.on('SIGTERM', sigTermHandler);
   }
 
   root.harness.coverage = FunctionPrototypeBind(collectCoverage, null, root, coverage);

--- a/lib/internal/test_runner/harness.js
+++ b/lib/internal/test_runner/harness.js
@@ -20,7 +20,7 @@ const {
     ERR_TEST_FAILURE,
   },
 } = require('internal/errors');
-const { exitCodes: { kGenericUserError } } = internalBinding('errors');
+const { exitCodes: { kGenericUserError, kSigInt, kSigTerm } } = internalBinding('errors');
 const { kCancelledByParent, Test, Suite } = require('internal/test_runner/test');
 const {
   parseCommandLine,
@@ -285,8 +285,8 @@ function setupProcessState(root, globalOptions) {
     process.removeListener('unhandledRejection', rejectionHandler);
     process.removeListener('beforeExit', exitHandler);
     if (globalOptions.isTestRunner) {
-      process.removeListener('SIGINT', terminationHandler);
-      process.removeListener('SIGTERM', terminationHandler);
+      process.removeListener('SIGINT', () => terminationHandler(kSigInt));
+      process.removeListener('SIGTERM', () => terminationHandler(kSigTerm));
     }
   };
 
@@ -310,7 +310,7 @@ function setupProcessState(root, globalOptions) {
     return running;
   };
 
-  const terminationHandler = async () => {
+  const terminationHandler = async (exitCode) => {
     const runningTests = findRunningTests(root);
     if (runningTests.length > 0) {
       root.reporter.interrupted(runningTests);
@@ -318,7 +318,7 @@ function setupProcessState(root, globalOptions) {
       await new Promise((resolve) => setImmediate(resolve));
     }
     await exitHandler(true);
-    process.exit();
+    process.exit(exitCode);
   };
 
   process.on('uncaughtException', exceptionHandler);
@@ -326,8 +326,8 @@ function setupProcessState(root, globalOptions) {
   process.on('beforeExit', exitHandler);
   // TODO(MoLow): Make it configurable to hook when isTestRunner === false.
   if (globalOptions.isTestRunner) {
-    process.on('SIGINT', terminationHandler);
-    process.on('SIGTERM', terminationHandler);
+    process.on('SIGINT', () => terminationHandler(kSigInt));
+    process.on('SIGTERM', () => terminationHandler(kSigTerm));
   }
 
   root.harness.coverage = FunctionPrototypeBind(collectCoverage, null, root, coverage);

--- a/src/node_exit_code.h
+++ b/src/node_exit_code.h
@@ -33,7 +33,9 @@ namespace node {
   /* typically the exit codes are 128 + signal number. We also exit with */    \
   /* certain error codes directly for legacy reasons. Here we define those */  \
   /* that are used to normalize the exit code on Windows. */                   \
-  V(Abort, 134)
+  V(Abort, 134)                                                                \
+  V(SigInt, 130)                                                               \
+  V(SigTerm, 143)
 
 // TODO(joyeecheung): expose this to user land when the codes are stable.
 // The underlying type should be an int, or we can get undefined behavior when


### PR DESCRIPTION
The test runner was exiting with a generic error code when interrupted by signals such as SIGINT, instead of using the standard signal-based exit codes.

This change ensures the runner returns the correct signal exit code (e.g., 130 for SIGINT) rather than 1.

Fixes: #62037 