### PR TITLE
test: avoid flaky run wait in debugger restart test

### DIFF
--- a/test/parallel/test-debugger-run-after-quit-restart.js
+++ b/test/parallel/test-debugger-run-after-quit-restart.js
@@ -41,7 +41,7 @@ const path = require('path');
     .then(() => {
       assert.match(cli.output, /Use `run` to start the app again/);
     })
-    .then(() => cli.stepCommand('run'))
+    .then(() => cli.command('run'))
     .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
@@ -71,7 +71,7 @@ const path = require('path');
     .then(() => {
       assert.match(cli.output, /Use `run` to start the app again/);
     })
-    .then(() => cli.stepCommand('run'))
+    .then(() => cli.command('run'))
     .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {


### PR DESCRIPTION
## Summary

Follow-up to #61773

`test/parallel/test-debugger-run-after-quit-restart.js` can still flake on macOS unusual-path runs around `run`.
`stepCommand('run')` expects a break message immediately, but `run` may return `ok`/prompt before the break output.
This change switches those calls to `command('run')` and keeps `waitForInitialBreak()` for the actual break sync.

failed CI logs:
- https://github.com/nodejs/node/actions/runs/22647161362  (line:44)
- https://github.com/nodejs/node/actions/runs/22158756428 (line:74)

## Testing

```bash
UNUSUAL="$HOME/dir with \$unusual\"chars?'åß∂ƒ©∆¬…\`"
mkdir -p "$UNUSUAL"
ln -sfn "$PWD" "$UNUSUAL/node"
cd "$UNUSUAL/node"
```

- [x] `./tools/test.py -p actions parallel/test-debugger-run-after-quit-restart`
- [x] `./tools/test.py -p actions -j1 --repeat 50 parallel/test-debugger-run-after-quit-restart`
- [x] `./tools/test.py -p actions -j1 --repeat 50 parallel/test-debugger-run-after-quit-restart` (unusual path)

Refs: https://github.com/nodejs/node/issues/61762
