### PR TITLE
doc: add note (and caveat) for `mock.module` about customization hooks

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -2508,6 +2508,11 @@ Node.js builtin modules. Any references to the original module prior to mocking 
 order to enable module mocking, Node.js must be started with the
 [`--experimental-test-module-mocks`][] command-line flag.
 
+**Note**: [module customization hooks][] registered via the **synchronous** API effect resolution of
+the `specifier` provided to `mock.module`. Customization hooks registered via the **asynchronous**
+API are currently ignored (because the test runner's loader is synchronous, and node does not
+support multi-chain / cross-chain loading).
+
 The following example demonstrates how a mock is created for a module.
 
 ```js
@@ -4255,6 +4260,7 @@ Can be used to abort test subtasks when the test has been aborted.
 [configuration files]: cli.md#--experimental-config-fileconfig
 [describe options]: #describename-options-fn
 [it options]: #testname-options-fn
+[module customization hooks]: module.md#customization-hooks
 [running tests from the command line]: #running-tests-from-the-command-line
 [stream.compose]: stream.md#streamcomposestreams
 [subtests]: #subtests


### PR DESCRIPTION
So for instance, if mocking a `tsx` module and a loader was registered via the **`async`** API (`module.register()`, `--loader`, etc), the test-runner doesn't use it and throws trying to validate `format` (even though it will actually work):

https://github.com/nodejs/node/blob/f8d5bad52f6df23dab94cdca5e33e491b00efbfe/lib/internal/test_runner/mock/mock.js#L650-L653

This is mainly problem within the `ModuleLoader` itself, which checks whether sync hooks exist; when they do, it uses that chain and ignores the potential existence of registered async hooks:

https://github.com/nodejs/node/blob/f8d5bad52f6df23dab94cdca5e33e491b00efbfe/lib/internal/modules/esm/loader.js#L727-L734

The problem for the test runner was created/exposed by switching the test-runner's loader to sync registration, which ensures there's always a **sync** chain (causing the async chain to be ignored internally).

Geoffrey, Joyee, Matteo, and I discussed this scenario ~a year ago in Dublin. The fix is not simple.

<details>
<summary>It would need to do something like this</summary>

![Leveraging async and sync hooks together, constantly jumping into and back out of the upside-down](https://github.com/user-attachments/assets/8f8486f4-1412-44b5-b883-c39ab2a79083)

[slack convo](https://openjs-foundation.slack.com/archives/C053UCCP940/p1743628186276709)
</details>