### PR TITLE
buffer: remove unused param from copyActual

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -268,7 +268,7 @@ function copyImpl(source, target, targetStart, sourceStart, sourceEnd) {
   return _copyActual(source, target, targetStart, sourceStart, sourceEnd);
 }
 
-function _copyActual(source, target, targetStart, sourceStart, sourceEnd, isUint8Copy = false) {
+function _copyActual(source, target, targetStart, sourceStart, sourceEnd) {
   if (sourceEnd - sourceStart > target.byteLength - targetStart)
     sourceEnd = sourceStart + target.byteLength - targetStart;
 
@@ -280,7 +280,7 @@ function _copyActual(source, target, targetStart, sourceStart, sourceEnd, isUint
   if (nb <= 0)
     return 0;
 
-  if (sourceStart === 0 && nb === sourceLen && (isUint8Copy || isUint8Array(target))) {
+  if (sourceStart === 0 && nb === sourceLen && isUint8Array(target)) {
     TypedArrayPrototypeSet(target, source, targetStart);
   } else {
     _copy(source, target, targetStart, sourceStart, nb);


### PR DESCRIPTION
Follow up to https://github.com/nodejs/node/pull/61721

We added this quirky parameter in https://github.com/nodejs/node/pull/60399 when implementing an optimization to `Buffer.concat` and `Buffer.copy` with the intention of eventually removing it when `.concat` used `TypedArrayPrototypeSet` in all cases

The parameter was only used in one place until it was removed in https://github.com/nodejs/node/pull/61721:

https://github.com/nodejs/node/pull/61721/changes#diff-3c2cd5c512dd026a7765b6b2ae3f85785d3b7ea3795e11949892b7b73beee630L635