### PR TITLE
fs: expose frsize field in statfs

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7895,6 +7895,7 @@ numeric values will be `bigint` instead of `number`.
 StatFs {
   type: 1397114950,
   bsize: 4096,
+  frsize: 4096,
   blocks: 121938943,
   bfree: 61058895,
   bavail: 61058895,
@@ -7909,6 +7910,7 @@ StatFs {
 StatFs {
   type: 1397114950n,
   bsize: 4096n,
+  frsize: 4096n,
   blocks: 121938943n,
   bfree: 61058895n,
   bavail: 61058895n,
@@ -7964,6 +7966,16 @@ added:
 * Type: {number|bigint}
 
 Optimal transfer block size.
+
+#### `statfs.frsize`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number|bigint}
+
+Fundamental file system block size.
 
 #### `statfs.ffree`
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -571,9 +571,10 @@ function getStatsFromBinding(stats, offset = 0) {
 }
 
 class StatFs {
-  constructor(type, bsize, blocks, bfree, bavail, files, ffree) {
+  constructor(type, bsize, frsize, blocks, bfree, bavail, files, ffree) {
     this.type = type;
     this.bsize = bsize;
+    this.frsize = frsize;
     this.blocks = blocks;
     this.bfree = bfree;
     this.bavail = bavail;
@@ -584,7 +585,7 @@ class StatFs {
 
 function getStatFsFromBinding(stats) {
   return new StatFs(
-    stats[0], stats[1], stats[2], stats[3], stats[4], stats[5], stats[6],
+    stats[0], stats[1], stats[2], stats[3], stats[4], stats[5], stats[6], stats[7],
   );
 }
 

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -153,6 +153,7 @@ void FillStatFsArray(AliasedBufferBase<NativeT, V8T>* fields,
 
   SET_FIELD(kType, s->f_type);
   SET_FIELD(kBSize, s->f_bsize);
+  SET_FIELD(kFrSize, s->f_frsize);
   SET_FIELD(kBlocks, s->f_blocks);
   SET_FIELD(kBFree, s->f_bfree);
   SET_FIELD(kBAvail, s->f_bavail);

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -44,6 +44,7 @@ constexpr size_t kFsStatsBufferLength =
 enum class FsStatFsOffset {
   kType = 0,
   kBSize,
+  kFrSize,
   kBlocks,
   kBFree,
   kBAvail,

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -89,6 +89,7 @@ function verifyStatFsObject(stat, isBigint = false) {
   assert.strictEqual(typeof stat, 'object');
   assert.strictEqual(typeof stat.type, valueType);
   assert.strictEqual(typeof stat.bsize, valueType);
+  assert.strictEqual(typeof stat.frsize, valueType);
   assert.strictEqual(typeof stat.blocks, valueType);
   assert.strictEqual(typeof stat.bfree, valueType);
   assert.strictEqual(typeof stat.bavail, valueType);

--- a/test/parallel/test-fs-statfs.js
+++ b/test/parallel/test-fs-statfs.js
@@ -7,7 +7,7 @@ function verifyStatFsObject(statfs, isBigint = false) {
   const valueType = isBigint ? 'bigint' : 'number';
 
   [
-    'type', 'bsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree',
+    'type', 'bsize', 'frsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree',
   ].forEach((k) => {
     assert.ok(Object.hasOwn(statfs, k));
     assert.strictEqual(typeof statfs[k], valueType,


### PR DESCRIPTION
Expose `f_frsize` from libuv's `uv_statfs_t` as `statfs.frsize`.

libuv 1.52.0 added `f_frsize` to `uv_statfs_t`, and this dependency update has already landed in Node.js (5bebd7eaea2),
so users can now compute accurate disk usage on every filesystem type.

Per POSIX, `f_blocks`, `f_bfree`, and `f_bavail` are in units of `f_frsize`, not `f_bsize`. On most filesystems the two values happen to be equal, so `blocks * bsize` gives a correct result. However, some filesystem drivers report a larger `bsize` as the I/O transfer size while `frsize` remains at the actual block size, producing a significant overestimation.

I hit this on a Docker container using virtiofs with a bind-mounted host directory:

```console
$ node -e "console.log(fs.statfsSync('/data'))"
StatFs {
  bsize: 1048576,   // 1 MiB — I/O transfer size
  frsize: 4096,     // 4 KiB — actual block size
  blocks: 120699413,
  ...
}
```

| Calculation       | Result      |                     |
| ----------------- | ----------- | ------------------- |
| `blocks × frsize` | ~460 GB     | correct             |
| `blocks × bsize`  | ~117,870 GB | 256× overestimation |

Without `frsize` exposed, there is no way to work around this using the Node.js API alone.

See also https://github.com/libuv/libuv/issues/4983 where the same problem was discussed.