### PR TITLE
doc: clarify execution timing and common use cases of --require flag

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2454,10 +2454,15 @@ changes:
     description: This option also supports ECMAScript module.
 -->
 
-Preload the specified module at startup.
+Preload the specified module at startup, before the main entry point
+of the application is executed.
 
 Follows `require()`'s module resolution
 rules. `module` may be either a path to a file, or a node module name.
+
+This option is commonly used to initialize global configuration,
+set up instrumentation, or apply polyfills before any application
+code runs.
 
 Modules preloaded with `--require` will run before modules preloaded with `--import`.
 


### PR DESCRIPTION
Improves clarity of the `--require` CLI flag documentation.

Adds a short explanation clarifying that the module is executed
before the main application entry point, and provides common
real-world use cases such as configuration setup, instrumentation,
or polyfills.

This change improves readability without modifying behavior.