### PR TITLE
doc: clarify fs.ReadStream and fs.WriteStream are not constructable

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7147,8 +7147,8 @@ added: v0.1.93
 
 * Extends: {stream.Readable}
 
-`fs.ReadStream` is not to be constructed directly; use
-[`fs.createReadStream()`][] instead.
+Instances of {fs.ReadStream} cannot be constructed directly. They are created and
+returned using the [`fs.createReadStream()`][] function.
 
 #### Event: `'close'`
 
@@ -7918,8 +7918,8 @@ added: v0.1.93
 
 * Extends {stream.Writable}
 
-`fs.WriteStream` is not to be constructed directly; use
-[`fs.createWriteStream()`][] instead.
+Instances of {fs.WriteStream} cannot be constructed directly. They are created and
+returned using the [`fs.createWriteStream()`][] function.
 
 #### Event: `'close'`
 


### PR DESCRIPTION
Add explicit wording that `fs.ReadStream` and `fs.WriteStream`
should not be constructed directly, matching the existing pattern
used by `fs.Stats` ("not to be created directly using the `new`
keyword"). The factory functions `fs.createReadStream()` and
`fs.createWriteStream()` are the supported API.

Verified against `lib/internal/fs/streams.js` — the constructors
exist as plain functions with `new` guards, but are not documented
as public constructors.

Fixes: https://github.com/nodejs/node/issues/40546