### PR TITLE
deps: V8: override `depot_tools` version

### DIFF
--- a/tools/v8/fetch_deps.py
+++ b/tools/v8/fetch_deps.py
@@ -24,6 +24,8 @@ GCLIENT_SOLUTION = [
     "deps_file"   : "DEPS",
     "managed"     : False,
     "custom_deps" : {
+      # Update depot_tools for compatibility with Python 3.12.
+      "v8/third_party/depot_tools"            : "https://chromium.googlesource.com/chromium/tools/depot_tools.git@284c5ccb591c3de4e9f71be4a4beb5d1916d5383",
       # These deps are already part of Node.js.
       "v8/base/trace_event/common"            : None,
       "v8/third_party/abseil-cpp"             : None,


### PR DESCRIPTION
For compatibility with Python >= 3.12 we need a newer version of `depot_tools` than is used for the older versions of V8.

Refs: https://github.com/nodejs/build/pull/4278

--- 

cc @nodejs/v8-update 

This will need to be cherry-picked onto all release lines that we want to run the V8 CI on as it is necessary to run on Ubuntu 24.04 where the default Python 3 is 3.12.

We should also undo it with/after https://github.com/nodejs/node/pull/61898 (or newer V8) as that will set a new enough version of `depot_tools` to be Python 3.12 compatible.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
