### PR TITLE
tools: fix daily wpt workflow nighly release version lookup

### DIFF
--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -49,7 +49,7 @@ jobs:
       # install a version and checkout
       - name: Get latest nightly
         if: matrix.node-version == 'latest-nightly'
-        run: echo "NIGHTLY=$(curl -s https://nodejs.org/download/nightly/index.json | jq -r '[.[] | select(.files[] | contains("linux-x64"))][0].version')" >> $GITHUB_ENV
+        run: echo "NIGHTLY=$(curl -s https://nodejs.org/download/nightly/index.json | jq -r '[.[] | select(.files[] | contains("linux-arm64"))][0].version')" >> $GITHUB_ENV
       - name: Install Node.js
         id: setup-node
         uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0


### PR DESCRIPTION
https://github.com/nodejs/node/pull/61903 updated the runner from x64 to arm, ever since we're at the mercy of jenkins to finish promoting the nighly arm release in time, this fixes that problem by selecting the last nightly for arm.