### PR TITLE
build: skip dockit on IBMi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -840,6 +840,10 @@ ifeq ($(OSTYPE),aix)
 # TODO(@nodejs/web-infra): AIX is currently hanging during HTML minification
 $(apidocs_html) $(apidocs_json) out/doc/api/all.html out/doc/api/all.json:
 	@echo "Skipping $@ (not currently supported by $(OSTYPE) machines)"
+else ifeq ($(OSTYPE),os400)
+# TODO(@nodejs/web-infra): IBMi is currently hanging during HTML minification
+$(apidocs_html) $(apidocs_json) out/doc/api/all.html out/doc/api/all.json:
+	@echo "Skipping $@ (not currently supported by $(OSTYPE) machines)"
 else
 $(apidocs_html) $(apidocs_json) out/doc/api/all.html out/doc/api/all.json &: $(apidoc_sources) tools/doc/node_modules | out/doc/api
 	@if [ "$(shell $(node_use_openssl_and_icu))" != "true" ]; then \


### PR DESCRIPTION
Similar to AIX, IBMi build was timing out after this [commit](https://github.com/nodejs/node/commit/76215dc9938dd151ff629d20546431be8d53f435#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52)

Link for the build - https://ci.nodejs.org/job/node-test-commit-ibmi/nodes=ibmi74-ppc64/2252/console
```
17:16:05 Building addon in /home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/benchmark/napi/type-tag
17:16:08 npm warn cli npm v11.11.0 does not support Node.js v26.0.0-pre. This version of npm supports the following node versions: `^20.17.0 || >=22.9.0`. You can find the latest version at https://nodejs.org/.
17:16:28 
17:16:28 added 315 packages, and audited 317 packages in 19s
17:16:28 
17:16:28 134 packages are looking for funding
17:16:28   run `npm fund` for details
17:16:28 
17:16:28 found 0 vulnerabilities
18:16:28 Build timed out (after 60 minutes). Marking the build as failed.
18:16:28 Build was aborted
```

@richard-lau applied the [commit](https://github.com/nodejs/node/commit/b7cffe025416845cf006a19b1e07b1d24fec7dd2) and after that we got the following error on IBMi 

Link for the build - https://ci.nodejs.org/job/node-test-commit-ibmi/nodes=ibmi74-ppc64/2254/console
```
mkdir -p out/doc
19:39:57 cp doc/node-config-schema.json out/doc
19:39:57 mkdir -p out/doc/api
19:39:58 cp -r doc/api out/doc
19:41:03 (node:22467975) ExperimentalWarning: Importing WebAssembly module instances is an experimental feature and might change at any time
19:41:03 (Use `node --trace-warnings ...` to show where the warning was created)
19:41:09 [14:54:39.946] ERROR: memory access out of bounds
19:41:09 RuntimeError: memory access out of bounds
19:41:09     at wasm://wasm/001c7aca:wasm-function[165]:0x204ef
19:41:09     at wasm://wasm/001c7aca:wasm-function[196]:0x236f6
19:41:09     at new OnigScanner (file:///home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/tools/doc/node_modules/@shikijs/engine-oniguruma/dist/index.mjs:306:36)
19:41:09     at Object.createScanner (file:///home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/tools/doc/node_modules/@shikijs/engine-oniguruma/dist/index.mjs:440:14)
19:41:09     at Object.createOnigScanner (file:///home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/tools/doc/node_modules/@shikijs/core/dist/index.mjs:1871:47)
19:41:09     at Grammar.createOnigScanner (file:///home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/tools/doc/node_modules/@shikijs/vscode-textmate/dist/index.js:2342:26)
19:41:09     at new CompiledRule (file:///home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/tools/doc/node_modules/@shikijs/vscode-textmate/dist/index.js:1667:28)
19:41:09     at RegExpSourceList._resolveAnchors (file:///home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/tools/doc/node_modules/@shikijs/vscode-textmate/dist/index.js:1660:12)
19:41:09     at RegExpSourceList.compileAG (file:///home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/tools/doc/node_modules/@shikijs/vscode-textmate/dist/index.js:1639:44)
19:41:11     at IncludeOnlyRule.compileAG (file:///home/IOJS/build/workspace/node-test-commit-ibmi/nodes/ibmi74-ppc64/tools/doc/node_modules/@shikijs/vscode-textmate/dist/index.js:1110:53)gmake[1]: *** [Makefile:845: out/doc/api/addons.html] Error 1
19:41:11 gmake: *** [Makefile:647: run-ci] Error 2
```
I need to reproduce and investigate what is causing the memory access out of bound issue
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
