### PR TITLE
src: expose `node::RegisterContext` to make a node managed context

### DIFF
--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -1056,9 +1056,9 @@ Maybe<bool> InitializeContext(Local<Context> context) {
 
 void RegisterContext(Environment* env,
                      v8::Local<v8::Context> context,
-                     const std::string& name,
-                     const std::string& origin) {
-  ContextInfo info(name, origin);
+                     std::string_view name,
+                     std::string_view origin) {
+  ContextInfo info{std::string(name), std::string(origin)};
   env->AssignToContext(context, nullptr, info);
 }
 

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -2,6 +2,7 @@
 #if HAVE_OPENSSL
 #include "crypto/crypto_util.h"
 #endif  // HAVE_OPENSSL
+#include "env.h"
 #include "env_properties.h"
 #include "node.h"
 #include "node_builtins.h"
@@ -1051,6 +1052,18 @@ Maybe<bool> InitializeContext(Local<Context> context) {
     return Nothing<bool>();
   }
   return Just(true);
+}
+
+void RegisterContext(Environment* env,
+                     v8::Local<v8::Context> context,
+                     const std::string& name,
+                     const std::string& origin) {
+  ContextInfo info(name, origin);
+  env->AssignToContext(context, nullptr, info);
+}
+
+void UnregisterContext(Environment* env, v8::Local<v8::Context> context) {
+  env->UnassignFromContext(context);
 }
 
 uv_loop_t* GetCurrentEventLoop(Isolate* isolate) {

--- a/src/env.h
+++ b/src/env.h
@@ -257,6 +257,8 @@ class NODE_EXTERN_PRIVATE IsolateData : public MemoryRetainer {
 
 struct ContextInfo {
   explicit ContextInfo(const std::string& name) : name(name) {}
+  ContextInfo(const std::string& name, const std::string& origin)
+      : name(name), origin(origin) {}
   const std::string name;
   std::string origin;
   bool is_default = false;

--- a/src/node.h
+++ b/src/node.h
@@ -563,6 +563,8 @@ NODE_EXTERN v8::Isolate* NewIsolate(
     const IsolateSettings& settings = {});
 
 // Creates a new context with Node.js-specific tweaks.
+// Call `RegisterContext` after the context been created to register
+// the context with Node.js specific setups like the inspector.
 NODE_EXTERN v8::Local<v8::Context> NewContext(
     v8::Isolate* isolate,
     v8::Local<v8::ObjectTemplate> object_template =
@@ -571,6 +573,18 @@ NODE_EXTERN v8::Local<v8::Context> NewContext(
 // Runs Node.js-specific tweaks on an already constructed context
 // Return value indicates success of operation
 NODE_EXTERN v8::Maybe<bool> InitializeContext(v8::Local<v8::Context> context);
+
+// Associate the context with the given Environment. This registers the context
+// as known to Node.js, makes it available to the inspector. This also registers
+// Node.js promise hooks on the context.
+NODE_EXTERN void RegisterContext(Environment* env,
+                                 v8::Local<v8::Context> context,
+                                 const std::string& name = "",
+                                 const std::string& origin = "");
+// Unregister the context. Call this when the embedder finished all work with
+// this context.
+NODE_EXTERN void UnregisterContext(Environment* env,
+                                   v8::Local<v8::Context> context);
 
 // If `platform` is passed, it will be used to register new Worker instances.
 // It can be `nullptr`, in which case creating new Workers inside of

--- a/src/node.h
+++ b/src/node.h
@@ -579,8 +579,8 @@ NODE_EXTERN v8::Maybe<bool> InitializeContext(v8::Local<v8::Context> context);
 // Node.js promise hooks on the context.
 NODE_EXTERN void RegisterContext(Environment* env,
                                  v8::Local<v8::Context> context,
-                                 const std::string& name = "",
-                                 const std::string& origin = "");
+                                 std::string_view name = "",
+                                 std::string_view origin = "");
 // Unregister the context. Call this when the embedder finished all work with
 // this context.
 NODE_EXTERN void UnregisterContext(Environment* env,

--- a/test/addons/new-context-inspector/binding.cc
+++ b/test/addons/new-context-inspector/binding.cc
@@ -1,0 +1,69 @@
+#include <node.h>
+#include <v8.h>
+
+namespace {
+
+using v8::Context;
+using v8::FunctionCallbackInfo;
+using v8::HandleScope;
+using v8::Isolate;
+using v8::Local;
+using v8::Object;
+using v8::Script;
+using v8::String;
+using v8::Value;
+
+void MakeContext(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope handle_scope(isolate);
+  Local<Context> context = isolate->GetCurrentContext();
+  node::Environment* env = node::GetCurrentEnvironment(context);
+  assert(env);
+
+  // Create a new context with Node.js-specific setup.
+  v8::MaybeLocal<Context> maybe_context = node::NewContext(isolate);
+  v8::Local<Context> new_context;
+  if (!maybe_context.ToLocal(&new_context)) {
+    return;
+  }
+  node::RegisterContext(env, new_context, "Addon Context", "addon://about");
+
+  // Return the global proxy object.
+  args.GetReturnValue().Set(new_context->Global());
+}
+
+void RunInContext(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = Isolate::GetCurrent();
+  HandleScope handle_scope(isolate);
+  assert(args.Length() == 2);
+
+  assert(args[0]->IsObject());
+  Local<Object> global_proxy = args[0].As<Object>();
+  v8::MaybeLocal<Context> maybe_context = global_proxy->GetCreationContext();
+  v8::Local<Context> new_context;
+  if (!maybe_context.ToLocal(&new_context)) {
+    return;
+  }
+  Context::Scope context_scope(new_context);
+
+  assert(args[1]->IsString());
+  Local<String> source = args[1].As<String>();
+  Local<Script> script;
+  Local<Value> result;
+
+  if (Script::Compile(new_context, source).ToLocal(&script) &&
+      script->Run(new_context).ToLocal(&result)) {
+    args.GetReturnValue().Set(result);
+  }
+}
+
+void Initialize(Local<Object> exports,
+                Local<Value> module,
+                Local<Context> context) {
+  NODE_SET_METHOD(exports, "makeContext", MakeContext);
+  NODE_SET_METHOD(exports, "runInContext", RunInContext);
+}
+
+}  // anonymous namespace
+
+NODE_MODULE_CONTEXT_AWARE(NODE_GYP_MODULE_NAME, Initialize)

--- a/test/addons/new-context-inspector/binding.gyp
+++ b/test/addons/new-context-inspector/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': ['binding.cc'],
+      'includes': ['../common.gypi'],
+    },
+  ]
+}

--- a/test/addons/new-context-inspector/test-inspector.js
+++ b/test/addons/new-context-inspector/test-inspector.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const common = require('../../common');
+common.skipIfInspectorDisabled();
+
+const assert = require('node:assert');
+const { once } = require('node:events');
+const { Session } = require('node:inspector');
+
+const binding = require(`./build/${common.buildType}/binding`);
+
+const session = new Session();
+session.connect();
+
+(async function() {
+  const mainContextPromise =
+      once(session, 'Runtime.executionContextCreated');
+  session.post('Runtime.enable', assert.ifError);
+  await mainContextPromise;
+
+  // Addon-created context should be reported to the inspector.
+  {
+    const addonContextPromise =
+        once(session, 'Runtime.executionContextCreated');
+
+    const ctx = binding.makeContext();
+    const result = binding.runInContext(ctx, '1 + 1');
+    assert.strictEqual(result, 2);
+
+    const { 0: contextCreated } = await addonContextPromise;
+    const { name, origin, auxData } = contextCreated.params.context;
+    assert.strictEqual(name, 'Addon Context',
+                       JSON.stringify(contextCreated));
+    assert.strictEqual(origin, 'addon://about',
+                       JSON.stringify(contextCreated));
+    assert.strictEqual(auxData.isDefault, false,
+                       JSON.stringify(contextCreated));
+  }
+
+  // `debugger` statement should pause in addon-created context.
+  {
+    session.post('Debugger.enable', assert.ifError);
+
+    const pausedPromise = once(session, 'Debugger.paused');
+    const ctx = binding.makeContext();
+    binding.runInContext(ctx, 'debugger');
+    await pausedPromise;
+
+    session.post('Debugger.resume');
+  }
+})().then(common.mustCall());

--- a/test/addons/new-context-inspector/test.js
+++ b/test/addons/new-context-inspector/test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const common = require('../../common');
+const assert = require('assert');
+
+const binding = require(`./build/${common.buildType}/binding`);
+
+// This verifies that the addon-created context has an independent
+// global object.
+{
+  const ctx = binding.makeContext();
+  const result = binding.runInContext(ctx, `
+  globalThis.foo = 'bar';
+  foo;
+  `);
+  assert.strictEqual(result, 'bar');
+  assert.strictEqual(globalThis.foo, undefined);
+}


### PR DESCRIPTION
This allows addons to create a context, with Node.js inspector support.

The API exposed is intended to be minimum, to be used together with
`node::NewContext`.