### PR TITLE
build: exclude more machines from doc gen

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -836,8 +836,8 @@ out/doc/api: doc/api
 
 # Generate all doc files (individual and all.html/all.json) in a single doc-kit call
 # Using grouped targets (&:) so Make knows one command produces all outputs
-ifeq ($(OSTYPE),aix)
-# TODO(@nodejs/web-infra): AIX is currently hanging during HTML minification
+ifneq (,$(filter aix os390,$(OSTYPE)))
+# TODO(@nodejs/web-infra): AIX and OS390 are not handling WASM very well
 $(apidocs_html) $(apidocs_json) out/doc/api/all.html out/doc/api/all.json:
 	@echo "Skipping $@ (not currently supported by $(OSTYPE) machines)"
 else


### PR DESCRIPTION
Fixes https://openjs-foundation.slack.com/archives/C09EXEEHFKP/p1772723396007549 by also exclude S390X machines from WASM. See https://github.com/nodejs/build/issues/4258 for more info on the AIX failures, it's fairly similar on S390X.

cc @Renegade334