### PR TITLE
doc: fix perf_hooks documentation gaps and inaccuracies

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -22,18 +22,16 @@ import { performance, PerformanceObserver } from 'node:perf_hooks';
 
 const obs = new PerformanceObserver((items) => {
   console.log(items.getEntries()[0].duration);
-  performance.clearMarks();
 });
 obs.observe({ type: 'measure' });
 performance.measure('Start to Now');
 
 performance.mark('A');
-doSomeLongRunningProcess(() => {
-  performance.measure('A to Now', 'A');
+await new Promise((r) => setTimeout(r, 5000));
+performance.measure('A to Now', 'A');
 
-  performance.mark('B');
-  performance.measure('A to B', 'A', 'B');
-});
+performance.mark('B');
+performance.measure('A to B', 'A', 'B');
 ```
 
 ```cjs
@@ -511,9 +509,7 @@ Performance Entry.
 ## Class: `PerformanceMark`
 
 <!-- YAML
-added:
-  - v18.2.0
-  - v16.17.0
+added: v16.0.0
 -->
 
 * Extends: {PerformanceEntry}
@@ -538,9 +534,7 @@ Additional detail specified when creating with `Performance.mark()` method.
 ## Class: `PerformanceMeasure`
 
 <!-- YAML
-added:
-  - v18.2.0
-  - v16.17.0
+added: v16.7.0
 -->
 
 * Extends: {PerformanceEntry}
@@ -906,6 +900,24 @@ resources.
 
 The constructor of this class is not exposed to users directly.
 
+### `performanceResourceTiming.initiatorType`
+
+<!-- YAML
+added:
+  - v18.6.0
+  - v16.17.0
+changes:
+  - version: v19.0.0
+    pr-url: https://github.com/nodejs/node/pull/44483
+    description: This property getter must be called with the
+                 `PerformanceResourceTiming` object as the receiver.
+-->
+
+* Type: {string}
+
+The string that represents the type of resource that initiated the
+performance entry, such as `'fetch'`.
+
 ### `performanceResourceTiming.workerStart`
 
 <!-- YAML
@@ -1071,6 +1083,27 @@ changes:
 The high resolution millisecond timestamp representing the time immediately
 before Node.js starts the handshake process to secure the current connection.
 
+### `performanceResourceTiming.nextHopProtocol`
+
+<!-- YAML
+added:
+  - v18.2.0
+  - v16.17.0
+changes:
+  - version: v19.0.0
+    pr-url: https://github.com/nodejs/node/pull/44483
+    description: This property getter must be called with the
+                 `PerformanceResourceTiming` object as the receiver.
+-->
+
+* Type: {string}
+
+A string representing the network protocol used to fetch the resource, as
+identified by the [ALPN Protocol ID][]. When a proxy is used, if a tunnel
+connection is established, this returns the ALPN Protocol ID of the tunneled
+protocol. Otherwise, this returns the ALPN Protocol ID of the first hop to
+the proxy.
+
 ### `performanceResourceTiming.requestStart`
 
 <!-- YAML
@@ -1087,7 +1120,25 @@ changes:
 * Type: {number}
 
 The high resolution millisecond timestamp representing the time immediately
-before Node.js receives the first byte of the response from the server.
+before Node.js starts requesting the resource from the server.
+
+### `performanceResourceTiming.responseStart`
+
+<!-- YAML
+added:
+  - v18.2.0
+  - v16.17.0
+changes:
+  - version: v19.0.0
+    pr-url: https://github.com/nodejs/node/pull/44483
+    description: This property getter must be called with the
+                 `PerformanceResourceTiming` object as the receiver.
+-->
+
+* Type: {number}
+
+The high resolution millisecond timestamp representing the time immediately
+after Node.js receives the first byte of the response from the server.
 
 ### `performanceResourceTiming.responseEnd`
 
@@ -1163,6 +1214,28 @@ changes:
 A number representing the size (in octets) received from the fetch
 (HTTP or cache), of the message body, after removing any applied
 content-codings.
+
+### `performanceResourceTiming.deliveryType`
+
+<!-- YAML
+added: v22.2.0
+-->
+
+* Type: {string}
+
+A string representing how the resource was delivered. For example,
+resources delivered from the cache will return `'cache'`.
+
+### `performanceResourceTiming.responseStatus`
+
+<!-- YAML
+added: v22.2.0
+-->
+
+* Type: {number}
+
+A number representing the HTTP response status code returned when
+fetching the resource.
 
 ### `performanceResourceTiming.toJSON()`
 
