### PR TITLE
quic: guard against null impl_ in UpdateDataStats

### DIFF
--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2232,6 +2232,7 @@ void Session::ExtendOffset(size_t amount) {
 }
 
 void Session::UpdateDataStats() {
+  if (!impl_) return;
   Debug(this, "Updating data stats");
   auto& stats_ = impl_->stats_;
   ngtcp2_conn_info info;

--- a/test/parallel/test-quic-session-update-data-stats-after-close.mjs
+++ b/test/parallel/test-quic-session-update-data-stats-after-close.mjs
@@ -1,0 +1,54 @@
+// Flags: --experimental-quic --no-warnings
+// Regression test for https://github.com/nodejs/node/pull/62126
+// UpdateDataStats() must not crash when called after the session's impl_ has
+// been reset to null (i.e. after the session is destroyed).
+//
+// The crash path is in Session::SendDatagram():
+//   auto on_exit = OnScopeLeave([&] { ...; UpdateDataStats(); });
+// If the send encounters an error it calls Close(SILENT) → Destroy() →
+// impl_.reset(). The on_exit lambda then fires with impl_ == nullptr.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('node:quic');
+const { createPrivateKey } = await import('node:crypto');
+
+const keys = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const certs = fixtures.readKey('agent1-cert.pem');
+
+// Datagrams must be enabled on both sides for sendDatagram() to work.
+const kDatagramOptions = {
+  transportParams: {
+    maxDatagramFrameSize: 1200n,
+  },
+};
+
+const serverEndpoint = await listen(
+  mustCall((serverSession) => {
+    serverSession.opened.then(mustCall(async () => {
+      // Send a datagram then immediately close. This exercises the
+      // UpdateDataStats() call that fires via on_exit after SendDatagram —
+      // the close can race with or precede the stats update, leaving
+      // impl_ == nullptr. Before the fix this would crash.
+      serverSession.sendDatagram(Buffer.from('hello')).catch(() => {});
+      serverSession.close();
+    }));
+  }),
+  { keys, certs, ...kDatagramOptions },
+);
+
+const clientSession = await connect(serverEndpoint.address, kDatagramOptions);
+await clientSession.opened;
+
+// Mirror the race on the client side.
+clientSession.sendDatagram(Buffer.from('world')).catch(() => {});
+clientSession.close();
+
+await clientSession.closed;
+serverEndpoint.close();
+await serverEndpoint.closed;

--- a/test/parallel/test-quic-session-update-data-stats-after-close.mjs
+++ b/test/parallel/test-quic-session-update-data-stats-after-close.mjs
@@ -1,12 +1,19 @@
 // Flags: --experimental-quic --no-warnings
 // Regression test for https://github.com/nodejs/node/pull/62126
-// UpdateDataStats() must not crash when called after the session's impl_ has
-// been reset to null (i.e. after the session is destroyed).
 //
-// The crash path is in Session::SendDatagram():
+// Validates that UpdateDataStats() does not crash when called on a session
+// whose impl_ has already been reset to null (i.e. after Destroy()).
+//
+// The crash path in Session::SendDatagram():
 //   auto on_exit = OnScopeLeave([&] { ...; UpdateDataStats(); });
-// If the send encounters an error it calls Close(SILENT) → Destroy() →
-// impl_.reset(). The on_exit lambda then fires with impl_ == nullptr.
+// When an internal send error calls Close(SILENT) -> Destroy() -> impl_.reset(),
+// the on_exit lambda fires with impl_ == nullptr.  The `if (!impl_) return;`
+// guard added by this PR prevents the crash.
+//
+// Note: the precise crash trigger (a packet-allocation failure inside
+// SendDatagram) cannot be induced from JS.  This test exercises the closest
+// reachable scenario: datagrams sent immediately before session close, racing
+// the on_exit UpdateDataStats() call against teardown.
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
@@ -21,28 +28,36 @@ const { createPrivateKey } = await import('node:crypto');
 const keys = createPrivateKey(fixtures.readKey('agent1-key.pem'));
 const certs = fixtures.readKey('agent1-cert.pem');
 
-// Datagrams must be enabled on both sides for sendDatagram() to work.
+// Both sides must negotiate datagram support (maxDatagramFrameSize > 0).
 const kDatagramOptions = {
   transportParams: {
     maxDatagramFrameSize: 1200n,
   },
 };
 
+const serverClosed = Promise.withResolvers();
+
 const serverEndpoint = await listen(
   mustCall((serverSession) => {
     serverSession.opened.then(mustCall(async () => {
-      // Send a datagram then immediately close. This exercises the
-      // UpdateDataStats() call that fires via on_exit after SendDatagram —
-      // the close can race with or precede the stats update, leaving
-      // impl_ == nullptr. Before the fix this would crash.
+      // Fire a datagram send then close immediately.  This races the
+      // UpdateDataStats() invoked by on_exit in SendDatagram() against the
+      // Destroy() triggered by close(), exercising the null-impl_ guard.
       serverSession.sendDatagram(Buffer.from('hello')).catch(() => {});
       serverSession.close();
     }));
+    serverSession.closed.then(mustCall(() => serverClosed.resolve()));
   }),
   { keys, certs, ...kDatagramOptions },
 );
 
-const clientSession = await connect(serverEndpoint.address, kDatagramOptions);
+// Pass the server certificate as the CA so TLS validation succeeds on the
+// client side (agent1-cert.pem is self-signed).
+const clientSession = await connect(serverEndpoint.address, {
+  ca: certs,
+  ...kDatagramOptions,
+});
+
 await clientSession.opened;
 
 // Mirror the race on the client side.
@@ -50,5 +65,6 @@ clientSession.sendDatagram(Buffer.from('world')).catch(() => {});
 clientSession.close();
 
 await clientSession.closed;
+await serverClosed.promise;
 serverEndpoint.close();
 await serverEndpoint.closed;


### PR DESCRIPTION
When a QUIC session's handshake fails or the connection is
terminated early, \`UpdateDataStats()\` can be called before \`impl_\`
has been initialized, leading to a null pointer dereference
and SIGSEGV.

Add an early return when \`impl_\` is nullptr to prevent the crash.

Fixes: https://github.com/nodejs/node/issues/62057