### PR TITLE
src: do not enable wasm trap handler if there's not enough vmem

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-initialization.h
+++ b/deps/v8/include/v8-initialization.h
@@ -253,6 +253,35 @@ class V8_EXPORT V8 {
   static size_t GetSandboxReservationSizeInBytes();
 #endif  // V8_ENABLE_SANDBOX
 
+  enum class WasmMemoryType {
+    kMemory32,
+    kMemory64,
+  };
+
+  /**
+   * Returns the virtual address space reservation size (in bytes) needed
+   * for one WebAssembly memory instance of the given capacity.
+   *
+   * \param type Whether this is a memory32 or memory64 instance.
+   * \param byte_capacity The maximum size, in bytes, of the WebAssembly
+   *   memory. Values exceeding the engine's maximum allocatable memory
+   *   size for the given type (determined by max_mem32_pages or
+   *   max_mem64_pages) are clamped.
+   *
+   * When trap-based bounds checking is enabled by
+   * EnableWebAssemblyTrapHandler(), the amount of virtual address space
+   * that V8 needs to reserve for each WebAssembly memory instance can
+   * be much bigger than the requested size. If the process does
+   * not have enough virtual memory available, WebAssembly memory allocation
+   * would fail. During the initialization of V8, embedders can use this method
+   * to estimate whether the process has enough virtual memory for their
+   * usage of WebAssembly, and decide whether to enable the trap handler
+   * via EnableWebAssemblyTrapHandler(), or to skip it and reduce the amount of
+   * virtual memory required to keep the application running.
+   */
+  static size_t GetWasmMemoryReservationSizeInBytes(WasmMemoryType type,
+                                                    size_t byte_capacity);
+
   /**
    * Activate trap-based bounds checking for WebAssembly.
    *

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -150,6 +150,7 @@
 #include "src/wasm/value-type.h"
 #include "src/wasm/wasm-engine.h"
 #include "src/wasm/wasm-js.h"
+#include "src/wasm/wasm-limits.h"
 #include "src/wasm/wasm-objects-inl.h"
 #include "src/wasm/wasm-result.h"
 #include "src/wasm/wasm-serialization.h"
@@ -6293,6 +6294,26 @@ bool TryHandleWebAssemblyTrapWindows(EXCEPTION_POINTERS* exception) {
 #endif
 }
 #endif
+
+size_t V8::GetWasmMemoryReservationSizeInBytes(WasmMemoryType type,
+                                               size_t byte_capacity) {
+#if V8_ENABLE_WEBASSEMBLY
+  bool is_memory64 = type == WasmMemoryType::kMemory64;
+  uint64_t max_byte_capacity =
+      is_memory64 ? i::wasm::max_mem64_bytes() : i::wasm::max_mem32_bytes();
+  if (byte_capacity > max_byte_capacity) {
+    byte_capacity = static_cast<size_t>(max_byte_capacity);
+  }
+#if V8_TRAP_HANDLER_SUPPORTED
+  if (!is_memory64 || i::v8_flags.wasm_memory64_trap_handling) {
+    return i::BackingStore::GetWasmReservationSize(
+        /* has_guard_regions */ true, byte_capacity,
+        /* is_wasm_memory64 */ is_memory64);
+  }
+#endif  // V8_TRAP_HANDLER_SUPPORTED
+#endif  // V8_ENABLE_WEBASSEMBLY
+  return byte_capacity;
+}
 
 bool V8::EnableWebAssemblyTrapHandler(bool use_v8_signal_handler) {
 #if V8_ENABLE_WEBASSEMBLY

--- a/deps/v8/src/objects/backing-store.cc
+++ b/deps/v8/src/objects/backing-store.cc
@@ -51,8 +51,25 @@ enum class AllocationStatus {
   kOtherFailure  // Failed for an unknown reason
 };
 
-size_t GetReservationSize(bool has_guard_regions, size_t byte_capacity,
-                          bool is_wasm_memory64) {
+base::AddressRegion GetReservedRegion(bool has_guard_regions,
+                                      bool is_wasm_memory64, void* buffer_start,
+                                      size_t byte_capacity) {
+  return base::AddressRegion(
+      reinterpret_cast<Address>(buffer_start),
+      BackingStore::GetWasmReservationSize(has_guard_regions, byte_capacity,
+                                           is_wasm_memory64));
+}
+
+void RecordStatus(Isolate* isolate, AllocationStatus status) {
+  isolate->counters()->wasm_memory_allocation_result()->AddSample(
+      static_cast<int>(status));
+}
+
+}  // namespace
+
+size_t BackingStore::GetWasmReservationSize(bool has_guard_regions,
+                                            size_t byte_capacity,
+                                            bool is_wasm_memory64) {
 #if V8_TARGET_ARCH_64_BIT && V8_ENABLE_WEBASSEMBLY
   DCHECK_IMPLIES(is_wasm_memory64 && has_guard_regions,
                  v8_flags.wasm_memory64_trap_handling);
@@ -72,21 +89,6 @@ size_t GetReservationSize(bool has_guard_regions, size_t byte_capacity,
 
   return byte_capacity;
 }
-
-base::AddressRegion GetReservedRegion(bool has_guard_regions,
-                                      bool is_wasm_memory64, void* buffer_start,
-                                      size_t byte_capacity) {
-  return base::AddressRegion(
-      reinterpret_cast<Address>(buffer_start),
-      GetReservationSize(has_guard_regions, byte_capacity, is_wasm_memory64));
-}
-
-void RecordStatus(Isolate* isolate, AllocationStatus status) {
-  isolate->counters()->wasm_memory_allocation_result()->AddSample(
-      static_cast<int>(status));
-}
-
-}  // namespace
 
 // The backing store for a Wasm shared memory remembers all the isolates
 // with which it has been shared.
@@ -168,7 +170,7 @@ BackingStore::~BackingStore() {
 
 #if V8_ENABLE_WEBASSEMBLY
   if (is_wasm_memory()) {
-    size_t reservation_size = GetReservationSize(
+    size_t reservation_size = GetWasmReservationSize(
         has_guard_regions(), byte_capacity_, is_wasm_memory64());
     TRACE_BS(
         "BSw:free  bs=%p mem=%p (length=%zu, capacity=%zu, reservation=%zu)\n",
@@ -324,8 +326,8 @@ std::unique_ptr<BackingStore> BackingStore::TryAllocateAndPartiallyCommitMemory(
   };
 
   size_t byte_capacity = maximum_pages * page_size;
-  size_t reservation_size =
-      GetReservationSize(has_guard_regions, byte_capacity, is_wasm_memory64);
+  size_t reservation_size = GetWasmReservationSize(
+      has_guard_regions, byte_capacity, is_wasm_memory64);
 
   //--------------------------------------------------------------------------
   // Allocate pages (inaccessible by default).

--- a/deps/v8/src/objects/backing-store.h
+++ b/deps/v8/src/objects/backing-store.h
@@ -183,6 +183,11 @@ class V8_EXPORT_PRIVATE BackingStore : public BackingStoreBase {
 
   uint32_t id() const { return id_; }
 
+  // Return the size of the reservation needed for a wasm backing store.
+  static size_t GetWasmReservationSize(bool has_guard_regions,
+                                       size_t byte_capacity,
+                                       bool is_wasm_memory64);
+
  private:
   friend class GlobalBackingStoreRegistry;
 

--- a/deps/v8/test/unittests/api/api-wasm-unittest.cc
+++ b/deps/v8/test/unittests/api/api-wasm-unittest.cc
@@ -122,6 +122,22 @@ void WasmStreamingMoreFunctionsCanBeSerializedCallback(
   streaming->SetMoreFunctionsCanBeSerializedCallback([](CompiledWasmModule) {});
 }
 
+TEST_F(ApiWasmTest, GetWasmMemoryReservationSizeInBytes) {
+  constexpr size_t kCapacity = 64 * 1024;  // 64 KiB
+  size_t reservation = V8::GetWasmMemoryReservationSizeInBytes(
+      V8::WasmMemoryType::kMemory32, kCapacity);
+  size_t reservation64 = V8::GetWasmMemoryReservationSizeInBytes(
+      V8::WasmMemoryType::kMemory64, kCapacity);
+
+#if V8_TRAP_HANDLER_SUPPORTED
+  EXPECT_GE(reservation, kCapacity);
+  EXPECT_GE(reservation64, kCapacity);
+#else
+  EXPECT_EQ(reservation, kCapacity);
+  EXPECT_EQ(reservation64, kCapacity);
+#endif  // V8_TRAP_HANDLER_SUPPORTED
+}
+
 TEST_F(ApiWasmTest, WasmStreamingCallback) {
   TestWasmStreaming(WasmStreamingCallbackTestCallbackIsCalled,
                     Promise::kPending);

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -754,40 +754,36 @@ vm.measureMemory();
 added:
 - v22.2.0
 - v20.15.0
+changes:
+  - version:
+    - REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62132
+    description: Node.js now automatically disables the trap handler when there is not
+                 enough virtual memory available at startup to allocate one cage.
 -->
 
-By default, Node.js enables trap-handler-based WebAssembly bound
-checks. As a result, V8 does not need to insert inline bound checks
-in the code compiled from WebAssembly which may speed up WebAssembly
-execution significantly, but this optimization requires allocating
-a big virtual memory cage (currently 10GB). If the Node.js process
-does not have access to a large enough virtual memory address space
-due to system configurations or hardware limitations, users won't
-be able to run any WebAssembly that involves allocation in this
-virtual memory cage and will see an out-of-memory error.
+Node.js enables V8's trap-handler-based WebAssembly bound checks on 64-bit platforms,
+which significantly improves WebAssembly performance by eliminating the need for
+inline bound checks. This optimization requires allocating a large virtual memory
+cage per WebAssembly memory instance (currently typically 8GB for 32-bit WebAssembly memory,
+16GB for 64-bit WebAssembly memory) to trap out-of-bound accesses. On most 64-bit
+platforms, the virtual memory address space is usually large enough (around 128TB)
+to accommodate typical WebAssembly usages, but if the machine has manual limits
+on virtual memory (e.g. through `ulimit -v`), WebAssembly memory allocation is
+more likely to fail with `WebAssembly.Memory(): could not allocate memory`.
 
-```console
-$ ulimit -v 5000000
-$ node -p "new WebAssembly.Memory({ initial: 10, maximum: 100 });"
-[eval]:1
-new WebAssembly.Memory({ initial: 10, maximum: 100 });
-^
+At startup, Node.js automatically checks whether there is enough virtual memory
+available to allocate at least one cage, and if not, the trap-handler optimization
+is automatically disabled so that WebAssembly can still run using inline
+bound checks (with less optimal performance). But if the application needs to create
+many WebAssembly memory instances and the machine still configures a relatively high
+limit on virtual memory, allocation of WebAssembly memory instances may still fail
+more quickly than expected due to the raised virtual memory usage.
 
-RangeError: WebAssembly.Memory(): could not allocate memory
-    at [eval]:1:1
-    at runScriptInThisContext (node:internal/vm:209:10)
-    at node:internal/process/execution:118:14
-    at [eval]-wrapper:6:24
-    at runScript (node:internal/process/execution:101:62)
-    at evalScript (node:internal/process/execution:136:3)
-    at node:internal/main/eval_string:49:3
-
-```
-
-`--disable-wasm-trap-handler` disables this optimization so that
-users can at least run WebAssembly (with less optimal performance)
-when the virtual memory address space available to their Node.js
-process is lower than what the V8 WebAssembly memory cage needs.
+`--disable-wasm-trap-handler` fully disables this optimization so that WebAssembly memory
+instances always use inline bound checks instead of reserving large virtual memory cages.
+This allows more instances to be created when the virtual memory address space available
+to the Node.js process is limited.
 
 ### `--disallow-code-generation-from-strings`
 

--- a/src/debug_utils.h
+++ b/src/debug_utils.h
@@ -44,6 +44,7 @@ void NODE_EXTERN_PRIVATE FWrite(FILE* file, const std::string& str);
 // from a provider type to a debug category.
 #define DEBUG_CATEGORY_NAMES(V)                                                \
   NODE_ASYNC_PROVIDER_TYPES(V)                                                 \
+  V(BOOTSTRAP)                                                                 \
   V(CRYPTO)                                                                    \
   V(COMPILE_CACHE)                                                             \
   V(DIAGNOSTICS)                                                               \

--- a/src/node.cc
+++ b/src/node.cc
@@ -1046,6 +1046,45 @@ static ExitCode InitializeNodeWithArgsInternal(
   return ExitCode::kNoFailure;
 }
 
+#if NODE_USE_V8_WASM_TRAP_HANDLER
+bool CanEnableWebAssemblyTrapHandler() {
+// On POSIX, the machine may have a limit on the amount of virtual memory
+// available, if it's not enough to allocate at least one cage for WASM,
+// then the trap-handler-based bound checks cannot be used.
+#ifdef __POSIX__
+  struct rlimit lim;
+  if (getrlimit(RLIMIT_AS, &lim) != 0 || lim.rlim_cur == RLIM_INFINITY) {
+    // Can't get the limit or there's no limit, assume trap handler can be
+    // enabled.
+    return true;
+  }
+  uint64_t virtual_memory_available = static_cast<uint64_t>(lim.rlim_cur);
+
+  size_t byte_capacity = 64 * 1024;  // 64KB, the minimum size of a WASM memory.
+  uint64_t cage_size_needed_32 = V8::GetWasmMemoryReservationSizeInBytes(
+      V8::WasmMemoryType::kMemory32, byte_capacity);
+  uint64_t cage_size_needed_64 = V8::GetWasmMemoryReservationSizeInBytes(
+      V8::WasmMemoryType::kMemory64, byte_capacity);
+  uint64_t cage_size_needed =
+      std::max(cage_size_needed_32, cage_size_needed_64);
+  bool can_enable = virtual_memory_available >= cage_size_needed;
+  per_process::Debug(DebugCategory::BOOTSTRAP,
+                     "Virtual memory available: %" PRIu64 " bytes,\n"
+                     "cage size needed for 32-bit: %" PRIu64 " bytes,\n"
+                     "cage size needed for 64-bit: %" PRIu64 " bytes,\n"
+                     "Can%senable WASM trap handler\n",
+                     virtual_memory_available,
+                     cage_size_needed_32,
+                     cage_size_needed_64,
+                     can_enable ? " " : " not ");
+
+  return can_enable;
+#else
+  return true;
+#endif  // __POSIX__
+}
+#endif  // NODE_USE_V8_WASM_TRAP_HANDLER
+
 static std::shared_ptr<InitializationResultImpl>
 InitializeOncePerProcessInternal(const std::vector<std::string>& args,
                                  ProcessInitializationFlags::Flags flags =
@@ -1248,7 +1287,9 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
   bool use_wasm_trap_handler =
       !per_process::cli_options->disable_wasm_trap_handler;
   if (!(flags & ProcessInitializationFlags::kNoDefaultSignalHandling) &&
-      use_wasm_trap_handler) {
+      use_wasm_trap_handler && CanEnableWebAssemblyTrapHandler()) {
+    per_process::Debug(DebugCategory::BOOTSTRAP,
+                       "Enabling WebAssembly trap handler for bounds checks\n");
 #if defined(_WIN32)
     constexpr ULONG first = TRUE;
     per_process::old_vectored_exception_handler =

--- a/test/testpy/__init__.py
+++ b/test/testpy/__init__.py
@@ -36,6 +36,7 @@ FLAGS_PATTERN = re.compile(r"//\s+Flags:(.*)")
 LS_RE = re.compile(r'^test-.*\.m?js$')
 ENV_PATTERN = re.compile(r"//\s+Env:(.*)")
 NODE_TEST_PATTERN = re.compile(r"('|`|\")node:test\1")
+RLIMIT_AS_PATTERN = re.compile(r"//\s+RLIMIT_AS:\s*(\d+)")
 
 class SimpleTestCase(test.TestCase):
 
@@ -98,6 +99,10 @@ class SimpleTestCase(test.TestCase):
         print(': Skipping as node was compiled without crypto support')
       else:
         result += flags
+
+    rlimit_as_match = RLIMIT_AS_PATTERN.search(source)
+    if rlimit_as_match:
+      self.max_virtual_memory = int(rlimit_as_match.group(1))
 
     if self.context.use_error_reporter and NODE_TEST_PATTERN.search(source):
       result += ['--test-reporter=./test/common/test-error-reporter.js',
@@ -188,16 +193,4 @@ class AbortTestConfiguration(SimpleTestConfiguration):
          current_path, path, arch, mode)
     for tst in result:
       tst.disable_core_files = True
-    return result
-
-class WasmAllocationTestConfiguration(SimpleTestConfiguration):
-  def __init__(self, context, root, section, additional=None):
-    super(WasmAllocationTestConfiguration, self).__init__(context, root, section,
-                                                          additional)
-
-  def ListTests(self, current_path, path, arch, mode):
-    result = super(WasmAllocationTestConfiguration, self).ListTests(
-         current_path, path, arch, mode)
-    for tst in result:
-      tst.max_virtual_memory = 5 * 1024 * 1024 * 1024 # 5GB
     return result

--- a/test/wasm-allocation/test-wasm-allocation-auto-adapt.js
+++ b/test/wasm-allocation/test-wasm-allocation-auto-adapt.js
@@ -1,0 +1,12 @@
+// RLIMIT_AS: 3221225472
+// When the virtual memory limit is 3GB, there is not enough virtual memory for
+// even one wasm cage. In this case Node.js should automatically adapt and
+// skip enabling trap-based bounds checks, so that WASM can at least run with
+// inline bound checks.
+'use strict';
+
+require('../common');
+new WebAssembly.Memory({ initial: 10, maximum: 100 });
+
+// Test memory64 works too.
+new WebAssembly.Memory({ address: 'i64', initial: 10n, maximum: 100n });

--- a/test/wasm-allocation/test-wasm-allocation-disable-trap-handler.js
+++ b/test/wasm-allocation/test-wasm-allocation-disable-trap-handler.js
@@ -1,0 +1,20 @@
+// Flags: --disable-wasm-trap-handler
+// RLIMIT_AS: 34359738368
+
+// 32GB should be enough for at least 2 cages, but not enough for 30.
+
+// Test that with limited virtual memory space, --disable-wasm-trap-handler
+// fully disables trap-based bounds checks, and thus allows WASM to run with
+// inline bound checks.
+'use strict';
+
+require('../common');
+const instances = [];
+for (let i = 0; i < 30; i++) {
+  instances.push(new WebAssembly.Memory({ initial: 10, maximum: 100 }));
+}
+
+// Test memory64 works too.
+for (let i = 0; i < 30; i++) {
+  instances.push(new WebAssembly.Memory({ initial: 10n, maximum: 100n, address: 'i64' }));
+}

--- a/test/wasm-allocation/test-wasm-allocation-memory64.js
+++ b/test/wasm-allocation/test-wasm-allocation-memory64.js
@@ -1,0 +1,22 @@
+// RLIMIT_AS: 21474836480
+// With 20GB virtual memory, there's enough space for the first wasm memory64
+// allocation to succeed, but not enough for subsequent ones since each
+// wasm memory64 with guard regions reserves 16GB of virtual address space.
+'use strict';
+
+require('../common');
+const assert = require('assert');
+
+// The first allocation should succeed.
+const first = new WebAssembly.Memory({ address: 'i64', initial: 10n, maximum: 100n });
+assert(first);
+
+// Subsequent allocations should eventually fail due to running out of
+// virtual address space. memory64 reserves 16GB per allocation (vs 8GB for
+// memory32), so the limit is reached even faster.
+assert.throws(() => {
+  const instances = [first];
+  for (let i = 1; i < 30; i++) {
+    instances.push(new WebAssembly.Memory({ address: 'i64', initial: 10n, maximum: 100n }));
+  }
+}, /WebAssembly\.Memory/);

--- a/test/wasm-allocation/test-wasm-allocation.js
+++ b/test/wasm-allocation/test-wasm-allocation.js
@@ -1,7 +1,21 @@
-// Flags: --disable-wasm-trap-handler
-// Test that with limited virtual memory space, --disable-wasm-trap-handler
-// allows WASM to at least run with inline bound checks.
+// RLIMIT_AS: 21474836480
+// With 20GB virtual memory, there's enough space for the first few wasm memory
+// allocation to succeed, but not enough for many subsequent ones since each
+// wasm memory32 with guard regions reserves 8GB of virtual address space.
 'use strict';
 
 require('../common');
-new WebAssembly.Memory({ initial: 10, maximum: 100 });
+const assert = require('assert');
+
+// The first allocation should succeed.
+const first = new WebAssembly.Memory({ initial: 10, maximum: 100 });
+assert(first);
+
+// Subsequent allocations should eventually fail due to running out of
+// virtual address space.
+assert.throws(() => {
+  const instances = [first];
+  for (let i = 1; i < 30; i++) {
+    instances.push(new WebAssembly.Memory({ initial: 10, maximum: 100 }));
+  }
+}, /WebAssembly\.Memory/);

--- a/test/wasm-allocation/testcfg.py
+++ b/test/wasm-allocation/testcfg.py
@@ -3,4 +3,4 @@ sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import testpy
 
 def GetConfiguration(context, root):
-  return testpy.WasmAllocationTestConfiguration(context, root, 'wasm-allocation')
+  return testpy.SimpleTestConfiguration(context, root, 'wasm-allocation')

--- a/test/wasm-allocation/wasm-allocation.status
+++ b/test/wasm-allocation/wasm-allocation.status
@@ -8,3 +8,9 @@ prefix wasm-allocation
 
 [$system!=linux || $asan==on || $pointer_compression==on]
 test-wasm-allocation: SKIP
+test-wasm-allocation-auto-adapt: SKIP
+test-wasm-allocation-memory64: SKIP
+
+[$arch!=x64 && $arch!=arm64]
+test-wasm-allocation: SKIP
+test-wasm-allocation-memory64: SKIP


### PR DESCRIPTION
The first commit is a backport of https://chromium-review.googlesource.com/c/v8/v8/+/7638233

This complements `--disable-wasm-trap-handler` and allows users to keep wasm functional in an environment with virtual memory restrictions (e.g. in the case of VS code server run for remote access, the user does not necessary always have the permission on the server to configure `NODE_OPTIONS` or `--disable-wasm-trap-handler` - in fact they don't even necessarily know this has anything to do with WASM on Node.js since they shouldn't be aware of what VS code server is implemented with).

Supersedes https://github.com/nodejs/node/pull/60788 - this keeps the estimation logic in Node.js instead, and also keeps it in POSIX because on other systems the issue that this is solving is not practical (e.g. on Windows, one cannot bound the virtual memory available without bounding the physical memory, and  it does not make a difference whether trap based bound checks are enabled or not when physical memory limit is reached)

1. When the amount of virtual memory available does not allow more than 1 wasm cage at startup, Node.js automatically disables trap-based bound checks for wasm - in this case, no wasm can run at all if we keep the trap-based bound checks, so there's no point enabling the optimization. This should remove a good enough of reproductions of https://github.com/microsoft/vscode/issues/251777 (which is triggered by  the usage of wasm in undici)
2. When the amount of virtual memory allows more than 1 cage, but still less than the usual 128TB on 64-bit systems, the optimization is still optimistically enabled. In this case some initial wasm cage may be allocated but may fail later when there's not enough virtual memory left. This maintains the current behavior when we unconditionally enable the optimzation.
3. --disable-wasm-trap-handler is kept as an escape hatch for 2.

We can tweak the threshold of estimation of needed wasm cages in 1 in Node.js to reduce the possibility of 2, this PR currently sets the threshold to 1, since even within Node.js core there's already undici that would use one cage whenever `fetch()` i sused.

Refs: https://github.com/microsoft/vscode/issues/251777
Refs: https://chromium-review.googlesource.com/c/v8/v8/+/7638233

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
