### PR TITLE
crypto: add crypto.signDigest() and crypto.verifyDigest() methods

### DIFF
--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -3825,6 +3825,23 @@ bool EVPKeyCtxPointer::setSignatureMd(const EVPMDCtxPointer& md) {
          1;
 }
 
+bool EVPKeyCtxPointer::setSignatureMd(const Digest& md) {
+  if (!ctx_ || !md) return false;
+  return EVP_PKEY_CTX_set_signature_md(ctx_.get(), md.get()) == 1;
+}
+
+#if OPENSSL_VERSION_MAJOR >= 3
+int EVPKeyCtxPointer::initForSignEx(const OSSL_PARAM params[]) {
+  if (!ctx_) return 0;
+  return EVP_PKEY_sign_init_ex(ctx_.get(), params);
+}
+
+int EVPKeyCtxPointer::initForVerifyEx(const OSSL_PARAM params[]) {
+  if (!ctx_) return 0;
+  return EVP_PKEY_verify_init_ex(ctx_.get(), params);
+}
+#endif
+
 bool EVPKeyCtxPointer::initForEncrypt() {
   if (!ctx_) return false;
   return EVP_PKEY_encrypt_init(ctx_.get()) == 1;

--- a/deps/ncrypto/ncrypto.h
+++ b/deps/ncrypto/ncrypto.h
@@ -798,6 +798,7 @@ class EVPKeyCtxPointer final {
   bool setRsaOaepLabel(DataPointer&& data);
 
   bool setSignatureMd(const EVPMDCtxPointer& md);
+  bool setSignatureMd(const Digest& md);
 
   bool publicCheck() const;
   bool privateCheck() const;
@@ -821,6 +822,10 @@ class EVPKeyCtxPointer final {
   bool initForKeygen();
   int initForVerify();
   int initForSign();
+#if OPENSSL_VERSION_MAJOR >= 3
+  int initForVerifyEx(const OSSL_PARAM params[]);
+  int initForSignEx(const OSSL_PARAM params[]);
+#endif
 
   static EVPKeyCtxPointer New(const EVPKeyPointer& key);
   static EVPKeyCtxPointer NewFromID(int id);

--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -6133,6 +6133,68 @@ additional properties can be passed:
 
 If the `callback` function is provided this function uses libuv's threadpool.
 
+### `crypto.signDigest(algorithm, digest, key[, callback])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+<!--lint disable maximum-line-length remark-lint-->
+
+* `algorithm` {string | null | undefined}
+* `digest` {ArrayBuffer|Buffer|TypedArray|DataView}
+* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
+* `callback` {Function}
+  * `err` {Error}
+  * `signature` {Buffer}
+* Returns: {Buffer} if the `callback` function is not provided.
+
+<!--lint enable maximum-line-length remark-lint-->
+
+Calculates and returns the signature for `digest` using the given private key
+and algorithm. Unlike [`crypto.sign()`][], this function does not hash the data
+internally — `digest` is expected to be a pre-computed hash digest.
+
+The interpretation of `algorithm` and `digest` depends on the key type:
+
+* RSA, ECDSA, DSA: `algorithm` identifies the hash function used to create
+  `digest`. The resulting signatures are compatible with [`crypto.verify()`][]
+  and signatures produced by [`crypto.sign()`][] can be verified with
+  [`crypto.verifyDigest()`][].
+
+* Ed25519, Ed448: `algorithm` must be `null` or `undefined`. These keys
+  use the Ed25519ph and Ed448ph prehash variants from [RFC 8032][]
+  respectively. `digest` must be the output of the appropriate prehash
+  function (SHA-512 for Ed25519ph, SHAKE256 with 64-byte output for
+  Ed448ph). The resulting signatures can only be verified with
+  [`crypto.verifyDigest()`][], not with [`crypto.verify()`][].
+
+If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
+passed to [`crypto.createPrivateKey()`][]. If it is an object, the following
+additional properties can be passed:
+
+* `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
+  format of the generated signature. It can be one of the following:
+  * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
+  * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
+* `padding` {integer} Optional padding value for RSA, one of the following:
+
+  * `crypto.constants.RSA_PKCS1_PADDING` (default)
+  * `crypto.constants.RSA_PKCS1_PSS_PADDING`
+
+  `RSA_PKCS1_PSS_PADDING` will use MGF1 with the same hash function
+  used to create the digest as specified in section 3.1 of [RFC 4055][].
+* `saltLength` {integer} Salt length for when padding is
+  `RSA_PKCS1_PSS_PADDING`. The special value
+  `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
+  size, `crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN` (default) sets it to the
+  maximum permissible value.
+* `context` {ArrayBuffer|Buffer|TypedArray|DataView} For Ed25519ph and Ed448ph,
+  this option specifies the optional context to differentiate signatures
+  generated for different purposes with the same key.
+
+If the `callback` function is provided this function uses libuv's threadpool.
+
 ### `crypto.subtle`
 
 <!-- YAML
@@ -6267,6 +6329,75 @@ additional properties can be passed:
   generated for different purposes with the same key.
 
 The `signature` argument is the previously calculated signature for the `data`.
+
+Because public keys can be derived from private keys, a private key or a public
+key may be passed for `key`.
+
+If the `callback` function is provided this function uses libuv's threadpool.
+
+### `crypto.verifyDigest(algorithm, digest, key, signature[, callback])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+<!--lint disable maximum-line-length remark-lint-->
+
+* `algorithm` {string|null|undefined}
+* `digest` {ArrayBuffer|Buffer|TypedArray|DataView}
+* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
+* `signature` {ArrayBuffer|Buffer|TypedArray|DataView}
+* `callback` {Function}
+  * `err` {Error}
+  * `result` {boolean}
+* Returns: {boolean} `true` or `false` depending on the validity of the
+  signature for the digest and public key if the `callback` function is not
+  provided.
+
+<!--lint enable maximum-line-length remark-lint-->
+
+Verifies the given signature for `digest` using the given key and algorithm.
+Unlike [`crypto.verify()`][], this function does not hash the data
+internally — `digest` is expected to be a pre-computed hash digest.
+
+The interpretation of `algorithm` and `digest` depends on the key type:
+
+* RSA, ECDSA, DSA: `algorithm` identifies the hash function used to create
+  `digest`. Signatures produced by [`crypto.sign()`][] can be verified with
+  this function, and signatures produced by [`crypto.signDigest()`][] can be
+  verified with [`crypto.verify()`][].
+* Ed25519, Ed448: `algorithm` must be `null` or `undefined`. These keys
+  use the Ed25519ph and Ed448ph prehash variants from [RFC 8032][]
+  respectively. `digest` must be the output of the appropriate prehash
+  function (SHA-512 for Ed25519ph, SHAKE256 with 64-byte output for
+  Ed448ph). Only signatures produced by [`crypto.signDigest()`][] can be
+  verified with this function, not those from [`crypto.sign()`][].
+
+If `key` is not a [`KeyObject`][], this function behaves as if `key` had been
+passed to [`crypto.createPublicKey()`][]. If it is an object, the following
+additional properties can be passed:
+
+* `dsaEncoding` {string} For DSA and ECDSA, this option specifies the
+  format of the signature. It can be one of the following:
+  * `'der'` (default): DER-encoded ASN.1 signature structure encoding `(r, s)`.
+  * `'ieee-p1363'`: Signature format `r || s` as proposed in IEEE-P1363.
+* `padding` {integer} Optional padding value for RSA, one of the following:
+
+  * `crypto.constants.RSA_PKCS1_PADDING` (default)
+  * `crypto.constants.RSA_PKCS1_PSS_PADDING`
+
+  `RSA_PKCS1_PSS_PADDING` will use MGF1 with the same hash function
+  used to create the digest as specified in section 3.1 of [RFC 4055][].
+* `saltLength` {integer} Salt length for when padding is
+  `RSA_PKCS1_PSS_PADDING`. The special value
+  `crypto.constants.RSA_PSS_SALTLEN_DIGEST` sets the salt length to the digest
+  size, `crypto.constants.RSA_PSS_SALTLEN_MAX_SIGN` (default) sets it to the
+  maximum permissible value.
+* `context` {ArrayBuffer|Buffer|TypedArray|DataView} For Ed25519ph and Ed448ph,
+  this option specifies the optional context to differentiate signatures
+  generated for different purposes with the same key.
+
+The `signature` argument is the previously calculated signature for the `digest`.
 
 Because public keys can be derived from private keys, a private key or a public
 key may be passed for `key`.
@@ -6899,7 +7030,9 @@ See the [list of SSL OP Flags][] for details.
 [`crypto.randomBytes()`]: #cryptorandombytessize-callback
 [`crypto.randomFill()`]: #cryptorandomfillbuffer-offset-size-callback
 [`crypto.sign()`]: #cryptosignalgorithm-data-key-callback
+[`crypto.signDigest()`]: #cryptosigndigestalgorithm-digest-key-callback
 [`crypto.verify()`]: #cryptoverifyalgorithm-data-key-signature-callback
+[`crypto.verifyDigest()`]: #cryptoverifydigestalgorithm-digest-key-signature-callback
 [`crypto.webcrypto.getRandomValues()`]: webcrypto.md#cryptogetrandomvaluestypedarray
 [`crypto.webcrypto.subtle`]: webcrypto.md#class-subtlecrypto
 [`decipher.final()`]: #decipherfinaloutputencoding

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -103,8 +103,10 @@ const {
 const {
   Sign,
   signOneShot,
+  signDigestOneShot,
   Verify,
   verifyOneShot,
+  verifyDigestOneShot,
 } = require('internal/crypto/sig');
 const {
   Hash,
@@ -223,11 +225,13 @@ module.exports = {
   scrypt,
   scryptSync,
   sign: signOneShot,
+  signDigest: signDigestOneShot,
   setEngine,
   timingSafeEqual,
   getFips,
   setFips,
   verify: verifyOneShot,
+  verifyDigest: verifyDigestOneShot,
   hash,
   encapsulate,
   decapsulate,

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -46,6 +46,7 @@ const { Writable } = require('stream');
 const { Buffer } = require('buffer');
 
 const {
+  isAnyArrayBuffer,
   isArrayBufferView,
 } = require('internal/util/types');
 
@@ -152,14 +153,29 @@ Sign.prototype.sign = function sign(options, encoding) {
   return ret;
 };
 
-function signOneShot(algorithm, data, key, callback) {
+function validateDigestOrData(data, prehashed) {
+  if (prehashed) {
+    if (!isArrayBufferView(data) && !isAnyArrayBuffer(data)) {
+      throw new ERR_INVALID_ARG_TYPE(
+        'digest',
+        ['ArrayBuffer', 'Buffer', 'TypedArray', 'DataView'],
+        data,
+      );
+    }
+    return data;
+  }
+
+  return getArrayBufferOrView(data, 'data');
+}
+
+function signOneShotImpl(algorithm, data, key, callback, prehashed) {
   if (algorithm != null)
     validateString(algorithm, 'algorithm');
 
   if (callback !== undefined)
     validateFunction(callback, 'callback');
 
-  data = getArrayBufferOrView(data, 'data');
+  data = validateDigestOrData(data, prehashed);
 
   if (!key)
     throw new ERR_CRYPTO_SIGN_KEY_REQUIRED();
@@ -194,7 +210,8 @@ function signOneShot(algorithm, data, key, callback) {
     rsaPadding,
     dsaSigEnc,
     context,
-    undefined);
+    undefined,
+    prehashed);
 
   if (!callback) {
     const { 0: err, 1: signature } = job.run();
@@ -248,22 +265,14 @@ Verify.prototype.verify = function verify(options, signature, sigEncoding) {
                               rsaPadding, pssSaltLength, dsaSigEnc);
 };
 
-function verifyOneShot(algorithm, data, key, signature, callback) {
+function verifyOneShotImpl(algorithm, data, key, signature, callback, prehashed) {
   if (algorithm != null)
     validateString(algorithm, 'algorithm');
 
   if (callback !== undefined)
     validateFunction(callback, 'callback');
 
-  data = getArrayBufferOrView(data, 'data');
-
-  if (!isArrayBufferView(data)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'data',
-      ['Buffer', 'TypedArray', 'DataView'],
-      data,
-    );
-  }
+  data = validateDigestOrData(data, prehashed);
 
   // Options specific to RSA
   const rsaPadding = getPadding(key);
@@ -303,7 +312,8 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
     rsaPadding,
     dsaSigEnc,
     context,
-    signature);
+    signature,
+    prehashed);
 
   if (!callback) {
     const { 0: err, 1: result } = job.run();
@@ -320,9 +330,27 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
   job.run();
 }
 
+function signOneShot(algorithm, data, key, callback) {
+  return signOneShotImpl(algorithm, data, key, callback, false /* not prehashed */);
+}
+
+function verifyOneShot(algorithm, data, key, signature, callback) {
+  return verifyOneShotImpl(algorithm, data, key, signature, callback, false /* not prehashed */);
+}
+
+function signDigestOneShot(algorithm, digest, key, callback) {
+  return signOneShotImpl(algorithm, digest, key, callback, true /* prehashed */);
+}
+
+function verifyDigestOneShot(algorithm, digest, key, signature, callback) {
+  return verifyOneShotImpl(algorithm, digest, key, signature, callback, true /* prehashed */);
+}
+
 module.exports = {
   Sign,
   signOneShot,
+  signDigestOneShot,
   Verify,
   verifyOneShot,
+  verifyDigestOneShot,
 };

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -203,6 +203,10 @@ void CheckThrow(Environment* env, SignBase::Error error) {
       return THROW_ERR_CRYPTO_OPERATION_FAILED(
           env, "Context parameter is unsupported");
 
+    case SignBase::Error::PrehashUnsupported:
+      return THROW_ERR_CRYPTO_OPERATION_FAILED(
+          env, "Prehashed signing is not supported for this key type");
+
     case SignBase::Error::Init:
     case SignBase::Error::Update:
     case SignBase::Error::PrivateKey:
@@ -683,6 +687,10 @@ Maybe<void> SignTraits::AdditionalConfig(
     }
   }
 
+  if (args[offset + 12]->IsTrue()) {
+    params->flags |= SignConfiguration::kHasPrehashed;
+  }
+
   return JustVoid();
 }
 
@@ -691,19 +699,139 @@ bool SignTraits::DeriveBits(Environment* env,
                             ByteSource* out,
                             CryptoJobMode mode,
                             CryptoErrorStore* errors) {
-  auto context = EVPMDCtxPointer::New();
-  if (!context) [[unlikely]]
-    return false;
   const auto& key = params.key.GetAsymmetricKey();
 
   bool has_context = (params.flags & SignConfiguration::kHasContextString &&
                       params.context_string.size() > 0);
+  bool is_prehashed = params.flags & SignConfiguration::kHasPrehashed;
+  bool is_sign = params.mode == SignConfiguration::Mode::Sign;
 
-  if (has_context && !SupportsContextString(key)) {
+  if (has_context && !is_prehashed && !SupportsContextString(key)) {
     errors->Insert(NodeCryptoError::CONTEXT_UNSUPPORTED);
     errors->SetNodeErrorCode("ERR_CRYPTO_OPERATION_FAILED");
     return false;
   }
+
+  // Prehashed signing: the caller already hashed the data and is providing
+  // the digest directly. Use the low-level EVP_PKEY_sign/EVP_PKEY_verify path.
+  if (is_prehashed) {
+    const int key_type = key.id();
+
+    EVPKeyCtxPointer pkctx = key.newCtx();
+    if (!pkctx) [[unlikely]] {
+      return false;
+    }
+
+    int init_ret;
+
+    switch (key_type) {
+      case EVP_PKEY_ED25519:
+      case EVP_PKEY_ED448: {
+#ifdef OSSL_SIGNATURE_PARAM_INSTANCE
+        const char* instance_name =
+            key_type == EVP_PKEY_ED25519 ? "Ed25519ph" : "Ed448ph";
+
+        std::vector<OSSL_PARAM> ossl_params;
+        ossl_params.push_back(
+            OSSL_PARAM_construct_utf8_string(OSSL_SIGNATURE_PARAM_INSTANCE,
+                                             const_cast<char*>(instance_name),
+                                             0));
+
+        if (has_context) {
+          ossl_params.push_back(OSSL_PARAM_construct_octet_string(
+              OSSL_SIGNATURE_PARAM_CONTEXT_STRING,
+              const_cast<unsigned char*>(
+                  params.context_string.data<unsigned char>()),
+              params.context_string.size()));
+        }
+        ossl_params.push_back(OSSL_PARAM_END);
+
+        init_ret = is_sign ? pkctx.initForSignEx(ossl_params.data())
+                           : pkctx.initForVerifyEx(ossl_params.data());
+        break;
+#else
+        errors->Insert(NodeCryptoError::PREHASH_UNSUPPORTED);
+        errors->SetNodeErrorCode("ERR_CRYPTO_OPERATION_FAILED");
+        return false;
+#endif  // OSSL_SIGNATURE_PARAM_INSTANCE
+      }
+
+      default:
+        if (key.isOneShotVariant()) {
+          errors->Insert(NodeCryptoError::PREHASH_UNSUPPORTED);
+          errors->SetNodeErrorCode("ERR_CRYPTO_OPERATION_FAILED");
+          return false;
+        }
+
+        init_ret = is_sign ? pkctx.initForSign() : pkctx.initForVerify();
+
+        if (init_ret <= 0) [[unlikely]] {
+          return false;
+        }
+
+        {
+          int padding = params.flags & SignConfiguration::kHasPadding
+                            ? params.padding
+                            : key.getDefaultSignPadding();
+
+          std::optional<int> salt_length =
+              params.flags & SignConfiguration::kHasSaltLength
+                  ? std::optional<int>(params.salt_length)
+                  : std::nullopt;
+
+          if (!ApplyRSAOptions(key, pkctx.get(), padding, salt_length)) {
+            return false;
+          }
+
+          if (!pkctx.setSignatureMd(params.digest)) {
+            return false;
+          }
+        }
+        break;
+    }
+
+    if (init_ret <= 0) [[unlikely]] {
+      return false;
+    }
+
+    ncrypto::Buffer<const unsigned char> data_buf{
+        .data = params.data.data<unsigned char>(),
+        .len = params.data.size(),
+    };
+
+    if (is_sign) {
+      auto sig = pkctx.sign(data_buf);
+      if (!sig) [[unlikely]] {
+        return false;
+      }
+      DCHECK(!sig.isSecure());
+      auto bs = ByteSource::Allocated(sig.release());
+
+      if (UseP1363Encoding(key, params.dsa_encoding)) {
+        *out = ConvertSignatureToP1363(env, key, std::move(bs));
+      } else {
+        *out = std::move(bs);
+      }
+    } else {
+      ncrypto::Buffer<const unsigned char> sig_buf{
+          .data = params.signature.data<unsigned char>(),
+          .len = params.signature.size(),
+      };
+      auto buf = DataPointer::Alloc(1);
+      static_cast<char*>(buf.get())[0] = 0;
+      if (pkctx.verify(sig_buf, data_buf)) {
+        static_cast<char*>(buf.get())[0] = 1;
+      }
+      *out = ByteSource::Allocated(buf.release());
+    }
+
+    return true;
+  }
+
+  // Non-prehashed path: use EVP_DigestSign/EVP_DigestVerify.
+  auto context = EVPMDCtxPointer::New();
+  if (!context) [[unlikely]]
+    return false;
 
   auto ctx = ([&] {
     if (has_context) {

--- a/src/crypto/crypto_sig.h
+++ b/src/crypto/crypto_sig.h
@@ -27,6 +27,7 @@ class SignBase : public BaseObject {
     PublicKey,
     MalformedSignature,
     ContextUnsupported,
+    PrehashUnsupported,
   };
 
   SignBase(Environment* env, v8::Local<v8::Object> wrap);
@@ -101,7 +102,8 @@ struct SignConfiguration final : public MemoryRetainer {
     kHasNone = 0,
     kHasSaltLength = 1,
     kHasPadding = 2,
-    kHasContextString = 4
+    kHasContextString = 4,
+    kHasPrehashed = 8,
   };
 
   CryptoJobMode job_mode;

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -88,6 +88,8 @@ void Decode(const v8::FunctionCallbackInfo<v8::Value>& args,
   V(KMAC_FAILED, "KMAC derivation failed")                                     \
   V(OK, "Ok")                                                                  \
   V(PBKDF2_FAILED, "PBKDF2 derivation failed")                                 \
+  V(PREHASH_UNSUPPORTED,                                                       \
+    "Prehashed signing is not supported for this key type")                    \
   V(SCRYPT_FAILED, "scrypt derivation failed")
 
 enum class NodeCryptoError {

--- a/test/parallel/test-crypto-eddsa-variants.js
+++ b/test/parallel/test-crypto-eddsa-variants.js
@@ -9,7 +9,8 @@ const {
   hasOpenSSL,
 } = require('../common/crypto');
 
-// RFC 8032 Section 7 test vectors for Ed25519, Ed25519ctx, and Ed448.
+// RFC 8032 Section 7 test vectors for Ed25519, Ed25519ctx, Ed25519ph,
+// Ed448, and Ed448ph.
 // https://www.rfc-editor.org/rfc/rfc8032.html#section-7
 
 /* eslint-disable @stylistic/js/max-len */
@@ -91,6 +92,14 @@ const vectors = [
     signature: '21655b5f1aa965996b3f97b3c849eafba922a0a62992f73b3d1b73106a84ad85e9b86a7b6005ea868337ff2d20a7f5fbd4cd10b0be49a68da2b2e0dc0ad8960f',
   },
   {
+    name: 'TEST abc',
+    algorithm: 'Ed25519ph',
+    secretKey: '833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42',
+    publicKey: 'ec172b93ad5e563bf4932c70e1245034c35467ef2efd4d64ebf819683467e2bf',
+    message: '616263',
+    signature: '98a70222f0b8121aa9d30f813d683f809e462b469c7ff87639499bb94e6dae4131f85042463c2a355a2003d062adf5aaa10b8c61e636062aaad11c2a26083406',
+  },
+  {
     name: 'Blank',
     algorithm: 'Ed448',
     secretKey: '6c82a562cb808d10d632be89c8513ebf6c929f34ddfa8c9f63c9960ef6e348a3528c8a3fcc2f044e39a3fc5b94492f8f032e7549a20098f95b',
@@ -163,6 +172,23 @@ const vectors = [
     message: '6ddf802e1aae4986935f7f981ba3f0351d6273c0a0c22c9c0e8339168e675412a3debfaf435ed651558007db4384b650fcc07e3b586a27a4f7a00ac8a6fec2cd86ae4bf1570c41e6a40c931db27b2faa15a8cedd52cff7362c4e6e23daec0fbc3a79b6806e316efcc7b68119bf46bc76a26067a53f296dafdbdc11c77f7777e972660cf4b6a9b369a6665f02e0cc9b6edfad136b4fabe723d2813db3136cfde9b6d044322fee2947952e031b73ab5c603349b307bdc27bc6cb8b8bbd7bd323219b8033a581b59eadebb09b3c4f3d2277d4f0343624acc817804728b25ab797172b4c5c21a22f9c7839d64300232eb66e53f31c723fa37fe387c7d3e50bdf9813a30e5bb12cf4cd930c40cfb4e1fc622592a49588794494d56d24ea4b40c89fc0596cc9ebb961c8cb10adde976a5d602b1c3f85b9b9a001ed3c6a4d3b1437f52096cd1956d042a597d561a596ecd3d1735a8d570ea0ec27225a2c4aaff26306d1526c1af3ca6d9cf5a2c98f47e1c46db9a33234cfd4d81f2c98538a09ebe76998d0d8fd25997c7d255c6d66ece6fa56f11144950f027795e653008f4bd7ca2dee85d8e90f3dc315130ce2a00375a318c7c3d97be2c8ce5b6db41a6254ff264fa6155baee3b0773c0f497c573f19bb4f4240281f0b1f4f7be857a4e59d416c06b4c50fa09e1810ddc6b1467baeac5a3668d11b6ecaa901440016f389f80acc4db977025e7f5924388c7e340a732e554440e76570f8dd71b7d640b3450d1fd5f0410a18f9a3494f707c717b79b4bf75c98400b096b21653b5d217cf3565c9597456f70703497a078763829bc01bb1cbc8fa04eadc9a6e3f6699587a9e75c94e5bab0036e0b2e711392cff0047d0d6b05bd2a588bc109718954259f1d86678a579a3120f19cfb2963f177aeb70f2d4844826262e51b80271272068ef5b3856fa8535aa2a88b2d41f2a0e2fda7624c2850272ac4a2f561f8f2f7a318bfd5caf9696149e4ac824ad3460538fdc25421beec2cc6818162d06bbed0c40a387192349db67a118bada6cd5ab0140ee273204f628aad1c135f770279a651e24d8c14d75a6059d76b96a6fd857def5e0b354b27ab937a5815d16b5fae407ff18222c6d1ed263be68c95f32d908bd895cd76207ae726487567f9a67dad79abec316f683b17f2d02bf07e0ac8b5bc6162cf94697b3c27cd1fea49b27f23ba2901871962506520c392da8b6ad0d99f7013fbc06c2c17a569500c8a7696481c1cd33e9b14e40b82e79a5f5db82571ba97bae3ad3e0479515bb0e2b0f3bfcd1fd33034efc6245eddd7ee2086ddae2600d8ca73e214e8c2b0bdb2b047c6a464a562ed77b73d2d841c4b34973551257713b753632efba348169abc90a68f42611a40126d7cb21b58695568186f7e569d2ff0f9e745d0487dd2eb997cafc5abf9dd102e62ff66cba87',
     signature: 'e301345a41a39a4d72fff8df69c98075a0cc082b802fc9b2b6bc503f926b65bddf7f4c8f1cb49f6396afc8a70abe6d8aef0db478d4c6b2970076c6a0484fe76d76b3a97625d79f1ce240e7c576750d295528286f719b413de9ada3e8eb78ed573603ce30d8bb761785dc30dbc320869e1a00',
   },
+  {
+    name: 'TEST abc',
+    algorithm: 'Ed448ph',
+    secretKey: '833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42ef7822e0d5104127dc05d6dbefde69e3ab2cec7c867c6e2c49',
+    publicKey: '259b71c19f83ef77a7abd26524cbdb3161b590a48f7d17de3ee0ba9c52beb743c09428a131d6b1b57303d90d8132c276d5ed3d5d01c0f53880',
+    message: '616263',
+    signature: '822f6901f7480f3d5f562c592994d9693602875614483256505600bbc281ae381f54d6bce2ea911574932f52a4e6cadd78769375ec3ffd1b801a0d9b3f4030cd433964b6457ea39476511214f97469b57dd32dbc560a9a94d00bff07620464a3ad203df7dc7ce360c3cd3696d9d9fab90f00',
+  },
+  {
+    name: 'TEST abc (with context)',
+    algorithm: 'Ed448ph',
+    secretKey: '833fe62409237b9d62ec77587520911e9a759cec1d19755b7da901b96dca3d42ef7822e0d5104127dc05d6dbefde69e3ab2cec7c867c6e2c49',
+    publicKey: '259b71c19f83ef77a7abd26524cbdb3161b590a48f7d17de3ee0ba9c52beb743c09428a131d6b1b57303d90d8132c276d5ed3d5d01c0f53880',
+    message: '616263',
+    context: '666f6f',
+    signature: 'c32299d46ec8ff02b54540982814dce9a05812f81962b649d528095916a2aa481065b1580423ef927ecf0af5888f90da0f6a9a85ad5dc3f280d91224ba9911a3653d00e484e2ce232521481c8658df304bb7745a73514cdb9bf3e15784ab71284f8d0704a608c54a6b62d97beb511d132100',
+  },
 ];
 /* eslint-enable @stylistic/js/max-len */
 
@@ -180,7 +206,7 @@ function createKeyPair(algorithm, secretKeyHex, publicKeyHex) {
 
 for (const v of vectors) {
   if (v.algorithm.startsWith('Ed448') && process.features.openssl_is_boringssl) continue;
-  if (v.algorithm.endsWith('ctx') || v.context) {
+  if (v.algorithm.endsWith('ctx') || v.algorithm.endsWith('ph') || v.context) {
     if (!hasOpenSSL(3, 2)) continue;
   }
   const { privateKey, publicKey } = createKeyPair(v.algorithm, v.secretKey, v.publicKey);
@@ -191,8 +217,22 @@ for (const v of vectors) {
   const signKey = context ? { key: privateKey, context } : privateKey;
   const verifyKey = context ? { key: publicKey, context } : publicKey;
 
-  const sig = crypto.sign(null, message, signKey);
-  assert.deepStrictEqual(sig, expectedSig);
-  assert.strictEqual(
-    crypto.verify(null, message, verifyKey, expectedSig), true);
+  const prehash = v.algorithm.endsWith('ph');
+
+  if (prehash) {
+    const hashAlgo = v.algorithm.startsWith('Ed448') ? 'shake256' : 'sha512';
+    const hashOpts = hashAlgo === 'shake256' ?
+      { outputLength: 64, outputEncoding: 'buffer' } : 'buffer';
+    const digest = crypto.hash(hashAlgo, message, hashOpts);
+
+    const sig = crypto.signDigest(null, digest, signKey);
+    assert.deepStrictEqual(sig, expectedSig);
+    assert.strictEqual(
+      crypto.verifyDigest(null, digest, verifyKey, expectedSig), true);
+  } else {
+    const sig = crypto.sign(null, message, signKey);
+    assert.deepStrictEqual(sig, expectedSig);
+    assert.strictEqual(
+      crypto.verify(null, message, verifyKey, expectedSig), true);
+  }
 }

--- a/test/parallel/test-crypto-sign-verify-digest.js
+++ b/test/parallel/test-crypto-sign-verify-digest.js
@@ -1,0 +1,617 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+const fixtures = require('../common/fixtures');
+const {
+  hasOpenSSL,
+} = require('../common/crypto');
+
+// Test crypto.signDigest() and crypto.verifyDigest() one-shot APIs.
+// These accept a pre-hashed digest and sign/verify it directly.
+
+const data = Buffer.from('Hello world');
+
+// --- RSA PKCS#1 v1.5 ---
+{
+  const privKey = fixtures.readKey('rsa_private_2048.pem', 'ascii');
+  const pubKey = fixtures.readKey('rsa_public_2048.pem', 'ascii');
+
+  const digest = crypto.createHash('sha256').update(data).digest();
+
+  const sig = crypto.signDigest('sha256', digest, privKey);
+  assert(Buffer.isBuffer(sig));
+  assert.strictEqual(sig.length, 256);
+
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, pubKey, sig), true);
+
+  // Cross-verify: sign with crypto.sign, verify with crypto.verifyDigest
+  const sig2 = crypto.sign('sha256', data, privKey);
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, pubKey, sig2), true);
+
+  // Cross-verify: sign with crypto.signDigest, verify with crypto.verify
+  assert.strictEqual(crypto.verify('sha256', data, pubKey, sig), true);
+
+  // Wrong digest should fail verification
+  const wrongDigest = crypto.createHash('sha256').update(Buffer.from('wrong')).digest();
+  assert.strictEqual(crypto.verifyDigest('sha256', wrongDigest, pubKey, sig), false);
+
+  // KeyObject forms
+  const privKeyObj = crypto.createPrivateKey(privKey);
+  const pubKeyObj = crypto.createPublicKey(pubKey);
+
+  const sig3 = crypto.signDigest('sha256', digest, privKeyObj);
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, pubKeyObj, sig3), true);
+
+  // Verify with private key (extracts public)
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, privKeyObj, sig3), true);
+}
+
+// --- RSA-PSS ---
+{
+  const privKey = fixtures.readKey('rsa_private_2048.pem', 'ascii');
+  const pubKey = fixtures.readKey('rsa_public_2048.pem', 'ascii');
+
+  const digest = crypto.createHash('sha256').update(data).digest();
+
+  const sig = crypto.signDigest('sha256', digest, {
+    key: privKey,
+    padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+    saltLength: 32,
+  });
+  assert(Buffer.isBuffer(sig));
+
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, {
+    key: pubKey,
+    padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+    saltLength: 32,
+  }, sig), true);
+
+  // Verify with auto salt length
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, {
+    key: pubKey,
+    padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+    saltLength: crypto.constants.RSA_PSS_SALTLEN_AUTO,
+  }, sig), true);
+
+  // Cross-verify: sign with crypto.signDigest, verify with crypto.verify
+  assert.strictEqual(crypto.verify('sha256', data, {
+    key: pubKey,
+    padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+    saltLength: crypto.constants.RSA_PSS_SALTLEN_AUTO,
+  }, sig), true);
+
+  // Cross-verify: sign with crypto.sign, verify with crypto.verifyDigest
+  const sig2 = crypto.sign('sha256', data, {
+    key: privKey,
+    padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+    saltLength: 32,
+  });
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, {
+    key: pubKey,
+    padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+    saltLength: crypto.constants.RSA_PSS_SALTLEN_AUTO,
+  }, sig2), true);
+
+  // Wrong digest
+  const wrongDigest = crypto.createHash('sha256').update(Buffer.from('wrong')).digest();
+  assert.strictEqual(crypto.verifyDigest('sha256', wrongDigest, {
+    key: pubKey,
+    padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+    saltLength: crypto.constants.RSA_PSS_SALTLEN_AUTO,
+  }, sig), false);
+}
+
+// --- RSA-PSS key type (hash/padding/salt baked into key) ---
+{
+  const privKey = fixtures.readKey('rsa_pss_private_2048_sha256_sha256_16.pem', 'ascii');
+  const pubKey = fixtures.readKey('rsa_pss_public_2048_sha256_sha256_16.pem', 'ascii');
+
+  const digest = crypto.createHash('sha256').update(data).digest();
+
+  const sig = crypto.signDigest('sha256', digest, privKey);
+  assert(Buffer.isBuffer(sig));
+
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, pubKey, sig), true);
+
+  // Cross-verify: sign with crypto.signDigest, verify with crypto.verify
+  assert.strictEqual(crypto.verify('sha256', data, pubKey, sig), true);
+
+  // Cross-verify: sign with crypto.sign, verify with crypto.verifyDigest
+  const sig2 = crypto.sign('sha256', data, privKey);
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, pubKey, sig2), true);
+
+  // Wrong digest
+  const wrongDigest = crypto.createHash('sha256').update(Buffer.from('wrong')).digest();
+  assert.strictEqual(crypto.verifyDigest('sha256', wrongDigest, pubKey, sig), false);
+}
+
+// --- ECDSA (DER encoding, default) ---
+{
+  const curves = [
+    { priv: 'ec_p256_private.pem', pub: 'ec_p256_public.pem', hash: 'sha256' },
+    { priv: 'ec_p384_private.pem', pub: 'ec_p384_public.pem', hash: 'sha384' },
+    { priv: 'ec_p521_private.pem', pub: 'ec_p521_public.pem', hash: 'sha512' },
+  ];
+
+  for (const { priv, pub, hash } of curves) {
+    const privKey = fixtures.readKey(priv, 'ascii');
+    const pubKey = fixtures.readKey(pub, 'ascii');
+
+    const digest = crypto.createHash(hash).update(data).digest();
+
+    const sig = crypto.signDigest(hash, digest, privKey);
+    assert(Buffer.isBuffer(sig));
+
+    assert.strictEqual(crypto.verifyDigest(hash, digest, pubKey, sig), true);
+
+    // Cross-verify: sign with crypto.signDigest, verify with crypto.verify
+    assert.strictEqual(crypto.verify(hash, data, pubKey, sig), true);
+
+    // Cross-verify: sign with crypto.sign, verify with crypto.verifyDigest
+    const sig2 = crypto.sign(hash, data, privKey);
+    assert.strictEqual(crypto.verifyDigest(hash, digest, pubKey, sig2), true);
+
+    // Wrong digest
+    const wrongDigest = crypto.createHash(hash).update(Buffer.from('wrong')).digest();
+    assert.strictEqual(crypto.verifyDigest(hash, wrongDigest, pubKey, sig), false);
+  }
+}
+
+// --- ECDSA (ieee-p1363 encoding) ---
+{
+  const privKey = fixtures.readKey('ec_p256_private.pem', 'ascii');
+  const pubKey = fixtures.readKey('ec_p256_public.pem', 'ascii');
+
+  const digest = crypto.createHash('sha256').update(data).digest();
+
+  const sig = crypto.signDigest('sha256', digest, {
+    key: privKey,
+    dsaEncoding: 'ieee-p1363',
+  });
+  assert(Buffer.isBuffer(sig));
+  // P-256 ieee-p1363 signature is exactly 64 bytes (2 * 32)
+  assert.strictEqual(sig.length, 64);
+
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, {
+    key: pubKey,
+    dsaEncoding: 'ieee-p1363',
+  }, sig), true);
+
+  // Cross-verify: sign with crypto.signDigest, verify with crypto.verify
+  assert.strictEqual(crypto.verify('sha256', data, {
+    key: pubKey,
+    dsaEncoding: 'ieee-p1363',
+  }, sig), true);
+
+  // Cross-verify: sign with crypto.sign, verify with crypto.verifyDigest
+  const sig2 = crypto.sign('sha256', data, {
+    key: privKey,
+    dsaEncoding: 'ieee-p1363',
+  });
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, {
+    key: pubKey,
+    dsaEncoding: 'ieee-p1363',
+  }, sig2), true);
+
+  // Wrong digest
+  const wrongDigest = crypto.createHash('sha256').update(Buffer.from('wrong')).digest();
+  assert.strictEqual(crypto.verifyDigest('sha256', wrongDigest, {
+    key: pubKey,
+    dsaEncoding: 'ieee-p1363',
+  }, sig), false);
+}
+
+// --- DSA ---
+{
+  const privKey = fixtures.readKey('dsa_private.pem', 'ascii');
+  const pubKey = fixtures.readKey('dsa_public.pem', 'ascii');
+
+  const digest = crypto.createHash('sha256').update(data).digest();
+
+  const sig = crypto.signDigest('sha256', digest, privKey);
+  assert(Buffer.isBuffer(sig));
+
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, pubKey, sig), true);
+
+  // Cross-verify: sign with crypto.signDigest, verify with crypto.verify
+  assert.strictEqual(crypto.verify('sha256', data, pubKey, sig), true);
+
+  // Cross-verify: sign with crypto.sign, verify with crypto.verifyDigest
+  const sig2 = crypto.sign('sha256', data, privKey);
+  assert.strictEqual(crypto.verifyDigest('sha256', digest, pubKey, sig2), true);
+
+  // Wrong digest
+  const wrongDigest = crypto.createHash('sha256').update(Buffer.from('wrong')).digest();
+  assert.strictEqual(crypto.verifyDigest('sha256', wrongDigest, pubKey, sig), false);
+}
+
+// --- Ed25519ph ---
+if (hasOpenSSL(3, 2)) {
+  const privKey = fixtures.readKey('ed25519_private.pem', 'ascii');
+  const pubKey = fixtures.readKey('ed25519_public.pem', 'ascii');
+
+  // Ed25519ph expects a SHA-512 prehash (64 bytes)
+  const digest = crypto.createHash('sha512').update(data).digest();
+  assert.strictEqual(digest.length, 64);
+
+  const sig = crypto.signDigest(null, digest, privKey);
+  assert(Buffer.isBuffer(sig));
+  assert.strictEqual(sig.length, 64);
+
+  assert.strictEqual(crypto.verifyDigest(null, digest, pubKey, sig), true);
+
+  // Wrong digest should fail
+  const wrongDigest = crypto.createHash('sha512').update(Buffer.from('wrong')).digest();
+  assert.strictEqual(crypto.verifyDigest(null, wrongDigest, pubKey, sig), false);
+
+  // Ed25519ph signatures are NOT compatible with Ed25519 signatures.
+  // Different domain separation means cross-verify must fail.
+  assert.strictEqual(crypto.verify(null, data, pubKey, sig), false);
+
+  // Ed25519 pure signatures are NOT compatible with Ed25519ph.
+  // sign() output cannot be verified by verifyDigest().
+  const pureSig = crypto.sign(null, data, privKey);
+  assert.strictEqual(crypto.verifyDigest(null, digest, pubKey, pureSig), false);
+
+  // KeyObject forms
+  const privKeyObj = crypto.createPrivateKey(privKey);
+  const pubKeyObj = crypto.createPublicKey(pubKey);
+
+  const sig2 = crypto.signDigest(null, digest, privKeyObj);
+  assert.strictEqual(crypto.verifyDigest(null, digest, pubKeyObj, sig2), true);
+
+  // Ed25519ph with context string
+  {
+    const context = Buffer.from('my context');
+    const sig3 = crypto.signDigest(null, digest, { key: privKey, context });
+    assert.strictEqual(crypto.verifyDigest(null, digest, { key: pubKey, context }, sig3), true);
+
+    // Wrong context should fail
+    assert.strictEqual(crypto.verifyDigest(null, digest, { key: pubKey }, sig3), false);
+    assert.strictEqual(crypto.verifyDigest(null, digest, {
+      key: pubKey,
+      context: Buffer.from('other'),
+    }, sig3), false);
+
+    // Ed25519ph+context signatures are NOT compatible with verify(ctx).
+    assert.strictEqual(crypto.verify(null, data, { key: pubKey, context }, sig3), false);
+  }
+}
+
+// --- Ed448ph ---
+if (hasOpenSSL(3, 2)) {
+  const privKey = fixtures.readKey('ed448_private.pem', 'ascii');
+  const pubKey = fixtures.readKey('ed448_public.pem', 'ascii');
+
+  // Ed448ph expects a SHAKE256 prehash (64 bytes)
+  const digest = crypto.createHash('shake256', { outputLength: 64 }).update(data).digest();
+  assert.strictEqual(digest.length, 64);
+
+  const sig = crypto.signDigest(null, digest, privKey);
+  assert(Buffer.isBuffer(sig));
+  assert.strictEqual(sig.length, 114);
+
+  assert.strictEqual(crypto.verifyDigest(null, digest, pubKey, sig), true);
+
+  // Wrong digest
+  const wrongDigest = crypto.createHash('shake256', { outputLength: 64 }).update(Buffer.from('wrong')).digest();
+  assert.strictEqual(crypto.verifyDigest(null, wrongDigest, pubKey, sig), false);
+
+  // Ed448ph signatures are NOT compatible with Ed448 signatures.
+  // Different domain separation means cross-verify must fail.
+  assert.strictEqual(crypto.verify(null, data, pubKey, sig), false);
+
+  // Ed448 pure signatures are NOT compatible with Ed448ph.
+  // sign() output cannot be verified by verifyDigest().
+  const pureSig = crypto.sign(null, data, privKey);
+  assert.strictEqual(crypto.verifyDigest(null, digest, pubKey, pureSig), false);
+
+  // Ed448ph with context string
+  {
+    const context = Buffer.from('my context');
+    const sig2 = crypto.signDigest(null, digest, { key: privKey, context });
+    assert.strictEqual(crypto.verifyDigest(null, digest, { key: pubKey, context }, sig2), true);
+
+    // Wrong context should fail
+    assert.strictEqual(crypto.verifyDigest(null, digest, { key: pubKey }, sig2), false);
+    assert.strictEqual(crypto.verifyDigest(null, digest, {
+      key: pubKey,
+      context: Buffer.from('other'),
+    }, sig2), false);
+
+    // Ed448ph+context signatures are NOT compatible with verify(ctx).
+    assert.strictEqual(crypto.verify(null, data, { key: pubKey, context }, sig2), false);
+  }
+
+  // Ed448+context signatures are NOT compatible with Ed448ph.
+  // sign(ctx) output cannot be verified by verifyDigest(ctx).
+  {
+    const context = Buffer.from('my context');
+    const ctxSig = crypto.sign(null, data, { key: privKey, context });
+    assert.strictEqual(crypto.verifyDigest(null, digest, { key: pubKey, context }, ctxSig), false);
+  }
+
+  // Ed448ph with empty context string
+  {
+    const context = new Uint8Array();
+    const sig3 = crypto.signDigest(null, digest, { key: privKey, context });
+    assert.strictEqual(crypto.verifyDigest(null, digest, { key: pubKey, context }, sig3), true);
+    // Empty context and no context should both verify for Ed448ph
+    assert.strictEqual(crypto.verifyDigest(null, digest, { key: pubKey }, sig3), true);
+  }
+}
+
+// --- Async (callback) mode ---
+{
+  const privKey = fixtures.readKey('rsa_private_2048.pem', 'ascii');
+  const pubKey = fixtures.readKey('rsa_public_2048.pem', 'ascii');
+
+  const digest = crypto.createHash('sha256').update(data).digest();
+
+  crypto.signDigest('sha256', digest, privKey, common.mustSucceed((sig) => {
+    assert(Buffer.isBuffer(sig));
+
+    crypto.verifyDigest('sha256', digest, pubKey, sig, common.mustSucceed((result) => {
+      assert.strictEqual(result, true);
+    }));
+  }));
+}
+
+// --- Async (callback) error handling ---
+{
+  // Non-signing key type error is delivered via callback
+  const x25519Priv = fixtures.readKey('x25519_private.pem', 'ascii');
+  crypto.signDigest('sha256', Buffer.alloc(32), x25519Priv, common.mustCall((err) => {
+    assert(err);
+    assert.match(err.message, /operation not supported for this keytype/);
+  }));
+}
+
+if (hasOpenSSL(3, 2)) {
+  // Wrong digest length error is delivered via callback
+  const edPrivKey = fixtures.readKey('ed25519_private.pem', 'ascii');
+  crypto.signDigest(null, Buffer.alloc(32), edPrivKey, common.mustCall((err) => {
+    assert(err);
+    assert.match(err.message, /invalid digest length/);
+  }));
+}
+
+// --- Error: unsupported key type for prehashed signing ---
+{
+  // Ed25519ph/Ed448ph require OpenSSL >= 3.2. On older versions, they
+  // should throw PrehashUnsupported.
+  if (!hasOpenSSL(3, 2)) {
+    const edPrivKey = fixtures.readKey('ed25519_private.pem', 'ascii');
+    const edPubKey = fixtures.readKey('ed25519_public.pem', 'ascii');
+
+    assert.throws(() => {
+      crypto.signDigest(null, Buffer.alloc(64), edPrivKey);
+    }, { code: 'ERR_CRYPTO_OPERATION_FAILED', message: /Prehashed signing is not supported/ });
+
+    assert.throws(() => {
+      crypto.verifyDigest(null, Buffer.alloc(64), edPubKey, Buffer.alloc(64));
+    }, { code: 'ERR_CRYPTO_OPERATION_FAILED', message: /Prehashed signing is not supported/ });
+  }
+
+  // Invalid algorithm argument type
+  assert.throws(() => {
+    crypto.signDigest(123, Buffer.alloc(32), fixtures.readKey('rsa_private_2048.pem', 'ascii'));
+  }, { code: 'ERR_INVALID_ARG_TYPE' });
+
+  // ML-DSA keys are not supported with signDigest/verifyDigest.
+  if (hasOpenSSL(3, 5)) {
+    for (const alg of ['ml_dsa_44', 'ml_dsa_65', 'ml_dsa_87']) {
+      const privKey = fixtures.readKey(`${alg}_private.pem`, 'ascii');
+      const pubKey = fixtures.readKey(`${alg}_public.pem`, 'ascii');
+
+      assert.throws(() => {
+        crypto.signDigest(null, Buffer.alloc(64), privKey);
+      }, { code: 'ERR_CRYPTO_OPERATION_FAILED', message: /Prehashed signing is not supported/ });
+
+      assert.throws(() => {
+        crypto.verifyDigest(null, Buffer.alloc(64), pubKey, Buffer.alloc(64));
+      }, { code: 'ERR_CRYPTO_OPERATION_FAILED', message: /Prehashed signing is not supported/ });
+    }
+  }
+}
+
+// --- Error: non-signing key types (X25519, X448) ---
+{
+  const x25519Priv = fixtures.readKey('x25519_private.pem', 'ascii');
+  const x25519Pub = fixtures.readKey('x25519_public.pem', 'ascii');
+
+  assert.throws(() => {
+    crypto.signDigest('sha256', Buffer.alloc(32), x25519Priv);
+  }, { code: 'ERR_OSSL_EVP_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE' });
+
+  assert.throws(() => {
+    crypto.verifyDigest('sha256', Buffer.alloc(32), x25519Pub, Buffer.alloc(64));
+  }, { code: 'ERR_OSSL_EVP_OPERATION_NOT_SUPPORTED_FOR_THIS_KEYTYPE' });
+}
+
+// --- Error: invalid/unsupported digest algorithm ---
+{
+  const privKey = fixtures.readKey('rsa_private_2048.pem', 'ascii');
+
+  assert.throws(() => {
+    crypto.signDigest('nonexistent', Buffer.alloc(32), privKey);
+  }, { code: 'ERR_CRYPTO_INVALID_DIGEST' });
+}
+
+// --- Error: string inputs are rejected (digest must be binary) ---
+{
+  const privKey = fixtures.readKey('rsa_private_2048.pem', 'ascii');
+  const pubKey = fixtures.readKey('rsa_public_2048.pem', 'ascii');
+
+  // 64-byte string (same length as a SHA-512 digest)
+  const strDigest64 = 'a'.repeat(64);
+  assert.throws(() => {
+    crypto.signDigest('sha256', strDigest64, privKey);
+  }, { code: 'ERR_INVALID_ARG_TYPE' });
+
+  assert.throws(() => {
+    crypto.verifyDigest('sha256', strDigest64, pubKey, Buffer.alloc(256));
+  }, { code: 'ERR_INVALID_ARG_TYPE' });
+
+  // 128-byte string
+  const strDigest128 = 'b'.repeat(128);
+  assert.throws(() => {
+    crypto.signDigest('sha256', strDigest128, privKey);
+  }, { code: 'ERR_INVALID_ARG_TYPE' });
+
+  assert.throws(() => {
+    crypto.verifyDigest('sha256', strDigest128, pubKey, Buffer.alloc(256));
+  }, { code: 'ERR_INVALID_ARG_TYPE' });
+}
+
+// --- ECDSA: hash larger than curve order (cross-verify) ---
+// Using SHA-512 (64 bytes) with P-256 (32-byte order) and P-384 (48-byte order).
+// The digest is larger than the curve's order; ECDSA truncates it internally.
+{
+  const curves = [
+    { priv: 'ec_p256_private.pem', pub: 'ec_p256_public.pem' },
+    { priv: 'ec_p384_private.pem', pub: 'ec_p384_public.pem' },
+  ];
+
+  for (const { priv, pub } of curves) {
+    const privKey = fixtures.readKey(priv, 'ascii');
+    const pubKey = fixtures.readKey(pub, 'ascii');
+
+    const digest = crypto.createHash('sha512').update(data).digest();
+
+    // signDigest + verifyDigest
+    const sig = crypto.signDigest('sha512', digest, privKey);
+    assert.strictEqual(crypto.verifyDigest('sha512', digest, pubKey, sig), true);
+
+    // Cross-verify: sign with crypto.signDigest, verify with crypto.verify
+    assert.strictEqual(crypto.verify('sha512', data, pubKey, sig), true);
+
+    // Cross-verify: sign with crypto.sign, verify with crypto.verifyDigest
+    const sig2 = crypto.sign('sha512', data, privKey);
+    assert.strictEqual(crypto.verifyDigest('sha512', digest, pubKey, sig2), true);
+  }
+}
+
+// --- Error: wrong digest length for Ed25519ph/Ed448ph ---
+if (hasOpenSSL(3, 2)) {
+  // Ed25519ph requires exactly 64-byte SHA-512 digest
+  {
+    const privKey = fixtures.readKey('ed25519_private.pem', 'ascii');
+    assert.throws(() => {
+      crypto.signDigest(null, Buffer.alloc(32), privKey);
+    }, { code: 'ERR_OSSL_INVALID_DIGEST_LENGTH' });
+  }
+
+  // Ed448ph requires exactly 64-byte SHAKE256 digest
+  {
+    const privKey = fixtures.readKey('ed448_private.pem', 'ascii');
+    assert.throws(() => {
+      crypto.signDigest(null, Buffer.alloc(32), privKey);
+    }, { code: 'ERR_OSSL_INVALID_DIGEST_LENGTH' });
+  }
+
+  // Ed448ph rejects a valid 128-byte SHAKE256 digest (must be exactly 64 bytes)
+  {
+    const privKey = fixtures.readKey('ed448_private.pem', 'ascii');
+    const shake256_128 = crypto.createHash('shake256', { outputLength: 128 }).update(data).digest();
+    assert.strictEqual(shake256_128.length, 128);
+
+    assert.throws(() => {
+      crypto.signDigest(null, shake256_128, privKey);
+    }, { code: 'ERR_OSSL_INVALID_DIGEST_LENGTH' });
+  }
+}
+
+// --- Error: wrong digest length for RSA/ECDSA ---
+// OpenSSL rejects wrong-length digests when signing. When verifying,
+// it returns false (signature mismatch) rather than throwing.
+{
+  const rsaDigestLengthError = hasOpenSSL(3, 0) ?
+    'ERR_OSSL_INVALID_DIGEST_LENGTH' :
+    'ERR_OSSL_RSA_INVALID_DIGEST_LENGTH';
+
+  // RSA PKCS#1 v1.5
+  {
+    const privKey = fixtures.readKey('rsa_private_2048.pem', 'ascii');
+    const pubKey = fixtures.readKey('rsa_public_2048.pem', 'ascii');
+    const correctDigest = crypto.createHash('sha256').update(data).digest();
+    const goodSig = crypto.signDigest('sha256', correctDigest, privKey);
+
+    // Too short
+    assert.throws(() => {
+      crypto.signDigest('sha256', Buffer.alloc(16), privKey);
+    }, { code: rsaDigestLengthError });
+
+    // Too long
+    assert.throws(() => {
+      crypto.signDigest('sha256', Buffer.alloc(64), privKey);
+    }, { code: rsaDigestLengthError });
+
+    // Verify with wrong-length digest returns false
+    assert.strictEqual(
+      crypto.verifyDigest('sha256', Buffer.alloc(16), pubKey, goodSig), false);
+  }
+
+  // RSA-PSS
+  {
+    const privKey = fixtures.readKey('rsa_private_2048.pem', 'ascii');
+    const pubKey = fixtures.readKey('rsa_public_2048.pem', 'ascii');
+    const correctDigest = crypto.createHash('sha256').update(data).digest();
+    const goodSig = crypto.signDigest('sha256', correctDigest, {
+      key: privKey,
+      padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+      saltLength: 32,
+    });
+
+    assert.throws(() => {
+      crypto.signDigest('sha256', Buffer.alloc(16), {
+        key: privKey,
+        padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+        saltLength: 32,
+      });
+    }, { code: rsaDigestLengthError });
+
+    assert.strictEqual(
+      crypto.verifyDigest('sha256', Buffer.alloc(16), {
+        key: pubKey,
+        padding: crypto.constants.RSA_PKCS1_PSS_PADDING,
+        saltLength: 32,
+      }, goodSig), false);
+  }
+
+  // ECDSA — OpenSSL 3.x rejects wrong-length digests; 1.1.x accepts them.
+  {
+    const privKey = fixtures.readKey('ec_p256_private.pem', 'ascii');
+    const pubKey = fixtures.readKey('ec_p256_public.pem', 'ascii');
+    const correctDigest = crypto.createHash('sha256').update(data).digest();
+    const goodSig = crypto.signDigest('sha256', correctDigest, privKey);
+
+    if (hasOpenSSL(3, 0)) {
+      const ecdsaDigestLengthError = hasOpenSSL(3, 2) ?
+        'ERR_OSSL_EVP_PROVIDER_SIGNATURE_FAILURE' :
+        'ERR_CRYPTO_OPERATION_FAILED';
+
+      // Too short
+      assert.throws(() => {
+        crypto.signDigest('sha256', Buffer.alloc(16), privKey);
+      }, { code: ecdsaDigestLengthError });
+
+      // Too long
+      assert.throws(() => {
+        crypto.signDigest('sha256', Buffer.alloc(64), privKey);
+      }, { code: ecdsaDigestLengthError });
+    } else {
+      // OpenSSL 1.1.x signs any length digest for ECDSA without error
+      assert.ok(crypto.signDigest('sha256', Buffer.alloc(16), privKey));
+      assert.ok(crypto.signDigest('sha256', Buffer.alloc(64), privKey));
+    }
+
+    // Verify with wrong-length digest returns false on all versions
+    assert.strictEqual(
+      crypto.verifyDigest('sha256', Buffer.alloc(16), pubKey, goodSig), false);
+  }
+}

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -574,6 +574,10 @@ if (hasOpenSSL(3, 2)) {
       key: pubKey,
       context: Buffer.from('wrong'),
     }, sig), false);
+
+    // Ed25519ctx signatures are NOT compatible with Ed25519ph (verifyDigest).
+    const digest = crypto.createHash('sha512').update(data).digest();
+    assert.strictEqual(crypto.verifyDigest(null, digest, { key: pubKey, context }, sig), false);
   }
 
   {


### PR DESCRIPTION
https://github.com/nodejs/node/labels/notable-change 👇 

Adds `crypto.signDigest()` and `crypto.verifyDigest()`, one-shot functions that sign/verify a pre-computed hash digest directly, without hashing internally.

---

```js
const digest = crypto.createHash('sha256').update(data).digest();

const sig = crypto.signDigest('sha256', digest, privateKey);
const ok = crypto.verifyDigest('sha256', digest, publicKey, sig);
```

Supports RSA (PKCS#1 v1.5, PSS), ECDSA, DSA, Ed25519, Ed448, and ~ML-DSA (external mu)~ I've removed ML-DSA external mu for now.

Resolves: https://github.com/nodejs/node/issues/60263

Pre-hash variants of Ed25519 and Ed448 are defined in [RFC8032](https://www.rfc-editor.org/rfc/rfc8032.html)