### PR TITLE
doc: add throwIfNoEntry version history to fs.stat

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -1709,6 +1709,10 @@ Removes files and directories (modeled on the standard POSIX `rm` utility).
 <!-- YAML
 added: v10.0.0
 changes:
+  - version: v25.7.0
+    pr-url: https://github.com/nodejs/node/pull/61178
+    description: Accepts a `throwIfNoEntry` option to specify whether
+                 an exception should be thrown if the entry does not exist.
   - version: v10.5.0
     pr-url: https://github.com/nodejs/node/pull/20220
     description: Accepts an additional `options` object to specify whether
@@ -4412,6 +4416,10 @@ completion callback.
 <!-- YAML
 added: v0.0.2
 changes:
+  - version: v25.7.0
+    pr-url: https://github.com/nodejs/node/pull/61178
+    description: Accepts a `throwIfNoEntry` option to specify whether
+                 an exception should be thrown if the entry does not exist.
   - version: v18.0.0
     pr-url: https://github.com/nodejs/node/pull/41678
     description: Passing an invalid callback to the `callback` argument


### PR DESCRIPTION
Add missing YAML version history entries for the `throwIfNoEntry` option on `fs.stat` and `fsPromises.stat`, added in v25.7.0 via #61178.

The synchronous variants (`fs.statSync`, `fsPromises.statSync`) already had entries from #33716. This brings the async/callback and promise-based APIs in line.

Verified: `git tag --contains 4cecbe1f53f` → v25.7.0.

Fixes: https://github.com/nodejs/node/issues/62185