### PR TITLE
doc: clarify fs.StatFs field descriptions

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7664,7 +7664,8 @@ added:
 
 * Type: {number|bigint}
 
-Free blocks available to unprivileged users.
+Free blocks available to unprivileged users. Multiply by `statfs.bsize`
+to get the value in bytes.
 
 #### `statfs.bfree`
 
@@ -7676,7 +7677,9 @@ added:
 
 * Type: {number|bigint}
 
-Free blocks in file system.
+Free blocks in file system. This includes blocks reserved for the
+superuser that are not reported by `statfs.bavail`. Multiply by
+`statfs.bsize` to get the value in bytes.
 
 #### `statfs.blocks`
 
@@ -7688,7 +7691,8 @@ added:
 
 * Type: {number|bigint}
 
-Total data blocks in file system.
+Total data blocks in file system. Multiply by `statfs.bsize` to get
+the total size in bytes.
 
 #### `statfs.bsize`
 
@@ -7700,7 +7704,8 @@ added:
 
 * Type: {number|bigint}
 
-Optimal transfer block size.
+Optimal transfer block size in bytes. This value is also the unit for
+the `statfs.blocks`, `statfs.bfree`, and `statfs.bavail` fields.
 
 #### `statfs.ffree`
 
@@ -7712,7 +7717,7 @@ added:
 
 * Type: {number|bigint}
 
-Free file nodes in file system.
+Free file nodes (inodes) in file system.
 
 #### `statfs.files`
 
@@ -7724,7 +7729,7 @@ added:
 
 * Type: {number|bigint}
 
-Total file nodes in file system.
+Total file nodes (inodes) in file system.
 
 #### `statfs.type`
 
@@ -7736,7 +7741,11 @@ added:
 
 * Type: {number|bigint}
 
-Type of file system.
+File system type as a numeric identifier. On Linux this is the
+file system magic number (e.g. `0xef53` for ext2/ext3/ext4,
+`0x01021994` for tmpfs). On other platforms the value is
+OS-dependent. See the `statfs(2)` man page on Linux or `statfs(2)`
+on macOS for platform-specific values.
 
 ### Class: `fs.Utf8Stream`
 


### PR DESCRIPTION
Clarify the `fs.StatFs` field descriptions:

- **`bsize`**: specify that the value is in bytes and serves as the unit for block count fields
- **`blocks`**, **`bfree`**, **`bavail`**: add "multiply by `bsize`" guidance so users can compute sizes; clarify the difference between `bfree` (includes superuser-reserved blocks) and `bavail` (unprivileged)
- **`type`**: explain that this is a file system magic number with common examples and a pointer to platform-specific man pages
- **`files`**, **`ffree`**: note that these count inodes

Picks up the work from #51301, #55279, and #59626 which all attempted to address this issue but stalled.

Fixes: https://github.com/nodejs/node/issues/50749