### PR TITLE
fix: ref event loop for Atomics.waitAsync promises

### DIFF
--- a/lib/internal/atomics.js
+++ b/lib/internal/atomics.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const {
+  AtomicsWaitAsync,
+  ObjectDefineProperty,
+  PromisePrototypeThen,
+  globalThis,
+} = primordials;
+
+const {
+  atomicsWaitAsyncRef,
+  atomicsWaitAsyncUnref,
+} = internalBinding('util');
+
+// Wrap Atomics.waitAsync so that its promise refs the event loop while pending.
+// Without this, the process exits before the promise resolves because V8's
+// internal wait mechanism does not create a libuv handle.
+// See: https://github.com/nodejs/node/issues/61941
+function setupAtomicsWaitAsync() {
+  ObjectDefineProperty(globalThis.Atomics, 'waitAsync', {
+    __proto__: null,
+    value: function waitAsync(typedArray, index, value, timeout) {
+      const result = AtomicsWaitAsync(typedArray, index, value, timeout);
+      if (result.async) {
+        atomicsWaitAsyncRef();
+        const settle = () => { atomicsWaitAsyncUnref(); };
+        PromisePrototypeThen(result.value, settle, settle);
+      }
+      return result;
+    },
+    writable: true,
+    enumerable: false,
+    configurable: true,
+  });
+}
+
+module.exports = { setupAtomicsWaitAsync };

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -119,6 +119,7 @@ function prepareExecution(options) {
   setupWebStorage();
   setupWebsocket();
   setupEventsource();
+  setupAtomicsWaitAsync();
   setupCodeCoverage();
   setupDebugEnv();
   // Process initial diagnostic reporting configuration, if present.
@@ -346,6 +347,11 @@ function setupWarningHandler() {
       });
     }
   }
