### PR TITLE
doc: correct `util.convertProcessSignalToExitCode` validation behavior

### DIFF
--- a/doc/api/util.md
+++ b/doc/api/util.md
@@ -89,7 +89,7 @@ callbackFunction((err, ret) => {
 });
 ```
 
-## `util.convertProcessSignalToExitCode(signalCode)`
+## `util.convertProcessSignalToExitCode(signal)`
 
 <!-- YAML
 added:
@@ -97,19 +97,21 @@ added:
  - v24.14.0
 -->
 
-* `signalCode` {string} A signal name (e.g., `'SIGTERM'`, `'SIGKILL'`).
-* Returns: {number|null} The exit code, or `null` if the signal is invalid.
+* `signal` {string} A signal name (e.g. `'SIGTERM'`)
+* Returns: {number} The exit code corresponding to `signal`
 
 The `util.convertProcessSignalToExitCode()` method converts a signal name to its
 corresponding POSIX exit code. Following the POSIX standard, the exit code
 for a process terminated by a signal is calculated as `128 + signal number`.
+
+If `signal` is not a valid signal name, then an error will be thrown. See
+[`signal(7)`][] for a list of valid signals.
 
 ```mjs
 import { convertProcessSignalToExitCode } from 'node:util';
 
 console.log(convertProcessSignalToExitCode('SIGTERM')); // 143 (128 + 15)
 console.log(convertProcessSignalToExitCode('SIGKILL')); // 137 (128 + 9)
-console.log(convertProcessSignalToExitCode('INVALID')); // null
 ```
 
 ```cjs
@@ -117,7 +119,6 @@ const { convertProcessSignalToExitCode } = require('node:util');
 
 console.log(convertProcessSignalToExitCode('SIGTERM')); // 143 (128 + 15)
 console.log(convertProcessSignalToExitCode('SIGKILL')); // 137 (128 + 9)
-console.log(convertProcessSignalToExitCode('INVALID')); // null
 ```
 
 This is particularly useful when working with processes to determine
@@ -3869,6 +3870,7 @@ npx codemod@latest @nodejs/util-is
 [`mime.toString()`]: #mimetostring
 [`mimeParams.entries()`]: #mimeparamsentries
 [`napi_create_external()`]: n-api.md#napi_create_external
+[`signal(7)`]: https://man7.org/linux/man-pages/man7/signal.7.html
 [`target` and `handler`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy#terminology
 [`tty.hasColors()`]: tty.md#writestreamhascolorscount-env
 [`util.diff()`]: #utildiffactual-expected


### PR DESCRIPTION
This method validates its argument and throws. It never returns `null`.

Additionally, remove ambiguous "signal code" nomenclature to refer to signal name.