### PR TITLE
test_runner: print failed coverage reports with dot runner

### DIFF
--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -4,12 +4,13 @@ const {
   MathMax,
 } = primordials;
 const colors = require('internal/util/colors');
-const { formatTestReport } = require('internal/test_runner/reporter/utils');
+const { formatTestReport, getCoverageReport } = require('internal/test_runner/reporter/utils');
 
 module.exports = async function* dot(source) {
   let count = 0;
   let columns = getLineLength();
   const failedTests = [];
+  const coverageFailures = [];
   for await (const { type, data } of source) {
     if (type === 'test:pass') {
       yield `${colors.green}.${colors.reset}`;
@@ -17,6 +18,16 @@ module.exports = async function* dot(source) {
     if (type === 'test:fail') {
       yield `${colors.red}X${colors.reset}`;
       ArrayPrototypePush(failedTests, data);
+    }
+    if (type === 'test:coverage') {
+      // Check if coverage failed (threshold not met)
+      if (data.summary && (
+        (data.summary.lines && data.summary.lines.pct < 100) ||
+        (data.summary.functions && data.summary.functions.pct < 100) ||
+        (data.summary.branches && data.summary.branches.pct < 100)
+      )) {
+        ArrayPrototypePush(coverageFailures, data);
+      }
     }
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
       yield '\n';
@@ -31,6 +42,12 @@ module.exports = async function* dot(source) {
     yield `\n${colors.red}Failed tests:${colors.white}\n\n`;
     for (const test of failedTests) {
       yield formatTestReport('test:fail', test);
+    }
+  }
+  if (coverageFailures.length > 0) {
+    yield `\n${colors.red}Coverage report failed:${colors.white}\n\n`;
+    for (const coverage of coverageFailures) {
+      yield getCoverageReport('', coverage.summary, 'ℹ ', colors.blue, true);
     }
   }
 };


### PR DESCRIPTION
Fixes #60884

## Summary

When running tests with both the dot reporter and coverage reports, if the coverage report fails there was no output (other than the dots) but the program exits with a failure status code.

This change adds coverage failure output to the dot reporter, similar to how the spec reporter handles coverage events. Now users can see why the command failed without needing to check F12 console.

## Changes

- Import `getCoverageReport` from reporter utils
- Track coverage events in dot reporter
- Print coverage failures at the end of test output

## Testing

- [x] Code follows project guidelines
- [x] Self-review completed
- [x] Commits are signed