### PR TITLE
inspector: auto collect webstorage data

### DIFF
--- a/lib/internal/inspector/webstorage.js
+++ b/lib/internal/inspector/webstorage.js
@@ -1,0 +1,107 @@
+'use strict';
+
+const { Storage } = internalBinding('webstorage');
+const { DOMStorage } = require('inspector');
+const path = require('path');
+const { getOptionValue } = require('internal/options');
+
+class InspectorLocalStorage extends Storage {
+  setItem(key, value) {
+    const oldValue = this.getItem(key);
+    super.setItem(key, value);
+    if (oldValue == null) {
+      itemAdded(key, value, true);
+    } else {
+      itemUpdated(key, oldValue, value, true);
+    }
+  }
+
+  removeItem(key) {
+    super.removeItem(key);
+    itemRemoved(key, true);
+  }
+
+  clear() {
+    super.clear();
+    itemsCleared(true);
+  }
+}
+
+const InspectorSessionStorage = class extends Storage {
+  setItem(key, value) {
+    const oldValue = this.getItem(key);
+    super.setItem(key, value);
+    if (oldValue == null) {
+      itemAdded(key, value, false);
+    } else {
+      itemUpdated(key, oldValue, value, false);
+    }
+  }
+
+  removeItem(key) {
+    super.removeItem(key);
+    itemRemoved(key, false);
+  }
+
+  clear() {
+    super.clear();
+    itemsCleared(false);
+  }
+};
+
+function itemAdded(key, value, isLocalStorage) {
+  DOMStorage.domStorageItemAdded({
+    key,
+    newValue: value,
+    storageId: {
+      securityOrigin: '',
+      isLocalStorage,
+      storageKey: getStorageKey(),
+    },
+  });
+}
+
+function itemUpdated(key, oldValue, newValue, isLocalStorage) {
+  DOMStorage.domStorageItemUpdated({
+    key,
+    oldValue,
+    newValue,
+    storageId: {
+      securityOrigin: '',
+      isLocalStorage,
+      storageKey: getStorageKey(),
+    },
+  });
+}
+
+function itemRemoved(key, isLocalStorage) {
+  DOMStorage.domStorageItemRemoved({
+    key,
+    storageId: {
+      securityOrigin: '',
+      isLocalStorage,
+      storageKey: getStorageKey(),
+    },
+  });
+}
+
+function itemsCleared(isLocalStorage) {
+  DOMStorage.domStorageItemsCleared({
+    storageId: {
+      securityOrigin: '',
+      isLocalStorage,
+      storageKey: getStorageKey(),
+    },
+  });
+}
+
+function getStorageKey() {
+  const localStorageFile = getOptionValue('--localstorage-file');
+  const resolvedAbsolutePath = path.resolve(localStorageFile);
+  return 'file://' + resolvedAbsolutePath;
+}
+
+module.exports = {
+  InspectorLocalStorage,
+  InspectorSessionStorage,
+};

--- a/lib/internal/webstorage.js
+++ b/lib/internal/webstorage.js
@@ -2,21 +2,31 @@
 const {
   ObjectDefineProperties,
 } = primordials;
+const { hasInspector } = internalBinding('config');
 const { getOptionValue } = require('internal/options');
 const { kConstructorKey, Storage } = internalBinding('webstorage');
 const { getValidatedPath } = require('internal/fs/utils');
-const { InspectorLocalStorage, InspectorSessionStorage } = require('internal/inspector/webstorage');
 const kInMemoryPath = ':memory:';
 
 module.exports = { Storage };
 
 let lazyLocalStorage;
 let lazySessionStorage;
+let lazyInspectorStorage;
 let localStorageWarned = false;
 
 // Check at load time if localStorage file is provided to determine enumerability.
 // If not provided, localStorage is non-enumerable to avoid breaking {...globalThis}.
 const localStorageLocation = getOptionValue('--localstorage-file');
