### PR TITLE
module: fix coverage of mocked CJS modules imported from ESM

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -106,7 +106,9 @@ const kShouldSkipModuleHooks = { __proto__: null, shouldSkipModuleHooks: true };
  * @param {boolean} isMain - Whether the module is the entrypoint
  */
 function loadCJSModule(module, source, url, filename, isMain) {
-  const compileResult = compileFunctionForCJSLoader(source, filename, false /* is_sea_main */, false);
+  // Use the full URL as the V8 resource name so that any search params
+  // (e.g. ?node-test-mock) are preserved in coverage reports.
+  const compileResult = compileFunctionForCJSLoader(source, url, false /* is_sea_main */, false);
 
   const { function: compiledWrapper, sourceMapURL, sourceURL } = compileResult;
   // Cache the source map for the cjs module if present.

--- a/test/fixtures/test-runner/coverage-with-mock/dependency.cjs
+++ b/test/fixtures/test-runner/coverage-with-mock/dependency.cjs
@@ -1,0 +1,9 @@
+throw new Error('This should never be called');
+
+exports.dependency = function dependency() {
+  return 'foo';
+}
+
+exports.unused = function unused() {
+  return 'bar';
+}

--- a/test/fixtures/test-runner/coverage-with-mock/subject.mjs
+++ b/test/fixtures/test-runner/coverage-with-mock/subject.mjs
@@ -1,0 +1,5 @@
+import { dependency } from './dependency.cjs';
+
+export function subject() {
+  return dependency();
+}

--- a/test/fixtures/test-runner/output/coverage-with-mock-cjs.mjs
+++ b/test/fixtures/test-runner/output/coverage-with-mock-cjs.mjs
@@ -1,0 +1,11 @@
+import { mock, test } from 'node:test';
+
+const dependency = mock.fn(() => 'mock-return-value');
+mock.module('../coverage-with-mock/dependency.cjs', { namedExports: { dependency } });
+
+const { subject } = await import('../coverage-with-mock/subject.mjs');
+
+test('subject calls dependency', (t) => {
+  t.assert.strictEqual(subject(), 'mock-return-value');
+  t.assert.strictEqual(dependency.mock.callCount(), 1);
+});

--- a/test/fixtures/test-runner/output/coverage-with-mock-cjs.snapshot
+++ b/test/fixtures/test-runner/output/coverage-with-mock-cjs.snapshot
@@ -1,0 +1,31 @@
+TAP version 13
+# Subtest: subject calls dependency
+ok 1 - subject calls dependency
+  ---
+  duration_ms: *
+  type: 'test'
+  ...
+1..1
+# tests 1
+# suites 0
+# pass 1
+# fail 0
+# cancelled 0
+# skipped 0
+# todo 0
+# duration_ms *
+# start of coverage report
+# -------------------------------------------------------------------------------
+# file                           | line % | branch % | funcs % | uncovered lines
+# -------------------------------------------------------------------------------
+# test                           |        |          |         |
+#  fixtures                      |        |          |         |
+#   test-runner                  |        |          |         |
+#    coverage-with-mock          |        |          |         |
+#     subject.mjs                | 100.00 |   100.00 |  100.00 |
+#    output                      |        |          |         |
+#     coverage-with-mock-cjs.mjs | 100.00 |   100.00 |  100.00 |
+# -------------------------------------------------------------------------------
+# all files                      | 100.00 |   100.00 |  100.00 |
+# -------------------------------------------------------------------------------
+# end of coverage report

--- a/test/test-runner/test-output-coverage-with-mock-cjs.mjs
+++ b/test/test-runner/test-output-coverage-with-mock-cjs.mjs
@@ -1,0 +1,22 @@
+import * as common from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import { spawnAndAssert, defaultTransform, ensureCwdIsProjectRoot } from '../common/assertSnapshot.js';
+
+if (!process.features.inspector) {
+  common.skip('inspector support required');
+}
+
+ensureCwdIsProjectRoot();
+await spawnAndAssert(
+  fixtures.path('test-runner/output/coverage-with-mock-cjs.mjs'),
+  defaultTransform,
+  {
+    flags: [
+      '--disable-warning=ExperimentalWarning',
+      '--test-reporter=tap',
+      '--experimental-test-module-mocks',
+      '--experimental-test-coverage',
+      '--test-coverage-exclude=!test/**',
+    ],
+  },
+);


### PR DESCRIPTION
When a CommonJS module is mocked via `mock.module()` and imported from an ESM module, the mocked module incorrectly appears in the coverage report with partial coverage, even though the original source was never executed.

The root cause is in `loadCJSModule`. It passes `filename` to `compileFunctionForCJSLoader` as the V8 resource name.
When the mock loader resolves a mocked module, it appends a `?node-test-mock` search param to the URL. However, `urlToFilename()` strips this param. The coverage filter in `shouldSkipFileCoverage` then fails to recognize it as a mocked module.

The fix passes the full `url` (which preserves the `?node-test-mock` search param) to `compileFunctionForCJSLoader` instead of the stripped `filename`.  For non-mocked CJS modules loaded via ESM, the `url` is `file:///path/to/file.cjs` which produces the same V8 behavior as passing the bare path

Fixes: https://github.com/nodejs/node/issues/61709