### PR TITLE
test_runner: print failed coverage reports with dot reporter fixes #60884

### DIFF
--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -18,6 +18,10 @@ module.exports = async function* dot(source) {
       yield `${colors.red}X${colors.reset}`;
       ArrayPrototypePush(failedTests, data);
     }
+    if (type === 'test:diagnostic') {
+      const levelColor = data.level === 'error' ? colors.red : data.level === 'warning' ? colors.yellow : colors.white;
+      yield `\n${levelColor}${data.message}${colors.reset}\n`;
+    }
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
       yield '\n';
 


### PR DESCRIPTION
When coverage threshold is not met, the dot reporter now outputs the error message so users can understand why tests failed.

## Problem
When running tests with both the dot reporter and coverage reports, if the coverage report fails there is no output (other than the dots) but the program exits with a failure status code.

## Solution
Similar to PR #52655, this adds support for the `test:diagnostic` event type in the dot reporter. When coverage threshold is not met, the error message will now be displayed.

## Changes
- Added handler for `test:diagnostic` event type in dot reporter
- Error messages are displayed in red, warnings in yellow

Refs: #60884