### PR TITLE
benchmark: fix destructuring in dgram/single-buffer and update N convention in crypto

### DIFF
--- a/benchmark/crypto/hash-stream-creation.js
+++ b/benchmark/crypto/hash-stream-creation.js
@@ -5,7 +5,7 @@ const common = require('../common.js');
 const crypto = require('crypto');
 
 const bench = common.createBenchmark(main, {
-  writes: [500],
+  n: [500],
   algo: [ 'sha256', 'md5' ],
   type: ['asc', 'utf', 'buf'],
   out: ['hex', 'binary', 'buffer'],
@@ -13,7 +13,7 @@ const bench = common.createBenchmark(main, {
   api: ['legacy', 'stream'],
 });
 
-function main({ api, type, len, out, writes, algo }) {
+function main({ api, type, len, out, n, algo }) {
   if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // Use the legacy, just so that we can compare them.
@@ -41,15 +41,15 @@ function main({ api, type, len, out, writes, algo }) {
   const fn = api === 'stream' ? streamWrite : legacyWrite;
 
   bench.start();
-  fn(algo, message, encoding, writes, len, out);
+  fn(algo, message, encoding, n, len, out);
 }
 
-function legacyWrite(algo, message, encoding, writes, len, outEnc) {
-  const written = writes * len;
+function legacyWrite(algo, message, encoding, n, len, outEnc) {
+  const written = n * len;
   const bits = written * 8;
   const gbits = bits / (1024 * 1024 * 1024);
 
-  while (writes-- > 0) {
+  while (n-- > 0) {
     const h = crypto.createHash(algo);
     h.update(message, encoding);
     h.digest(outEnc);
@@ -58,12 +58,12 @@ function legacyWrite(algo, message, encoding, writes, len, outEnc) {
   bench.end(gbits);
 }
 
-function streamWrite(algo, message, encoding, writes, len, outEnc) {
-  const written = writes * len;
+function streamWrite(algo, message, encoding, n, len, outEnc) {
+  const written = n * len;
   const bits = written * 8;
   const gbits = bits / (1024 * 1024 * 1024);
 
-  while (writes-- > 0) {
+  while (n-- > 0) {
     const h = crypto.createHash(algo);
 
     if (outEnc !== 'buffer')

--- a/benchmark/crypto/hash-stream-throughput.js
+++ b/benchmark/crypto/hash-stream-throughput.js
@@ -5,14 +5,14 @@ const common = require('../common.js');
 const crypto = require('crypto');
 
 const bench = common.createBenchmark(main, {
-  writes: [500],
+  n: [500],
   algo: ['sha1', 'sha256', 'sha512'],
   type: ['asc', 'utf', 'buf'],
   len: [2, 1024, 102400, 1024 * 1024],
   api: ['legacy', 'stream'],
 });
 
-function main({ api, type, len, algo, writes }) {
+function main({ api, type, len, algo, n }) {
   if (api === 'stream' && /^v0\.[0-8]\./.test(process.version)) {
     console.error('Crypto streams not available until v0.10');
     // Use the legacy, just so that we can compare them.
@@ -40,16 +40,16 @@ function main({ api, type, len, algo, writes }) {
   const fn = api === 'stream' ? streamWrite : legacyWrite;
 
   bench.start();
-  fn(algo, message, encoding, writes, len);
+  fn(algo, message, encoding, n, len);
 }
 
-function legacyWrite(algo, message, encoding, writes, len) {
-  const written = writes * len;
+function legacyWrite(algo, message, encoding, n, len) {
+  const written = n * len;
   const bits = written * 8;
   const gbits = bits / (1024 * 1024 * 1024);
   const h = crypto.createHash(algo);
 
-  while (writes-- > 0)
+  while (n-- > 0)
     h.update(message, encoding);
 
   h.digest();
@@ -57,13 +57,13 @@ function legacyWrite(algo, message, encoding, writes, len) {
   bench.end(gbits);
 }
 
-function streamWrite(algo, message, encoding, writes, len) {
-  const written = writes * len;
+function streamWrite(algo, message, encoding, n, len) {
+  const written = n * len;
   const bits = written * 8;
   const gbits = bits / (1024 * 1024 * 1024);
   const h = crypto.createHash(algo);
 
-  while (writes-- > 0)
+  while (n-- > 0)
     h.write(message, encoding);
 
   h.end();

--- a/benchmark/crypto/rsa-sign-verify-throughput.js
+++ b/benchmark/crypto/rsa-sign-verify-throughput.js
@@ -17,20 +17,20 @@ keylen_list.forEach((key) => {
 });
 
 const bench = common.createBenchmark(main, {
-  writes: [500],
+  n: [500],
   algo: ['SHA1', 'SHA224', 'SHA256', 'SHA384', 'SHA512'],
   keylen: keylen_list,
   len: [1024, 102400, 2 * 102400, 3 * 102400, 1024 * 1024],
 });
 
-function main({ len, algo, keylen, writes }) {
+function main({ len, algo, keylen, n }) {
   const message = Buffer.alloc(len, 'b');
   bench.start();
-  StreamWrite(algo, keylen, message, writes, len);
+  StreamWrite(algo, keylen, message, n, len);
 }
 
-function StreamWrite(algo, keylen, message, writes, len) {
-  const written = writes * len;
+function StreamWrite(algo, keylen, message, n, len) {
+  const written = n * len;
   const bits = written * 8;
   const kbits = bits / (1024);
 
@@ -38,7 +38,7 @@ function StreamWrite(algo, keylen, message, writes, len) {
   const s = crypto.createSign(algo);
   const v = crypto.createVerify(algo);
 
-  while (writes-- > 0) {
+  while (n-- > 0) {
     s.update(message);
     v.update(message);
   }

--- a/benchmark/dgram/single-buffer.js
+++ b/benchmark/dgram/single-buffer.js
@@ -5,7 +5,7 @@ const common = require('../common.js');
 const dgram = require('dgram');
 const PORT = common.PORT;
 
-// `num` is the number of send requests to queue up each time.
+// `n` is the number of send requests to queue up each time.
 // Keep it reasonably high (>10) otherwise you're benchmarking the speed of
 // event loop cycles more than anything else.
 const bench = common.createBenchmark(main, {
@@ -15,7 +15,7 @@ const bench = common.createBenchmark(main, {
   dur: [5],
 });
 
-function main({ dur, len, num: n, type }) {
+function main({ dur, len, n, type }) {
   const chunk = Buffer.allocUnsafe(len);
   let sent = 0;
   let received = 0;


### PR DESCRIPTION
#59872 renamed the config key from `num` to `n` but did not update the destructuring in main()
Rename the `writes` config parameter to `n` in three crypto benchmark files to align with the standard iteration-count convention

Refs: https://github.com/nodejs/node/pull/59872
Refs: https://github.com/nodejs/performance/issues/187

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
