### PR TITLE
doc: clarify diffieHellman.generateKeys recomputes same key

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1121,8 +1121,10 @@ If `encoding` is provided a string is returned; otherwise a
 [`Buffer`][] is returned.
 
 This function is a thin wrapper around [`DH_generate_key()`][]. In particular,
-once a private key has been generated or set, calling this function only updates
-the public key but does not generate a new private key.
+once a private key has been generated or set, calling this function only
+recomputes the public key from the existing private key. Since the public key is
+determined by the private key, the result will be the same unless the private key
+has been changed via [`diffieHellman.setPrivateKey()`][].
 
 ### `diffieHellman.getGenerator([encoding])`
 
@@ -6572,6 +6574,7 @@ See the [list of SSL OP Flags][] for details.
 [`decipher.final()`]: #decipherfinaloutputencoding
 [`decipher.update()`]: #decipherupdatedata-inputencoding-outputencoding
 [`diffieHellman.generateKeys()`]: #diffiehellmangeneratekeysencoding
+[`diffieHellman.setPrivateKey()`]: #diffiehellmansetprivatekeyprivatekey-encoding
 [`diffieHellman.setPublicKey()`]: #diffiehellmansetpublickeypublickey-encoding
 [`ecdh.generateKeys()`]: #ecdhgeneratekeysencoding-format
 [`ecdh.setPrivateKey()`]: #ecdhsetprivatekeyprivatekey-encoding


### PR DESCRIPTION
Clarify that calling `generateKeys()` after a private key has been
set recomputes the same public key deterministically. The current
wording ("only updates the public key") implies the public key
changes, but since it is fully determined by the private key, the
result is identical unless the private key was changed via
`setPrivateKey()`.

Verified against `lib/internal/crypto/diffiehellman.js` —
`dhGenerateKeys()` calls `this[kHandle].generateKeys()` which wraps
OpenSSL's `DH_generate_key()`, which deterministically computes
the public key from the private key.

Fixes: https://github.com/nodejs/node/issues/56990