### PR TITLE
crypto: default ML-KEM and ML-DSA pkcs8 export to seed-only format

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2121,6 +2121,11 @@ type, value, and parameters. This method is not
 <!-- YAML
 added: v11.6.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62178
+    description: ML-KEM and ML-DSA private key `'pkcs8'` export now
+                 uses seed-only format by default when a seed is
+                 available.
   - version: v15.9.0
     pr-url: https://github.com/nodejs/node/pull/37081
     description: Added support for `'jwk'` format.

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -138,6 +138,23 @@ void InitCryptoOnce() {
 #endif
 
   OPENSSL_init_ssl(0, settings);
+
+#if OPENSSL_WITH_PQC
+  // Configure all loaded providers to prefer seed-only format for ML-KEM and
+  // ML-DSA private keys in PKCS#8 export, falling back to priv-only when a
+  // seed is not available. The provider encoder reads these parameters at
+  // encoding time via ossl_prov_ctx_get_param().
+  OSSL_PROVIDER_do_all(
+      nullptr,
+      [](OSSL_PROVIDER* provider, void*) -> int {
+        OSSL_PROVIDER_add_conf_parameter(
+            provider, "ml-kem.output_formats", "seed-only,priv-only");
+        OSSL_PROVIDER_add_conf_parameter(
+            provider, "ml-dsa.output_formats", "seed-only,priv-only");
+        return 1;
+      },
+      nullptr);
+#endif
   OPENSSL_INIT_free(settings);
   settings = nullptr;
 

--- a/test/parallel/test-crypto-pqc-key-objects-ml-dsa.js
+++ b/test/parallel/test-crypto-pqc-key-objects-ml-dsa.js
@@ -69,7 +69,7 @@ for (const [asymmetricKeyType, pubLen] of [
     assertPublicKey(createPublicKey(key));
     key.export({ format: 'der', type: 'pkcs8' });
     if (hasSeed) {
-      assert.strictEqual(key.export({ format: 'pem', type: 'pkcs8' }), keys.private);
+      assert.strictEqual(key.export({ format: 'pem', type: 'pkcs8' }), keys.private_seed_only);
     } else {
       assert.strictEqual(key.export({ format: 'pem', type: 'pkcs8' }), keys.private_priv_only);
     }

--- a/test/parallel/test-crypto-pqc-key-objects-ml-kem.js
+++ b/test/parallel/test-crypto-pqc-key-objects-ml-kem.js
@@ -48,7 +48,7 @@ for (const asymmetricKeyType of ['ml-kem-512', 'ml-kem-768', 'ml-kem-1024']) {
     assertPublicKey(createPublicKey(key));
     key.export({ format: 'der', type: 'pkcs8' });
     if (hasSeed) {
-      assert.strictEqual(key.export({ format: 'pem', type: 'pkcs8' }), keys.private);
+      assert.strictEqual(key.export({ format: 'pem', type: 'pkcs8' }), keys.private_seed_only);
     } else {
       assert.strictEqual(key.export({ format: 'pem', type: 'pkcs8' }), keys.private_priv_only);
     }


### PR DESCRIPTION
Configure OpenSSL provider parameters to prefer seed-only format when exporting ML-KEM and ML-DSA private keys that contain a seed. Keys without a seed continue to use the private-only (`expandedKey`) format.

The `both` format (current default) will not be supported by BoringSSL and Web Cryptography at all and seed-only is overall the better format.

Note: this isn't possible on a per-encode basis [until 4.0](https://github.com/openssl/openssl/pull/29206)