### PR TITLE
test_runner: sync ESM exports when mocking timers

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -24,6 +24,8 @@ const {
   validateNumber,
   validateStringArray,
 } = require('internal/validators');
+const { Module } = require('internal/modules/cjs/loader');
+const { syncBuiltinESMExports } = Module;
 
 const {
   AbortError,
@@ -440,9 +442,9 @@ class MockTimers {
 
     const eventIt = EventEmitter.on(emitter, 'data');
     const timer = this.#createTimer(true,
-                                    () => emitter.emit('data'),
-                                    interval,
-                                    options);
+      () => emitter.emit('data'),
+      interval,
+      options);
 
     try {
       // eslint-disable-next-line no-unused-vars
@@ -628,6 +630,7 @@ class MockTimers {
     const target = activate ? options.toFake : options.toReal;
     ArrayPrototypeForEach(this.#timersInContext, (timer) => target[timer]());
     this.#isEnabled = activate;
+    syncBuiltinESMExports();
   }
 
   /**

--- a/test/parallel/test-runner-mock-timers-esm.mjs
+++ b/test/parallel/test-runner-mock-timers-esm.mjs
@@ -1,0 +1,45 @@
+import '../common/index.mjs';
+import { describe, it } from 'node:test';
+import { setTimeout } from 'node:timers/promises';
+import assert from 'node:assert';
+
+describe('Mock Timers ESM Regression', () => {
+    it('should work with node:timers/promises and runAll() in ESM', async (t) => {
+        t.mock.timers.enable({ apis: ['Date', 'setTimeout'] });
+        const startTime = Date.now();
+        let t1 = 0;
+
+        await Promise.all([
+            (async () => {
+                await setTimeout(1000);
+                t1 = Date.now();
+            })(),
+            (async () => {
+                // Wait for the next tick to ensure setTimeout has been called
+                await new Promise((resolve) => process.nextTick(resolve));
+                t.mock.timers.runAll();
+            })(),
+        ]);
+
+        assert.strictEqual(t1 - startTime, 1000);
+    });
+
+    it('should work with node:timers/promises and tick() in ESM', async (t) => {
+        t.mock.timers.enable({ apis: ['Date', 'setTimeout'] });
+        const startTime = Date.now();
+        let t1 = 0;
+
+        await Promise.all([
+            (async () => {
+                await setTimeout(500);
+                t1 = Date.now();
+            })(),
+            (async () => {
+                await new Promise((resolve) => process.nextTick(resolve));
+                t.mock.timers.tick(500);
+            })(),
+        ]);
+
+        assert.strictEqual(t1 - startTime, 500);
+    });
+});


### PR DESCRIPTION
This change ensures that ESM imports of node:timers/promises are correctly mocked when using mock.timers.enable(). This is achieved by calling syncBuiltinESMExports() whenever the mocked timers are toggled or reset.

Fixes: https://github.com/nodejs/node/issues/62081

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.