### PR TITLE
doc: move signal 0 out of Signal Events list

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -712,9 +712,6 @@ process.on('SIGTERM', handle);
   artificially using kill(2), inherently leave the process in a state from
   which it is not safe to call JS listeners. Doing so might cause the process
   to stop responding.
-* `0` can be sent to test for the existence of a process, it has no effect if
-  the process exists, but will throw an error if the process does not exist.
-
 Windows does not support signals so has no equivalent to termination by signal,
 but Node.js offers some emulation with [`process.kill()`][], and
 [`subprocess.kill()`][]:
@@ -722,8 +719,9 @@ but Node.js offers some emulation with [`process.kill()`][], and
 * Sending `SIGINT`, `SIGTERM`, and `SIGKILL` will cause the unconditional
   termination of the target process, and afterwards, subprocess will report that
   the process was terminated by signal.
-* Sending signal `0` can be used as a platform independent way to test for the
-  existence of a process.
+
+Signal `0` can be sent via [`process.kill()`][] to test for the existence of a
+process without actually sending a signal.
 
 ## `process.abort()`
 


### PR DESCRIPTION
Signal `0` is not a signal that can be listened for via
`process.on()` — it is only meaningful when sent via
`process.kill()` to test for process existence. Remove it from the
signal events bullet list (which documents receivable signals) and
the Windows emulation list, replacing both with a brief
cross-reference to `process.kill()` where signal `0` is already
documented.

Verified: `process.on(0, ...)` / `process.on('0', ...)` does not
register a signal handler. The `process.kill()` docs at the same
page already document signal `0` behavior.

Fixes: https://github.com/nodejs/node/issues/42287