### PR TITLE
http: fix no_proxy leading-dot suffix matching

### DIFF
--- a/lib/internal/http.js
+++ b/lib/internal/http.js
@@ -158,7 +158,7 @@ class ProxyConfig {
       // Follow curl's behavior: strip leading dot before matching suffixes.
       if (entry[0] === '.') {
         const suffix = entry.substring(1);
-        if (host.endsWith(suffix)) return false;
+        if (host === suffix || (host.endsWith(suffix) && host[host.length - suffix.length - 1] === '.')) return false;
       }
 
       // Handle wildcards like *.example.com

--- a/test/client-proxy/test-http-proxy-request-no-proxy-domain.mjs
+++ b/test/client-proxy/test-http-proxy-request-no-proxy-domain.mjs
@@ -10,7 +10,7 @@ import { runProxiedRequest } from '../common/proxy-server.js';
 const server = http.createServer(common.mustCall((req, res) => {
   res.writeHead(200, { 'Content-Type': 'text/plain' });
   res.end('Hello World\n');
-}, 3));
+}, 5));
 server.on('error', common.mustNotCall((err) => { console.error('Server error', err); }));
 server.listen(0, '127.0.0.1');
 await once(server, 'listening');
@@ -77,5 +77,42 @@ await once(proxy, 'listening');
   assert.strictEqual(code, 0);
   assert.strictEqual(signal, null);
 }
+
+// Test NO_PROXY with leading-dot entry should NOT match partial domain names.
+// Regression test: .example.com must not match notexample.com or badexample.com.
+{
+  const { code, signal, stderr, stdout } = await runProxiedRequest({
+    NODE_USE_ENV_PROXY: 1,
+    REQUEST_URL: `http://notexample.com:${server.address().port}/test`,
+    HTTP_PROXY: `http://localhost:${server.address().port}`,
+    RESOLVE_TO_LOCALHOST: 'notexample.com',
+    NO_PROXY: '.example.com',
+  });
+
+  // The request should go through the proxy (not bypass it),
+  // because notexample.com is not a subdomain of example.com.
+  assert.match(stdout, /Status Code: 200/);
+  assert.strictEqual(stderr.trim(), '');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+}
+
+{
+  const { code, signal, stderr, stdout } = await runProxiedRequest({
+    NODE_USE_ENV_PROXY: 1,
+    REQUEST_URL: `http://badexample.com:${server.address().port}/test`,
+    HTTP_PROXY: `http://localhost:${server.address().port}`,
+    RESOLVE_TO_LOCALHOST: 'badexample.com',
+    NO_PROXY: '.example.com',
+  });
+
+  // The request should go through the proxy (not bypass it),
+  // because badexample.com is not a subdomain of example.com.
+  assert.match(stdout, /Status Code: 200/);
+  assert.strictEqual(stderr.trim(), '');
+  assert.strictEqual(code, 0);
+  assert.strictEqual(signal, null);
+}
+
 proxy.close();
 server.close();


### PR DESCRIPTION
Fix `NO_PROXY` suffix matching to prevent partial domain matches

This PR improves `NO_PROXY` logic by ensuring suffix matches occur only on exact domains or subdomains. Previously, using `endsWith()` caused false positives (e.g., myexample.com matching .example.com). This aligns with the expected domain boundary matching behavior.

```js
// Run with: ./node --expose-internals -e "$(cat this_file.js)"
'use strict';

const { parseProxyConfigFromEnv } = require('internal/http');
const assert = require('assert');

const config = parseProxyConfigFromEnv({
  http_proxy: 'http://proxy.test:8080',
  no_proxy: '.example.com',
}, 'http:', false);

// These should bypass proxy (false)
assert.strictEqual(config.shouldUseProxy('sub.example.com'), false);
assert.strictEqual(config.shouldUseProxy('example.com'), false);

// These should use proxy (true) — currently returns false without the fix
assert.strictEqual(config.shouldUseProxy('notexample.com'), true);
assert.strictEqual(config.shouldUseProxy('badexample.com'), true);

console.log('All assertions passed');
```