### PR TITLE
test: avoid initial-break wait in restart-message

### DIFF
--- a/test/parallel/test-debugger-restart-message.js
+++ b/test/parallel/test-debugger-restart-message.js
@@ -20,7 +20,7 @@ const startCLI = require('../common/debugger');
 
   async function onWaitForInitialBreak() {
     try {
-      await cli.waitForInitialBreak();
+      await cli.waitFor(/ ok\n/);
       await cli.waitForPrompt();
       assert.strictEqual(cli.output.match(listeningRegExp).length, 1);
 


### PR DESCRIPTION
## Summary

Follow-up to #61773 

`test/parallel/test-debugger-restart-message.js` can still flake on macOS unusual-path runs at the initial `waitForInitialBreak()`. This change syncs startup on the debugger CLI's `ok` connection-completion output plus the prompt.

failed CI log (main branch): https://github.com/nodejs/node/actions/runs/22545396955

## Testing

```
UNUSUAL="$HOME/dir with \$unusual\"chars?'åß∂ƒ©∆¬…\`"
mkdir -p "$UNUSUAL"
ln -sfn "$PWD" "$UNUSUAL/node"
cd "$UNUSUAL/node"
```

- [x] `./tools/test.py -p actions parallel/test-debugger-restart-message`
- [x] `./tools/test.py -p actions -j1 --repeat 40 parallel/test-debugger-restart-message`
- [x] CI passes on macOS

Refs: https://github.com/nodejs/node/issues/61762
