### PR TITLE
stream: replace bind with arrow function for onwrite callback

### DIFF
--- a/lib/internal/streams/writable.js
+++ b/lib/internal/streams/writable.js
@@ -347,7 +347,7 @@ function WritableState(options, stream, isDuplex) {
   this.corked = 0;
 
   // The callback that's passed to _write(chunk, cb).
-  this.onwrite = onwrite.bind(undefined, stream);
+  this.onwrite = (er) => onwrite(stream, er);
 
   // The amount that is being written when _write is called.
   this.writelen = 0;


### PR DESCRIPTION
Replace `onwrite.bind(undefined, stream)` with an arrow function. 

Writable creation +29.92%
Duplex creation +19.91%


> streams/creation.js kind='duplex' n=50000000                                                    ***     19.91 %       ±0.92% ±1.23% ±1.60%
streams/creation.js kind='readable' n=50000000                                                          -0.53 %       ±1.14% ±1.53% ±2.01%
streams/creation.js kind='transform' n=50000000                                                 ***      5.06 %       ±1.03% ±1.37% ±1.79%
streams/creation.js kind='writable' n=50000000                                                  ***     29.92 %       ±1.16% ±1.55% ±2.01%
streams/pipe-object-mode.js n=5000000                                                                    0.12 %       ±1.16% ±1.55% ±2.04%
streams/pipe.js n=5000000                                                                               -0.12 %       ±0.80% ±1.07% ±1.39%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='no' n=100000                     1.82 %       ±2.31% ±3.10% ±4.10%
streams/writable-manywrites.js len=1024 callback='no' writev='no' sync='yes' n=100000                   -0.77 %       ±1.88% ±2.50% ±3.26%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='no' n=100000                    0.33 %       ±1.24% ±1.66% ±2.17%
streams/writable-manywrites.js len=1024 callback='no' writev='yes' sync='yes' n=100000                   0.48 %       ±1.48% ±1.97% ±2.56%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='no' n=100000                    0.08 %       ±0.73% ±0.97% ±1.26%
streams/writable-manywrites.js len=1024 callback='yes' writev='no' sync='yes' n=100000                  -2.24 %       ±4.73% ±6.36% ±8.42%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='no' n=100000                  -1.10 %       ±1.66% ±2.20% ±2.87%
streams/writable-manywrites.js len=1024 callback='yes' writev='yes' sync='yes' n=100000                 -0.78 %       ±1.58% ±2.11% ±2.75%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='no' n=100000                   -0.12 %       ±0.83% ±1.11% ±1.45%
streams/writable-manywrites.js len=32768 callback='no' writev='no' sync='yes' n=100000                  -0.61 %       ±1.88% ±2.51% ±3.26%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='no' n=100000                  -0.12 %       ±0.68% ±0.91% ±1.18%
streams/writable-manywrites.js len=32768 callback='no' writev='yes' sync='yes' n=100000                 -1.37 %       ±4.54% ±6.10% ±8.04%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='no' n=100000                   3.08 %       ±4.28% ±5.76% ±7.63%
streams/writable-manywrites.js len=32768 callback='yes' writev='no' sync='yes' n=100000                  0.18 %       ±1.71% ±2.28% ±2.97%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='no' n=100000                  1.83 %       ±3.21% ±4.32% ±5.72%
streams/writable-manywrites.js len=32768 callback='yes' writev='yes' sync='yes' n=100000                 0.00 %       ±1.64% ±2.19% ±2.86%
>
>Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 22 comparisons, you can thus
expect the following amount of false-positive results:
  1.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.22 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