@@ -1864,8 +1937,8 @@ added: v11.10.0
 
 * Type: {number}
 
-The number of times the event loop delay exceeded the maximum 1 hour event
-loop delay threshold.
+The number of times the recorded value exceeded the `highest` recordable
+value of the histogram.
 
 ### `histogram.exceedsBigInt`
 
@@ -1877,8 +1950,8 @@ added:
 
 * Type: {bigint}
 
-The number of times the event loop delay exceeded the maximum 1 hour event
-loop delay threshold.
+The number of times the recorded value exceeded the `highest` recordable
+value of the histogram.
 
 ### `histogram.max`
 
@@ -1888,7 +1961,7 @@ added: v11.10.0
 
 * Type: {number}
 
-The maximum recorded event loop delay.
+The maximum recorded value.
 
 ### `histogram.maxBigInt`
 
@@ -1900,7 +1973,7 @@ added:
 
 * Type: {bigint}
 
-The maximum recorded event loop delay.
+The maximum recorded value.
 
 ### `histogram.mean`
 
@@ -1910,7 +1983,7 @@ added: v11.10.0
 
 * Type: {number}
 
-The mean of the recorded event loop delays.
+The mean of the recorded values.
 
 ### `histogram.min`
 
@@ -1920,7 +1993,7 @@ added: v11.10.0
 
 * Type: {number}
 
-The minimum recorded event loop delay.
+The minimum recorded value.
 
 ### `histogram.minBigInt`
 
@@ -1932,7 +2005,7 @@ added:
 
 * Type: {bigint}
 
-The minimum recorded event loop delay.
+The minimum recorded value.
 
 ### `histogram.percentile(percentile)`
 
@@ -1996,7 +2069,7 @@ added: v11.10.0
 
 * Type: {number}
 
-The standard deviation of the recorded event loop delays.
+The standard deviation of the recorded values.
 
 ## Class: `IntervalHistogram extends Histogram`
 
@@ -2348,6 +2421,7 @@ dns.lookup('localhost', () => {});
 dns.promises.resolve('localhost');
 ```
 
+[ALPN Protocol ID]: https://www.iana.org/assignments/tls-extensiontype-values/tls-extensiontype-values.xhtml#alpn-protocol-ids
 [Async Hooks]: async_hooks.md
 [Fetch Response Body Info]: https://fetch.spec.whatwg.org/#response-body-info
 [Fetch Timing Info]: https://fetch.spec.whatwg.org/#fetch-timing-info


### PR DESCRIPTION
## Summary

Audit of `doc/api/perf_hooks.md` fixing several long-standing documentation
issues:

- **Fix introductory ESM example** — the example referenced an undefined
  `doSomeLongRunningProcess` callback and prematurely called
  `performance.clearMarks()` in the observer, which would cause subsequent
  `performance.measure()` calls to throw

- **Add 5 missing `PerformanceResourceTiming` properties** —
  `initiatorType` (added v18.6.0/v16.17.0, PR #43593),
  `nextHopProtocol` and `responseStart` (added v18.2.0/v16.17.0, PR #42725),
  `deliveryType` and `responseStatus` (added v22.2.0, PR #51589) are
  implemented in `lib/internal/perf/resource_timing.js` but were absent from
  the docs

- **Correct `PerformanceMark` version metadata** — introduced in v16.0.0
  (PR #37136), not v18.2.0/v16.17.0 (which is when PR #44483 reorganized the
  doc sections)

- **Correct `PerformanceMeasure` version metadata** — exported from the module
  in v16.7.0 (PR #39297), not v18.2.0/v16.17.0

- **Fix `histogram.exceeds` description** — the docs claimed a "1 hour event
  loop delay threshold" but the C++ source (`src/histogram-inl.h`) shows
  `exceeds_` increments when `hdr_record_value` returns false, i.e. the value
  exceeds the histogram's configured `highest` trackable value

- **Fix `requestStart` description** — was incorrectly described as "before
  Node.js receives the first byte of the response" (that's `responseStart`);
  corrected to "before Node.js starts requesting the resource"

- **Generalize `Histogram` property descriptions** — `min`, `max`, `mean`,
  `stddev` described "event loop delay" but `Histogram` is a generic class
  also used by `createHistogram()` and `timerify()`

All version metadata verified against full git history (`git tag --contains`).

Fixes: https://github.com/nodejs/node/issues/40558
Fixes: https://github.com/nodejs/node/issues/40096
Fixes: https://github.com/nodejs/node/issues/40723
Fixes: https://github.com/nodejs/node/issues/55792
Fixes: https://github.com/nodejs/node/issues/55793