### PR TITLE
deps: V8: cherry-pick aa0b288f87cc

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.12',
+    'v8_embedder_string': '-node.13',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/wasm/jump-table-assembler.cc
+++ b/deps/v8/src/wasm/jump-table-assembler.cc
@@ -426,7 +426,8 @@ void JumpTableAssembler::EmitFarJumpSlot(Address target) {
 // static
 void JumpTableAssembler::PatchFarJumpSlot(WritableJitAllocation& jit_allocation,
                                           Address slot, Address target) {
-  Address target_addr = slot + 8;
+  // See {EmitFarJumpSlot} for the offset of the target.
+  Address target_addr = slot + kFarJumpTableSlotSize - kSystemPointerSize;
   jit_allocation.WriteValue(target_addr, target, kRelaxedStore);
 }
 
@@ -636,7 +637,7 @@ bool JumpTableAssembler::EmitJumpSlot(Address target) {
 
   CHECK_EQ(0, relative_target & (kAAMask | kLKMask));
   // The jump table is updated live, so the write has to be atomic.
-  emit<uint32_t>(inst[0] | relative_target, kRelaxedStore);
+  emit<uint32_t>(inst[0] | (relative_target & kImm26Mask), kRelaxedStore);
   return true;
 }
 
@@ -671,7 +672,9 @@ void JumpTableAssembler::EmitFarJumpSlot(Address target) {
 // static
 void JumpTableAssembler::PatchFarJumpSlot(WritableJitAllocation& jit_allocation,
                                           Address slot, Address target) {
-  Address target_addr = slot + kFarJumpTableSlotSize - 8;
+  // See {EmitFarJumpSlot} for the offset of the target.
+  Address target_addr =
+      slot + kFarJumpTableSlotSize - (2 * kInstrSize) - kSystemPointerSize;
   jit_allocation.WriteValue(target_addr, target, kRelaxedStore);
 }
 


### PR DESCRIPTION
Original commit message:

    PPC/S390: [wasm] Fix jump table offset when patching

    ... need to make sure patching of target occurs at the correct spot
    based on what `EmitFarJumpSlot` emits. Also mask the branch offset in
    PPC64 EmitJumpSlot to match `Assembler::b()`.

    Change-Id: I5a8079d0079d8ad427034761d42c90b64d5746dd
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7642190
    Reviewed-by: John <junyan1@ibm.com>
    Commit-Queue: Milad Farazmand <mfarazma@ibm.com>
    Reviewed-by: Clemens Backes <clemensb@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#105646}

Refs: https://github.com/v8/v8/commit/aa0b288f87ccfc2ad25f5d828af6627a7dccc9cb
Refs: https://github.com/nodejs/node/pull/62116#issuecomment-4012532388

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
