### PR TITLE
assert: add partialDeepEqual to strict mode

### DIFF
--- a/lib/assert.js
+++ b/lib/assert.js
@@ -128,6 +128,7 @@ function Assert(options) {
     this.deepEqual = this.deepStrictEqual;
     this.notEqual = this.notStrictEqual;
     this.notDeepEqual = this.notDeepStrictEqual;
+    this.partialDeepEqual = this.partialDeepStrictEqual;
   }
 }
 
@@ -896,6 +897,7 @@ assert.strict = ObjectAssign(strict, assert, {
   deepEqual: assert.deepStrictEqual,
   notEqual: assert.notStrictEqual,
   notDeepEqual: assert.notDeepStrictEqual,
+  partialDeepEqual: assert.partialDeepStrictEqual,
 });
 
 assert.strict.Assert = Assert;

--- a/test/parallel/test-assert-class.js
+++ b/test/parallel/test-assert-class.js
@@ -148,6 +148,10 @@ test('Assert class strict', () => {
     assertInstance.notDeepEqual,
     assertInstance.notDeepStrictEqual
   );
+  assertInstance.equal(
+    assertInstance.partialDeepEqual,
+    assertInstance.partialDeepStrictEqual
+  );
 });
 
 test('Assert class with invalid diff option', () => {

--- a/test/parallel/test-assert.js
+++ b/test/parallel/test-assert.js
@@ -1596,6 +1596,13 @@ test('assert/strict exists', () => {
   assert.strictEqual(require('assert/strict'), assert.strict);
 });
 
+test('assert.strict.partialDeepEqual is an alias for partialDeepStrictEqual', () => {
+  assert.strictEqual(
+    assert.strict.partialDeepEqual,
+    assert.strict.partialDeepStrictEqual
+  );
+});
+
 test('Printf-like format strings as error message', () => {
   assert.throws(
     () => assert.equal(1, 2, 'The answer to all questions is %i', 42),


### PR DESCRIPTION
The `partialDeepStrictEqual` method was not re-exported as `partialDeepEqual` in strict assertion mode, unlike other methods such as `deepEqual` and `equal`.

Add the alias so that strict mode users can call
`assert.partialDeepEqual()` consistently with the existing naming convention.

Fixes: https://github.com/nodejs/node/issues/62327

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
When using `node:assert/strict`, methods like `deepEqual` and `equal`
are automatically aliased to their strict counterparts. However,
`partialDeepStrictEqual` was missing this alias.

This PR adds the `partialDeepEqual` alias in two places:

1. `Assert` constructor: when `options.strict` is true,
   `this.partialDeepEqual = this.partialDeepStrictEqual`
2. `assert.strict` object: `partialDeepEqual` mapped to
   `assert.partialDeepStrictEqual`

Tests added in `test-assert-class.js` and `test-assert.js`
following the existing alias verification pattern.

Fixes: https://github.com/nodejs/node/issues/62327