### PR TITLE
loader: lazy-load source map cache in CJS loader

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -132,9 +132,6 @@ module.exports = {
 };
 
 const { BuiltinModule } = require('internal/bootstrap/realm');
-const {
-  maybeCacheSourceMap,
-} = require('internal/source_map/source_map_cache');
 const { pathToFileURL, fileURLToPath, isURL, URL } = require('internal/url');
 const {
   pendingDeprecate,
@@ -220,6 +217,8 @@ let { startTimer, endTimer } = debugWithTimer('module_timer', (start, end) => {
   endTimer = end;
 });
 
+const lazyMaybeCacheSourceMap = getLazy(() =>
+  require('internal/source_map/source_map_cache').maybeCacheSourceMap);
 const { tracingChannel } = require('diagnostics_channel');
 const onRequire = getLazy(() => tracingChannel('module.require'));
 
@@ -1738,7 +1737,7 @@ function wrapSafe(filename, content, cjsModuleInstance, format) {
     // Cache the source map for the module if present.
     const { sourceMapURL, sourceURL } = script;
     if (sourceMapURL) {
-      maybeCacheSourceMap(filename, content, cjsModuleInstance, false, sourceURL, sourceMapURL);
+      lazyMaybeCacheSourceMap()(filename, content, cjsModuleInstance, false, sourceURL, sourceMapURL);
     }
 
     return {
@@ -1763,7 +1762,7 @@ function wrapSafe(filename, content, cjsModuleInstance, format) {
 
   // Cache the source map for the module if present.
   if (result.sourceMapURL) {
-    maybeCacheSourceMap(filename, content, cjsModuleInstance, false, result.sourceURL, result.sourceMapURL);
+    lazyMaybeCacheSourceMap()(filename, content, cjsModuleInstance, false, result.sourceURL, result.sourceMapURL);
   }
 
   return result;


### PR DESCRIPTION
Not sure why we're not lazy loading this? Seems like a good candidate