### PR TITLE
deps: V8: cherry-pick b25cd62c7ba2

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/objects/string-inl.h
+++ b/deps/v8/src/objects/string-inl.h
@@ -1221,6 +1221,12 @@ size_t String::Utf8Length(Isolate* isolate, DirectHandle<String> string) {
         reinterpret_cast<const char*>(vec.begin()), vec.size());
   }
 
+  base::Vector<const base::uc16> vec = content.ToUC16Vector();
+  const char16_t* data = reinterpret_cast<const char16_t*>(vec.begin());
+  if (simdutf::validate_utf16(data, vec.size())) {
+    return simdutf::utf8_length_from_utf16(data, vec.size());
+  }
+
   // TODO(419496232): Use simdutf once upstream bug is resolved.
   size_t utf8_length = 0;
   uint16_t last_character = unibrow::Utf16::kNoPreviousCharacter;


### PR DESCRIPTION
Backport V8 upstream commit b25cd62c7ba2 using `git node v8 backport`.

refs:
https://github.com/nodejs/node/pull/61601
https://github.com/nodejs/node/pull/62349

original commit: https://github.com/v8/v8/commit/b25cd62c7ba2 @anonrig 

fyi @aduh95 @Renegade334 