### PR TITLE
deps: disable rust icu compiled_data features

### DIFF
--- a/deps/crates/Cargo.lock
+++ b/deps/crates/Cargo.lock
@@ -191,11 +191,9 @@ name = "node_crates"
 version = "0.1.0"
 dependencies = [
  "icu_calendar",
- "icu_calendar_data",
  "icu_collections",
  "icu_locale",
  "icu_locale_core",
- "icu_locale_data",
  "icu_provider",
  "temporal_capi",
  "temporal_rs",

--- a/deps/crates/Cargo.toml
+++ b/deps/crates/Cargo.toml
@@ -12,24 +12,35 @@ crate-type = ["staticlib"]
 
 [dependencies]
 # Pin all temporal dependencies to the last version support rustc 1.82
-icu_calendar = "~2.0.0"
-icu_calendar_data = "~2.0.0"
 icu_collections = "~2.0.0"
-icu_locale = "~2.0.0"
 icu_locale_core = "~2.0.0"
-icu_locale_data = "~2.0.0"
 icu_provider = "~2.0.0"
 timezone_provider = "=0.1.0"
 
 [dependencies.temporal_capi]
 version = "=0.1.0"
 features = ["zoneinfo64"]
+default-features = false
 
 [dependencies.temporal_rs]
 version = "=0.1.0"
 default-features = false
 # This is necessary to enable a spec-compliance quirk when upgrading to v0.1.2
 # features = ["float64_representable_durations"]
+
+# Disable `icu_calendar_data` and `icu_locale_data` crates with disabling
+# `compiled_data` features. However these datasets are still enabled until
+# https://github.com/boa-dev/temporal/pull/694 lands.
+[dependencies.icu_calendar]
+version = "~2.0.0"
+features = [
+  "ixdtf", # Parser for Internet eXtended DateTime Format
+]
+default-features = false
+
+[dependencies.icu_locale]
+version = "~2.0.0"
+default-features = false
 
 [patch.crates-io]
 # Float https://github.com/unicode-org/icu4x/pull/7658 until crate is updated.


### PR DESCRIPTION
Disable `icu_calendar` and `icu_locale` default features so `compiled_data`
features are not enabled by default. The `compiled_data` feature might be
enabled indirectly, but it could be removed when upgrading `temporal_rs`.