### PR TITLE
src: fix missing file error when --watch used without argument

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -32,6 +32,11 @@ const { once } = require('events');
 prepareMainThreadExecution(false, false);
 markBootstrapComplete();
 
+if (!process.argv[1]) {
+  process.stderr.write('node: --watch requires specifying a file\n')
+  process.exit(9);
+}
+
 const kKillSignal = convertToValidSignal(getOptionValue('--watch-kill-signal'));
 const kShouldFilterModules = getOptionValue('--watch-path').length === 0;
 const kEnvFiles = [

--- a/test/parallel/test-watch-mode-without-file.mjs
+++ b/test/parallel/test-watch-mode-without-file.mjs
@@ -1,0 +1,9 @@
+'use strict';
+
+import { spawnSync } from 'child_process';
+import { strictEqual, match } from "node:assert";
+
+const result = spawnSync(process.execPath, ['--watch'], { encoding: 'utf8' });
+
+strictEqual(result.status, 9);
+match(result.stderr, /--watch requires specifying a file/)


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## Problem

Previously, running `node --watch` without specifying a file would
start the REPL instead of exiting with code 9. This was a regression
found in issue #62305.

## Solution

- Add an explicit check for `process.argv[1]` immediately after
`markBootstrapComplete()`. If no file is provided, print the
original error message and exit with code `9`.
- Add new test `test/parallel/test-watch-mode-without-file.mjs` for check error message and exit with correct code.
