### PR TITLE
test: skip test-cluster-dgram-reuse on AIX 7.3

### DIFF
--- a/test/parallel/test-cluster-dgram-reuse.js
+++ b/test/parallel/test-cluster-dgram-reuse.js
@@ -1,7 +1,10 @@
 'use strict';
 const common = require('../common');
+const os = require('os');
 if (common.isWindows)
   common.skip('dgram clustering is currently not supported on windows.');
+if (common.isAIX && os.release() === '7.3')
+  common.skip('dgram clutering with reuse does not work if built on AIX 7.3.');
 
 const assert = require('assert');
 const cluster = require('cluster');


### PR DESCRIPTION
Identified during AIX 7.3 testing being done under https://github.com/nodejs/node/issues/61660

TL;DR This is a workaround for a hang which is showing up when node is built on or AIX 7.3 machines. If the binary is built on 7.2 and then run on 7.3 (which would be true for anyone using our release builds) then it seems to work ok. It is a consistently reproducible failure.

While this version check technically stops an AIX 7.2 binary being tested on 7.3 it is an appropriate change to allow AIX 7.3 to be included in the CI without impacting the coverage we have on 7.2.

Alternate solutions:
- Expose this through `common` and use it there (Suggestions on variable names etc. welcome if we go for this, but I don't think there's too much precedent)
- Identify and fix the underlying problem (Analysis there will continue todo this anyway, but I'd rather not hold up adding 7.3 - which is now nearly 5 years old - into the mix right now if possible since we're very close to being able to do that now)
