### PR TITLE
doc(test_runner): add example for mocking thrown errors

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -2460,6 +2460,29 @@ test('spies on an object method', (t) => {
 });
 ```
 
+The same approach can be used to mock a method that throws and verify the
+error with [`assert.throws()`][]:
+
+```js
+test('mocks a method that throws', (t) => {
+  const number = {
+    value: 5,
+    subtract(a) {
+      return this.value - a;
+    },
+  };
+
+  t.mock.method(number, 'subtract', () => {
+    throw new Error('boom');
+  });
+
+  assert.throws(() => number.subtract(3), {
+    message: 'boom',
+  });
+});
+```
+
+
 ### `mock.module(specifier[, options])`
 
 <!-- YAML


### PR DESCRIPTION
## Description
Adds a small example to the test runner mocking docs showing how to mock a method that throws and assert it with `assert.throws()`.

Fixes: #52357

## Validation
- `git diff --check`
