### PR TITLE
worker: parse NODE_OPTIONS when env option is not provided

### DIFF
--- a/src/node_worker.cc
+++ b/src/node_worker.cc
@@ -561,7 +561,7 @@ void Worker::New(const FunctionCallbackInfo<Value>& args) {
     THROW_ERR_OPERATION_FAILED(env, "Failed to copy environment variables");
   }
 
-  if (args[1]->IsObject() || args[2]->IsArray()) {
+  if (args[1]->IsNull() || args[1]->IsObject() || args[2]->IsArray()) {
     per_isolate_opts.reset(new PerIsolateOptions());
 
     HandleEnvOptions(per_isolate_opts->per_env, [&env_vars](const char* name) {

--- a/test/fixtures/spawn-worker-without-env-option.js
+++ b/test/fixtures/spawn-worker-without-env-option.js
@@ -1,0 +1,17 @@
+'use strict';
+
+// Tests that NODE_OPTIONS set at runtime in the parent process
+// are picked up by a worker thread even when the env option is
+// not explicitly provided to the Worker constructor.
+const { Worker, isMainThread } = require('worker_threads');
+
+if (isMainThread) {
+  process.env.NODE_OPTIONS = '--trace-exit';
+  new Worker(__filename);
+} else {
+  setImmediate(() => {
+    process.nextTick(() => {
+      process.exit(0);
+    });
+  });
+}

--- a/test/parallel/test-worker-node-options.js
+++ b/test/parallel/test-worker-node-options.js
@@ -38,3 +38,20 @@ spawnSyncAndAssert(
     stderr: /spawn-worker-with-trace-exit\.js:17/
   }
 );
+
+// Test that NODE_OPTIONS set at runtime in the parent process are
+// picked up by a worker even when the env option is not provided.
+spawnSyncAndAssert(
+  process.execPath,
+  [
+    fixtures.path('spawn-worker-without-env-option'),
+  ],
+  {
+    env: {
+      ...process.env,
+    }
+  },
+  {
+    stderr: /spawn-worker-without-env-option\.js:14/
+  }
+);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
When env option is not explicitly provided to new Worker(),
runtime changes to process.env.NODE_OPTIONS (e.g. adding --import)
are not picked up by the worker thread.

This happens because in node_worker.cc, the NODE_OPTIONS parsing
block is gated behind args[1]->IsObject() || args[2]->IsArray().
When env is not provided, args[1] is null (cloned from
process.env), so the condition is false and NODE_OPTIONS parsing
is skipped entirely.

This fix adds args[1]->IsNull() to the condition so that
NODE_OPTIONS is also parsed when the env is inherited (cloned)
from the parent process.

Fixes: https://github.com/nodejs/node/issues/62301