### PR TITLE
src: support V8 sandbox memory cage in allocators

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -303,14 +303,17 @@ void SetIsolateUpForNode(v8::Isolate* isolate) {
   SetIsolateUpForNode(isolate, settings);
 }
 
-//
 IsolateGroup GetOrCreateIsolateGroup() {
-  // When pointer compression is disabled, we cannot create new groups,
-  // in which case we'll always return the default.
+#ifndef V8_ENABLE_SANDBOX
+  // When the V8 sandbox is enabled, all isolates must share the same sandbox
+  // so that ArrayBuffer backing stores allocated via NewDefaultAllocator()
+  // (which uses the default IsolateGroup's sandbox) are valid for all
+  // isolates. Creating new groups would give each group its own sandbox,
+  // causing a mismatch with the allocator.
   if (IsolateGroup::CanCreateNewGroups()) {
     return IsolateGroup::Create();
   }
-
+#endif
   return IsolateGroup::GetDefault();
 }
 

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -305,11 +305,15 @@ void SetIsolateUpForNode(v8::Isolate* isolate) {
 
 IsolateGroup GetOrCreateIsolateGroup() {
 #ifndef V8_ENABLE_SANDBOX
-  // When the V8 sandbox is enabled, all isolates must share the same sandbox
-  // so that ArrayBuffer backing stores allocated via NewDefaultAllocator()
-  // (which uses the default IsolateGroup's sandbox) are valid for all
-  // isolates. Creating new groups would give each group its own sandbox,
-  // causing a mismatch with the allocator.
+  // IsolateGroup::CanCreateNewGroups() only reflects whether multiple pointer
+  // compression cages are supported at build time; it has no awareness of the
+  // V8 sandbox (they are orthogonal concepts). However, when the sandbox is
+  // enabled the cage-allocation helpers (node_v8_sandbox.h) route through the
+  // default allocator, which allocates inside the *default* group's sandbox.
+  // Creating a new group would give it its own sandbox, so ArrayBuffers
+  // allocated by the default allocator would be invalid for isolates in that
+  // group. We therefore always fall through to GetDefault() when the sandbox
+  // is enabled.
   if (IsolateGroup::CanCreateNewGroups()) {
     return IsolateGroup::Create();
   }

--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -7,6 +7,7 @@
 #include "memory_tracker-inl.h"
 #include "ncrypto.h"
 #include "node_errors.h"
+#include "node_v8_sandbox.h"
 #ifndef OPENSSL_IS_BORINGSSL
 #include "openssl/bnerr.h"
 #endif
@@ -22,8 +23,6 @@ using ncrypto::DHPointer;
 using ncrypto::EVPKeyCtxPointer;
 using ncrypto::EVPKeyPointer;
 using v8::ArrayBuffer;
-using v8::BackingStoreInitializationMode;
-using v8::BackingStoreOnFailureMode;
 using v8::ConstructorBehavior;
 using v8::Context;
 using v8::DontDelete;
@@ -61,17 +60,10 @@ MaybeLocal<Value> DataPointerToBuffer(Environment* env, DataPointer&& data) {
     bool secure;
   };
 #ifdef V8_ENABLE_SANDBOX
-  auto backing = ArrayBuffer::NewBackingStore(
-      env->isolate(),
-      data.size(),
-      BackingStoreInitializationMode::kUninitialized,
-      BackingStoreOnFailureMode::kReturnNull);
+  auto backing = CopyCageBackingStore(data.get(), data.size());
   if (!backing) {
     THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
     return MaybeLocal<Value>();
-  }
-  if (data.size() > 0) {
-    memcpy(backing->Data(), data.get(), data.size());
   }
 #else
   auto backing = ArrayBuffer::NewBackingStore(

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -7,6 +7,7 @@
 #include "ncrypto.h"
 #include "node_buffer.h"
 #include "node_options-inl.h"
+#include "node_v8_sandbox.h"
 #include "string_bytes.h"
 #include "threadpoolwork-inl.h"
 #include "util-inl.h"
@@ -34,8 +35,6 @@ using ncrypto::EnginePointer;
 using ncrypto::SSLPointer;
 using v8::ArrayBuffer;
 using v8::BackingStore;
-using v8::BackingStoreInitializationMode;
-using v8::BackingStoreOnFailureMode;
 using v8::BigInt;
 using v8::Context;
 using v8::EscapableHandleScope;
@@ -364,22 +363,12 @@ std::unique_ptr<BackingStore> ByteSource::ReleaseToBackingStore(
   // only if size_ is zero.
   CHECK_IMPLIES(size_ > 0, allocated_data_ != nullptr);
 #ifdef V8_ENABLE_SANDBOX
-  // If the v8 sandbox is enabled, then all array buffers must be allocated
-  // via the isolate. External buffers are not allowed. So, instead of wrapping
-  // the allocated data we'll copy it instead.
-
-  // TODO(@jasnell): It would be nice to use an abstracted utility to do this
-  // branch instead of duplicating the V8_ENABLE_SANDBOX check each time.
-  std::unique_ptr<BackingStore> ptr = ArrayBuffer::NewBackingStore(
-      env->isolate(),
-      size(),
-      BackingStoreInitializationMode::kUninitialized,
-      BackingStoreOnFailureMode::kReturnNull);
+  std::unique_ptr<BackingStore> ptr =
+      CopyCageBackingStore(allocated_data_, size());
   if (!ptr) {
     THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
     return nullptr;
   }
-  memcpy(ptr->Data(), allocated_data_, size());
   OPENSSL_clear_free(allocated_data_, size_);
 #else
   std::unique_ptr<BackingStore> ptr = ArrayBuffer::NewBackingStore(
@@ -690,20 +679,18 @@ namespace {
 // using OPENSSL_malloc. However, if the secure heap is
 // initialized, SecureBuffer will automatically use it.
 void SecureBuffer(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-#ifdef V8_ENABLE_SANDBOX
-  // The v8 sandbox is enabled, so we cannot use the secure heap because
-  // the sandbox requires that all array buffers be allocated via the isolate.
-  // That is fundamentally incompatible with the secure heap which allocates
-  // in openssl's secure heap area. Instead we'll just throw an error here.
-  //
-  // That said, we really shouldn't get here in the first place since the
-  // option to enable the secure heap is only available when the sandbox
-  // is disabled.
-  UNREACHABLE();
-#else
   CHECK(args[0]->IsUint32());
   uint32_t len = args[0].As<Uint32>()->Value();
+#ifdef V8_ENABLE_SANDBOX
+  // The V8 sandbox requires all array buffers to be allocated inside the cage,
+  // which is incompatible with OpenSSL's secure heap. Fall back to a regular
+  // V8-managed allocation. The --secure-heap option is disabled at the CLI
+  // level when the sandbox is enabled, but this function can still be reached
+  // via internal callers like randomUUID.
+  Local<ArrayBuffer> buffer = ArrayBuffer::New(args.GetIsolate(), len);
+  args.GetReturnValue().Set(Uint8Array::New(buffer, 0, len));
+#else
+  Environment* env = Environment::GetCurrent(args);
 
   auto data = DataPointer::SecureAlloc(len);
   CHECK(data.isSecure());

--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -7,6 +7,7 @@
 #include "memory_tracker-inl.h"
 #include "ncrypto.h"
 #include "node_errors.h"
+#include "node_v8_sandbox.h"
 #include "util-inl.h"
 #include "v8.h"
 
@@ -29,7 +30,6 @@ using v8::Array;
 using v8::ArrayBuffer;
 using v8::ArrayBufferView;
 using v8::BackingStoreInitializationMode;
-using v8::BackingStoreOnFailureMode;
 using v8::Boolean;
 using v8::Context;
 using v8::Date;
@@ -141,19 +141,11 @@ MaybeLocal<Value> ToBuffer(Environment* env, BIOPointer* bio) {
   if (!mem) [[unlikely]]
     return {};
 #ifdef V8_ENABLE_SANDBOX
-  // If the v8 sandbox is enabled, then all array buffers must be allocated
-  // via the isolate. External buffers are not allowed. So, instead of wrapping
-  // the BIOPointer we'll copy it instead.
-  auto backing = ArrayBuffer::NewBackingStore(
-      env->isolate(),
-      mem->length,
-      BackingStoreInitializationMode::kUninitialized,
-      BackingStoreOnFailureMode::kReturnNull);
+  auto backing = CopyCageBackingStore(mem->data, mem->length);
   if (!backing) {
     THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
     return MaybeLocal<Value>();
   }
-  memcpy(backing->Data(), mem->data, mem->length);
 #else
   auto backing = ArrayBuffer::NewBackingStore(
       mem->data,

--- a/src/env.cc
+++ b/src/env.cc
@@ -642,7 +642,23 @@ void IsolateData::MemoryInfo(MemoryTracker* tracker) const {
   // TODO(joyeecheung): implement MemoryRetainer in the option classes.
 }
 
+void Environment::AddTraceCategoryMapping(const uint8_t* source,
+                                          uint8_t* dest) {
+  trace_category_mappings_.push_back({source, dest});
+}
+
+void Environment::SyncTraceCategoryBuffers() {
+  for (const auto& mapping : trace_category_mappings_) {
+    *mapping.dest = *mapping.source;
+  }
+}
+
 void TrackingTraceStateObserver::UpdateTraceCategoryState() {
+  // Sync sandbox-copied trace category buffers before anything else.
+  // This must happen regardless of thread/JS-callability checks below,
+  // because the underlying enabled_pointer values have already changed.
+  env_->SyncTraceCategoryBuffers();
+
   if (!env_->owns_process_state() || !env_->can_call_into_js()) {
     // Ideally, we’d have a consistent story that treats all threads/Environment
     // instances equally here. However, tracing is essentially global, and this

--- a/src/env.h
+++ b/src/env.h
@@ -472,6 +472,15 @@ class TickInfo : public MemoryRetainer {
   AliasedUint8Array fields_;
 };
 
+// Mapping between a trace category enabled pointer (owned by the trace
+// infrastructure, outside the V8 sandbox) and a cage-allocated copy that
+// backs a JS Uint8Array. Used to keep the two in sync when V8_ENABLE_SANDBOX
+// prevents wrapping the external pointer directly.
+struct TraceCategoryMapping {
+  const uint8_t* source;  // Original enabled_pointer (external, read-only).
+  uint8_t* dest;          // Cage-allocated copy backing the JS buffer.
+};
+
 class TrackingTraceStateObserver :
     public v8::TracingController::TraceStateObserver {
  public:
@@ -730,6 +739,9 @@ class Environment final : public MemoryRetainer {
 
   void PrintSyncTrace() const;
   inline void set_trace_sync_io(bool value);
+
+  void AddTraceCategoryMapping(const uint8_t* source, uint8_t* dest);
+  void SyncTraceCategoryBuffers();
 
   inline void set_force_context_aware(bool value);
   inline bool force_context_aware() const;
@@ -1162,6 +1174,7 @@ class Environment final : public MemoryRetainer {
   int should_not_abort_scope_counter_ = 0;
 
   std::unique_ptr<TrackingTraceStateObserver> trace_state_observer_;
+  std::vector<TraceCategoryMapping> trace_category_mappings_;
 
   AliasedInt32Array stream_base_state_;
 

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -32,6 +32,7 @@
 #include "simdutf.h"
 #include "string_bytes.h"
 
+#include "node_v8_sandbox.h"
 #include "util-inl.h"
 #include "v8-fast-api-calls.h"
 #include "v8.h"
@@ -123,6 +124,18 @@ Local<ArrayBuffer> CallbackInfo::CreateTrackedArrayBuffer(
   CHECK_NOT_NULL(callback);
   CHECK_IMPLIES(data == nullptr, length == 0);
 
+#ifdef V8_ENABLE_SANDBOX
+  // When the V8 sandbox is enabled, external backing stores are not supported.
+  // Copy the data into the cage and immediately free the original via callback.
+  void* cage_data = SandboxAllocate(length, /* zero_fill */ false);
+  CHECK_NOT_NULL(cage_data);
+  if (length > 0) memcpy(cage_data, data, length);
+  callback(data, hint);
+  std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+      cage_data, length, SandboxBackingStoreDeleter, nullptr);
+  Local<ArrayBuffer> ab = ArrayBuffer::New(env->isolate(), std::move(bs));
+  // No CallbackInfo needed — the original data has already been freed.
+#else
   CallbackInfo* self = new CallbackInfo(env, callback, data, hint);
   std::unique_ptr<BackingStore> bs =
       ArrayBuffer::NewBackingStore(data, length, [](void*, size_t, void* arg) {
@@ -140,6 +153,7 @@ Local<ArrayBuffer> CallbackInfo::CreateTrackedArrayBuffer(
     self->persistent_.Reset(env->isolate(), ab);
     self->persistent_.SetWeak();
   }
+#endif  // V8_ENABLE_SANDBOX
 
   return ab;
 }
@@ -1452,9 +1466,7 @@ inline size_t CheckNumberToSize(Local<Value> number) {
   double maxSize = static_cast<double>(std::numeric_limits<size_t>::max());
   CHECK(value >= 0 && value < maxSize);
   size_t size = static_cast<size_t>(value);
-#ifdef V8_ENABLE_SANDBOX
-  CHECK_LE(size, v8::internal::kMaxSafeBufferSizeForSandbox);
-#endif
+  CHECK_LE(size, v8::ArrayBuffer::kMaxByteLength);
   return size;
 }
 
@@ -1476,35 +1488,13 @@ void CreateUnsafeArrayBuffer(const FunctionCallbackInfo<Value>& args) {
       env->isolate_data()->is_building_snapshot()) {
     buf = ArrayBuffer::New(isolate, size);
   } else {
-#ifdef V8_ENABLE_SANDBOX
-    std::unique_ptr<ArrayBuffer::Allocator> allocator(
-        ArrayBuffer::Allocator::NewDefaultAllocator());
-    void* data = allocator->AllocateUninitialized(size);
+    void* data = SandboxAllocate(size, /* zero_fill */ false);
     if (!data) [[unlikely]] {
       THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
       return;
     }
     std::unique_ptr<BackingStore> store = ArrayBuffer::NewBackingStore(
-        data,
-        size,
-        [](void* data, size_t length, void*) {
-          std::unique_ptr<ArrayBuffer::Allocator> allocator(
-              ArrayBuffer::Allocator::NewDefaultAllocator());
-          allocator->Free(data, length);
-        },
-        nullptr);
-#else
-    std::unique_ptr<BackingStore> store = ArrayBuffer::NewBackingStore(
-        isolate,
-        size,
-        BackingStoreInitializationMode::kUninitialized,
-        v8::BackingStoreOnFailureMode::kReturnNull);
-
-    if (!store) [[unlikely]] {
-      THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
-      return;
-    }
-#endif
+        data, size, SandboxBackingStoreDeleter, nullptr);
 
     buf = ArrayBuffer::New(isolate, std::move(store));
   }

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -529,7 +529,7 @@ MaybeLocal<Object> New(Environment* env,
     }
   }
 
-#if defined(V8_ENABLE_SANDBOX)
+#ifdef V8_ENABLE_SANDBOX
   // When v8 sandbox is enabled, external backing stores are not supported
   // since all arraybuffer allocations are expected to be done by the isolate.
   // Since this violates the contract of this function, let's free the data and
@@ -1453,7 +1453,7 @@ inline size_t CheckNumberToSize(Local<Value> number) {
   CHECK(value >= 0 && value < maxSize);
   size_t size = static_cast<size_t>(value);
 #ifdef V8_ENABLE_SANDBOX
-  CHECK_LE(size, kMaxSafeBufferSizeForSandbox);
+  CHECK_LE(size, v8::internal::kMaxSafeBufferSizeForSandbox);
 #endif
   return size;
 }
@@ -1476,6 +1476,24 @@ void CreateUnsafeArrayBuffer(const FunctionCallbackInfo<Value>& args) {
       env->isolate_data()->is_building_snapshot()) {
     buf = ArrayBuffer::New(isolate, size);
   } else {
+#ifdef V8_ENABLE_SANDBOX
+    std::unique_ptr<ArrayBuffer::Allocator> allocator(
+        ArrayBuffer::Allocator::NewDefaultAllocator());
+    void* data = allocator->AllocateUninitialized(size);
+    if (!data) [[unlikely]] {
+      THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
+      return;
+    }
+    std::unique_ptr<BackingStore> store = ArrayBuffer::NewBackingStore(
+        data,
+        size,
+        [](void* data, size_t length, void*) {
+          std::unique_ptr<ArrayBuffer::Allocator> allocator(
+              ArrayBuffer::Allocator::NewDefaultAllocator());
+          allocator->Free(data, length);
+        },
+        nullptr);
+#else
     std::unique_ptr<BackingStore> store = ArrayBuffer::NewBackingStore(
         isolate,
         size,
@@ -1486,6 +1504,7 @@ void CreateUnsafeArrayBuffer(const FunctionCallbackInfo<Value>& args) {
       THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
       return;
     }
+#endif
 
     buf = ArrayBuffer::New(isolate, std::move(store));
   }

--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -105,7 +105,13 @@ namespace {
 template <typename T>
 MaybeLocal<Object> ToBufferEndian(Environment* env, MaybeStackBuffer<T>* buf) {
   Local<Object> ret;
+#ifdef V8_ENABLE_SANDBOX
+  if (!Buffer::Copy(
+           env, reinterpret_cast<char*>(buf->out()), buf->length() * sizeof(T))
+           .ToLocal(&ret)) {
+#else
   if (!Buffer::New(env, buf).ToLocal(&ret)) {
+#endif
     return {};
   }
 
@@ -182,7 +188,13 @@ MaybeLocal<Object> TranscodeLatin1ToUcs2(Environment* env,
     return {};
   }
 
+#ifdef V8_ENABLE_SANDBOX
+  return Buffer::Copy(env,
+                      reinterpret_cast<char*>(destbuf.out()),
+                      destbuf.length() * sizeof(char16_t));
+#else
   return Buffer::New(env, &destbuf);
+#endif
 }
 
 MaybeLocal<Object> TranscodeFromUcs2(Environment* env,
@@ -227,7 +239,13 @@ MaybeLocal<Object> TranscodeUcs2FromUtf8(Environment* env,
     return {};
   }
 
+#ifdef V8_ENABLE_SANDBOX
+  return Buffer::Copy(env,
+                      reinterpret_cast<char*>(destbuf.out()),
+                      destbuf.length() * sizeof(char16_t));
+#else
   return Buffer::New(env, &destbuf);
+#endif
 }
 
 MaybeLocal<Object> TranscodeUtf8FromUcs2(Environment* env,
@@ -251,7 +269,13 @@ MaybeLocal<Object> TranscodeUtf8FromUcs2(Environment* env,
     return {};
   }
 
+#ifdef V8_ENABLE_SANDBOX
+  return Buffer::Copy(env,
+                      reinterpret_cast<char*>(destbuf.out()),
+                      destbuf.length() * sizeof(char));
+#else
   return Buffer::New(env, &destbuf);
+#endif
 }
 
 constexpr const char* EncodingName(const enum encoding encoding) {

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -11,6 +11,7 @@
 #include "node_snapshot_builder.h"
 #include "node_union_bytes.h"
 #include "node_v8_platform-inl.h"
+#include "node_v8_sandbox.h"
 #include "simdjson.h"
 #include "util-inl.h"
 
@@ -833,6 +834,11 @@ void GetAsset(const FunctionCallbackInfo<Value>& args) {
   if (it == sea_resource.assets.end()) {
     return;
   }
+#ifdef V8_ENABLE_SANDBOX
+  std::unique_ptr<v8::BackingStore> store =
+      CopyCageBackingStore(it->second.data(), it->second.size());
+  CHECK(store);
+#else
   // We cast away the constness here, the JS land should ensure that
   // the data is not mutated.
   std::unique_ptr<v8::BackingStore> store = ArrayBuffer::NewBackingStore(
@@ -840,6 +846,7 @@ void GetAsset(const FunctionCallbackInfo<Value>& args) {
       it->second.size(),
       [](void*, size_t, void*) {},
       nullptr);
+#endif
   Local<ArrayBuffer> ab = ArrayBuffer::New(args.GetIsolate(), std::move(store));
   args.GetReturnValue().Set(ab);
 }

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -3,6 +3,7 @@
 #include "node_errors.h"
 #include "node_external_reference.h"
 #include "node_internals.h"
+#include "node_v8_sandbox.h"
 #include "util-inl.h"
 
 namespace node {
@@ -28,26 +29,6 @@ using v8::ValueDeserializer;
 using v8::ValueSerializer;
 
 namespace serdes {
-
-v8::ArrayBuffer::Allocator* GetAllocator() {
-  static v8::ArrayBuffer::Allocator* allocator =
-      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
-  return allocator;
-}
-
-void* Reallocate(void* data, size_t old_length, size_t new_length) {
-  if (old_length == new_length) return data;
-  uint8_t* new_data = reinterpret_cast<uint8_t*>(
-      GetAllocator()->AllocateUninitialized(new_length));
-  if (new_data == nullptr) return nullptr;
-  size_t bytes_to_copy = std::min(old_length, new_length);
-  memcpy(new_data, data, bytes_to_copy);
-  if (new_length > bytes_to_copy) {
-    memset(new_data + bytes_to_copy, 0, new_length - bytes_to_copy);
-  }
-  GetAllocator()->Free(data, old_length);
-  return new_data;
-}
 
 class SerializerContext : public BaseObject,
                           public ValueSerializer::Delegate {
@@ -176,17 +157,17 @@ void* SerializerContext::ReallocateBufferMemory(void* old_buffer,
                                                 size_t* new_length) {
   *new_length = std::max(static_cast<size_t>(4096), requested_size);
   if (old_buffer) {
-    void* ret = Reallocate(old_buffer, last_length_, *new_length);
+    void* ret = SandboxReallocate(old_buffer, last_length_, *new_length);
     last_length_ = *new_length;
     return ret;
   } else {
     last_length_ = *new_length;
-    return GetAllocator()->Allocate(*new_length);
+    return SandboxAllocate(*new_length);
   }
 }
 
 void SerializerContext::FreeBufferMemory(void* buffer) {
-  GetAllocator()->Free(buffer, last_length_);
+  SandboxFree(buffer, last_length_);
 }
 
 Maybe<bool> SerializerContext::WriteHostObject(Isolate* isolate,
@@ -253,26 +234,13 @@ void SerializerContext::ReleaseBuffer(const FunctionCallbackInfo<Value>& args) {
   ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
   std::pair<uint8_t*, size_t> ret = ctx->serializer_.Release();
-#ifdef V8_ENABLE_SANDBOX
-  Local<Object> buf;
-  if (Buffer::New(ctx->env(), reinterpret_cast<char*>(ret.first), ret.second)
-          .ToLocal(&buf)) {
-    args.GetReturnValue().Set(buf);
-  }
-#else
   std::unique_ptr<v8::BackingStore> bs = v8::ArrayBuffer::NewBackingStore(
-      reinterpret_cast<char*>(ret.first),
-      ret.second,
-      [](void* data, size_t length, void* deleter_data) {
-        if (data) GetAllocator()->Free(reinterpret_cast<char*>(data), length);
-      },
-      nullptr);
+      ret.first, ret.second, SandboxBackingStoreDeleter, nullptr);
   Local<ArrayBuffer> ab =
       v8::ArrayBuffer::New(ctx->env()->isolate(), std::move(bs));
 
   auto buf = Buffer::New(ctx->env(), ab, 0, ret.second);
   if (!buf.IsEmpty()) args.GetReturnValue().Set(buf.ToLocalChecked());
-#endif
 }
 
 void SerializerContext::TransferArrayBuffer(

--- a/src/node_serdes.cc
+++ b/src/node_serdes.cc
@@ -29,6 +29,26 @@ using v8::ValueSerializer;
 
 namespace serdes {
 
+v8::ArrayBuffer::Allocator* GetAllocator() {
+  static v8::ArrayBuffer::Allocator* allocator =
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator();
+  return allocator;
+}
+
+void* Reallocate(void* data, size_t old_length, size_t new_length) {
+  if (old_length == new_length) return data;
+  uint8_t* new_data = reinterpret_cast<uint8_t*>(
+      GetAllocator()->AllocateUninitialized(new_length));
+  if (new_data == nullptr) return nullptr;
+  size_t bytes_to_copy = std::min(old_length, new_length);
+  memcpy(new_data, data, bytes_to_copy);
+  if (new_length > bytes_to_copy) {
+    memset(new_data + bytes_to_copy, 0, new_length - bytes_to_copy);
+  }
+  GetAllocator()->Free(data, old_length);
+  return new_data;
+}
+
 class SerializerContext : public BaseObject,
                           public ValueSerializer::Delegate {
  public:
@@ -37,10 +57,15 @@ class SerializerContext : public BaseObject,
 
   ~SerializerContext() override = default;
 
+  // v8::ValueSerializer::Delegate
   void ThrowDataCloneError(Local<String> message) override;
   Maybe<bool> WriteHostObject(Isolate* isolate, Local<Object> object) override;
   Maybe<uint32_t> GetSharedArrayBufferId(
       Isolate* isolate, Local<SharedArrayBuffer> shared_array_buffer) override;
+  void* ReallocateBufferMemory(void* old_buffer,
+                               size_t old_length,
+                               size_t* new_length) override;
+  void FreeBufferMemory(void* buffer) override;
 
   static void SetTreatArrayBufferViewsAsHostObjects(
       const FunctionCallbackInfo<Value>& args);
@@ -61,6 +86,7 @@ class SerializerContext : public BaseObject,
 
  private:
   ValueSerializer serializer_;
+  size_t last_length_ = 0;
 };
 
 class DeserializerContext : public BaseObject,
@@ -145,6 +171,24 @@ Maybe<uint32_t> SerializerContext::GetSharedArrayBufferId(
   return id->Uint32Value(env()->context());
 }
 
+void* SerializerContext::ReallocateBufferMemory(void* old_buffer,
+                                                size_t requested_size,
+                                                size_t* new_length) {
+  *new_length = std::max(static_cast<size_t>(4096), requested_size);
+  if (old_buffer) {
+    void* ret = Reallocate(old_buffer, last_length_, *new_length);
+    last_length_ = *new_length;
+    return ret;
+  } else {
+    last_length_ = *new_length;
+    return GetAllocator()->Allocate(*new_length);
+  }
+}
+
+void SerializerContext::FreeBufferMemory(void* buffer) {
+  GetAllocator()->Free(buffer, last_length_);
+}
+
 Maybe<bool> SerializerContext::WriteHostObject(Isolate* isolate,
                                                Local<Object> input) {
   Local<Value> args[1] = { input };
@@ -208,14 +252,27 @@ void SerializerContext::ReleaseBuffer(const FunctionCallbackInfo<Value>& args) {
   SerializerContext* ctx;
   ASSIGN_OR_RETURN_UNWRAP(&ctx, args.This());
 
-  // Note: Both ValueSerializer and this Buffer::New() variant use malloc()
-  // as the underlying allocator.
   std::pair<uint8_t*, size_t> ret = ctx->serializer_.Release();
+#ifdef V8_ENABLE_SANDBOX
   Local<Object> buf;
   if (Buffer::New(ctx->env(), reinterpret_cast<char*>(ret.first), ret.second)
           .ToLocal(&buf)) {
     args.GetReturnValue().Set(buf);
   }
+#else
+  std::unique_ptr<v8::BackingStore> bs = v8::ArrayBuffer::NewBackingStore(
+      reinterpret_cast<char*>(ret.first),
+      ret.second,
+      [](void* data, size_t length, void* deleter_data) {
+        if (data) GetAllocator()->Free(reinterpret_cast<char*>(data), length);
+      },
+      nullptr);
+  Local<ArrayBuffer> ab =
+      v8::ArrayBuffer::New(ctx->env()->isolate(), std::move(bs));
+
+  auto buf = Buffer::New(ctx->env(), ab, 0, ret.second);
+  if (!buf.IsEmpty()) args.GetReturnValue().Set(buf.ToLocalChecked());
+#endif
 }
 
 void SerializerContext::TransferArrayBuffer(

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -5,6 +5,7 @@
 #include "node_external_reference.h"
 #include "node_internals.h"
 #include "node_v8_platform-inl.h"
+#include "node_v8_sandbox.h"
 #include "tracing/agent.h"
 #include "util-inl.h"
 
@@ -123,29 +124,26 @@ static void SetTraceCategoryStateUpdateHandler(
 static void GetCategoryEnabledBuffer(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsString());
 
-  Isolate* isolate = args.GetIsolate();
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
   node::Utf8Value category_name(isolate, args[0]);
 
   const uint8_t* enabled_pointer =
       TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category_name.out());
   uint8_t* enabled_pointer_cast = const_cast<uint8_t*>(enabled_pointer);
-  uint8_t size = sizeof(*enabled_pointer_cast);
+  constexpr size_t size = sizeof(*enabled_pointer_cast);
 
 #ifdef V8_ENABLE_SANDBOX
-  std::unique_ptr<ArrayBuffer::Allocator> allocator(
-      ArrayBuffer::Allocator::NewDefaultAllocator());
-  void* v8_data = allocator->Allocate(size);
-  CHECK(v8_data);
-  memcpy(v8_data, enabled_pointer_cast, size);
-  std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
-      v8_data,
-      size,
-      [](void* data, size_t length, void*) {
-        std::unique_ptr<ArrayBuffer::Allocator> allocator(
-            ArrayBuffer::Allocator::NewDefaultAllocator());
-        allocator->Free(data, length);
-      },
-      nullptr);
+  // The V8 sandbox requires all ArrayBuffer backing stores to be inside the
+  // memory cage, so we cannot wrap enabled_pointer directly. Instead, allocate
+  // a cage-resident copy and register a mapping so that
+  // TrackingTraceStateObserver::UpdateTraceCategoryState() keeps it in sync
+  // with the original pointer whenever trace categories change.
+  std::unique_ptr<BackingStore> bs =
+      CopyCageBackingStore(enabled_pointer_cast, size);
+  CHECK(bs);
+  uint8_t* cage_copy = static_cast<uint8_t*>(bs->Data());
+  env->AddTraceCategoryMapping(enabled_pointer, cage_copy);
 #else
   std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
       enabled_pointer_cast, size, [](void*, size_t, void*) {}, nullptr);

--- a/src/node_trace_events.cc
+++ b/src/node_trace_events.cc
@@ -129,12 +129,28 @@ static void GetCategoryEnabledBuffer(const FunctionCallbackInfo<Value>& args) {
   const uint8_t* enabled_pointer =
       TRACE_EVENT_API_GET_CATEGORY_GROUP_ENABLED(category_name.out());
   uint8_t* enabled_pointer_cast = const_cast<uint8_t*>(enabled_pointer);
+  uint8_t size = sizeof(*enabled_pointer_cast);
 
+#ifdef V8_ENABLE_SANDBOX
+  std::unique_ptr<ArrayBuffer::Allocator> allocator(
+      ArrayBuffer::Allocator::NewDefaultAllocator());
+  void* v8_data = allocator->Allocate(size);
+  CHECK(v8_data);
+  memcpy(v8_data, enabled_pointer_cast, size);
   std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
-      enabled_pointer_cast,
-      sizeof(*enabled_pointer_cast),
-      [](void*, size_t, void*) {},
+      v8_data,
+      size,
+      [](void* data, size_t length, void*) {
+        std::unique_ptr<ArrayBuffer::Allocator> allocator(
+            ArrayBuffer::Allocator::NewDefaultAllocator());
+        allocator->Free(data, length);
+      },
       nullptr);
+#else
+  std::unique_ptr<BackingStore> bs = ArrayBuffer::NewBackingStore(
+      enabled_pointer_cast, size, [](void*, size_t, void*) {}, nullptr);
+#endif
+
   auto ab = ArrayBuffer::New(isolate, std::move(bs));
   v8::Local<Uint8Array> u8 = v8::Uint8Array::New(ab, 0, 1);
 

--- a/src/node_v8_sandbox.h
+++ b/src/node_v8_sandbox.h
@@ -1,0 +1,120 @@
+#ifndef SRC_NODE_V8_SANDBOX_H_
+#define SRC_NODE_V8_SANDBOX_H_
+
+#if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#include "v8.h"
+
+#include <cstring>
+#include <memory>
+
+namespace node {
+
+#ifdef V8_ENABLE_SANDBOX
+
+// When V8_ENABLE_SANDBOX is enabled, all ArrayBuffer backing stores must live
+// inside the V8 memory cage. External pointers cannot be wrapped directly via
+// ArrayBuffer::NewBackingStore(data, ...). These helpers centralise the
+// allocate-in-cage / free-in-cage pattern so that call sites don't need to
+// repeat #ifdef guards.
+
+// Allocate memory inside the V8 sandbox cage.
+// When zero_fill is true the memory is zeroed (Allocate); otherwise it is
+// left uninitialised (AllocateUninitialized).
+inline void* SandboxAllocate(size_t size, bool zero_fill = true) {
+  std::unique_ptr<v8::ArrayBuffer::Allocator> allocator(
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator());
+  if (zero_fill) {
+    return allocator->Allocate(size);
+  }
+  return allocator->AllocateUninitialized(size);
+}
+
+// Free memory that was allocated with SandboxAllocate.
+inline void SandboxFree(void* data, size_t size) {
+  std::unique_ptr<v8::ArrayBuffer::Allocator> allocator(
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator());
+  allocator->Free(data, size);
+}
+
+// Reallocate memory inside the V8 sandbox cage. Copies min(old, new) bytes
+// from the old buffer and zero-fills any additional bytes. Frees the old
+// buffer on success. Returns nullptr on allocation failure (old buffer is
+// NOT freed in that case).
+inline void* SandboxReallocate(void* data,
+                               size_t old_length,
+                               size_t new_length) {
+  if (old_length == new_length) return data;
+  std::unique_ptr<v8::ArrayBuffer::Allocator> allocator(
+      v8::ArrayBuffer::Allocator::NewDefaultAllocator());
+  void* new_data = allocator->AllocateUninitialized(new_length);
+  if (new_data == nullptr) return nullptr;
+  size_t bytes_to_copy = std::min(old_length, new_length);
+  memcpy(new_data, data, bytes_to_copy);
+  if (new_length > bytes_to_copy) {
+    memset(static_cast<uint8_t*>(new_data) + bytes_to_copy,
+           0,
+           new_length - bytes_to_copy);
+  }
+  allocator->Free(data, old_length);
+  return new_data;
+}
+
+// BackingStore deleter that frees cage-allocated memory.
+inline void SandboxBackingStoreDeleter(void* data, size_t length, void*) {
+  SandboxFree(data, length);
+}
+
+// Allocate cage memory, copy |source| into it, and wrap in a BackingStore.
+// The caller is responsible for freeing the original |source| memory.
+inline std::unique_ptr<v8::BackingStore> CopyCageBackingStore(
+    const void* source, size_t size) {
+  // No need to zero-fill since we overwrite immediately.
+  void* cage_data = SandboxAllocate(size, /* zero_fill */ false);
+  if (cage_data == nullptr) return nullptr;
+  memcpy(cage_data, source, size);
+  return v8::ArrayBuffer::NewBackingStore(
+      cage_data, size, SandboxBackingStoreDeleter, nullptr);
+}
+
+#else  // !V8_ENABLE_SANDBOX
+
+// When the sandbox is disabled these are thin wrappers around malloc/free.
+
+inline void* SandboxAllocate(size_t size, bool zero_fill = true) {
+  if (zero_fill) {
+    return calloc(1, size);
+  }
+  return malloc(size);
+}
+
+inline void SandboxFree(void* data, size_t size) {
+  free(data);
+}
+
+inline void* SandboxReallocate(void* data,
+                               size_t old_length,
+                               size_t new_length) {
+  return realloc(data, new_length);
+}
+
+inline void SandboxBackingStoreDeleter(void* data, size_t length, void*) {
+  free(data);
+}
+
+inline std::unique_ptr<v8::BackingStore> CopyCageBackingStore(
+    const void* source, size_t size) {
+  void* copy = malloc(size);
+  if (copy == nullptr) return nullptr;
+  memcpy(copy, source, size);
+  return v8::ArrayBuffer::NewBackingStore(
+      copy, size, SandboxBackingStoreDeleter, nullptr);
+}
+
+#endif  // V8_ENABLE_SANDBOX
+
+}  // namespace node
+
+#endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
+
+#endif  // SRC_NODE_V8_SANDBOX_H_


### PR DESCRIPTION
When `V8_ENABLE_SANDBOX` is enabled, all ArrayBuffer backing stores must be allocated within the V8 memory cage — external pointers cannot be directly wrapped and must be copied into V8-managed memory instead. This commit refactors allocators in `node_buffer.cc`, `node_serdes.cc`, and `node_trace_events.cc` to route allocations through `ArrayBuffer::Allocator::NewDefaultAllocator()` when the sandbox is enabled, ensuring memory lands inside the cage. In `node_serdes.cc`, `ValueSerializer::Delegate` is also extended with `ReallocateBufferMemory`/`FreeBufferMemory` overrides so the serializer's internal buffer is cage-allocated from the start.

Tested by making the following change:

```diff
diff --git a/configure.py b/configure.py
index fa47e9c4854..f4342d2c718 100755
--- a/configure.py
+++ b/configure.py
@@ -2047,7 +2047,7 @@ def configure_v8(o, configs):
   # Until we manage to get rid of all those, v8_enable_sandbox cannot be used.
   # Note that enabling pointer compression without enabling sandbox is unsupported by V8,
   # so this can be broken at any time.
-  o['variables']['v8_enable_sandbox'] = 0
+  o['variables']['v8_enable_sandbox'] = 1 if options.enable_pointer_compression else 0
   # We set v8_enable_pointer_compression_shared_cage to 0 always, even when
   # pointer compression is enabled so that we don't accidentally enable shared
   # cage mode when pointer compression is on.
```

and running with `./configure --ninja --experimental-enable-pointer-compression`

This allows Electron to reduce/remove a patch.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
