### PR TITLE
lib: make SubtleCrypto.supports enumerable

### DIFF
--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -1894,13 +1894,9 @@ ObjectDefineProperties(
     },
   });
 
-ObjectDefineProperties(
-  SubtleCrypto, {
-    supports: {
-      __proto__: null,
-      enumerable: true,
-    },
-  });
+ObjectDefineProperties(SubtleCrypto, {
+  supports: kEnumerableProperty,
+});
 
 module.exports = {
   Crypto,

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -1894,6 +1894,14 @@ ObjectDefineProperties(
     },
   });
 
+ObjectDefineProperties(
+  SubtleCrypto, {
+    supports: {
+      __proto__: null,
+      enumerable: true,
+    },
+  });
+
 module.exports = {
   Crypto,
   CryptoKey,


### PR DESCRIPTION
Per [WebIDL § 3.7.7](https://webidl.spec.whatwg.org/#js-operations), static operations use the same "define the operations" algorithm as regular operations:

> To **define the operations** *operations* of interface or namespace *definition* on *target*, given realm *realm*, run the following steps:
>
> 1. For each operation *op* of *operations*:
>    1. If *op* is not exposed in *realm*, then continue.
>    2. Let *method* be the result of creating an operation function given *op*, *definition*, and *realm*.
>    3. Let *modifiable* be **false** if *op* is unforgeable and **true** otherwise.
>    4. Let *desc* be the PropertyDescriptor{[[Value]]: *method*, [[Writable]]: *modifiable*, **[[Enumerable]]: true**, [[Configurable]]: *modifiable*}.
>    5. Let *id* be *op*'s identifier.
>    6. Perform ! DefinePropertyOrThrow(*target*, *id*, *desc*).

The `[[Enumerable]]: true` in step 4 applies to both regular and static operations. JavaScript `static` class methods are non-enumerable by default, so we need to explicitly set `enumerable: true` on `SubtleCrypto.supports` to match the spec just like we do with all other prototype methods.