### PR TITLE
url: optimize URLSearchParams set/delete duplicate handling

### DIFF
--- a/benchmark/url/url-searchparams-mutation.js
+++ b/benchmark/url/url-searchparams-mutation.js
@@ -1,0 +1,43 @@
+'use strict';
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  method: ['set', 'delete'],
+  type: ['unique', 'duplicates'],
+  count: [10, 1000],
+  n: [1e4],
+});
+
+function buildSeed(type, count) {
+  const parts = new Array(count);
+
+  if (type === 'duplicates') {
+    for (let i = 0; i < count; i++) {
+      parts[i] = `dup=${i}`;
+    }
+  } else {
+    for (let i = 0; i < count; i++) {
+      parts[i] = `k${i}=${i}`;
+    }
+  }
+
+  return new URLSearchParams(parts.join('&'));
+}
+
+function main({ method, type, count, n }) {
+  const seed = buildSeed(type, count);
+  const key = type === 'duplicates' ? 'dup' : 'k0';
+  const mutate = method === 'set' ?
+    (params) => params.set(key, 'updated') :
+    (params) => params.delete(key);
+
+  for (let i = 0; i < 1e3; i++) {
+    mutate(new URLSearchParams(seed));
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    mutate(new URLSearchParams(seed));
+  }
+  bench.end(n);
+}

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -495,12 +495,12 @@ class URLSearchParams {
 
     const list = this.#searchParams;
     name = StringPrototypeToWellFormed(`${name}`);
-    const len = list.length;
+    const { length } = list;
     let write = 0;
 
     if (value !== undefined) {
       value = StringPrototypeToWellFormed(`${value}`);
-      for (let i = 0; i < len; i += 2) {
+      for (let i = 0; i < length; i += 2) {
         if (list[i] === name && list[i + 1] === value) {
           continue;
         }
@@ -511,7 +511,7 @@ class URLSearchParams {
         write += 2;
       }
     } else {
-      for (let i = 0; i < len; i += 2) {
+      for (let i = 0; i < length; i += 2) {
         if (list[i] === name) {
           continue;
         }
@@ -523,7 +523,7 @@ class URLSearchParams {
       }
     }
 
-    if (write !== len)
+    if (write !== length)
       list.length = write;
 
     if (this.#context) {
@@ -605,14 +605,14 @@ class URLSearchParams {
     const list = this.#searchParams;
     name = StringPrototypeToWellFormed(`${name}`);
     value = StringPrototypeToWellFormed(`${value}`);
-    const len = list.length;
+    const { length } = list;
 
     // If there are any name-value pairs whose name is `name`, in `list`, set
     // the value of the first such name-value pair to `value` and remove the
     // others.
     let found = false;
     let write = 0;
-    for (let i = 0; i < len; i += 2) {
+    for (let i = 0; i < length; i += 2) {
       const cur = list[i];
       let keep = true;
       if (cur === name) {
@@ -631,7 +631,7 @@ class URLSearchParams {
         write += 2;
     }
 
-    if (found && write !== len) {
+    if (found && write !== length) {
       list.length = write;
     }
 

--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -495,25 +495,36 @@ class URLSearchParams {
 
     const list = this.#searchParams;
     name = StringPrototypeToWellFormed(`${name}`);
+    const len = list.length;
+    let write = 0;
 
     if (value !== undefined) {
       value = StringPrototypeToWellFormed(`${value}`);
-      for (let i = 0; i < list.length;) {
+      for (let i = 0; i < len; i += 2) {
         if (list[i] === name && list[i + 1] === value) {
-          list.splice(i, 2);
-        } else {
-          i += 2;
+          continue;
         }
+        if (write !== i) {
+          list[write] = list[i];
+          list[write + 1] = list[i + 1];
+        }
+        write += 2;
       }
     } else {
-      for (let i = 0; i < list.length;) {
+      for (let i = 0; i < len; i += 2) {
         if (list[i] === name) {
-          list.splice(i, 2);
-        } else {
-          i += 2;
+          continue;
         }
+        if (write !== i) {
+          list[write] = list[i];
+          list[write + 1] = list[i + 1];
+        }
+        write += 2;
       }
     }
+
+    if (write !== len)
+      list.length = write;
 
     if (this.#context) {
       setURLSearchParamsModified(this.#context);
@@ -594,24 +605,34 @@ class URLSearchParams {
     const list = this.#searchParams;
     name = StringPrototypeToWellFormed(`${name}`);
     value = StringPrototypeToWellFormed(`${value}`);
+    const len = list.length;
 
     // If there are any name-value pairs whose name is `name`, in `list`, set
     // the value of the first such name-value pair to `value` and remove the
     // others.
     let found = false;
-    for (let i = 0; i < list.length;) {
+    let write = 0;
+    for (let i = 0; i < len; i += 2) {
       const cur = list[i];
+      let keep = true;
       if (cur === name) {
         if (!found) {
-          list[i + 1] = value;
+          list[write] = cur;
+          list[write + 1] = value;
           found = true;
-          i += 2;
         } else {
-          list.splice(i, 2);
+          keep = false;
         }
-      } else {
-        i += 2;
+      } else if (write !== i) {
+        list[write] = cur;
+        list[write + 1] = list[i + 1];
       }
+      if (keep)
+        write += 2;
+    }
+
+    if (found && write !== len) {
+      list.length = write;
     }
 
     // Otherwise, append a new name-value pair whose name is `name` and value


### PR DESCRIPTION
This changes set and delete to use a single pass instead of repeated array.splice() while scanning

master:

```sh
url/url-searchparams-mutation.js n=10000 count=10 type="unique" method="set": 4,495,307.348658735
url/url-searchparams-mutation.js n=10000 count=1000 type="unique" method="set": 397,595.2168977331
> url/url-searchparams-mutation.js n=10000 count=10 type="duplicates" method="set": 2,309,513.092283293
> url/url-searchparams-mutation.js n=10000 count=1000 type="duplicates" method="set": 7,585.0868936063125
url/url-searchparams-mutation.js n=10000 count=10 type="unique" method="delete": 4,530,011.325028313
url/url-searchparams-mutation.js n=10000 count=1000 type="unique" method="delete": 305,692.37412161205
> url/url-searchparams-mutation.js n=10000 count=10 type="duplicates" method="delete": 2,222,098.772290428
> url/url-searchparams-mutation.js n=10000 count=1000 type="duplicates" method="delete": 7,601.665867066438
```

branch:

```sh
url/url-searchparams-mutation.js n=10000 count=10 type="unique" method="set": 4,314,296.500026965
url/url-searchparams-mutation.js n=10000 count=1000 type="unique" method="set": 398,303.2282476649
> url/url-searchparams-mutation.js n=10000 count=10 type="duplicates" method="set": 4,662,911.158019998
> url/url-searchparams-mutation.js n=10000 count=1000 type="duplicates" method="set": 199,327.60023302992
url/url-searchparams-mutation.js n=10000 count=10 type="unique" method="delete": 4,569,515.119611628
url/url-searchparams-mutation.js n=10000 count=1000 type="unique" method="delete": 284,133.96507300285
> url/url-searchparams-mutation.js n=10000 count=10 type="duplicates" method="delete": 5,081,732.037220638
> url/url-searchparams-mutation.js n=10000 count=1000 type="duplicates" method="delete": 213,852.28153652867
```