### PR TITLE
build: add --shared-v8 flags

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1109,6 +1109,68 @@ shipping with these options to:
   external dependencies. There may be little or no test coverage
   within the Node.js project CI for these non-default options.
 
+### Shared V8
+
+Node.js can be built against a shared V8 library using the `--shared-v8`
+configure flag. This completely excludes the bundled `deps/v8/` from
+compilation and links against an external V8 instead.
+
+```console
+./configure --shared-v8 \
+  --shared-v8-includes=/usr/include \
+  --shared-v8-libpath=/usr/lib \
+  --shared-v8-libname=v8,v8_libplatform
+```
+
+The following flags are available:
+
+* `--shared-v8`: Link to a shared V8 library instead of building the
+  bundled copy.
+* `--shared-v8-includes=<path>`: Directory containing V8 header files
+  (`v8.h`, `v8-platform.h`, `v8config.h`, `v8-version.h`, etc.).
+* `--shared-v8-libpath=<path>`: Directory containing the shared V8
+  library.
+* `--shared-v8-libname=<name>`: Library name(s) to link against,
+  comma-separated for multiple. Default: `v8,v8_libplatform`.
+
+The shared V8 must meet the build configuration requirements listed
+below. Configure-time validation checks these automatically; hard
+requirements produce errors, performance requirements produce warnings.
+
+#### V8 build configuration spec
+
+**Hard requirements** (configure errors if violated):
+
+| Flag | Required value | Reason |
+|------|---------------|--------|
+| V8 major.minor version | Must match bundled `deps/v8/` | ABI compatibility (e.g., 14.3.x) |
+| `v8_enable_sandbox` | `false` | Node.js C++ backing stores are not sandbox-allocated |
+| `v8_enable_extensible_ro_snapshot` | `false` | Snapshot compatibility |
+| `v8_enable_pointer_compression` | Auto-detected | ABI: struct layout must match. Node.js reads the shared V8's `v8config.h` and auto-matches. |
+
+**Performance requirements** (configure warns if not met):
+
+| Flag | Recommended value | Reason |
+|------|------------------|--------|
+| `v8_promise_internal_field_count` | `1` | Fast async\_hooks Promise tracking. Fallback to symbol-property tracking exists when 0, but is ~2x slower for promise-heavy workloads. |
+
+**Recommended** (not validated):
+
+| Flag | Recommended value | Reason |
+|------|------------------|--------|
+| `v8_use_siphash` | `true` | Hash table randomization |
+| `v8_enable_webassembly` | `true` | Unless building with `--v8-lite-mode` |
+
+**Standard V8 embedder API** (must be present in any compliant V8):
+
+* `v8::Context::SetPromiseHooks()`
+* `v8::Isolate::SetPromiseHook()`
+* `v8::Context::SetAlignedPointerInEmbedderData()`
+* `v8::SnapshotCreator` / `v8::StartupData`
+* `v8::ScriptCompiler::CreateCodeCache()`
+
+The deprecated `--without-bundled-v8` flag is aliased to `--shared-v8`.
+
 ## Note for downstream distributors of Node.js
 
 The Node.js ecosystem is reliant on ABI compatibility within a major release.

--- a/configure.py
+++ b/configure.py
@@ -730,6 +730,28 @@ shared_optgroup.add_argument('--shared-zstd-libpath',
     dest='shared_zstd_libpath',
     help='a directory to search for the shared zstd DLL')
 
+shared_optgroup.add_argument('--shared-v8',
+    action='store_true',
+    dest='shared_v8',
+    default=None,
+    help='link to a shared v8 DLL instead of static linking')
+
+shared_optgroup.add_argument('--shared-v8-includes',
+    action='store',
+    dest='shared_v8_includes',
+    help='directory containing v8 header files')
+
+shared_optgroup.add_argument('--shared-v8-libname',
+    action='store',
+    dest='shared_v8_libname',
+    default='v8,v8_libplatform',
+    help='alternative lib name to link to [default: %(default)s]')
+
+shared_optgroup.add_argument('--shared-v8-libpath',
+    action='store',
+    dest='shared_v8_libpath',
+    help='a directory to search for the shared v8 DLL')
+
 parser.add_argument_group(shared_optgroup)
 
 for builtin in shareable_builtins:
