### PR TITLE
test_runner: add skip, todo, only, and expectFailure to subtest context

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -261,38 +261,40 @@ class TestContext {
   constructor(test) {
     this.#test = test;
 
-    const runSubtest = (name, options, fn, loc, extraOverrides) => {
-      const overrides = {
-        __proto__: null,
-        ...extraOverrides,
-        loc,
-      };
-
-      const { plan } = this.#test;
-      if (plan !== null) {
-        plan.count();
-      }
-
-      const subtest = this.#test.createSubtest(
-        // eslint-disable-next-line no-use-before-define
-        Test, name, options, fn, overrides,
-      );
-
-      return subtest.start();
-    };
-
+    // Attach .skip, .todo, .only, .expectFailure variants to this.test,
+    // matching the same set exposed on the top-level test() in harness.js.
     this.test = (name, options, fn) =>
-      runSubtest(name, options, fn, getCallerLocation());
+      this.#runTest(name, options, fn, getCallerLocation());
     ArrayPrototypeForEach(
-      ['expectFailure', 'skip', 'todo', 'only'],
+      ['expectFailure', 'only', 'skip', 'todo'],
       (keyword) => {
         this.test[keyword] = (name, options, fn) =>
-          runSubtest(name, options, fn, getCallerLocation(), {
+          this.#runTest(name, options, fn, getCallerLocation(), {
             __proto__: null,
             [keyword]: true,
           });
       },
     );
+  }
+
+  #runTest(name, options, fn, loc, extraOverrides) {
+    const overrides = {
+      __proto__: null,
+      ...extraOverrides,
+      loc,
+    };
+
+    const { plan } = this.#test;
+    if (plan !== null) {
+      plan.count();
+    }
+
+    const subtest = this.#test.createSubtest(
+      // eslint-disable-next-line no-use-before-define
+      Test, name, options, fn, overrides,
+    );
+
+    return subtest.start();
   }
 
   get signal() {

--- a/test/parallel/test-runner-subtest-skip-todo-only.js
+++ b/test/parallel/test-runner-subtest-skip-todo-only.js
@@ -1,48 +1,50 @@
 'use strict';
+// Regression test for https://github.com/nodejs/node/issues/50665
+// t.test() should expose the same .skip, .todo, .only, .expectFailure
+// variants as the top-level test() function.
 const common = require('../common');
 const assert = require('node:assert');
 const { test } = require('node:test');
 
-// Verify that all subtest variants exist on TestContext.
-test('subtest variants exist on TestContext', common.mustCall(async (t) => {
-  assert.strictEqual(typeof t.test, 'function');
-  assert.strictEqual(typeof t.test.skip, 'function');
-  assert.strictEqual(typeof t.test.todo, 'function');
-  assert.strictEqual(typeof t.test.only, 'function');
-  assert.strictEqual(typeof t.test.expectFailure, 'function');
-}));
+test('context test function exposes all variant methods', async (t) => {
+  for (const variant of ['skip', 'todo', 'only', 'expectFailure']) {
+    assert.strictEqual(
+      typeof t.test[variant], 'function',
+      `t.test.${variant} should be a function`,
+    );
+  }
+});
 
-// t.test.skip: callback must NOT be called.
-test('t.test.skip prevents callback execution', common.mustCall(async (t) => {
-  await t.test.skip('skipped subtest', common.mustNotCall());
-}));
+test('skip variant does not execute the callback', async (t) => {
+  await t.test.skip('this is skipped', common.mustNotCall());
+});
 
-// t.test.todo without callback: subtest is marked as todo and skipped.
-test('t.test.todo without callback', common.mustCall(async (t) => {
-  await t.test.todo('todo subtest without callback');
-}));
+test('todo variant without callback marks subtest as todo', async (t) => {
+  await t.test.todo('pending feature');
+});
 
-// t.test.todo with callback: callback runs but subtest is marked as todo.
-test('t.test.todo with callback runs the callback', common.mustCall(async (t) => {
-  await t.test.todo('todo subtest with callback', common.mustCall());
-}));
+test('todo variant with callback still runs', async (t) => {
+  let ran = false;
+  await t.test.todo('work in progress', () => { ran = true; });
+  assert.ok(ran, 'todo callback should have been invoked');
+});
 
-// Plan counting works with subtest variants.
-test('plan counts subtest variants', common.mustCall(async (t) => {
-  t.plan(3);
-  await t.test('normal subtest', common.mustCall());
-  await t.test.skip('skipped subtest');
-  await t.test.todo('todo subtest');
-}));
+test('variants increment the plan counter', async (t) => {
+  t.plan(4);
+  await t.test('regular', common.mustCall());
+  await t.test.skip('skipped');
+  await t.test.todo('todo');
+  await t.test.todo('todo with cb', common.mustCall());
+});
 
-// Nested subtests also expose the variants.
-test('nested subtests have variants', common.mustCall(async (t) => {
-  await t.test('level 1', common.mustCall(async (t2) => {
-    assert.strictEqual(typeof t2.test.skip, 'function');
-    assert.strictEqual(typeof t2.test.todo, 'function');
-    assert.strictEqual(typeof t2.test.only, 'function');
-    assert.strictEqual(typeof t2.test.expectFailure, 'function');
-
-    await t2.test.skip('nested skipped', common.mustNotCall());
-  }));
-}));
+test('variants propagate to nested subtests', async (t) => {
+  await t.test('outer', async (t2) => {
+    for (const variant of ['skip', 'todo', 'only', 'expectFailure']) {
+      assert.strictEqual(
+        typeof t2.test[variant], 'function',
+        `nested t.test.${variant} should be a function`,
+      );
+    }
+    await t2.test.skip('inner skip', common.mustNotCall());
+  });
+});


### PR DESCRIPTION
The top-level `test()` function exposes `test.skip()`, `test.todo()`, `test.only()`, and `test.expectFailure()` variants, but these were missing from `TestContext`'s `test()` method. Calling `t.test.skip()` inside a test callback threw `TypeError: t.test.skip is not a function`.

The [documentation](https://nodejs.org/api/test.html#class-testcontext) states that `t.test()` "behaves identically to the top level `test()`", so this is a bug.

## Changes

- Move `test()` from the `TestContext` class prototype to an arrow function in the constructor, allowing variant methods to be attached as properties
- Extract a shared `runSubtest()` helper to avoid duplicating plan counting and `createSubtest` logic
- Attach `.skip`, `.todo`, `.only`, and `.expectFailure` — matching the exact same list used in `harness.js` for the top-level `test()`

### Trade-off

This trades one shared prototype method for 5 closures per `TestContext` instance (one base + four variants). This is acceptable given V8's closure optimization for same-shape functions, and is the same pattern used by the top-level `test()` in `harness.js`.

## Test plan

- Verify all variant functions exist on `TestContext` (including `expectFailure`)
- `t.test.skip()` prevents callback execution
- `t.test.todo()` without callback (marks as todo, skips)
- `t.test.todo()` with callback (runs callback, marks as todo)
- `t.plan()` counting works with subtest variants
- Nested subtests also expose all variants

Fixes: https://github.com/nodejs/node/issues/50665