### PR TITLE
util: fix styleText to accept format aliases

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -32,6 +32,7 @@ const {
   ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptors,
+  ObjectGetOwnPropertyNames,
   ObjectKeys,
   ObjectSetPrototypeOf,
   ObjectValues,
@@ -115,7 +116,7 @@ function getStyleCache() {
   if (styleCache === undefined) {
     styleCache = { __proto__: null };
     const colors = inspect.colors;
-    for (const key of ObjectKeys(colors)) {
+    for (const key of ObjectGetOwnPropertyNames(colors)) {
       const codes = colors[key];
       if (codes) {
         const openNum = codes[0];
@@ -206,7 +207,7 @@ function styleText(format, text, options) {
     if (key === 'none') continue;
     const style = cache[key];
     if (style === undefined) {
-      validateOneOf(key, 'format', ObjectKeys(inspect.colors));
+      validateOneOf(key, 'format', ObjectGetOwnPropertyNames(inspect.colors));
     }
     openCodes += style.openSeq;
     closeCodes = style.closeSeq + closeCodes;

--- a/test/parallel/test-util-styletext.js
+++ b/test/parallel/test-util-styletext.js
@@ -138,6 +138,29 @@ assert.throws(() => {
   code: 'ERR_INVALID_ARG_VALUE',
 });
 
+// Color aliases should be accepted (e.g. 'grey' is an alias for 'gray')
+// See https://github.com/nodejs/node/issues/62177
+assert.strictEqual(
+  util.styleText('grey', 'test', { validateStream: false }),
+  util.styleText('gray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('bgGrey', 'test', { validateStream: false }),
+  util.styleText('bgGray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('blackBright', 'test', { validateStream: false }),
+  util.styleText('gray', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText('faint', 'test', { validateStream: false }),
+  util.styleText('dim', 'test', { validateStream: false }),
+);
+assert.strictEqual(
+  util.styleText(['grey', 'bold'], 'test', { validateStream: false }),
+  util.styleText(['gray', 'bold'], 'test', { validateStream: false }),
+);
+
 assert.throws(() => {
   util.styleText('red', 'text', { stream: {} });
 }, {


### PR DESCRIPTION
The optimization in #61792 introduced a style cache using ObjectKeys(inspect.colors), which only returns enumerable properties. Color aliases (e.g. 'grey', 'blackBright', 'faint') are defined as non-enumerable via defineColorAlias(), so they were excluded from the cache, causing ERR_INVALID_ARG_VALUE when used with styleText().

Replace ObjectKeys with ObjectGetOwnPropertyNames to include non-enumerable alias properties in both the style cache and the validation error message.

Fixes: https://github.com/nodejs/node/issues/62177

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
