### PR TITLE
doc: remove spawn with shell example from bat/cmd section

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -2356,7 +2356,7 @@ Therefore, this feature requires opting in by setting the
 or [`child_process.fork()`][].
 
 [Advanced serialization]: #advanced-serialization
-[DEP0190]: deprecations.md#dep0190-passing-args-to-nodechild_process-execfilespawn-with-shell-option-true
+[DEP0190]: deprecations.md#DEP0190
 [Default Windows shell]: #default-windows-shell
 [HTML structured clone algorithm]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Structured_clone_algorithm
 [Shell requirements]: #shell-requirements


### PR DESCRIPTION
Remove the suggestion to use `child_process.spawn()` with the `shell`
option for running `.bat` and `.cmd` files on Windows. Passing arguments
through `spawn` with `shell: true` is deprecated ([DEP0190][]) due to
shell injection risks. The `exec()` and direct `cmd.exe` spawn
alternatives remain documented.

Continues the work from #58739 which addressed the same issue but
stale-closed without review.

Fixes: https://github.com/nodejs/node/issues/58735

[DEP0190]: https://nodejs.org/api/deprecations.html#dep0190-passing-args-to-nodechild_process-execfilespawn-with-shell-option-true