### PR TITLE
src: map UINT64_MAX to 0 in process.constrainedMemory()

### DIFF
--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -22,6 +22,7 @@
 #endif
 
 #include <climits>  // PATH_MAX
+#include <cstdint>  // UINT64_MAX
 #include <cstdio>
 
 #if defined(_MSC_VER)
@@ -250,6 +251,9 @@ static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
 
 static void GetConstrainedMemory(const FunctionCallbackInfo<Value>& args) {
   uint64_t value = uv_get_constrained_memory();
+  // UINT64_MAX means a constraining mechanism exists but no limit is set.
+  // Map to 0 per documented behavior: "If there is no constraint, 0 is returned."
+  if (value == UINT64_MAX) value = 0;
   args.GetReturnValue().Set(static_cast<double>(value));
 }
 

--- a/src/node_process_methods.cc
+++ b/src/node_process_methods.cc
@@ -251,8 +251,11 @@ static void MemoryUsage(const FunctionCallbackInfo<Value>& args) {
 
 static void GetConstrainedMemory(const FunctionCallbackInfo<Value>& args) {
   uint64_t value = uv_get_constrained_memory();
-  // UINT64_MAX means a constraining mechanism exists but no limit is set.
-  // Map to 0 per documented behavior: "If there is no constraint, 0 is returned."
+  // When cgroups are enabled but no memory limit is set (e.g. a default
+  // Docker container without --memory), libuv returns UINT64_MAX instead of 0.
+  // UINT64_MAX is not a meaningful memory constraint, so map it to 0 to
+  // indicate "no constraint", consistent with the documented behavior of
+  // process.constrainedMemory(): "If there is no constraint, 0 is returned."
   if (value == UINT64_MAX) value = 0;
   args.GetReturnValue().Set(static_cast<double>(value));
 }


### PR DESCRIPTION
## Summary

When `uv_get_constrained_memory()` returns `UINT64_MAX`, it indicates there is a constraining mechanism (e.g., cgroups on Linux) but no constraint is actually set. According to the [Node.js documentation](https://nodejs.org/api/process.html#processconstrainedmemory), this case should return `0`:

> If there is no constraint, or the constraint is unknown, `0` is returned.

Currently, the raw `UINT64_MAX` value (`18446744073709552000` as a double) is exposed to JavaScript, which contradicts the documented behavior.

### Changes

- In `GetConstrainedMemory()`, check if `uv_get_constrained_memory()` returns `UINT64_MAX` and map it to `0`
- Added `<cstdint>` include to ensure `UINT64_MAX` is defined

### References

- libuv docs: https://docs.libuv.org/en/v1.x/misc.html#c.uv_get_constrained_memory
- Node.js docs: https://nodejs.org/api/process.html#processconstrainedmemory

Fixes: https://github.com/nodejs/node/issues/59227