### PR TITLE
doc: fix markdown for `expectFailure` values

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1730,11 +1730,7 @@ changes:
     **Default:** `false`.
   * `expectFailure` {boolean|string|RegExp|Function|Object|Error} If truthy, the
     test is expected to fail. If a non-empty string is provided, that string is displayed
-    in the test results as the reason why the test is expected to fail. If a
-    [<RegExp>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp),
-    [<Function>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function),
-    [<Object>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object), or
-    [<Error>](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error)
+    in the test results as the reason why the test is expected to fail. If a {RegExp|Function|Object|Error}
     is provided directly (without wrapping in `{ match: … }`), the test passes
     only if the thrown error matches, following the behavior of
     [`assert.throws`][]. To provide both a reason and validation, pass an object


### PR DESCRIPTION
Currently, about half the test API doc is broken (text outside of codeblocks below here is blank).

<img width="917" height="259" alt="2026-03-04_11-35 test api doc broken link" src="https://github.com/user-attachments/assets/3018f976-399a-4e00-b6fc-be2737053733" />
