### PR TITLE
fs: avoid unhandled rejection in filehandle readableWebStream close

### DIFF
--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -335,7 +335,11 @@ class FileHandle extends EventEmitter {
     } = require('internal/webstreams/readablestream');
     this[kRef]();
     this.once('close', () => {
-      readableStreamCancel(readable);
+      PromisePrototypeThen(
+        readableStreamCancel(readable),
+        undefined,
+        () => undefined,
+      );
     });
 
     return readable;

--- a/test/parallel/test-filehandle-readablestream-error-close.js
+++ b/test/parallel/test-filehandle-readablestream-error-close.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+async function runScript(source) {
+  const child = await common.spawnPromisified(process.execPath, [
+    '--unhandled-rejections=strict',
+    '-e',
+    source,
+  ]);
+
+  assert.strictEqual(child.code, 0, child.stderr);
+  assert.strictEqual(child.signal, null);
+  assert.strictEqual(child.stderr, '');
+}
+
+// Regression: once a readableWebStream read fails, explicitly closing the
+// FileHandle must not trigger an unhandled rejection.
+(async () => {
+  await runScript(`
+    const { closeSync } = require('node:fs');
+    const { open } = require('node:fs/promises');
+    const assert = require('node:assert');
+
+    async function consume(readable) {
+      for await (const _ of readable);
+    }
+
+    (async () => {
+      const file = await open(process.execPath);
+      const readable = file.readableWebStream();
+      closeSync(file.fd);
+
+      await assert.rejects(consume(readable), { code: 'EBADF' });
+      await assert.rejects(file.close(), { code: 'EBADF' });
+    })().catch((err) => {
+      console.error(err);
+      process.exitCode = 1;
+    });
+  `);
+})().then(common.mustCall());
+
+// Edge: BYOB readers should not leak unhandled rejections on the same path.
+(async () => {
+  await runScript(`
+    const { closeSync } = require('node:fs');
+    const { open } = require('node:fs/promises');
+    const assert = require('node:assert');
+
+    (async () => {
+      const file = await open(process.execPath);
+      const readable = file.readableWebStream();
+      const reader = readable.getReader({ mode: 'byob' });
+      closeSync(file.fd);
+
+      await assert.rejects(reader.read(new DataView(new ArrayBuffer(1024))), {
+        code: 'EBADF',
+      });
+      await assert.rejects(file.close(), { code: 'EBADF' });
+    })().catch((err) => {
+      console.error(err);
+      process.exitCode = 1;
+    });
+  `);
+})().then(common.mustCall());
+
+// Safety: successful reads must remain unaffected.
+(async () => {
+  await runScript(`
+    const { open } = require('node:fs/promises');
+
+    (async () => {
+      const file = await open(process.execPath);
+      for await (const _ of file.readableWebStream());
+      await file.close();
+    })().catch((err) => {
+      console.error(err);
+      process.exitCode = 1;
+    });
+  `);
+})().then(common.mustCall());


### PR DESCRIPTION
Fixes: #56116

When FileHandle emits 'close', readableWebStream currently calls readableStreamCancel(readable) without handling rejection. If the stream has already errored (for example after EBADF), this can surface as an unhandled rejection.

This change consumes that cancel rejection on the close-notify path.

Tests:
- add regression for errored readableWebStream + explicit file.close() (no unhandled rejection)
- add BYOB variant for the same edge path
- keep a success-path safety check