### PR TITLE
benchmark (WIP): reduce config for fs benchmarks

### DIFF
--- a/benchmark/fs/read-stream-throughput.js
+++ b/benchmark/fs/read-stream-throughput.js
@@ -12,7 +12,7 @@ const filename = tmpdir.resolve(`.removeme-benchmark-garbage-${process.pid}`);
 const bench = common.createBenchmark(main, {
   encodingType: ['buf', 'asc', 'utf'],
   filesize: [1000 * 1024],
-  highWaterMark: [1024, 4096, 65535, 1024 * 1024],
+  highWaterMark: [1024, 65535, 1024 * 1024],
   n: 1024,
 });
 

--- a/benchmark/fs/readfile-promises.js
+++ b/benchmark/fs/readfile-promises.js
@@ -17,8 +17,6 @@ const bench = common.createBenchmark(main, {
     1024,
     512 * 1024,
     4 * 1024 ** 2,
-    8 * 1024 ** 2,
-    16 * 1024 ** 2,
     32 * 1024 ** 2,
   ],
   concurrent: [1, 10],

--- a/benchmark/fs/write-stream-throughput.js
+++ b/benchmark/fs/write-stream-throughput.js
@@ -11,7 +11,7 @@ const filename = tmpdir.resolve(`.removeme-benchmark-garbage-${process.pid}`);
 const bench = common.createBenchmark(main, {
   dur: [5],
   encodingType: ['buf', 'asc', 'utf'],
-  size: [2, 1024, 65535, 1024 * 1024],
+  size: [1024, 65535, 1024 * 1024],
 });
 
 function main({ dur, encodingType, size }) {

--- a/benchmark/fs/writefile-promises.js
+++ b/benchmark/fs/writefile-promises.js
@@ -13,7 +13,7 @@ let filesWritten = 0;
 const bench = common.createBenchmark(main, {
   duration: [5],
   encodingType: ['buf', 'asc', 'utf'],
-  size: [2, 1024, 65535, 1024 * 1024],
+  size: [1024, 65535, 1024 * 1024],
   concurrent: [1, 10],
 });
 


### PR DESCRIPTION
Reduce configuration matrix for four fs benchmark files to cut `benchmark/run.js` time without losing code path coverage

### Changes

| File | Config | Before | After | Removed |
|---|---|---|---|---|
| `readfile-promises.js` | `len` | 6 values | 4 | 8MB, 16MB |
| `writefile-promises.js` | `size` | 4 values | 3 | 2 |
| `write-stream-throughput.js` | `size` | 4 values | 3 | 2 |
| `read-stream-throughput.js` | `highWaterMark` | 4 values | 3 | 4096 |

### Timing (`benchmark/run.js --track --set duration=5 fs`)

| File | Before | After | Saved |
|---|---|---|---|
| `readfile-promises.js` | 121s | 81s | 40s (33%) |
| `writefile-promises.js` | 202s | 143s | 59s (29%) |
| `write-stream-throughput.js` | 62s | 47s | 15s (24%) |
| `read-stream-throughput.js` | 45s | 35s | 10s (22%) |
| **fs suite total** | **608s** | **482s** | **126s (21%)** |

Refs: https://github.com/nodejs/performance/issues/186

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
