### PR TITLE
doc: remove extensionless CJS exception for type:module

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -95,6 +95,8 @@ By default, Node.js will treat the following as CommonJS modules:
   when the nearest parent `package.json` file contains a top-level field
   [`"type"`][] with a value of `"module"`.
 
+See [Determining module system][] for more details.
+
 Calling `require()` always use the CommonJS module loader. Calling `import()`
 always use the ECMAScript module loader.
 


### PR DESCRIPTION
The CJS documentation has included an exception since v16 (added in https://github.com/nodejs/node/pull/41383) stating that extensionless files in `type: "module"` packages are recognized as CommonJS when included via `require()`. This exception conflicts with the [ESM resolution specification](https://nodejs.org/docs/latest-v25.x/api/esm.html#:~:text=If%20url%20does%20not%20have%20any%20extension%2C%20then) which states that extensionless files within a package scope with an explicit `type` field follow the format of the `type` field.

Since #61600, the behavior on `main` already matches the ESM spec: extensionless files respect the `type` field. This change aligns the CJS documentation accordingly by removing the contradicting exception.

For v25.x, #62083 restores the documented exception as a targeted fix to avoid breaking packages like yargs v17 that relied on the old behavior.

Refs: https://github.com/nodejs/node/pull/61600
Refs: https://github.com/nodejs/node/pull/62083
Refs: https://github.com/nodejs/node/issues/61971