@@ -1087,8 +1109,7 @@ parser.add_argument('--without-bundled-v8',
     action='store_true',
     dest='without_bundled_v8',
     default=False,
-    help='do not use V8 includes from the bundled deps folder. ' +
-         '(This mode is not officially supported for regular applications)')
+    help='DEPRECATED: Use --shared-v8 instead.')
 
 parser.add_argument('--verbose',
     action='store_true',
@@ -2015,6 +2036,110 @@ def configure_library(lib, output, pkgname=None):
       output['libraries'] += pkg_libs.split()
 
 
+def read_v8_version_from_header(header_path):
+  """Read V8 version components from v8-version.h."""
+  version = {}
+  with open(header_path, 'r') as f:
+    for line in f:
+      for component in ('V8_MAJOR_VERSION', 'V8_MINOR_VERSION',
+                        'V8_BUILD_NUMBER', 'V8_PATCH_LEVEL'):
+        if '#define ' + component in line:
+          version[component] = int(line.strip().split()[-1])
+  return version
+
+def parse_promise_field_count(header_path):
+  """Read V8_PROMISE_INTERNAL_FIELD_COUNT from v8-promise.h."""
+  with open(header_path, 'r') as f:
+    for line in f:
+      if '#define V8_PROMISE_INTERNAL_FIELD_COUNT' in line:
+        # Line format: #define V8_PROMISE_INTERNAL_FIELD_COUNT <n>
+        return int(line.strip().split()[-1])
+  return 0  # V8 default if not defined
+
+def has_define_in_header(header_path, define_name):
+  """Check if a header file contains a #define for the given name."""
+  with open(header_path, 'r') as f:
+    for line in f:
+      if f'#define {define_name}' in line:
+        return True
+  return False
+
+def find_shared_v8_includes():
+  """Resolve shared V8 include path from --shared-v8-includes or pkg-config."""
+  if options.shared_v8_includes:
+    return options.shared_v8_includes
+  (_, pkg_cflags, _, _) = pkg_config('v8')
+  if pkg_cflags:
+    for flag in pkg_cflags.split():
+      if flag.startswith('-I'):
+        return flag[2:]
+  return None
+
+def validate_shared_v8(shared_includes):
+  """Validate that the shared V8 meets Node.js build configuration requirements.
+  Errors are fatal. Configure will not proceed with an incompatible V8."""
+
+  # --- Version check (hard error on major.minor mismatch) ---
+  bundled_header = os.path.join('deps', 'v8', 'include', 'v8-version.h')
+  shared_header = os.path.join(shared_includes, 'v8-version.h')
+  if not os.path.exists(shared_header):
+    alt = os.path.join(shared_includes, 'v8', 'v8-version.h')
+    if os.path.exists(alt):
+      shared_header = alt
+    else:
+      error('Could not find v8-version.h in shared V8 includes at '
+            f'{shared_includes}. Cannot validate V8 compatibility. '
+            'Use --shared-v8-includes to specify the correct path.')
+
+  bundled = read_v8_version_from_header(bundled_header)
+  shared = read_v8_version_from_header(shared_header)
+  b_ver = f"{bundled['V8_MAJOR_VERSION']}.{bundled['V8_MINOR_VERSION']}.{bundled['V8_BUILD_NUMBER']}"
+  s_ver = f"{shared['V8_MAJOR_VERSION']}.{shared['V8_MINOR_VERSION']}.{shared['V8_BUILD_NUMBER']}"
+
+  if bundled['V8_MAJOR_VERSION'] != shared['V8_MAJOR_VERSION'] or \
+     bundled['V8_MINOR_VERSION'] != shared['V8_MINOR_VERSION']:
+    error(f'Shared V8 version ({s_ver}) does not match required '
+          f'({b_ver}). Major and minor version must match.')
+
+  if bundled['V8_BUILD_NUMBER'] != shared['V8_BUILD_NUMBER']:
+    warn(f'Shared V8 build number ({s_ver}) differs from bundled ({b_ver}). '
+         f'Build may succeed but runtime behavior may differ.')
+
+  # --- Promise internal field count (warning, not error; fallback exists) ---
+  promise_header = os.path.join(shared_includes, 'v8-promise.h')
+  if os.path.exists(promise_header):
+    field_count = parse_promise_field_count(promise_header)
+    if field_count < 1:
+      warn(f'Shared V8 has V8_PROMISE_INTERNAL_FIELD_COUNT={field_count}. '
+           f'async_hooks will use slower symbol-property fallback. '
+           f'For best performance, rebuild V8 with '
+           f'v8_promise_internal_field_count=1.')
+
+  # --- Pointer compression: auto-detect from shared V8, set Node.js to match ---
+  v8config = os.path.join(shared_includes, 'v8config.h')
+  if os.path.exists(v8config):
+    shared_has_pc = has_define_in_header(v8config, 'V8_COMPRESS_POINTERS')
+    if shared_has_pc != bool(options.enable_pointer_compression):
+      # Auto-match instead of erroring. Node.js adapts to the shared V8
+      options.enable_pointer_compression = shared_has_pc
+      warn(f'Auto-{"enabling" if shared_has_pc else "disabling"} pointer '
+           f'compression to match shared V8.')
+
+    shared_has_sandbox = has_define_in_header(v8config, 'V8_ENABLE_SANDBOX')
+    if shared_has_sandbox:
+      error('Shared V8 was built with V8_ENABLE_SANDBOX. Node.js does not '
+            'support the V8 sandbox (backing store pointers are in C++ '
+            'memory, not sandbox memory). Rebuild V8 with: '
+            'v8_enable_sandbox=false')
+
+    # --- Extensible RO snapshot: must be disabled for snapshot compatibility ---
+    shared_has_ext_ro = has_define_in_header(v8config, 'V8_ENABLE_EXTENSIBLE_RO_SNAPSHOT')
+    if shared_has_ext_ro:
+      error('Shared V8 was built with V8_ENABLE_EXTENSIBLE_RO_SNAPSHOT. '
+            'Node.js requires this to be disabled for snapshot compatibility. '
+            'Rebuild V8 with: v8_enable_extensible_ro_snapshot=false')
+
+
 def configure_v8(o, configs):
   set_configuration_variable(configs, 'v8_enable_v8_checks', release=0, debug=1)
 
@@ -2064,16 +2189,40 @@ def configure_v8(o, configs):
   o['variables']['node_enable_v8windbg'] = b(options.enable_v8windbg)
   if options.enable_d8:
     o['variables']['test_isolation_mode'] = 'noop'  # Needed by d8.gyp.
+
   if options.without_bundled_v8:
+    if not options.shared_v8:
+      warn('--without-bundled-v8 is deprecated. Use --shared-v8 instead.')
+      options.shared_v8 = True
+
+  if options.shared_v8:
+    o['variables']['node_use_bundled_v8'] = b(False)
+
     if options.enable_d8:
-      raise Exception('--enable-d8 is incompatible with --without-bundled-v8.')
+      error('--enable-d8 is incompatible with --shared-v8')
     if options.enable_v8windbg:
-      raise Exception('--enable-v8windbg is incompatible with --without-bundled-v8.')
-    (pkg_libs, pkg_cflags, pkg_libpath, _) = pkg_config("v8")
-    if pkg_libs and pkg_libpath:
-      output['libraries'] += [pkg_libpath] + pkg_libs.split()
-    if pkg_cflags:
-      output['include_dirs'] += [flag for flag in [flag.strip() for flag in pkg_cflags.split('-I')] if flag]
+      error('--enable-v8windbg is incompatible with --shared-v8')
+
+    # Standard configure_library call - handles pkg-config, includes,
+    # libpath, libname exactly like every other shared dependency.
+    configure_library('v8', o)
+
+    # Ensure the build can find the shared V8 at mksnapshot execution time
+    if options.shared_v8_libpath:
+      o['variables']['node_shared_v8_libpath'] = options.shared_v8_libpath
+
+    # validate shared v8 meets Node.js requirements (hard errors on failure)
+    shared_includes = find_shared_v8_includes()
+    if shared_includes:
+      validate_shared_v8(shared_includes)
+    else:
+      warn('Could not determine shared v8 include path. '
+      'Skipping build configuration validation. '
+      'use --shared-v8-includes to enable validation.')
+
+  else:
+    o['variables']['node_use_bundled_v8'] = b(True)
+
   if options.static_zoslib_gyp:
     o['variables']['static_zoslib_gyp'] = options.static_zoslib_gyp
   if flavor != 'linux' and options.v8_enable_hugepage:

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -4261,6 +4261,7 @@ node --stack-trace-limit=12 -p -e "Error.stackTraceLimit" # prints 12
 [context-aware]: addons.md#context-aware-addons
 [debugger]: debugger.md
 [debugging security implications]: https://nodejs.org/en/docs/guides/debugging-getting-started/#security-implications
+[Building to use shared dependencies at runtime]: ../../BUILDING.md#building-to-use-shared-dependencies-at-runtime
 [deprecation warnings]: deprecations.md#list-of-deprecated-apis
 [emit_warning]: process.md#processemitwarningwarning-options
 [environment_variables]: #environment-variables_1

--- a/node.gyp
+++ b/node.gyp
@@ -26,6 +26,8 @@
     'node_shared_sqlite%': 'false',
     'node_shared_temporal_capi%': 'false',
     'node_shared_uvwasi%': 'false',
+    'node_shared_v8%': 'false',
+    'node_shared_v8_libpath%': '',
     'node_shared_zlib%': 'false',
     'node_shared_zstd%': 'false',
     'node_shared%': 'false',
@@ -53,21 +55,27 @@
       '<@(linked_module_files)',
     ],
     'deps_files': [
-      'deps/v8/tools/splaytree.mjs',
-      'deps/v8/tools/codemap.mjs',
-      'deps/v8/tools/consarray.mjs',
-      'deps/v8/tools/csvparser.mjs',
-      'deps/v8/tools/profile.mjs',
-      'deps/v8/tools/profile_view.mjs',
-      'deps/v8/tools/logreader.mjs',
-      'deps/v8/tools/arguments.mjs',
-      'deps/v8/tools/tickprocessor.mjs',
-      'deps/v8/tools/sourcemap.mjs',
-      'deps/v8/tools/tickprocessor-driver.mjs',
       'deps/acorn/acorn/dist/acorn.js',
       'deps/acorn/acorn-walk/dist/walk.js',
       'deps/minimatch/index.js',
       '<@(node_builtin_shareable_builtins)',
+    ],
+    'conditions': [
+      ['node_shared_v8=="false"', {
+        'deps_files': [
+          'deps/v8/tools/splaytree.mjs',
+          'deps/v8/tools/codemap.mjs',
+          'deps/v8/tools/consarray.mjs',
+          'deps/v8/tools/csvparser.mjs',
+          'deps/v8/tools/profile.mjs',
+          'deps/v8/tools/profile_view.mjs',
+          'deps/v8/tools/logreader.mjs',
+          'deps/v8/tools/arguments.mjs',
+          'deps/v8/tools/tickprocessor.mjs',
+          'deps/v8/tools/sourcemap.mjs',
+          'deps/v8/tools/tickprocessor-driver.mjs',
+        ]
+      }],
     ],
     'node_sources': [
       'src/api/async_resource.cc',
@@ -579,8 +587,12 @@
 
       'include_dirs': [
         'src',
-        'deps/v8/include',
         'deps/postject'
+      ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'include_dirs': ['deps/v8/include'],
+        }],
       ],
 
       'sources': [
@@ -897,17 +909,25 @@
       'dependencies': [
         'node_js2c#host',
       ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'dependencies': ['tools/v8_gypfiles/abseil.gyp:abseil'],
+        }],
+      ],
 
       'sources': [
         '<@(node_sources)',
-        # Dependency headers
-        'deps/v8/include/v8.h',
         'deps/postject/postject-api.h',
         # javascript files to make for an even more pleasant IDE experience
         '<@(library_files)',
         '<@(deps_files)',
         # node.gyp is added by default, common.gypi is added for change detection
         'common.gypi',
+      ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'sources': ['deps/v8/include/v8.h'],
+        }],
       ],
 
       'variables': {
@@ -1130,10 +1150,14 @@
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
-        'deps/v8/include',
         'deps/cares/include',
         'deps/uv/include',
         'test/cctest',
+      ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'include_dirs': ['deps/v8/include'],
+        }],
       ],
 
       'defines': [
@@ -1176,10 +1200,14 @@
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
-        'deps/v8/include',
         'deps/cares/include',
         'deps/uv/include',
         'test/cctest',
+      ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'include_dirs': ['deps/v8/include'],
+        }],
       ],
       'defines': [
         'NODE_ARCH="<(target_arch)"',
@@ -1225,10 +1253,14 @@
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
-        'deps/v8/include',
         'deps/cares/include',
         'deps/uv/include',
         'test/cctest',
+      ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'include_dirs': ['deps/v8/include'],
+        }],
       ],
       'defines': [
         'NODE_ARCH="<(target_arch)"',
@@ -1279,6 +1311,11 @@
       'dependencies': [
         '<(node_lib_target_name)',
       ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'dependencies': ['tools/v8_gypfiles/abseil.gyp:abseil'],
+        }],
+      ],
 
       'includes': [
         'node.gypi'
@@ -1287,10 +1324,14 @@
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
-        'deps/v8/include',
         'deps/cares/include',
         'deps/uv/include',
         'test/cctest',
+      ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'include_dirs': ['deps/v8/include'],
+        }],
       ],
 
       'defines': [
@@ -1401,10 +1442,14 @@
         'src',
         'tools',
         'tools/msvs/genfiles',
-        'deps/v8/include',
         'deps/cares/include',
         'deps/uv/include',
         'test/embedding',
+      ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'include_dirs': ['deps/v8/include'],
+        }],
       ],
 
       'sources': [
@@ -1459,8 +1504,10 @@
 
       # Don't depend on node.gypi - it otherwise links to
       # the static libraries and resolve symbols at build time.
-      'include_dirs': [
-        'deps/v8/include',
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'include_dirs': ['deps/v8/include'],
+        }],
       ],
 
       'sources': [
@@ -1588,9 +1635,13 @@
       'include_dirs': [
         'src',
         'tools/msvs/genfiles',
-        'deps/v8/include',
         'deps/cares/include',
         'deps/uv/include',
+      ],
+      'conditions': [
+        ['node_shared_v8=="false"', {
+          'include_dirs': ['deps/v8/include'],
+        }],
       ],
 
       'defines': [ 'NODE_WANT_INTERNALS=1' ],
@@ -1649,6 +1700,9 @@
         ['enable_lto=="true"', {
           'ldflags': [ '-fno-lto' ],
         }],
+        ['node_shared_v8=="true" and OS!="win" and node_shared_v8_libpath!=""', {
+          'ldflags': ['-Wl,-rpath,<(node_shared_v8_libpath)'],
+        }],
       ],
     }, # node_mksnapshot
   ], # end targets
