### PR TITLE
tools: improve error handling in test426 update script

### DIFF
--- a/tools/dep_updaters/update-test426-fixtures.sh
+++ b/tools/dep_updaters/update-test426-fixtures.sh
@@ -6,10 +6,16 @@ BASE_DIR=$(cd "$(dirname "$0")/../.." && pwd)
 
 TARGET_DIR="$BASE_DIR/test/fixtures/test426"
 README="$BASE_DIR/test/test426/README.md"
-TARBALL_URL=$(curl -fsIo /dev/null -w '%header{Location}' https://github.com/tc39/source-map-tests/archive/HEAD.tar.gz)
-SHA=$(basename "$TARBALL_URL")
 
 CURRENT_SHA=$(sed -n 's#^.*https://github.com/tc39/source-map-tests/commit/\([0-9a-f]*\).*$#\1#p' "$README")
+
+if [ -z "$CURRENT_SHA" ]; then
+  echo "Could not find source-map-tests commit marker in $README" >&2
+  exit 1
+fi
+
+TARBALL_URL=$(curl -fsIo /dev/null -w '%header{Location}' https://github.com/tc39/source-map-tests/archive/HEAD.tar.gz)
+SHA=$(basename "$TARBALL_URL")
 
 if [ "$CURRENT_SHA" = "$SHA" ]; then
   echo "Already up-to-date"


### PR DESCRIPTION
If the current SHA is not found in the README for some reason, exit with an error.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