+}
+
+function setupAtomicsWaitAsync() {
+  const { setupAtomicsWaitAsync: setup } = require('internal/atomics');
+  setup();
 }
 
 // https://websockets.spec.whatwg.org/

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -436,6 +436,16 @@ static void DefineLazyProperties(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+void AtomicsWaitAsyncRef(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  env->add_refs(1);
+}
+
+void AtomicsWaitAsyncUnref(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  env->add_refs(-1);
+}
+
 void ConstructSharedArrayBuffer(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   int64_t length;
@@ -478,6 +488,8 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(DefineLazyProperties);
   registry->Register(DefineLazyPropertiesGetter);
   registry->Register(ConstructSharedArrayBuffer);
+  registry->Register(AtomicsWaitAsyncRef);
+  registry->Register(AtomicsWaitAsyncUnref);
 }
 
 void Initialize(Local<Object> target,
@@ -583,6 +595,8 @@ void Initialize(Local<Object> target,
             target,
             "constructSharedArrayBuffer",
             ConstructSharedArrayBuffer);
+  SetMethod(context, target, "atomicsWaitAsyncRef", AtomicsWaitAsyncRef);
+  SetMethod(context, target, "atomicsWaitAsyncUnref", AtomicsWaitAsyncUnref);
 
   Local<String> should_abort_on_uncaught_toggle =
       FIXED_ONE_BYTE_STRING(env->isolate(), "shouldAbortOnUncaughtToggle");

--- a/test/parallel/test-atomics-waitasync-event-loop.js
+++ b/test/parallel/test-atomics-waitasync-event-loop.js
@@ -1,0 +1,141 @@
+'use strict';
+
+// Verify that Atomics.waitAsync() keeps the event loop alive until the
+// promise settles. Without the fix, the process exits before the promise
+// resolves because V8's internal wait mechanism does not create a libuv handle.
+// Ref: https://github.com/nodejs/node/issues/61941
+
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+// Test 1: Atomics.waitAsync with timeout keeps the loop alive.
+// The waitAsync promise is the only pending async work; the event loop must
+// not exit before it settles.
+{
+  const result = spawnSync(process.execPath, [
+    '--no-warnings',
+    '-e',
+    `
+      const assert = require('assert');
+      const sab = new SharedArrayBuffer(4);
+      const i32 = new Int32Array(sab);
+
+      const result = Atomics.waitAsync(i32, 0, 0, 50);
+      assert.strictEqual(result.async, true);
+
+      result.value.then((val) => {
+        assert.strictEqual(val, 'timed-out');
+        process.exitCode = 0;
+      });
+    `,
+  ], { timeout: 10_000 });
+
+  assert.strictEqual(
+    result.status, 0,
+    `expected exit code 0, got ${result.status}. ` +
+    `stderr: ${result.stderr?.toString()}`
+  );
+}
+
+// Test 2: Synchronous waitAsync (value already changed) does not leak a ref.
+// The process should exit normally without hanging.
+{
+  const result = spawnSync(process.execPath, [
+    '--no-warnings',
+    '-e',
+    `
+      const sab = new SharedArrayBuffer(4);
+      const i32 = new Int32Array(sab);
+
+      // Value is already 1, waitAsync expects 0, so it returns synchronously.
+      Atomics.store(i32, 0, 1);
+      const result = Atomics.waitAsync(i32, 0, 0);
+
+      // Sync case: the result is not async, no ref should be added.
+      if (!result.async) {
+        process.exitCode = 0;
+      }
+    `,
+  ], { timeout: 5_000 });
+
+  assert.strictEqual(
+    result.status, 0,
+    `expected exit code 0, got ${result.status}. ` +
+    `stderr: ${result.stderr?.toString()}`
+  );
+}
+
+// Test 3: Multiple concurrent waitAsync calls properly ref-count.
+// All pending waits must resolve before the process exits.
+{
+  const result = spawnSync(process.execPath, [
+    '--no-warnings',
+    '-e',
+    `
+      const assert = require('assert');
+      const sab = new SharedArrayBuffer(12);
+      const i32 = new Int32Array(sab);
+
+      let resolved = 0;
+      for (let idx = 0; idx < 3; idx++) {
+        const result = Atomics.waitAsync(i32, idx, 0, 50);
+        assert.strictEqual(result.async, true);
+        result.value.then((val) => {
+          assert.strictEqual(val, 'timed-out');
+          resolved++;
+          if (resolved === 3) {
+            process.exitCode = 0;
+          }
+        });
+      }
+    `,
+  ], { timeout: 10_000 });
+
+  assert.strictEqual(
+    result.status, 0,
+    `expected exit code 0, got ${result.status}. ` +
+    `stderr: ${result.stderr?.toString()}`
+  );
+}
+
+// Test 4: Worker thread notifies Atomics.waitAsync on the main thread.
+// This is the real-world Emscripten/pthreads pattern from the issue.
+{
+  const result = spawnSync(process.execPath, [
+    '--no-warnings',
+    '-e',
+    `
+      const assert = require('assert');
+      const { Worker } = require('worker_threads');
+      const sab = new SharedArrayBuffer(4);
+      const view = new Int32Array(sab, 0, 1);
+      view[0] = 0;
+
+      const code = \`
+        const { workerData, parentPort } = require('worker_threads');
+        const view = new Int32Array(workerData, 0, 1);
+        setTimeout(() => {
+          Atomics.store(view, 0, 1);
+          Atomics.notify(view, 0, 1);
+        }, 50);
+        parentPort.postMessage('ready');
+      \`;
+
+      const w = new Worker(code, { eval: true, workerData: sab });
+      w.on('message', async () => {
+        w.unref();
+        const result = Atomics.waitAsync(view, 0, 0);
+        const v = await result.value;
+        assert.strictEqual(v, 'ok');
+        process.exitCode = 0;
+      });
+    `,
+  ], { timeout: 10_000 });
+
+  assert.strictEqual(
+    result.status, 0,
+    `expected exit code 0, got ${result.status}. ` +
+    `stderr: ${result.stderr?.toString()}`
+  );
+}


### PR DESCRIPTION
## Summary

- Wrap `Atomics.waitAsync()` to ref the event loop while the promise is pending and unref when it settles
- Add C++ bindings (`atomicsWaitAsyncRef`/`atomicsWaitAsyncUnref`) that call `Environment::add_refs()` -- the same mechanism used by Worker threads
- Register the wrapper during bootstrap via `prepareExecution()` so it applies to both main and worker threads

`Atomics.waitAsync()` returns a promise that resolves when a shared memory location changes via `Atomics.notify()`. V8's internal wait mechanism does not create a libuv handle, so the event loop has no ref'd handles and exits before the promise resolves. This breaks WebAssembly + threads (Emscripten/pthreads) where C++ workers notify via `Atomics.notify` but never create JS-visible libuv handles.

Fixes: https://github.com/nodejs/node/issues/61941

## Test plan

- [ ] `test/parallel/test-atomics-waitasync-event-loop.js` -- 4 tests:
  1. `waitAsync` with timeout keeps the loop alive until resolution
  2. Synchronous `waitAsync` (value already changed) does not leak a ref
  3. Multiple concurrent `waitAsync` calls properly ref-count
  4. Worker thread notifying `waitAsync` on the main thread (Emscripten pattern from the issue)
- [ ] Existing `test/parallel/test-atomics-wake.js` still passes
- [ ] No regressions in event loop exit behavior (sync waitAsync exits immediately)