### PR TITLE
lib: fix sequence argument handling in Blob constructor

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const {
-  ArrayFrom,
   MathMax,
   MathMin,
   ObjectDefineProperties,
@@ -15,7 +14,6 @@ const {
   StringPrototypeSplit,
   StringPrototypeToLowerCase,
   Symbol,
-  SymbolIterator,
   SymbolToStringTag,
   Uint8Array,
 } = primordials;
@@ -54,12 +52,15 @@ const {
   lazyDOMException,
 } = require('internal/util');
 const { inspect } = require('internal/util/inspect');
-const { convertToInt } = require('internal/webidl');
+const {
+  converters,
+  convertToInt,
+  createSequenceConverter,
+} = require('internal/webidl');
 
 const {
   codes: {
     ERR_BUFFER_TOO_LARGE,
-    ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_INVALID_STATE,
     ERR_INVALID_THIS,
@@ -112,7 +113,6 @@ function getSource(source, endings) {
   if (isAnyArrayBuffer(source)) {
     source = new Uint8Array(source);
   } else if (!isArrayBufferView(source)) {
-    source = `${source}`;
     if (endings === 'native')
       source = RegExpPrototypeSymbolReplace(/\n|\r\n/g, source, EOL);
     source = enc.encode(source);
@@ -125,6 +125,13 @@ function getSource(source, endings) {
   const slice = buffer.slice(byteOffset, byteOffset + byteLength);
   return [byteLength, new Uint8Array(slice)];
 }
+
+const sourcesConverter = createSequenceConverter((source, opts = kEmptyObject) => {
+  if (isBlob(source) || isAnyArrayBuffer(source) || isArrayBufferView(source)) {
+    return source;
+  }
+  return converters.DOMString(source, opts);
+});
 
 class Blob {
   /**
@@ -142,11 +149,8 @@ class Blob {
   constructor(sources = [], options) {
     markTransferMode(this, true, false);
 
-    if (sources === null ||
-        typeof sources[SymbolIterator] !== 'function' ||
-        typeof sources === 'string') {
-      throw new ERR_INVALID_ARG_TYPE('sources', 'a sequence', sources);
-    }
+    const sources_ = sourcesConverter(sources);
+
     validateDictionary(options, 'options');
     let {
       endings = 'transparent',
@@ -158,11 +162,11 @@ class Blob {
       throw new ERR_INVALID_ARG_VALUE('options.endings', endings);
 
     let length = 0;
-    const sources_ = ArrayFrom(sources, (source) => {
-      const { 0: len, 1: src } = getSource(source, endings);
+    for (let i = 0; i < sources_.length; ++i) {
+      const { 0: len, 1: src } = getSource(sources_[i], endings);
       length += len;
-      return src;
-    });
+      sources_[i] = src;
+    }
 
     if (length > kMaxLength)
       throw new ERR_BUFFER_TOO_LARGE(kMaxLength);

--- a/test/wpt/status/FileAPI/blob.cjs
+++ b/test/wpt/status/FileAPI/blob.cjs
@@ -25,14 +25,6 @@ module.exports = {
   },
   'Blob-constructor.any.js': {
     fail: {
-      expected: [
-        'blobParts not an object: boolean with Boolean.prototype[Symbol.iterator]',
-        'blobParts not an object: number with Number.prototype[Symbol.iterator]',
-        'blobParts not an object: BigInt with BigInt.prototype[Symbol.iterator]',
-        'blobParts not an object: Symbol with Symbol.prototype[Symbol.iterator]',
-        'Getters and value conversions should happen in order until an exception is thrown.',
-        'Arguments should be evaluated from left to right.',
-      ],
       flaky: [
         'Passing typed arrays as elements of the blobParts array should work.',
         'Passing a Float16Array as element of the blobParts array should work.',


### PR DESCRIPTION
This uses the existing WebIDL infrastructure to handle the iteration over the argument correctly according to the specification.

Note that we can't avoid looping over the input twice: we only know the value of the 'endings' option after converting the blob parts into an array.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
