### PR TITLE
util: allow color aliases in styleText

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -32,6 +32,7 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptors,
+  ObjectGetOwnPropertyNames,
   ObjectKeys,
   ObjectSetPrototypeOf,
   ObjectValues,
@@ -115,7 +116,7 @@ function getStyleCache() {
   if (styleCache === undefined) {
     styleCache = { __proto__: null };
     const colors = inspect.colors;
-    for (const key of ObjectKeys(colors)) {
+    for (const key of ObjectGetOwnPropertyNames(colors)) {
       const codes = colors[key];
       if (codes) {
         const openNum = codes[0];
@@ -206,7 +207,7 @@ function styleText(format, text, options) {
     if (key === 'none') continue;
     const style = cache[key];
     if (style === undefined) {
-      validateOneOf(key, 'format', ObjectKeys(inspect.colors));
+      validateOneOf(key, 'format', ObjectGetOwnPropertyNames(inspect.colors));
     }
     openCodes += style.openSeq;
     closeCodes = style.closeSeq + closeCodes;

--- a/test/parallel/test-util-styletext.js
+++ b/test/parallel/test-util-styletext.js
@@ -42,6 +42,16 @@ assert.strictEqual(
 );
 
 assert.strictEqual(
+  util.styleText('gray', 'test', { validateStream: false }),
+  '\u001b[90mtest\u001b[39m',
+);
+
+assert.strictEqual(
+  util.styleText('grey', 'test', { validateStream: false }),
+  '\u001b[90mtest\u001b[39m',
+);
+
+assert.strictEqual(
   util.styleText(['bold', 'red'], 'test', { validateStream: false }),
   '\u001b[1m\u001b[31mtest\u001b[39m\u001b[22m',
 );

--- a/test/parallel/test-util-styletext.js
+++ b/test/parallel/test-util-styletext.js
@@ -154,6 +154,29 @@ assert.throws(() => {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 
+// Color aliases should be accepted (e.g. 'grey' is an alias for 'gray')
+// See https://github.com/nodejs/node/issues/62177
+assert.strictEqual(
+  util.styleText('grey', 'test', { validateStream: false }),
+  util.styleText('gray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('bgGrey', 'test', { validateStream: false }),
+  util.styleText('bgGray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('blackBright', 'test', { validateStream: false }),
+  util.styleText('gray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('faint', 'test', { validateStream: false }),
+  util.styleText('dim', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText(['grey', 'bold'], 'test', { validateStream: false }),
+  util.styleText(['gray', 'bold'], 'test', { validateStream: false }),
+);
+
 // does not throw
 util.styleText('red', 'text', { stream: {}, validateStream: false });
 


### PR DESCRIPTION
Fixes an issue where `util.styleText()` would throw an error for valid color aliases like 'grey' in Node.js >= 25.7.0. It now uses `ObjectGetOwnPropertyNames` instead of `ObjectKeys` to fetch both keys and aliases.

Fixes: https://github.com/nodejs/node/issues/62177