+const experimentalStorageInspection =
+  hasInspector && getOptionValue('--experimental-storage-inspection');
+
+function getInspectorStorage() {
+  if (lazyInspectorStorage === undefined) {
+    lazyInspectorStorage = require('internal/inspector/webstorage');
+  }
+  return lazyInspectorStorage;
+}
 
 ObjectDefineProperties(module.exports, {
   __proto__: null,
@@ -37,7 +47,8 @@ ObjectDefineProperties(module.exports, {
           return undefined;
         }
 
-        if (getOptionValue('--experimental-storage-inspection')) {
+        if (experimentalStorageInspection) {
+          const { InspectorLocalStorage } = getInspectorStorage();
           lazyLocalStorage = new InspectorLocalStorage(kConstructorKey, getValidatedPath(localStorageLocation), true);
         } else {
           lazyLocalStorage = new Storage(kConstructorKey, getValidatedPath(localStorageLocation));
@@ -52,7 +63,8 @@ ObjectDefineProperties(module.exports, {
     enumerable: true,
     get() {
       if (lazySessionStorage === undefined) {
-        if (getOptionValue('--experimental-storage-inspection')) {
+        if (experimentalStorageInspection) {
+          const { InspectorSessionStorage } = getInspectorStorage();
           lazySessionStorage = new InspectorSessionStorage(kConstructorKey, kInMemoryPath, false);
         } else {
           lazySessionStorage = new Storage(kConstructorKey, kInMemoryPath);

--- a/lib/internal/webstorage.js
+++ b/lib/internal/webstorage.js
@@ -5,6 +5,7 @@ const {
 const { getOptionValue } = require('internal/options');
 const { kConstructorKey, Storage } = internalBinding('webstorage');
 const { getValidatedPath } = require('internal/fs/utils');
+const { InspectorLocalStorage, InspectorSessionStorage } = require('internal/inspector/webstorage');
 const kInMemoryPath = ':memory:';
 
 module.exports = { Storage };
@@ -36,9 +37,12 @@ ObjectDefineProperties(module.exports, {
           return undefined;
         }
 
-        lazyLocalStorage = new Storage(kConstructorKey, getValidatedPath(localStorageLocation));
+        if (getOptionValue('--experimental-storage-inspection')) {
+          lazyLocalStorage = new InspectorLocalStorage(kConstructorKey, getValidatedPath(localStorageLocation), true);
+        } else {
+          lazyLocalStorage = new Storage(kConstructorKey, getValidatedPath(localStorageLocation));
+        }
       }
-
       return lazyLocalStorage;
     },
   },
@@ -48,7 +52,11 @@ ObjectDefineProperties(module.exports, {
     enumerable: true,
     get() {
       if (lazySessionStorage === undefined) {
-        lazySessionStorage = new Storage(kConstructorKey, kInMemoryPath);
+        if (getOptionValue('--experimental-storage-inspection')) {
+          lazySessionStorage = new InspectorSessionStorage(kConstructorKey, kInMemoryPath, false);
+        } else {
+          lazySessionStorage = new Storage(kConstructorKey, kInMemoryPath);
+        }
       }
 
       return lazySessionStorage;

--- a/src/inspector/dom_storage_agent.cc
+++ b/src/inspector/dom_storage_agent.cc
@@ -253,10 +253,7 @@ void DOMStorageAgent::registerStorage(Local<Context> context,
     }
     node::TwoByteValue key_utf16(isolate, key_value);
     node::TwoByteValue value_utf16(isolate, value_value);
-    storage_map[std::u16string(reinterpret_cast<const char16_t*>(*key_utf16),
-                               key_utf16.length())] =
-        std::u16string(reinterpret_cast<const char16_t*>(*value_utf16),
-                       value_utf16.length());
+    storage_map[key_utf16.ToU16String()] = value_utf16.ToU16String();
   }
 }
 

--- a/src/inspector/dom_storage_agent.cc
+++ b/src/inspector/dom_storage_agent.cc
@@ -89,15 +89,13 @@ protocol::DispatchResponse DOMStorageAgent::getDOMStorageItems(
   }
   bool is_local_storage = storageId->getIsLocalStorage();
   std::optional<StorageMap> storage_map =
-      is_local_storage
-          ? std::make_optional<StorageMap>(local_storage_map_)
-          : std::make_optional<StorageMap>(session_storage_map_);
+      is_local_storage ? std::make_optional<StorageMap>(local_storage_map_)
+                       : std::make_optional<StorageMap>(session_storage_map_);
   if (storage_map->empty()) {
     auto web_storage_obj = getWebStorage(is_local_storage);
     if (web_storage_obj) {
       StorageMap all_items = web_storage_obj.value()->GetAll();
-      storage_map =
-          std::make_optional<StorageMap>(std::move(all_items));
+      storage_map = std::make_optional<StorageMap>(std::move(all_items));
     }
   }
 
@@ -105,12 +103,12 @@ protocol::DispatchResponse DOMStorageAgent::getDOMStorageItems(
       std::make_unique<protocol::Array<protocol::Array<protocol::String>>>();
   for (const auto& pair : *storage_map) {
     auto item = std::make_unique<protocol::Array<protocol::String>>();
-    item->push_back(
-      protocol::StringUtil::fromUTF16(reinterpret_cast<const uint16_t*>(pair.first.data()),
-                                        pair.first.size())); 
-    item->push_back(
-      protocol::StringUtil::fromUTF16(reinterpret_cast<const uint16_t*>(pair.second.data()),
-                                        pair.second.size()));
+    item->push_back(protocol::StringUtil::fromUTF16(
+        reinterpret_cast<const uint16_t*>(pair.first.data()),
+        pair.first.size()));
+    item->push_back(protocol::StringUtil::fromUTF16(
+        reinterpret_cast<const uint16_t*>(pair.second.data()),
+        pair.second.size()));
     result->push_back(std::move(item));
   }
   *items = std::move(result);
@@ -255,11 +253,11 @@ void DOMStorageAgent::registerStorage(Local<Context> context,
     }
     node::TwoByteValue key_utf16(isolate, key_value);
     node::TwoByteValue value_utf16(isolate, value_value);
-    storage_map[std::u16string(
-        reinterpret_cast<const char16_t*>(*key_utf16), key_utf16.length())] =
+    storage_map[std::u16string(reinterpret_cast<const char16_t*>(*key_utf16),
+                               key_utf16.length())] =
         std::u16string(reinterpret_cast<const char16_t*>(*value_utf16),
                        value_utf16.length());
-      }
+  }
 }
 
 std::optional<node::webstorage::Storage*> DOMStorageAgent::getWebStorage(

--- a/src/inspector/dom_storage_agent.cc
+++ b/src/inspector/dom_storage_agent.cc
@@ -85,11 +85,26 @@ protocol::DispatchResponse DOMStorageAgent::getDOMStorageItems(
         "DOMStorage domain is not enabled");
   }
   bool is_local_storage = storageId->getIsLocalStorage();
-  const std::unordered_map<std::string, std::string>& storage_map =
-      is_local_storage ? local_storage_map_ : session_storage_map_;
+  std::unique_ptr<std::unordered_map<std::string, std::string>> storage_map =
+      is_local_storage
+          ? std::make_unique<std::unordered_map<std::string, std::string>>(
+                local_storage_map_)
+          : std::make_unique<std::unordered_map<std::string, std::string>>(
+                session_storage_map_);
+  if (storage_map->empty()) {
+    auto web_storage_obj = getWebStorage(is_local_storage);
+    if (web_storage_obj) {
+      std::unordered_map<std::string, std::string> all_items =
+          web_storage_obj.value()->GetAll();
+      storage_map =
+          std::make_unique<std::unordered_map<std::string, std::string>>(
+              std::move(all_items));
+    }
+  }
+
   auto result =
       std::make_unique<protocol::Array<protocol::Array<protocol::String>>>();
-  for (const auto& pair : storage_map) {
+  for (const auto& pair : *storage_map) {
     auto item = std::make_unique<protocol::Array<protocol::String>>();
     item->push_back(pair.first);
     item->push_back(pair.second);
@@ -238,6 +253,28 @@ void DOMStorageAgent::registerStorage(Local<Context> context,
     node::Utf8Value key_utf8(isolate, key_value);
     node::Utf8Value value_utf8(isolate, value_value);
     storage_map[*key_utf8] = *value_utf8;
+  }
+}
+
+std::optional<node::webstorage::Storage*> DOMStorageAgent::getWebStorage(
+    bool is_local_storage) {
+  std::string var_name = is_local_storage ? "localStorage" : "sessionStorage";
+  v8::Isolate* isolate = env_->isolate();
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Object> global = env_->context()->Global();
+  v8::Local<v8::Value> web_storage_val;
+  if (!global
+           ->Get(env_->context(),
+                 v8::String::NewFromUtf8(env_->isolate(), var_name.c_str())
+                     .ToLocalChecked())
+           .ToLocal(&web_storage_val) ||
+      !web_storage_val->IsObject()) {
+    return std::nullopt;
+  } else {
+    node::webstorage::Storage* storage;
+    ASSIGN_OR_RETURN_UNWRAP(
+        &storage, web_storage_val.As<v8::Object>(), std::nullopt);
+    return storage;
   }
 }
 

--- a/src/inspector/dom_storage_agent.cc
+++ b/src/inspector/dom_storage_agent.cc
@@ -88,14 +88,14 @@ protocol::DispatchResponse DOMStorageAgent::getDOMStorageItems(
         "DOMStorage domain is not enabled");
   }
   bool is_local_storage = storageId->getIsLocalStorage();
-  std::optional<StorageMap> storage_map =
-      is_local_storage ? std::make_optional<StorageMap>(local_storage_map_)
-                       : std::make_optional<StorageMap>(session_storage_map_);
+  const StorageMap* storage_map =
+      is_local_storage ? &local_storage_map_ : &session_storage_map_;
+  std::optional<StorageMap> storage_map_fallback;
   if (storage_map->empty()) {
     auto web_storage_obj = getWebStorage(is_local_storage);
     if (web_storage_obj) {
-      StorageMap all_items = web_storage_obj.value()->GetAll();
-      storage_map = std::make_optional<StorageMap>(std::move(all_items));
+      storage_map_fallback = web_storage_obj.value()->GetAll();
+      storage_map = &storage_map_fallback.value();
     }
   }
 

--- a/src/inspector/dom_storage_agent.cc
+++ b/src/inspector/dom_storage_agent.cc
@@ -88,20 +88,16 @@ protocol::DispatchResponse DOMStorageAgent::getDOMStorageItems(
         "DOMStorage domain is not enabled");
   }
   bool is_local_storage = storageId->getIsLocalStorage();
-  std::optional<std::unordered_map<std::string, std::string>> storage_map =
+  std::optional<StorageMap> storage_map =
       is_local_storage
-          ? std::make_optional<std::unordered_map<std::string, std::string>>(
-                local_storage_map_)
-          : std::make_optional<std::unordered_map<std::string, std::string>>(
-                session_storage_map_);
+          ? std::make_optional<StorageMap>(local_storage_map_)
+          : std::make_optional<StorageMap>(session_storage_map_);
   if (storage_map->empty()) {
     auto web_storage_obj = getWebStorage(is_local_storage);
     if (web_storage_obj) {
-      std::unordered_map<std::string, std::string> all_items =
-          web_storage_obj.value()->GetAll();
+      StorageMap all_items = web_storage_obj.value()->GetAll();
       storage_map =
-          std::make_optional<std::unordered_map<std::string, std::string>>(
-              std::move(all_items));
+          std::make_optional<StorageMap>(std::move(all_items));
     }
   }
 
@@ -109,8 +105,12 @@ protocol::DispatchResponse DOMStorageAgent::getDOMStorageItems(
       std::make_unique<protocol::Array<protocol::Array<protocol::String>>>();
   for (const auto& pair : *storage_map) {
     auto item = std::make_unique<protocol::Array<protocol::String>>();
-    item->push_back(pair.first);
-    item->push_back(pair.second);
+    item->push_back(
+      protocol::StringUtil::fromUTF16(reinterpret_cast<const uint16_t*>(pair.first.data()),
+                                        pair.first.size())); 
+    item->push_back(
+      protocol::StringUtil::fromUTF16(reinterpret_cast<const uint16_t*>(pair.second.data()),
+                                        pair.second.size()));
     result->push_back(std::move(item));
   }
   *items = std::move(result);
@@ -237,7 +237,7 @@ void DOMStorageAgent::registerStorage(Local<Context> context,
            .ToLocal(&storage_map_obj)) {
     return;
   }
-  std::unordered_map<std::string, std::string>& storage_map =
+  StorageMap& storage_map =
       is_local_storage ? local_storage_map_ : session_storage_map_;
   Local<Array> property_names;
   if (!storage_map_obj->GetOwnPropertyNames(context).ToLocal(&property_names)) {
@@ -253,10 +253,13 @@ void DOMStorageAgent::registerStorage(Local<Context> context,
     if (!storage_map_obj->Get(context, key_value).ToLocal(&value_value)) {
       return;
     }
-    node::Utf8Value key_utf8(isolate, key_value);
-    node::Utf8Value value_utf8(isolate, value_value);
-    storage_map[*key_utf8] = *value_utf8;
-  }
+    node::TwoByteValue key_utf16(isolate, key_value);
+    node::TwoByteValue value_utf16(isolate, value_value);
+    storage_map[std::u16string(
+        reinterpret_cast<const char16_t*>(*key_utf16), key_utf16.length())] =
+        std::u16string(reinterpret_cast<const char16_t*>(*value_utf16),
+                       value_utf16.length());
+      }
 }
 
 std::optional<node::webstorage::Storage*> DOMStorageAgent::getWebStorage(

--- a/src/inspector/dom_storage_agent.cc
+++ b/src/inspector/dom_storage_agent.cc
@@ -1,6 +1,9 @@
 #include "dom_storage_agent.h"
+#include <optional>
 #include "env-inl.h"
 #include "inspector/inspector_object_utils.h"
+#include "util.h"
+#include "v8-exception.h"
 #include "v8-isolate.h"
 
 namespace node {
@@ -85,11 +88,11 @@ protocol::DispatchResponse DOMStorageAgent::getDOMStorageItems(
         "DOMStorage domain is not enabled");
   }
   bool is_local_storage = storageId->getIsLocalStorage();
-  std::unique_ptr<std::unordered_map<std::string, std::string>> storage_map =
+  std::optional<std::unordered_map<std::string, std::string>> storage_map =
       is_local_storage
-          ? std::make_unique<std::unordered_map<std::string, std::string>>(
+          ? std::make_optional<std::unordered_map<std::string, std::string>>(
                 local_storage_map_)
-          : std::make_unique<std::unordered_map<std::string, std::string>>(
+          : std::make_optional<std::unordered_map<std::string, std::string>>(
                 session_storage_map_);
   if (storage_map->empty()) {
     auto web_storage_obj = getWebStorage(is_local_storage);
@@ -97,7 +100,7 @@ protocol::DispatchResponse DOMStorageAgent::getDOMStorageItems(
       std::unordered_map<std::string, std::string> all_items =
           web_storage_obj.value()->GetAll();
       storage_map =
-          std::make_unique<std::unordered_map<std::string, std::string>>(
+          std::make_optional<std::unordered_map<std::string, std::string>>(
               std::move(all_items));
     }
   }
@@ -258,17 +261,18 @@ void DOMStorageAgent::registerStorage(Local<Context> context,
 
 std::optional<node::webstorage::Storage*> DOMStorageAgent::getWebStorage(
     bool is_local_storage) {
-  std::string var_name = is_local_storage ? "localStorage" : "sessionStorage";
   v8::Isolate* isolate = env_->isolate();
   v8::HandleScope handle_scope(isolate);
   v8::Local<v8::Object> global = env_->context()->Global();
   v8::Local<v8::Value> web_storage_val;
+  v8::TryCatch try_catch(isolate);
   if (!global
            ->Get(env_->context(),
-                 v8::String::NewFromUtf8(env_->isolate(), var_name.c_str())
-                     .ToLocalChecked())
+                 is_local_storage
+                     ? FIXED_ONE_BYTE_STRING(isolate, "localStorage")
+                     : FIXED_ONE_BYTE_STRING(isolate, "sessionStorage"))
            .ToLocal(&web_storage_val) ||
-      !web_storage_val->IsObject()) {
+      !web_storage_val->IsObject() || try_catch.HasCaught()) {
     return std::nullopt;
   } else {
     node::webstorage::Storage* storage;

--- a/src/inspector/dom_storage_agent.h
+++ b/src/inspector/dom_storage_agent.h
@@ -52,11 +52,12 @@ class DOMStorageAgent : public protocol::DOMStorage::Backend,
   DOMStorageAgent& operator=(const DOMStorageAgent&) = delete;
 
  private:
+  typedef std::unordered_map<std::u16string, std::u16string> StorageMap;
   std::optional<node::webstorage::Storage*> getWebStorage(
       bool is_local_storage);
   std::unique_ptr<protocol::DOMStorage::Frontend> frontend_;
-  std::unordered_map<std::string, std::string> local_storage_map_ = {};
-  std::unordered_map<std::string, std::string> session_storage_map_ = {};
+  StorageMap local_storage_map_ = {};
+  StorageMap session_storage_map_ = {};
   bool enabled_ = false;
   Environment* env_;
 };

--- a/src/inspector/dom_storage_agent.h
+++ b/src/inspector/dom_storage_agent.h
@@ -1,9 +1,11 @@
 #ifndef SRC_INSPECTOR_DOM_STORAGE_AGENT_H_
 #define SRC_INSPECTOR_DOM_STORAGE_AGENT_H_
 
+#include <optional>
 #include <string>
 #include "env.h"
 #include "node/inspector/protocol/DOMStorage.h"
+#include "node_webstorage.h"
 #include "notification_emitter.h"
 #include "v8.h"
 
@@ -50,6 +52,8 @@ class DOMStorageAgent : public protocol::DOMStorage::Backend,
   DOMStorageAgent& operator=(const DOMStorageAgent&) = delete;
 
  private:
+  std::optional<node::webstorage::Storage*> getWebStorage(
+      bool is_local_storage);
   std::unique_ptr<protocol::DOMStorage::Frontend> frontend_;
   std::unordered_map<std::string, std::string> local_storage_map_ = {};
   std::unordered_map<std::string, std::string> session_storage_map_ = {};

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -121,6 +121,7 @@ BuiltinLoader::BuiltinCategories BuiltinLoader::GetBuiltinCategories() const {
         "internal/inspector/network", "internal/inspector/network_http",
         "internal/inspector/network_http2", "internal/inspector/network_undici",
         "internal/inspector_async_hook", "internal/inspector_network_tracking",
+        "internal/inspector/webstorage",
 #endif  // !HAVE_INSPECTOR
 
 #if !NODE_USE_V8_PLATFORM || !defined(NODE_HAVE_I18N_SUPPORT)

--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -144,6 +144,7 @@ BuiltinLoader::BuiltinCategories BuiltinLoader::GetBuiltinCategories() const {
         "wasi",    // Experimental.
 #if !HAVE_SQLITE
         "internal/webstorage",  // Experimental.
+        "internal/inspector/webstorage",
 #endif
         "internal/test/binding", "internal/v8_prof_polyfill",
   };

--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -281,7 +281,7 @@ MaybeLocal<Array> Storage::Enumerate() {
   return Array::New(env()->isolate(), values.data(), values.size());
 }
 
-std::unordered_map<std::string, std::string> Storage::GetAll() {
+std::unordered_map<std::u16string, std::u16string> Storage::GetAll() {
   if (!Open().IsJust()) {
     return {};
   }
@@ -291,7 +291,7 @@ std::unordered_map<std::string, std::string> Storage::GetAll() {
   sqlite3_stmt* s = nullptr;
   int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr);
   auto stmt = stmt_unique_ptr(s);
-  std::unordered_map<std::string, std::string> result;
+  std::unordered_map<std::u16string, std::u16string> result;
   while ((r = sqlite3_step(stmt.get())) == SQLITE_ROW) {
     CHECK(sqlite3_column_type(stmt.get(), 0) == SQLITE_BLOB);
     CHECK(sqlite3_column_type(stmt.get(), 1) == SQLITE_BLOB);
@@ -301,20 +301,9 @@ std::unordered_map<std::string, std::string> Storage::GetAll() {
         reinterpret_cast<const char16_t*>(sqlite3_column_blob(stmt.get(), 0)));
     auto value_uint16(
         reinterpret_cast<const char16_t*>(sqlite3_column_blob(stmt.get(), 1)));
-    size_t key_utf8_size =
-        simdutf::utf8_length_from_utf16(key_uint16, key_size);
-    std::string key;
-    key.resize(key_utf8_size);
-    size_t written =
-        simdutf::convert_utf16_to_utf8(key_uint16, key_size, key.data());
-    key.resize(written);
-    size_t value_utf8_size =
-        simdutf::utf8_length_from_utf16(value_uint16, value_size);
-    std::string value;
-    value.resize(value_utf8_size);
-    written =
-        simdutf::convert_utf16_to_utf8(value_uint16, value_size, value.data());
-    value.resize(written);
+
+    std::u16string key(key_uint16, key_size);
+    std::u16string value(value_uint16, value_size);
 
     result.emplace(std::move(key), std::move(value));
   }

--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -9,6 +9,7 @@
 #include "node_errors.h"
 #include "node_mem-inl.h"
 #include "path.h"
+#include "simdutf.h"
 #include "sqlite3.h"
 #include "util-inl.h"
 
@@ -297,17 +298,23 @@ std::unordered_map<std::string, std::string> Storage::GetAll() {
     auto key_size = sqlite3_column_bytes(stmt.get(), 0) / sizeof(uint16_t);
     auto value_size = sqlite3_column_bytes(stmt.get(), 1) / sizeof(uint16_t);
     auto key_uint16(
-        reinterpret_cast<const uint16_t*>(sqlite3_column_blob(stmt.get(), 0)));
+        reinterpret_cast<const char16_t*>(sqlite3_column_blob(stmt.get(), 0)));
     auto value_uint16(
-        reinterpret_cast<const uint16_t*>(sqlite3_column_blob(stmt.get(), 1)));
+        reinterpret_cast<const char16_t*>(sqlite3_column_blob(stmt.get(), 1)));
+    size_t key_utf8_size =
+        simdutf::utf8_length_from_utf16(key_uint16, key_size);
     std::string key;
-    for (size_t i = 0; i < key_size; ++i) {
-      key.push_back(static_cast<char>(key_uint16[i]));
-    }
+    key.resize(key_utf8_size);
+    size_t written =
+        simdutf::convert_utf16_to_utf8(key_uint16, key_size, key.data());
+    key.resize(written);
+    size_t value_utf8_size =
+        simdutf::utf8_length_from_utf16(value_uint16, value_size);
     std::string value;
-    for (size_t i = 0; i < value_size; ++i) {
-      value.push_back(static_cast<char>(value_uint16[i]));
-    }
+    value.resize(value_utf8_size);
+    written =
+        simdutf::convert_utf16_to_utf8(value_uint16, value_size, value.data());
+    value.resize(written);
 
     result.emplace(std::move(key), std::move(value));
   }

--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -1,4 +1,6 @@
 #include "node_webstorage.h"
+#include <string>
+#include <unordered_map>
 #include "base_object-inl.h"
 #include "debug_utils-inl.h"
 #include "env-inl.h"
@@ -276,6 +278,40 @@ MaybeLocal<Array> Storage::Enumerate() {
   }
   CHECK_ERROR_OR_THROW(env(), r, SQLITE_DONE, Local<Array>());
   return Array::New(env()->isolate(), values.data(), values.size());
+}
+
+std::unordered_map<std::string, std::string> Storage::GetAll() {
+  if (!Open().IsJust()) {
+    return {};
+  }
+
+  static constexpr std::string_view sql =
+      "SELECT key, value FROM nodejs_webstorage";
+  sqlite3_stmt* s = nullptr;
+  int r = sqlite3_prepare_v2(db_.get(), sql.data(), sql.size(), &s, nullptr);
+  auto stmt = stmt_unique_ptr(s);
+  std::unordered_map<std::string, std::string> result;
+  while ((r = sqlite3_step(stmt.get())) == SQLITE_ROW) {
+    CHECK(sqlite3_column_type(stmt.get(), 0) == SQLITE_BLOB);
+    CHECK(sqlite3_column_type(stmt.get(), 1) == SQLITE_BLOB);
+    auto key_size = sqlite3_column_bytes(stmt.get(), 0) / sizeof(uint16_t);
+    auto value_size = sqlite3_column_bytes(stmt.get(), 1) / sizeof(uint16_t);
+    auto key_uint16(
+        reinterpret_cast<const uint16_t*>(sqlite3_column_blob(stmt.get(), 0)));
+    auto value_uint16(
+        reinterpret_cast<const uint16_t*>(sqlite3_column_blob(stmt.get(), 1)));
+    std::string key;
+    for (size_t i = 0; i < key_size; ++i) {
+      key.push_back(static_cast<char>(key_uint16[i]));
+    }
+    std::string value;
+    for (size_t i = 0; i < value_size; ++i) {
+      value.push_back(static_cast<char>(value_uint16[i]));
+    }
+
+    result.emplace(std::move(key), std::move(value));
+  }
+  return result;
 }
 
 MaybeLocal<Value> Storage::Length() {

--- a/src/node_webstorage.h
+++ b/src/node_webstorage.h
@@ -41,7 +41,7 @@ class Storage : public BaseObject {
   v8::MaybeLocal<v8::Value> LoadKey(const int index);
   v8::Maybe<void> Remove(v8::Local<v8::Name> key);
   v8::Maybe<void> Store(v8::Local<v8::Name> key, v8::Local<v8::Value> value);
-  std::unordered_map<std::string, std::string> GetAll();
+  std::unordered_map<std::u16string, std::u16string> GetAll();
 
   SET_MEMORY_INFO_NAME(Storage)
   SET_SELF_SIZE(Storage)

--- a/src/node_webstorage.h
+++ b/src/node_webstorage.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <unordered_map>
 #include "base_object.h"
 #include "node_mem.h"
 #include "sqlite3.h"
@@ -40,6 +41,7 @@ class Storage : public BaseObject {
   v8::MaybeLocal<v8::Value> LoadKey(const int index);
   v8::Maybe<void> Remove(v8::Local<v8::Name> key);
   v8::Maybe<void> Store(v8::Local<v8::Name> key, v8::Local<v8::Value> value);
+  std::unordered_map<std::string, std::string> GetAll();
 
   SET_MEMORY_INFO_NAME(Storage)
   SET_SELF_SIZE(Storage)

--- a/test/parallel/test-inspector-dom-storage.js
+++ b/test/parallel/test-inspector-dom-storage.js
@@ -3,6 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
+common.skipIfSQLiteMissing();
 common.skipIfInspectorDisabled();
 const { DOMStorage, Session } = require('node:inspector/promises');
 const { pathToFileURL } = require('node:url');
@@ -35,6 +36,7 @@ async function testRegisterStorage() {
         key2: 'value2',
         [1]: 2,
         [true]: 'booleanKey',
+        ['ключ']: 'значение',
       },
     });
     const result = await session.post('DOMStorage.getDOMStorageItems', {
@@ -51,6 +53,7 @@ async function testRegisterStorage() {
       ['key1', 'value1'],
       ['key2', 'value2'],
       ['true', 'booleanKey'],
+      ['ключ', 'значение'],
     ]);
   }
 }
@@ -71,6 +74,7 @@ async function testGetData() {
     webStorage.setItem('key1', 'value');
     webStorage.setItem('key2', 1);
     webStorage.setItem('key3', JSON.stringify({ a: 1 }));
+    webStorage.setItem('ключ', 'значение');
 
     const result = await session.post('DOMStorage.getDOMStorageItems', {
       storageId: {
@@ -79,11 +83,12 @@ async function testGetData() {
         storageKey: storageKey.storageKey,
       },
     });
-    assert.strictEqual(result.entries.length, 3);
+    assert.strictEqual(result.entries.length, 4);
     const entries = Object.fromEntries(result.entries);
     assert.strictEqual(entries.key1, 'value');
     assert.strictEqual(entries.key2, '1');
     assert.strictEqual(entries.key3, JSON.stringify({ a: 1 }));
+    assert.strictEqual(entries['ключ'], 'значение');
     session.disconnect();
   }
 }

--- a/test/parallel/test-inspector-dom-storage.js
+++ b/test/parallel/test-inspector-dom-storage.js
@@ -8,8 +8,7 @@ const { DOMStorage, Session } = require('node:inspector/promises');
 const { pathToFileURL } = require('node:url');
 const path = require('node:path');
 
-
-async function test() {
+async function testRegisterStorage() {
   const session = new Session();
   await session.connect();
 
@@ -26,6 +25,7 @@ async function test() {
 
   await checkStorage(true);
   await checkStorage(false);
+  session.disconnect();
 
   async function checkStorage(isLocalStorage) {
     DOMStorage.registerStorage({
@@ -43,7 +43,9 @@ async function test() {
         securityOrigin: 'node-inspector://default-dom-storage',
       },
     });
-    const sortedEntries = result.entries.sort((a, b) => a[0].localeCompare(b[0]));
+    const sortedEntries = result.entries.sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
     assert.deepStrictEqual(sortedEntries, [
       ['1', '2'],
       ['key1', 'value1'],
@@ -53,4 +55,111 @@ async function test() {
   }
 }
 
+async function testGetData() {
+  await test(true);
+  await test(false);
+
+  async function test(isLocalStorage) {
+    const webStorage = isLocalStorage ? localStorage : sessionStorage;
+    const session = new Session();
+    webStorage.clear();
+    await session.connect();
+
+    const storageKey = await session.post('Storage.getStorageKey');
+    await session.post('DOMStorage.enable');
+
+    webStorage.setItem('key1', 'value');
+    webStorage.setItem('key2', 1);
+    webStorage.setItem('key3', JSON.stringify({ a: 1 }));
+
+    const result = await session.post('DOMStorage.getDOMStorageItems', {
+      storageId: {
+        isLocalStorage,
+        securityOrigin: '',
+        storageKey: storageKey.storageKey,
+      },
+    });
+    assert.strictEqual(result.entries.length, 3);
+    const entries = Object.fromEntries(result.entries);
+    assert.strictEqual(entries.key1, 'value');
+    assert.strictEqual(entries.key2, '1');
+    assert.strictEqual(entries.key3, JSON.stringify({ a: 1 }));
+    session.disconnect();
+  }
+}
+
+async function testEvents() {
+  await test(true);
+  await test(false);
+  async function test(isLocalStorage) {
+    const webStorage = isLocalStorage ? localStorage : sessionStorage;
+    webStorage.clear();
+    const session = new Session();
+    await session.connect();
+    await session.post('DOMStorage.enable');
+    const storageKey = await session.post('Storage.getStorageKey');
+    session.on(
+      'DOMStorage.domStorageItemAdded',
+      common.mustCall(({ params }) => {
+        assert.strictEqual(params.key, 'key');
+        assert.strictEqual(params.newValue, 'value');
+        assert.deepStrictEqual(params.storageId, {
+          securityOrigin: '',
+          isLocalStorage,
+          storageKey: storageKey.storageKey,
+        });
+      }),
+    );
+    webStorage.setItem('key', 'value');
+
+    session.on(
+      'DOMStorage.domStorageItemUpdated',
+      common.mustCall(({ params }) => {
+        assert.strictEqual(params.key, 'key');
+        assert.strictEqual(params.oldValue, 'value');
+        assert.strictEqual(params.newValue, 'newValue');
+        assert.deepStrictEqual(params.storageId, {
+          securityOrigin: '',
+          isLocalStorage,
+          storageKey: storageKey.storageKey,
+        });
+      }),
+    );
+
+    webStorage.setItem('key', 'newValue');
+
+    session.on(
+      'DOMStorage.domStorageItemRemoved',
+      common.mustCall(({ params }) => {
+        assert.strictEqual(params.key, 'key');
+        assert.deepStrictEqual(params.storageId, {
+          securityOrigin: '',
+          isLocalStorage,
+          storageKey: storageKey.storageKey,
+        });
+      }),
+    );
+
+    webStorage.removeItem('key');
+
+    session.on(
+      'DOMStorage.domStorageItemsCleared',
+      common.mustCall(({ params }) => {
+        assert.deepStrictEqual(params.storageId, {
+          securityOrigin: '',
+          isLocalStorage,
+          storageKey: storageKey.storageKey,
+        });
+      }),
+    );
+    webStorage.clear();
+    session.disconnect();
+  }
+}
+
+async function test() {
+  await testRegisterStorage();
+  await testGetData();
+  await testEvents();
+}
 test().then(common.mustCall());


### PR DESCRIPTION
Web Storage data collection, which previously required explicitly firing events to send data to DevTools, is now performed automatically within Node.js.
Web Storage will appear in DevTools simply by specifying `--experimental-storage-inspection`, without requiring any code changes.

This feature relies on the changes introduced in the following change request, so it can be verified with the latest DevTools commit:
https://chromium-review.googlesource.com/c/devtools/devtools-frontend/+/7274801

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
