### PR TITLE
build: fix `--node-builtin-modules-path`

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -948,7 +948,13 @@
           },
         }],
         [ 'node_builtin_modules_path!=""', {
-          'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ]
+          'defines': [ 'NODE_BUILTIN_MODULES_PATH="<(node_builtin_modules_path)"' ],
+          # When loading builtins from disk, JS source files do not need to
+          # trigger rebuilds since the binary reads them at runtime.
+          'sources!': [
+            '<@(library_files)',
+            '<@(deps_files)',
+          ],
         }],
         [ 'node_shared=="true"', {
           'sources': [
@@ -1102,6 +1108,16 @@
             '<@(library_files)',
             '<@(deps_files)',
             'config.gypi'
+          ],
+          'conditions': [
+            [ 'node_builtin_modules_path!=""', {
+              # When loading builtins from disk, JS source files do not need
+              # to trigger rebuilds since the binary reads them at runtime.
+              'inputs!': [
+                '<@(library_files)',
+                '<@(deps_files)',
+              ],
+            }],
           ],
           'outputs': [
             '<(SHARED_INTERMEDIATE_DIR)/node_javascript.cc',

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -74,7 +74,8 @@ const BuiltinSource* BuiltinLoader::AddFromDisk(const char* id,
                                                 const std::string& filename,
                                                 const UnionBytes& source) {
   BuiltinSourceType type = GetBuiltinSourceType(id, filename);
-  auto result = source_.write()->emplace(id, BuiltinSource{id, source, type});
+  auto result =
+      source_.write()->insert_or_assign(id, BuiltinSource{id, source, type});
   return &(result.first->second);
 }
 


### PR DESCRIPTION
Disclaimer: I am way out of my depth here and am more than happy to pawn this off to someone who's not. The following stopped working for me some time back in that it no longer picks up js changes without re-`make`.

```
./configure --node-builtin-modules-path $(pwd) --ninja 
make
```

I threw Claude at the problem and it came up with this which fixed the issue for me. I'm opening this ~as a draft~ so hopefully other collaborators with more insight into how this works can chime in and verify whether there is something awry or not.

```
Darwin M1-MacBook-Pro.local 25.3.0 Darwin Kernel Version 25.3.0: Wed Jan 28 20:53:15 PST 2026; root:xnu-12377.81.4~5/RELEASE_ARM64_T6000 arm64
```