### PR TITLE
test_runner: print failed coverage reports with dot runner

### DIFF
--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -10,6 +10,7 @@ module.exports = async function* dot(source) {
   let count = 0;
   let columns = getLineLength();
   const failedTests = [];
+  const coverageErrors = [];
   for await (const { type, data } of source) {
     if (type === 'test:pass') {
       yield `${colors.green}.${colors.reset}`;
@@ -17,6 +18,10 @@ module.exports = async function* dot(source) {
     if (type === 'test:fail') {
       yield `${colors.red}X${colors.reset}`;
       ArrayPrototypePush(failedTests, data);
+    }
+    if (type === 'test:diagnostic' && data.level === 'error') {
+      // Collect coverage errors (coverage threshold failures)
+      ArrayPrototypePush(coverageErrors, data.message);
     }
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
       yield '\n';
@@ -31,6 +36,12 @@ module.exports = async function* dot(source) {
     yield `\n${colors.red}Failed tests:${colors.white}\n\n`;
     for (const test of failedTests) {
       yield formatTestReport('test:fail', test);
+    }
+  }
+  if (coverageErrors.length > 0) {
+    yield `\n${colors.red}Coverage errors:${colors.white}\n\n`;
+    for (const error of coverageErrors) {
+      yield `${colors.red}${error}${colors.white}\n`;
     }
   }
 };


### PR DESCRIPTION
Fixes #60884

When running tests with both the dot reporter and coverage reports, if a coverage report fails (e.g., line coverage threshold not met), there was no visible output indicating the failure. The process would exit with a failure code, but only dots would be printed with no explanation.

This PR adds collection and display of coverage threshold failure diagnostics in the dot reporter. When coverage threshold checks fail, error diagnostic messages are now displayed at the end of the test output, similar to how failed tests are displayed.

The coverage error messages are collected from test:diagnostic events with level='error' that are emitted by the test runner when coverage thresholds are not met.

Refs: #52655