### PR TITLE
doc: enhance clarification about the main field

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -1012,7 +1012,7 @@ added: v0.4.0
 The `"main"` field defines the entry point of a package when imported by name
 via a `node_modules` lookup.  Its value is a path.
 
-The [`"exports"`][] field, if it exists, will take precedence over the
+The [`"exports"`][] field, if it exists, takes precedence over the
 `"main"` field when importing the package by name.
 
 It also defines the script that is used when the [package directory is loaded


### PR DESCRIPTION
removed "this" to enhance sentence flow.

because a reader might assume that **this** is referencing the **main** field which is the title of the section.
