### PR TITLE
test_runner: omit ignored uncovered branches in lcov

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -197,6 +197,7 @@ class TestCoverage {
               __proto__: null,
               line: range.lines[0]?.line,
               count: range.count,
+              ignored: range.ignoredLines !== 0,
             });
 
             if (range.count !== 0 ||

--- a/lib/internal/test_runner/reporter/lcov.js
+++ b/lib/internal/test_runner/reporter/lcov.js
@@ -68,15 +68,26 @@ class LcovReporter extends Transform {
         // Taken is either '-' if the basic block containing the branch was
         // never executed or a number indicating how often that branch was
         // taken.
+        let lcovBranchCount = 0;
+        let lcovCoveredBranchCount = 0;
         for (let j = 0; j < file.branches.length; j++) {
-          lcov += `BRDA:${file.branches[j].line},${j},0,${file.branches[j].count}\n`;
+          const branch = file.branches[j];
+          // Ignored lines should not produce uncovered BRDA entries.
+          if (branch.ignored && branch.count === 0) {
+            continue;
+          }
+          lcov += `BRDA:${branch.line},${j},0,${branch.count}\n`;
+          lcovBranchCount++;
+          if (branch.count > 0) {
+            lcovCoveredBranchCount++;
+          }
         }
 
         // Branch coverage summaries are stored in two lines:
         // ## BRF:\<number of branches found\>
         // ## BRH:\<number of branches hit\>
-        lcov += `BRF:${file.totalBranchCount}\n`;
-        lcov += `BRH:${file.coveredBranchCount}\n`;
+        lcov += `BRF:${lcovBranchCount}\n`;
+        lcov += `BRH:${lcovCoveredBranchCount}\n`;
 
         // Then there is a list of execution counts for each instrumented line
         // (i.e. a line which resulted in executable code):

--- a/test/fixtures/test-runner/coverage-ignore-next-branch.js
+++ b/test/fixtures/test-runner/coverage-ignore-next-branch.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert');
+
+function getValue(condition) {
+  if (condition) {
+    return 'truthy';
+  }
+  /* node:coverage ignore next */
+  return 'falsy';
+}
+
+test('returns truthy', () => {
+  assert.strictEqual(getValue(true), 'truthy');
+});

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -511,6 +511,26 @@ test('coverage with included and excluded files', skipIfNoInspector, () => {
   assert(!findCoverageFileForPid(result.pid));
 });
 
+test('lcov omits uncovered ignored branches', skipIfNoInspector, () => {
+  const fixture = fixtures.path('test-runner', 'coverage-ignore-next-branch.js');
+  const args = [
+    '--test',
+    '--experimental-test-coverage',
+    '--test-reporter',
+    'lcov',
+    fixture,
+  ];
+  const result = spawnSync(process.execPath, args);
+  const stdout = result.stdout.toString();
+
+  assert.strictEqual(result.stderr.toString(), '');
+  assert.strictEqual(result.status, 0);
+  assert.match(stdout, /SF:test\/fixtures\/test-runner\/coverage-ignore-next-branch\.js/);
+  assert.match(stdout, /BRF:\d+/);
+  assert.match(stdout, /BRH:\d+/);
+  assert.doesNotMatch(stdout, /^BRDA:.*,0$/m);
+});
+
 test('correctly prints the coverage report of files contained in parent directories', skipIfNoInspector, () => {
   let report = [
     '# start of coverage report',


### PR DESCRIPTION
## Summary
- omit uncovered BRDA entries in lcov when branch maps to ignored `node:coverage` lines
- compute BRF/BRH from emitted BRDA entries so lcov totals stay consistent
- add a regression fixture/test for ignored-branch behavior in lcov reporter

## Test plan
- not run in this environment (missing `out/Release/node`)
- run: `python3 tools/test.py test/parallel/test-runner-coverage.js`
