### PR TITLE
src: use simdutf for two-byte string utf8 conversion in utf8 value

### DIFF
--- a/benchmark/util/utf8-value.js
+++ b/benchmark/util/utf8-value.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  type: ['ascii', 'two_bytes', 'three_bytes', 'mixed'],
+  n: [5e6],
+});
+
+const urls = {
+  ascii: 'https://example.com/path/to/resource?query=value&foo=bar',
+  two_bytes: 'https://example.com/yol/türkçe/içerik?sağlık=değer',
+  three_bytes: 'https://example.com/路径/资源?查询=值&名称=数据',
+  mixed: 'https://example.com/hello/世界/path?name=değer&key=数据',
+};
+
+function main({ n, type }) {
+  const str = urls[type];
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    URL.canParse(str);
+  }
+  bench.end(n);
+}

--- a/src/util.cc
+++ b/src/util.cc
@@ -121,13 +121,20 @@ static void MakeUtf8String(Isolate* isolate,
     return;
   }
 
-  // Add +1 for null termination.
-  size_t storage = (3 * value_length) + 1;
+  auto const_char16 = reinterpret_cast<const char16_t*>(value_view.data16());
+  size_t storage = static_cast<size_t>(value_length) * 3 + 1;
   target->AllocateSufficientStorage(storage);
 
-  size_t length = string->WriteUtf8V2(
-      isolate, target->out(), storage, String::WriteFlags::kReplaceInvalidUtf8);
-  target->SetLengthAndZeroTerminate(length);
+  size_t actual_length =
+      simdutf::convert_utf16_to_utf8(const_char16, value_length, target->out());
+  if (actual_length == 0 && value_length > 0) {
+    actual_length =
+        string->WriteUtf8V2(isolate,
+                            target->out(),
+                            storage,
+                            String::WriteFlags::kReplaceInvalidUtf8);
+  }
+  target->SetLengthAndZeroTerminate(actual_length);
 }
 
 Utf8Value::Utf8Value(Isolate* isolate, Local<Value> value) {

--- a/src/util.cc
+++ b/src/util.cc
@@ -127,7 +127,7 @@ static void MakeUtf8String(Isolate* isolate,
 
   size_t actual_length =
       simdutf::convert_utf16_to_utf8(const_char16, value_length, target->out());
-  if (actual_length == 0 && value_length > 0) {
+  if (actual_length == 0) {
     actual_length =
         string->WriteUtf8V2(isolate,
                             target->out(),


### PR DESCRIPTION
latin-1 already used simdutf https://github.com/nodejs/node/pull/61696,

I changed WriteUtf8V2 to simdutf for two-byte strings.

```sh
➜  node git:(mert/use-simdutf-for-two-byte-utf8) ✗ node-benchmark-compare ./result.csv
                                                confidence improvement accuracy (*)   (**)  (***)
util/utf8-value.js n=5000000 type='ascii'                      -0.11 %       ±2.64% ±3.69% ±5.18%
util/utf8-value.js n=5000000 type='mixed'              ***     49.60 %       ±1.90% ±2.67% ±3.78%
util/utf8-value.js n=5000000 type='three_bytes'        ***     31.10 %       ±2.42% ±3.34% ±4.60%
util/utf8-value.js n=5000000 type='two_bytes'          ***     42.75 %       ±1.42% ±1.94% ±2.66%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 4 comparisons, you can thus expect the following amount of false-positive results:
  0.20 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.04 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```