### PR TITLE
doc: fix URL postMessage example in worker_threads

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1416,17 +1416,14 @@ port2.postMessage(new Foo());
 // Prints: { c: 3 }
 ```
 
-This limitation extends to many built-in objects, such as the global `URL`
-object:
+Some built-in objects cannot be cloned at all. For example, posting a
+`URL` object throws a `DataCloneError`:
 
 ```js
 const { port1, port2 } = new MessageChannel();
 
-port1.onmessage = ({ data }) => console.log(data);
-
 port2.postMessage(new URL('https://example.org'));
-
-// Prints: { }
+// Throws DataCloneError: Cannot clone object of unsupported type.
 ```
 
 ### `port.hasRef()`


### PR DESCRIPTION
Fix the `postMessage(new URL(...))` example in `doc/api/worker_threads.md` which claims to print `{}` but actually throws `DataCloneError` since v21.0.0 (d920b7c94b8).

Verified against `src/node_messaging.cc` — `URL` objects are not serializable and throw `DataCloneError: Cannot clone object of unsupported type`.

Fixes: https://github.com/nodejs/node/issues/60504