### PR TITLE
meta: add `vfs` subsystem label

### DIFF
--- a/.github/label-pr-config.yml
+++ b/.github/label-pr-config.yml
@@ -214,6 +214,7 @@ allJsSubSystems:
   - url
   - util
   - v8
+  - vfs
   - vm
   - wasi
   - worker


### PR DESCRIPTION
Adds https://github.com/nodejs/node/labels/vfs as a subsystem label.

Refs: #61478