### PR TITLE
doc: fix ES module code blocks rendering in modules.md

### DIFF
--- a/doc/api/modules.md
+++ b/doc/api/modules.md
@@ -217,12 +217,14 @@ return the [module namespace object][]. In this case it is similar to dynamic
 `import()` but is run synchronously and returns the name space object
 directly.
 
-With the following ES Modules:
+With the following ES module `distance.mjs`:
 
 ```mjs
 // distance.mjs
 export function distance(a, b) { return Math.sqrt((b.x - a.x) ** 2 + (b.y - a.y) ** 2); }
 ```
+
+`point.mjs`:
 
 ```mjs
 // point.mjs


### PR DESCRIPTION
The two consecutive `mjs` code blocks in the ["Loading ECMAScript modules using require()"](https://nodejs.org/docs/latest/api/modules.html#loading-ecmascript-modules-using-require) section were being incorrectly grouped into a CJS/ESM toggle tab by doc-kit's highlighter. Add text between the two code blocks so they render as independent code blocks.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
