### PR TITLE
test_runner: add context subtests `expectFailure` `only` `skip` `todo`

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -359,10 +359,10 @@ class TestContext {
     this.#test.todo(message);
   }
 
-  #runTest(name, options, fn) {
+  #runTest(name, options, fn, loc) {
     const overrides = {
       __proto__: null,
-      loc: getCallerLocation(),
+      loc,
     };
 
     const { plan } = this.#test;
@@ -378,12 +378,39 @@ class TestContext {
     return subtest.start();
   }
 
-  test = ObjectAssign((...args) => this.#runTest(...args), {
+  // [1] `getCallerLocation` cannot be nested (that causes it to cite the nested location instead).
+
+  test = ObjectAssign((name, options, fn) => this.#runTest(
+    name,
+    options,
+    fn,
+    getCallerLocation(), // [1]
+  ), {
     __proto__: null,
-    expectFailure: (name, opts, fn) => this.#runTest(name, { __proto__: null, ...opts, expectFailure: true }, fn),
-    only: (name, opts, fn) => this.#runTest(name, { __proto__: null, ...opts, only: true }, fn),
-    skip: (name, opts, fn) => this.#runTest(name, { __proto__: null, ...opts, skip: true }, fn),
-    todo: (name, opts, fn) => this.#runTest(name, { __proto__: null, ...opts, todo: true }, fn),
+    expectFailure: (name, opts, fn) => this.#runTest(
+      name,
+      { __proto__: null, ...opts, expectFailure: true },
+      fn,
+      getCallerLocation(), // [1]
+    ),
+    only: (name, opts, fn) => this.#runTest(
+      name,
+      { __proto__: null, ...opts, only: true },
+      fn,
+      getCallerLocation(), // [1]
+    ),
+    skip: (name, opts, fn) => this.#runTest(
+      name,
+      { __proto__: null, ...opts, skip: true },
+      fn,
+      getCallerLocation(), // [1]
+    ),
+    todo: (name, opts, fn) => this.#runTest(
+      name,
+      { __proto__: null, ...opts, todo: true },
+      fn,
+      getCallerLocation(), // [1]
+    ),
   });
 
   before(fn, options) {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -359,11 +359,11 @@ class TestContext {
     this.#test.todo(message);
   }
 
-  #runTest(name, options, fn, extraOverrides) {
-    const overrides = ObjectAssign({
+  #runTest(name, options, fn) {
+    const overrides = {
       __proto__: null,
       loc: getCallerLocation(),
-    }, extraOverrides);
+    };
 
     const { plan } = this.#test;
     if (plan !== null) {
@@ -380,10 +380,10 @@ class TestContext {
 
   test = ObjectAssign((...args) => this.#runTest(...args), {
     __proto__: null,
-    expectFailure: (name, opts, fn) => this.#runTest(name, opts, fn, { __proto__: null, expectFailure: true }),
-    only: (name, opts, fn) => this.#runTest(name, opts, fn, { __proto__: null, only: true }),
-    skip: (name, opts, fn) => this.#runTest(name, opts, fn, { __proto__: null, skip: true }),
-    todo: (name, opts, fn) => this.#runTest(name, opts, fn, { __proto__: null, todo: true }),
+    expectFailure: (name, opts, fn) => this.#runTest(name, { __proto__: null, ...opts, expectFailure: true }, fn),
+    only: (name, opts, fn) => this.#runTest(name, { __proto__: null, ...opts, only: true }, fn),
+    skip: (name, opts, fn) => this.#runTest(name, { __proto__: null, ...opts, skip: true }, fn),
+    todo: (name, opts, fn) => this.#runTest(name, { __proto__: null, ...opts, todo: true }, fn),
   });
 
   before(fn, options) {

--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -14,6 +14,7 @@ const {
   MathMax,
   Number,
   NumberPrototypeToFixed,
+  ObjectAssign,
   ObjectKeys,
   ObjectSeal,
   Promise,
@@ -358,11 +359,11 @@ class TestContext {
     this.#test.todo(message);
   }
 
-  test(name, options, fn) {
-    const overrides = {
+  #runTest(name, options, fn, extraOverrides) {
+    const overrides = ObjectAssign({
       __proto__: null,
       loc: getCallerLocation(),
-    };
+    }, extraOverrides);
 
     const { plan } = this.#test;
     if (plan !== null) {
@@ -376,6 +377,14 @@ class TestContext {
 
     return subtest.start();
   }
+
+  test = ObjectAssign((...args) => this.#runTest(...args), {
+    __proto__: null,
+    expectFailure: (name, opts, fn) => this.#runTest(name, opts, fn, { __proto__: null, expectFailure: true }),
+    only: (name, opts, fn) => this.#runTest(name, opts, fn, { __proto__: null, only: true }),
+    skip: (name, opts, fn) => this.#runTest(name, opts, fn, { __proto__: null, skip: true }),
+    todo: (name, opts, fn) => this.#runTest(name, opts, fn, { __proto__: null, todo: true }),
+  });
 
   before(fn, options) {
     this.#test.createHook('before', fn, {

--- a/test/parallel/test-runner-subtest-methods.js
+++ b/test/parallel/test-runner-subtest-methods.js
@@ -20,20 +20,18 @@ test('subtest should return a promise', async (t) => {
 });
 
 test('t.test[variant]() should return a promise', async (t) => {
-  const xfail = t.test.expectFailure('expectFailure subtest', () => { throw new Error('This should pass'); });
-  const only = t.test.only('only subtest');
-  const skip = t.test.skip('skip subtest');
-  const todo = t.test.todo('todo subtest');
-
-  assert.ok(isPromise(xfail));
-  assert.ok(isPromise(only));
-  assert.ok(isPromise(skip));
-  assert.ok(isPromise(todo));
-
-  await xfail;
-  await only;
-  await skip;
-  await todo;
+  assert.ok(isPromise(
+    t.test.expectFailure('expectFailure subtest', () => { throw new Error('This should pass'); })
+  ));
+  assert.ok(isPromise(
+    t.test.only('only subtest')
+  ));
+  assert.ok(isPromise(
+    t.test.skip('skip subtest')
+  ));
+  assert.ok(isPromise(
+    t.test.todo('todo subtest')
+  ));
 });
 
 test('nested subtests should have test variants', async (t) => {

--- a/test/parallel/test-runner-subtest-methods.js
+++ b/test/parallel/test-runner-subtest-methods.js
@@ -1,0 +1,53 @@
+'use strict';
+
+require('../common');
+const assert = require('node:assert');
+const { test } = require('node:test');
+const { isPromise } = require('node:util/types');
+
+test('subtest context should have test variants', async (t) => {
+  assert.strictEqual(typeof t.test, 'function');
+  assert.strictEqual(typeof t.test.expectFailure, 'function');
+  assert.strictEqual(typeof t.test.only, 'function');
+  assert.strictEqual(typeof t.test.skip, 'function');
+  assert.strictEqual(typeof t.test.todo, 'function');
+});
+
+test('subtest should return a promise', async (t) => {
+  const normal = t.test('normal subtest');
+  assert.ok(isPromise(normal));
+  await normal;
+});
+
+test('t.test[variant]() should return a promise', async (t) => {
+  assert.ok(isPromise(
+    t.test.expectFailure('expectFailure subtest', () => { throw new Error('This should pass'); })
+  ));
+  assert.ok(isPromise(
+    t.test.only('only subtest')
+  ));
+  assert.ok(isPromise(
+    t.test.skip('skip subtest')
+  ));
+  assert.ok(isPromise(
+    t.test.todo('todo subtest')
+  ));
+});
+
+test('nested subtests should have test variants', async (t) => {
+  await t.test('level 1', async (t) => {
+    assert.strictEqual(typeof t.test, 'function');
+    assert.strictEqual(typeof t.test.expectFailure, 'function');
+    assert.strictEqual(typeof t.test.only, 'function');
+    assert.strictEqual(typeof t.test.skip, 'function');
+    assert.strictEqual(typeof t.test.todo, 'function');
+
+    await t.test('level 2', async (t) => {
+      assert.strictEqual(typeof t.test, 'function');
+      assert.strictEqual(typeof t.test.expectFailure, 'function');
+      assert.strictEqual(typeof t.test.skip, 'function');
+      assert.strictEqual(typeof t.test.todo, 'function');
+      assert.strictEqual(typeof t.test.only, 'function');
+    });
+  });
+});

--- a/test/parallel/test-runner-subtest-methods.js
+++ b/test/parallel/test-runner-subtest-methods.js
@@ -20,18 +20,20 @@ test('subtest should return a promise', async (t) => {
 });
 
 test('t.test[variant]() should return a promise', async (t) => {
-  assert.ok(isPromise(
-    t.test.expectFailure('expectFailure subtest', () => { throw new Error('This should pass'); })
-  ));
-  assert.ok(isPromise(
-    t.test.only('only subtest')
-  ));
-  assert.ok(isPromise(
-    t.test.skip('skip subtest')
-  ));
-  assert.ok(isPromise(
-    t.test.todo('todo subtest')
-  ));
+  const xfail = t.test.expectFailure('expectFailure subtest', () => { throw new Error('This should pass'); });
+  const only = t.test.only('only subtest');
+  const skip = t.test.skip('skip subtest');
+  const todo = t.test.todo('todo subtest');
+
+  assert.ok(isPromise(xfail));
+  assert.ok(isPromise(only));
+  assert.ok(isPromise(skip));
+  assert.ok(isPromise(todo));
+
+  await xfail;
+  await only;
+  await skip;
+  await todo;
 });
 
 test('nested subtests should have test variants', async (t) => {


### PR DESCRIPTION
Closes https://github.com/nodejs/node/pull/61251
Closes https://github.com/nodejs/node/pull/62156
Fixes https://github.com/nodejs/node/issues/50665