### PR TITLE
worker: heap profile optimizations

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -1121,7 +1121,8 @@ static bool serializeProfile(Isolate* isolate, std::ostringstream& out_stream) {
   if (!profile) {
     return false;
   }
-  JSONWriter writer(out_stream, false);
+  profiler->StopSamplingHeapProfiler();
+  JSONWriter writer(out_stream, true);
   writer.json_start();
 
   writer.json_arraystart("samples");
@@ -1139,7 +1140,6 @@ static bool serializeProfile(Isolate* isolate, std::ostringstream& out_stream) {
   writer.json_objectend();
 
   writer.json_end();
-  profiler->StopSamplingHeapProfiler();
   return true;
 }
 


### PR DESCRIPTION
This PR makes two small optimizations to worker heap profile serialization:

 - Stop the sampling heap profiler immediately after `GetAllocationProfile()` instead of after JSON serialization completes.
 - Serialize heap profiles without extra indentation and newlines.