### PR TITLE
stream: fix TypeError in writev when writer.ready rejects

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayIsArray,
   ArrayPrototypeFilter,
   ArrayPrototypeMap,
   Boolean,
@@ -313,9 +314,15 @@ function newStreamWritableFromWritableStream(writableStream, options = kEmptyObj
 
     writev(chunks, callback) {
       function done(error) {
-        error = error.filter((e) => e);
+        // When error comes from SafePromiseAll, it is an array of
+        // errors (one per chunk). When it comes from writer.ready
+        // rejection, it is a single error. Normalize to handle both.
+        if (ArrayIsArray(error)) {
+          error = ArrayPrototypeFilter(error, Boolean);
+          error = error.length === 0 ? undefined : error;
+        }
         try {
-          callback(error.length === 0 ? undefined : error);
+          callback(error);
         } catch (error) {
           // In a next tick because this is happening within
           // a promise context, and if there are any errors
@@ -775,9 +782,15 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
 
     writev(chunks, callback) {
       function done(error) {
-        error = error.filter((e) => e);
+        // When error comes from SafePromiseAll, it is an array of
+        // errors (one per chunk). When it comes from writer.ready
+        // rejection, it is a single error. Normalize to handle both.
+        if (ArrayIsArray(error)) {
+          error = ArrayPrototypeFilter(error, Boolean);
+          error = error.length === 0 ? undefined : error;
+        }
         try {
-          callback(error.length === 0 ? undefined : error);
+          callback(error);
         } catch (error) {
           // In a next tick because this is happening within
           // a promise context, and if there are any errors

--- a/test/parallel/test-whatwg-webstreams-adapters-writev-no-unhandled-rejection.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-writev-no-unhandled-rejection.js
@@ -1,0 +1,56 @@
+// Flags: --no-warnings --expose-internals
+'use strict';
+
+// Regression test for https://github.com/nodejs/node/issues/62199
+// Verifies that the writev done callback in webstream adapters does not
+// throw a TypeError when the error comes from writer.ready rejection
+// (a single error) rather than SafePromiseAll (an array of errors).
+
+const common = require('../common');
+
+const {
+  TransformStream,
+  WritableStream,
+} = require('stream/web');
+
+const {
+  newStreamWritableFromWritableStream,
+  newStreamDuplexFromReadableWritablePair,
+} = require('internal/webstreams/adapters');
+
+const { Duplex } = require('stream');
+
+// Test 1: Duplex.fromWeb writev path should not cause unhandled rejection
+{
+  const output = Duplex.fromWeb(new TransformStream());
+  output.on('error', common.mustCall());
+  output.cork();
+  output.write('test');
+  output.write('test');
+  output.uncork();
+  output.destroy();
+}
+
+// Test 2: newStreamDuplexFromReadableWritablePair writev path
+{
+  const transform = new TransformStream();
+  const duplex = newStreamDuplexFromReadableWritablePair(transform);
+  duplex.on('error', common.mustCall());
+  duplex.cork();
+  duplex.write('test');
+  duplex.write('test');
+  duplex.uncork();
+  duplex.destroy();
+}
+
+// Test 3: newStreamWritableFromWritableStream writev path
+{
+  const writableStream = new WritableStream();
+  const writable = newStreamWritableFromWritableStream(writableStream);
+  writable.on('error', common.mustCall());
+  writable.cork();
+  writable.write('test');
+  writable.write('test');
+  writable.uncork();
+  writable.destroy();
+}


### PR DESCRIPTION
The `done` callback in the `writev` handlers of both
`newStreamWritableFromWritableStream` and
`newStreamDuplexFromReadableWritablePair` unconditionally called
`error.filter()`, assuming `error` is always an array (from
`SafePromiseAll`). However, `done` is also used as the rejection
handler for `writer.ready`, which passes a single error value,
not an array. This caused a `TypeError: Cannot read properties of
null (reading 'filter')` which became an unhandled rejection,
crashing the process.

**Root cause:** When a `Duplex.fromWeb()` stream is corked, writes
are batched into a `_writev` call. If `destroy()` is called in the
same microtask (after `uncork()`), the underlying `WritableStream`
writer gets aborted, causing `writer.ready` to reject. The `done`
callback then receives a single error instead of the array it
expects from `SafePromiseAll`.

**Fix:** Check whether `error` is an array before calling
`ArrayPrototypeFilter` on it. This handles both code paths:
- `SafePromiseAll` resolution/rejection → array of results/errors
- `writer.ready` rejection → single error value

Also uses `ArrayIsArray`/`ArrayPrototypeFilter` from primordials,
consistent with Node.js internal conventions.

Includes a regression test that reproduces the exact scenario from
the issue report (cork → write → write → uncork → destroy).

Fixes: https://github.com/nodejs/node/issues/62199