@@ -1668,7 +1722,11 @@
           'dependencies': ['<(node_lib_target_name)'],
           'include_dirs': [
             'src',
-            'deps/v8/include',
+          ],
+          'conditions': [
+            ['node_shared_v8=="false"', {
+              'include_dirs': ['deps/v8/include'],
+            }],
           ],
           'sources': [
             '<@(library_files)',

--- a/node.gypi
+++ b/node.gypi
@@ -96,6 +96,12 @@
         'tools/v8_gypfiles/v8.gyp:v8_libplatform',
       ],
     }],
+    [ 'node_shared_v8=="false"', {
+      'dependencies': [
+        'tools/v8_gypfiles/v8.gyp:v8_snapshot',
+        'tools/v8_gypfiles/v8.gyp:v8_libplatform',
+      ],
+    }],
     [ 'node_use_v8_platform=="true"', {
       'defines': [
         'NODE_USE_V8_PLATFORM=1',

--- a/shell.nix
+++ b/shell.nix
@@ -107,7 +107,7 @@ pkgs.mkShell {
   BUILD_WITH = if (ninja != null) then "ninja" else "make";
   NINJA = pkgs.lib.optionalString (ninja != null) "${pkgs.lib.getExe ninja}";
   CONFIG_FLAGS = builtins.toString (
-    configureFlags ++ pkgs.lib.optional (useSeparateDerivationForV8 != false) "--without-bundled-v8"
+    configureFlags ++ pkgs.lib.optional (useSeparateDerivationForV8 != false) "--shared-v8"
   );
   NOSQLITE = pkgs.lib.optionalString (!withSQLite) "1";
 }


### PR DESCRIPTION
## Summary

Add `--shared-v8` support using the `configure_library` pattern, matching
every other shared dependency in Node.js. Includes configure-time
validation of the shared V8's build configuration and documentation of
the V8 Build Configuration Spec in `BUILDING.md` and `doc/api/cli.md`.

## What this does

- Adds `--shared-v8`, `--shared-v8-includes`, `--shared-v8-libpath`,
  `--shared-v8-libname` flags
- Calls `configure_library('v8', o)` inside `configure_v8()` (same
  pattern as OpenSSL, SQLite, LIEF)
- Guards all `deps/v8/include` references, `abseil` dependencies,
  `deps/v8/tools/*.mjs` deps_files, and `deps/v8/include/v8.h`
  sources behind `node_shared_v8=="false"`
- Adds rpath for `node_mksnapshot` to find shared V8 at build time
- Deprecates `--without-bundled-v8` (aliased to `--shared-v8`)
- Validates the shared V8 at configure time (see below)
- Documents the V8 Build Configuration Spec in `BUILDING.md`

## What this does NOT do

- Does not change the default build (bundled V8 is still the default)
- Does not disable snapshot generation (snapshots work correctly with
  shared V8; `node_mksnapshot` links against the configured V8)

## The floating patches concern: resolved

Node.js floats ~12 patches over bundled V8. Decomposition shows these
are NOT source-level API changes. They are build configuration flags
and compiler compatibility fixes:

**Build flags (hard errors at configure time):**
- `v8_enable_sandbox=false` - required because Node.js backing
  stores live in C++ memory. Standard V8 build flag.
- `v8_enable_extensible_ro_snapshot=false` - required for snapshot
  compatibility. Standard V8 build flag.
- `v8_enable_pointer_compression` - must match between Node.js and
  V8 or struct layouts differ. Auto-detected from v8config.h.

**Build flags (warning at configure time):**
- `v8_promise_internal_field_count=1` - recommended for fast
  async_hooks Promise tracking. When 0, a slower symbol-property
  fallback is used. Standard V8 build flag, not a source patch.

**Compiler fixes (irrelevant for shared V8):**
- MSVC inline method fixes, warning suppression. These affect V8
  compilation, not Node.js compilation. A pre-built shared V8 has
  already dealt with its own compiler issues.

**Standard V8 embedder API (not patched):**
- Promise hooks, context embedder data, snapshot creator. All
  upstream V8 API that Node.js uses but does not modify.

The configure step hard-errors if the shared V8 doesn't meet
requirements, with clear messages explaining exactly which V8 build
flag to change. Distributors get a concrete, machine-verifiable spec
instead of "good luck with the floating patches."

## V8 build flags for distributors

**Hard requirements (configure errors):**
```
v8_enable_sandbox = false               # C++ backing stores incompatible
v8_enable_extensible_ro_snapshot = false # Snapshot compatibility
v8_enable_pointer_compression = <match> # Auto-detected from shared V8
V8 major.minor version must match       # e.g., 14.3.x
```

**Performance (configure warns):**
```
v8_promise_internal_field_count = 1     # Fast async_hooks (fallback exists)
```

## Testing

The `test-shared.yml` workflow exercises `--shared-v8` on every PR.
`tools/nix/v8.nix` builds V8 separately from `deps/v8/` as static
libraries with a pkg-config file, and `shell.nix` passes `--shared-v8`
(updated from the deprecated `--without-bundled-v8`). The full test
suite runs against the shared V8 build on x86_64-linux, aarch64-linux,
x86_64-darwin, and aarch64-darwin.

| Test | What it validates |
|------|-------------------|
| `./configure --shared-v8` with pkg-config | `configure_library` pkg-config path works |
| `./configure --shared-v8 --shared-v8-includes=... --shared-v8-libpath=... --shared-v8-libname=v8_monolith` | Manual path overrides work |
| `./configure --without-bundled-v8` | Deprecated flag prints warning, aliases to `--shared-v8` |
| `./configure --shared-v8 --enable-d8` | Fails with clear error |
| `./configure --shared-v8 --enable-v8windbg` | Fails with clear error |
| Version mismatch: point at V8 13.x headers | Hard error from `validate_shared_v8()` |
| Promise field count = 0 in shared headers | Warning about slower async_hooks fallback |
| Pointer compression mismatch | Auto-detected and matched from shared V8 |
| V8 sandbox enabled in shared build | Hard error: "rebuild V8 with v8_enable_sandbox=false" |
| Extensible RO snapshot enabled | Hard error: "rebuild V8 with v8_enable_extensible_ro_snapshot=false" |
| `node -e "console.log(process.versions.v8)"` | Reports correct shared V8 version |
| `node -e "console.log('hello')"` | Basic functionality with shared V8 |
| `node -p "process.config.variables.node_shared_v8"` | Reports `true` |
| Full test suite (`make test`) | No regressions |
| Snapshot validation: `node --v8-pool-size=0 -e "1+1"` | Snapshot loaded correctly from shared V8 build |

### Build validation

Verify that when `--shared-v8` is used, nothing from `deps/v8/` is compiled:

```bash
find out/Release/obj/deps/v8/ -name '*.o' 2>/dev/null | wc -l       # Expected: 0
find out/Release/obj/tools/v8_gypfiles/ -name '*.o' 2>/dev/null | wc -l  # Expected: 0
```

Fixes: #53509