### PR TITLE
stream: fix writev unhandled rejection in fromWeb

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -314,9 +314,8 @@ function newStreamWritableFromWritableStream(writableStream, options = kEmptyObj
 
     writev(chunks, callback) {
       function done(error) {
-        error = error.filter((e) => e);
         try {
-          callback(error.length === 0 ? undefined : error);
+          callback(error);
         } catch (error) {
           // In a next tick because this is happening within
           // a promise context, and if there are any errors
@@ -334,7 +333,7 @@ function newStreamWritableFromWritableStream(writableStream, options = kEmptyObj
             SafePromiseAll(
               chunks,
               (data) => writer.write(data.chunk)),
-            done,
+            () => done(),
             done);
         },
         done);
@@ -787,9 +786,8 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
 
     writev(chunks, callback) {
       function done(error) {
-        error = error.filter((e) => e);
         try {
-          callback(error.length === 0 ? undefined : error);
+          callback(error);
         } catch (error) {
           // In a next tick because this is happening within
           // a promise context, and if there are any errors
@@ -807,7 +805,7 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
             SafePromiseAll(
               chunks,
               (data) => writer.write(data.chunk)),
-            done,
+            () => done(),
             done);
         },
         done);

--- a/test/parallel/test-webstreams-duplex-fromweb-writev-unhandled-rejection.js
+++ b/test/parallel/test-webstreams-duplex-fromweb-writev-unhandled-rejection.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// Regression test for https://github.com/nodejs/node/issues/62199
+//
+// When Duplex.fromWeb is corked, writes are batched into _writev. If destroy()
+// is called in the same microtask (after uncork()), writer.ready rejects with a
+// non-array value. The done() callback inside _writev unconditionally called
+// error.filter(), which throws TypeError on non-arrays. This TypeError became
+// an unhandled rejection that crashed the process.
+//
+// The same bug exists in newStreamWritableFromWritableStream (Writable.fromWeb).
+
+const common = require('../common');
+const { Duplex, Writable } = require('stream');
+const { TransformStream, WritableStream } = require('stream/web');
+
+// Exact reproduction from the issue report (davidje13).
+// Before the fix: process crashes with unhandled TypeError.
+// After the fix: stream closes cleanly with no unhandled rejection.
+{
+  const output = Duplex.fromWeb(new TransformStream());
+
+  output.on('close', common.mustCall());
+
+  output.cork();
+  output.write('test');
+  output.write('test');
+  output.uncork();
+  output.destroy();
+}
+
+// Same bug in Writable.fromWeb (newStreamWritableFromWritableStream).
+{
+  const writable = Writable.fromWeb(new WritableStream());
+
+  writable.on('close', common.mustCall());
+
+  writable.cork();
+  writable.write('test');
+  writable.write('test');
+  writable.uncork();
+  writable.destroy();
+}
+
+// Regression: normal cork/uncork/_writev success path must still work.
+// Verifies that () => done() correctly signals success via callback().
+{
+  const writable = Writable.fromWeb(new WritableStream({ write() {} }));
+
+  writable.cork();
+  writable.write('foo');
+  writable.write('bar');
+  writable.uncork();
+  writable.end(common.mustCall());
+}


### PR DESCRIPTION
## Summary

Fixes #62199

When using `Duplex.fromWeb()` or `Writable.fromWeb()` with `cork()`/`uncork()`, writes are batched into `_writev()`. If `destroy()` is called in the same microtask (after `uncork()`), the underlying `WritableStream` writer gets aborted, causing `SafePromiseAll()` to reject with a non-array value (e.g. an `AbortError` or `null`).

The `done()` callback in `_writev()` of both `newStreamDuplexFromReadableWritablePair` and `newStreamWritableFromWritableStream` unconditionally called `error.filter()`, assuming the value was always an array from `SafePromiseAll`. This caused a `TypeError: Cannot read properties of null (reading 'filter')` that became an unhandled rejection, crashing the process.

## Root cause

`done` was used as both the resolve and reject handler for `SafePromiseAll`:

```js
PromisePrototypeThen(SafePromiseAll(chunks, ...), done, done);
```

- **Resolve path**: `done([undefined, undefined, ...])` — array, `.filter()` works
- **Reject path**: `done(abortError)` or `done(null)` — non-array, `.filter()` throws

## Fix

Separate the resolve and reject handlers of `SafePromiseAll`. `Promise.all` resolving means all writes succeeded — there is no error to report. `Promise.all` rejecting passes a single error value directly.

```js
PromisePrototypeThen(SafePromiseAll(chunks, ...), () => done(), done);
```

- `() => done()` — resolve path: all writes succeeded, call callback with no error
- `done` — reject path: single error passed directly to callback

The same fix is applied to both `newStreamDuplexFromReadableWritablePair` and `newStreamWritableFromWritableStream`.

## Test

Added `test/parallel/test-webstreams-duplex-fromweb-writev-unhandled-rejection.js` with the exact reproduction from the issue report (cork → write → write → uncork → destroy).