### PR TITLE
test: avoid flaky restart sync in debugger exceptions test

### DIFF
--- a/test/parallel/test-debugger-exceptions.js
+++ b/test/parallel/test-debugger-exceptions.js
@@ -27,8 +27,10 @@ const path = require('path');
       await cli.waitFor(/disconnect/);
 
       // Next run: With `breakOnException` it pauses in both places.
-      await cli.stepCommand('r');
+      await cli.command('r');
+      await cli.waitFor(/ ok\n/);
       await cli.waitForInitialBreak();
+      await cli.waitForPrompt();
       assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 1 });
       await cli.command('breakOnException');
       await cli.stepCommand('c');
@@ -38,16 +40,20 @@ const path = require('path');
 
       // Next run: With `breakOnUncaught` it only pauses on the 2nd exception.
       await cli.command('breakOnUncaught');
-      await cli.stepCommand('r'); // Also, the setting survives the restart.
+      await cli.command('r'); // Also, the setting survives the restart.
+      await cli.waitFor(/ ok\n/);
       await cli.waitForInitialBreak();
+      await cli.waitForPrompt();
       assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 1 });
       await cli.stepCommand('c');
       assert.ok(cli.output.includes(`exception in ${script}:9`));
 
       // Next run: Back to the initial state! It should die again.
       await cli.command('breakOnNone');
-      await cli.stepCommand('r');
+      await cli.command('r');
+      await cli.waitFor(/ ok\n/);
       await cli.waitForInitialBreak();
+      await cli.waitForPrompt();
       assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 1 });
       await cli.command('c');
       await cli.waitFor(/disconnect/);


### PR DESCRIPTION
In `test/parallel/test-debugger-exceptions.js`, using `stepCommand('r')` can intermittently time out while waiting for `BREAK_MESSAGE`. This PR preserves the test intent, but changes the reconnect sync point for r to wait for `ok` before `waitForInitialBreak()`.

Same approach as https://github.com/nodejs/node/pull/62807

## CI logs
- https://github.com/nodejs/node/actions/runs/22025863299 (line:30)
- https://github.com/nodejs/node/actions/runs/22532700362 (line:41)
- https://github.com/nodejs/node/actions/runs/22632786580 (line:49)

## Testing

```
UNUSUAL="$HOME/dir with \$unusual\"chars?'åß∂ƒ©∆¬…\`"
mkdir -p "$UNUSUAL"
ln -sfn "$PWD" "$UNUSUAL/node"
cd "$UNUSUAL/node"
```

- [x] `./tools/test.py -p actions parallel/test-debugger-exceptions`
- [x] `./tools/test.py -p actions -j1 --repeat 40 parallel/test-debugger-exceptions`
- [x] `./tools/test.py -p actions parallel/test-debugger-restart-message parallel/test-debugger-run-after-quit-restart`
- [x] CI passes on macOS

Refs: https://github.com/nodejs/node/issues/61762