### PR TITLE
dns: add experimental c-ares cache and lookup support

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -40,10 +40,12 @@ const {
 } = require('internal/errors');
 const {
   bindDefaultResolver,
+  getDefaultResolver,
   setDefaultResolver,
   validateHints,
   getDefaultResultOrder,
   setDefaultResultOrder,
+  getUseCares,
   errorCodes: dnsErrorCodes,
   validDnsOrders,
   validFamilies,
@@ -227,9 +229,13 @@ function lookup(hostname, options, callback) {
     order = DNS_ORDER_IPV6_FIRST;
   }
 
-  const err = cares.getaddrinfo(
-    req, hostname, family, hints, order,
-  );
+  let err;
+  if (getUseCares()) {
+    const resolver = getDefaultResolver();
+    err = resolver._handle.getaddrinfo(req, hostname, family, hints, order);
+  } else {
+    err = cares.getaddrinfo(req, hostname, family, hints, order);
+  }
   if (err) {
     process.nextTick(callback, new DNSException(err, 'getaddrinfo', hostname));
     return {};

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -10,11 +10,13 @@ const {
 const {
   bindDefaultResolver,
   createResolverClass,
+  getDefaultResolver,
   validateHints,
   errorCodes: dnsErrorCodes,
   getDefaultResultOrder,
   setDefaultResultOrder,
   setDefaultResolver,
+  getUseCares,
   validDnsOrders,
   validFamilies,
 } = require('internal/dns/utils');
@@ -163,7 +165,13 @@ function createLookupPromise(family, hostname, all, hints, dnsOrder) {
       order = DNS_ORDER_IPV6_FIRST;
     }
 
-    const err = getaddrinfo(req, hostname, family, hints, order);
+    let err;
+    if (getUseCares()) {
+      const resolver = getDefaultResolver();
+      err = resolver._handle.getaddrinfo(req, hostname, family, hints, order);
+    } else {
+      err = getaddrinfo(req, hostname, family, hints, order);
+    }
 
     if (err) {
       reject(new DNSException(err, 'getaddrinfo', hostname));

--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -20,6 +20,7 @@ const {
 } = require('internal/errors');
 const { isIP } = require('internal/net');
 const { getOptionValue } = require('internal/options');
+const { emitExperimentalWarning } = require('internal/util');
 const {
   validateArray,
   validateInt32,
@@ -62,6 +63,12 @@ function validateTries(options) {
   return tries;
 }
 
+function validateCacheMaxTTL(options) {
+  const { cacheMaxTTL = defaultCacheMaxTTL } = { ...options };
+  validateUint32(cacheMaxTTL, 'options.cacheMaxTTL');
+  return cacheMaxTTL;
+}
+
 const kSerializeResolver = Symbol('dns:resolver:serialize');
 const kDeserializeResolver = Symbol('dns:resolver:deserialize');
 const kSnapshotStates = Symbol('dns:resolver:config');
@@ -75,17 +82,21 @@ class ResolverBase {
     const timeout = validateTimeout(options);
     const tries = validateTries(options);
     const maxTimeout = validateMaxTimeout(options);
+    const cacheMaxTTL = validateCacheMaxTTL(options);
+    if (cacheMaxTTL > 0 && options?.cacheMaxTTL !== undefined) {
+      emitExperimentalWarning('dns.Resolver cacheMaxTTL');
+    }
     // If we are building snapshot, save the states of the resolver along
     // the way.
     if (isBuildingSnapshot()) {
-      this[kSnapshotStates] = { timeout, tries, maxTimeout };
+      this[kSnapshotStates] = { timeout, tries, maxTimeout, cacheMaxTTL };
     }
-    this[kInitializeHandle](timeout, tries, maxTimeout);
+    this[kInitializeHandle](timeout, tries, maxTimeout, cacheMaxTTL);
   }
 
-  [kInitializeHandle](timeout, tries, maxTimeout) {
+  [kInitializeHandle](timeout, tries, maxTimeout, cacheMaxTTL) {
     const { ChannelWrap } = lazyBinding();
-    this._handle = new ChannelWrap(timeout, tries, maxTimeout);
+    this._handle = new ChannelWrap(timeout, tries, maxTimeout, cacheMaxTTL);
   }
 
   cancel() {
@@ -195,8 +206,8 @@ class ResolverBase {
   }
 
   [kDeserializeResolver]() {
-    const { timeout, tries, maxTimeout, localAddress, servers } = this[kSnapshotStates];
-    this[kInitializeHandle](timeout, tries, maxTimeout);
+    const { timeout, tries, maxTimeout, cacheMaxTTL, localAddress, servers } = this[kSnapshotStates];
+    this[kInitializeHandle](timeout, tries, maxTimeout, cacheMaxTTL);
     if (localAddress) {
       const { ipv4, ipv6 } = localAddress;
       this._handle.setLocalAddress(ipv4, ipv6);
@@ -209,6 +220,8 @@ class ResolverBase {
 
 let defaultResolver;
 let dnsOrder;
+let defaultCacheMaxTTL = 0;
+let useCares = false;
 const validDnsOrders = ['verbatim', 'ipv4first', 'ipv6first'];
 const validFamilies = [0, 4, 6];
 
@@ -220,6 +233,17 @@ function initializeDns() {
     // Allow the deserialized application to override order from CLI.
     validateOneOf(orderFromCLI, '--dns-result-order', validDnsOrders);
     dnsOrder = orderFromCLI;
+  }
+
+  const cacheMaxTTLFromCLI = getOptionValue('--experimental-dns-cache-max-ttl');
+  if (cacheMaxTTLFromCLI > 0) {
+    emitExperimentalWarning('--experimental-dns-cache-max-ttl');
+    defaultCacheMaxTTL = cacheMaxTTLFromCLI;
+  }
+
+  if (getOptionValue('--experimental-dns-lookup-cares')) {
+    emitExperimentalWarning('--experimental-dns-lookup-cares');
+    useCares = true;
   }
 
   if (!isBuildingSnapshot()) {
@@ -340,6 +364,10 @@ const errorCodes = {
   CANCELLED: 'ECANCELLED',
 };
 
+function getUseCares() {
+  return useCares;
+}
+
 module.exports = {
   bindDefaultResolver,
   getDefaultResolver,
@@ -349,6 +377,7 @@ module.exports = {
   validateTries,
   getDefaultResultOrder,
   setDefaultResultOrder,
+  getUseCares,
   errorCodes,
   createResolverClass,
   initializeDns,

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -816,11 +816,13 @@ ChannelWrap::ChannelWrap(Environment* env,
                          Local<Object> object,
                          int timeout,
                          int tries,
-                         int max_timeout)
+                         int max_timeout,
+                         unsigned int qcache_max_ttl)
     : AsyncWrap(env, object, PROVIDER_DNSCHANNEL),
       timeout_(timeout),
       tries_(tries),
-      max_timeout_(max_timeout) {
+      max_timeout_(max_timeout),
+      qcache_max_ttl_(qcache_max_ttl) {
   MakeWeak();
 
   Setup();
@@ -834,15 +836,17 @@ void ChannelWrap::MemoryInfo(MemoryTracker* tracker) const {
 
 void ChannelWrap::New(const FunctionCallbackInfo<Value>& args) {
   CHECK(args.IsConstructCall());
-  CHECK_EQ(args.Length(), 3);
+  CHECK_EQ(args.Length(), 4);
   CHECK(args[0]->IsInt32());
   CHECK(args[1]->IsInt32());
   CHECK(args[2]->IsInt32());
+  CHECK(args[3]->IsUint32());
   const int timeout = args[0].As<Int32>()->Value();
   const int tries = args[1].As<Int32>()->Value();
   const int max_timeout = args[2].As<Int32>()->Value();
+  const unsigned int qcache_max_ttl = args[3].As<Uint32>()->Value();
   Environment* env = Environment::GetCurrent(args);
-  new ChannelWrap(env, args.This(), timeout, tries, max_timeout);
+  new ChannelWrap(env, args.This(), timeout, tries, max_timeout, qcache_max_ttl);
 }
 
 GetAddrInfoReqWrap::GetAddrInfoReqWrap(Environment* env,
@@ -894,7 +898,7 @@ void ChannelWrap::Setup() {
   options.sock_state_cb_data = this;
   options.timeout = timeout_;
   options.tries = tries_;
-  options.qcache_max_ttl = 0;
+  options.qcache_max_ttl = qcache_max_ttl_;
 
   int r;
   if (!library_inited_) {
@@ -2016,6 +2020,195 @@ void GetAddrInfo(const FunctionCallbackInfo<Value>& args) {
   args.GetReturnValue().Set(err);
 }
 
+}  // anonymous namespace
+class AresGetAddrInfoReqWrap final : public AsyncWrap {
+ public:
+  AresGetAddrInfoReqWrap(Environment* env,
+                         Local<Object> req_wrap_obj,
+                         uint8_t order)
+      : AsyncWrap(env, req_wrap_obj, PROVIDER_GETADDRINFOREQWRAP),
+        order_(order) {
+    MakeWeak();
+  }
+
+  uint8_t order() const { return order_; }
+
+  void MemoryInfo(MemoryTracker* tracker) const override {}
+  SET_MEMORY_INFO_NAME(AresGetAddrInfoReqWrap)
+  SET_SELF_SIZE(AresGetAddrInfoReqWrap)
+
+ private:
+  const uint8_t order_;
+};
+
+struct AresGetAddrInfoCallbackData {
+  ChannelWrap* channel;
+  AresGetAddrInfoReqWrap* req_wrap;
+  AresGetAddrInfoCallbackData(ChannelWrap* c,
+                              AresGetAddrInfoReqWrap* r)
+      : channel(c), req_wrap(r) {}
+};
+
+void AfterAresGetAddrInfo(void* arg,
+                          int status,
+                          int timeouts,
+                          struct ares_addrinfo* result) {
+  auto data = std::unique_ptr<AresGetAddrInfoCallbackData>(
+      static_cast<AresGetAddrInfoCallbackData*>(arg));
+  auto cleanup = OnScopeLeave([&]() {
+    if (result) ares_freeaddrinfo(result);
+  });
+
+  ChannelWrap* channel = data->channel;
+  AresGetAddrInfoReqWrap* req_wrap = data->req_wrap;
+  Environment* env = req_wrap->env();
+
+  HandleScope handle_scope(env->isolate());
+  Context::Scope context_scope(env->context());
+
+  channel->ModifyActivityQueryCount(-1);
+
+  Local<Value> argv[] = {
+    Integer::New(env->isolate(), status),
+    Null(env->isolate())
+  };
+
+  uint32_t n = 0;
+  const uint8_t order = req_wrap->order();
+
+  if (status == ARES_SUCCESS) {
+    Local<Array> results = Array::New(env->isolate());
+
+    auto add = [&](bool want_ipv4, bool want_ipv6) -> Maybe<void> {
+      for (auto p = result->nodes; p != nullptr; p = p->ai_next) {
+        const char* addr;
+        if (want_ipv4 && p->ai_family == AF_INET) {
+          addr = reinterpret_cast<char*>(
+              &(reinterpret_cast<struct sockaddr_in*>(p->ai_addr)->sin_addr));
+        } else if (want_ipv6 && p->ai_family == AF_INET6) {
+          addr = reinterpret_cast<char*>(
+              &(reinterpret_cast<struct sockaddr_in6*>(p->ai_addr)->sin6_addr));
+        } else {
+          continue;
+        }
+
+        char ip[INET6_ADDRSTRLEN];
+        if (uv_inet_ntop(p->ai_family, addr, ip, sizeof(ip)))
+          continue;
+
+        Local<String> s = OneByteString(env->isolate(), ip);
+        if (results->Set(env->context(), n, s).IsNothing())
+          return Nothing<void>();
+        n++;
+      }
+      return JustVoid();
+    };
+
+    switch (order) {
+      case DNS_ORDER_IPV4_FIRST:
+        if (add(true, false).IsNothing() || add(false, true).IsNothing())
+          return;
+        break;
+      case DNS_ORDER_IPV6_FIRST:
+        if (add(false, true).IsNothing() || add(true, false).IsNothing())
+          return;
+        break;
+      default:
+        if (add(true, true).IsNothing()) return;
+        break;
+    }
+
+    if (n == 0) {
+      argv[0] = Integer::New(env->isolate(), ARES_ENOTFOUND);
+    }
+
+    argv[1] = results;
+  }
+
+  TRACE_EVENT_NESTABLE_ASYNC_END2(TRACING_CATEGORY_NODE2(dns, native),
+                                  "lookup",
+                                  req_wrap,
+                                  "count",
+                                  n,
+                                  "order",
+                                  order);
+
+  req_wrap->MakeCallback(env->oncomplete_string(), arraysize(argv), argv);
+}
+
+void ChannelWrap::AresGetAddrInfo(const FunctionCallbackInfo<Value>& args) {
+  ChannelWrap* channel;
+  ASSIGN_OR_RETURN_UNWRAP(&channel, args.This());
+  Environment* env = channel->env();
+
+  CHECK(args[0]->IsObject());
+  CHECK(args[1]->IsString());
+  CHECK(args[2]->IsInt32());
+  CHECK(args[4]->IsUint32());
+
+  Local<Object> req_wrap_obj = args[0].As<Object>();
+  node::Utf8Value hostname(env->isolate(), args[1]);
+
+  ERR_ACCESS_DENIED_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kNet, hostname.ToStringView(), args);
+
+  std::string ascii_hostname = ada::idna::to_ascii(hostname.ToStringView());
+
+  int32_t flags = 0;
+  if (args[3]->IsInt32()) {
+    flags = args[3].As<Int32>()->Value();
+  }
+
+  int family;
+  switch (args[2].As<Int32>()->Value()) {
+    case 0:
+      family = AF_UNSPEC;
+      break;
+    case 4:
+      family = AF_INET;
+      break;
+    case 6:
+      family = AF_INET6;
+      break;
+    default:
+      UNREACHABLE("bad address family");
+  }
+
+  uint8_t order = args[4].As<Uint32>()->Value();
+
+  auto req_wrap = new AresGetAddrInfoReqWrap(env, req_wrap_obj, order);
+
+  struct ares_addrinfo_hints hints;
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = family;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_flags = flags;
+
+  auto callback_data = new AresGetAddrInfoCallbackData(channel, req_wrap);
+
+  TRACE_EVENT_NESTABLE_ASYNC_BEGIN2(TRACING_CATEGORY_NODE2(dns, native),
+                                    "lookup",
+                                    req_wrap,
+                                    "hostname",
+                                    TRACE_STR_COPY(ascii_hostname.data()),
+                                    "family",
+                                    family == AF_INET    ? "ipv4"
+                                    : family == AF_INET6 ? "ipv6"
+                                                         : "unspec");
+
+  channel->EnsureServers();
+  channel->ModifyActivityQueryCount(1);
+  ares_getaddrinfo(channel->cares_channel(),
+                   ascii_hostname.data(),
+                   nullptr,
+                   &hints,
+                   AfterAresGetAddrInfo,
+                   callback_data);
+
+  args.GetReturnValue().Set(0);
+}
+
+namespace {
 
 void GetNameInfo(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
@@ -2342,6 +2535,8 @@ void Initialize(Local<Object> target,
   SetProtoMethod(isolate, channel_wrap, "setServers", SetServers);
   SetProtoMethod(isolate, channel_wrap, "setLocalAddress", SetLocalAddress);
   SetProtoMethod(isolate, channel_wrap, "cancel", Cancel);
+  SetProtoMethod(
+      isolate, channel_wrap, "getaddrinfo", ChannelWrap::AresGetAddrInfo);
 
   SetConstructorFunction(context, target, "ChannelWrap", channel_wrap);
 }
@@ -2362,6 +2557,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(SetServers);
   registry->Register(SetLocalAddress);
   registry->Register(Cancel);
+  registry->Register(ChannelWrap::AresGetAddrInfo);
 }
 
 }  // namespace cares_wrap

--- a/src/cares_wrap.h
+++ b/src/cares_wrap.h
@@ -156,10 +156,13 @@ class ChannelWrap final : public AsyncWrap {
               v8::Local<v8::Object> object,
               int timeout,
               int tries,
-              int max_timeout);
+              int max_timeout,
+              unsigned int qcache_max_ttl);
   ~ChannelWrap() override;
 
   static void New(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void AresGetAddrInfo(
+      const v8::FunctionCallbackInfo<v8::Value>& args);
 
   void Setup();
   void EnsureServers();
@@ -192,6 +195,7 @@ class ChannelWrap final : public AsyncWrap {
   int timeout_;
   int tries_;
   int max_timeout_;
+  unsigned int qcache_max_ttl_;
   int active_query_count_ = 0;
   NodeAresTask::List task_list_;
 };

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -549,6 +549,17 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             &EnvironmentOptions::disable_sigusr1,
             kAllowedInEnvvar,
             false);
+  AddOption("--experimental-dns-cache-max-ttl",
+            "set the maximum TTL in seconds for the c-ares DNS query cache "
+            "(0 disables the cache, default: 0). This is experimental.",
+            &EnvironmentOptions::experimental_dns_cache_max_ttl,
+            kAllowedInEnvvar);
+  AddOption("--experimental-dns-lookup-cares",
+            "use c-ares ares_getaddrinfo for dns.lookup instead of the "
+            "system getaddrinfo(3). Enables truly async DNS and c-ares "
+            "query caching for all HTTP/net connections.",
+            &EnvironmentOptions::experimental_dns_lookup_cares,
+            kAllowedInEnvvar);
   AddOption("--dns-result-order",
             "set default value of verbatim in dns.lookup. Options are "
             "'ipv4first' (IPv4 addresses are placed before IPv6 addresses) "

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -121,6 +121,8 @@ class EnvironmentOptions : public Options {
   bool print_required_tla = false;
   bool require_module = true;
   std::string dns_result_order;
+  uint64_t experimental_dns_cache_max_ttl = 0;
+  bool experimental_dns_lookup_cares = false;
   bool enable_source_maps = false;
   bool experimental_addon_modules = false;
   bool experimental_eventsource = false;

--- a/test/parallel/test-dns-cache-max-ttl-cli.js
+++ b/test/parallel/test-dns-cache-max-ttl-cli.js
@@ -1,0 +1,45 @@
+// Flags: --experimental-dns-cache-max-ttl=300
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const dnstools = require('../common/dns');
+const dns = require('dns');
+
+const server = dgram.createSocket('udp4');
+let queryCount = 0;
+
+server.on('message', (msg, rinfo) => {
+  queryCount++;
+  const parsed = dnstools.parseDNSPacket(msg);
+  const domain = parsed.questions[0].domain;
+  const response = dnstools.writeDNSPacket({
+    id: parsed.id,
+    questions: parsed.questions,
+    answers: [{
+      type: 'A',
+      domain,
+      ttl: 300,
+      address: '127.0.0.1',
+    }],
+  });
+  server.send(response, rinfo.port, rinfo.address);
+});
+
+server.bind(0, '127.0.0.1', common.mustCall(() => {
+  const port = server.address().port;
+  dns.setServers([`127.0.0.1:${port}`]);
+
+  dns.resolve4('example.com', common.mustCall((err, addresses) => {
+    assert.ifError(err);
+    assert.deepStrictEqual(addresses, ['127.0.0.1']);
+    assert.strictEqual(queryCount, 1);
+
+    dns.resolve4('example.com', common.mustCall((err, addresses) => {
+      assert.ifError(err);
+      assert.deepStrictEqual(addresses, ['127.0.0.1']);
+      assert.strictEqual(queryCount, 1);
+      server.close();
+    }));
+  }));
+}));

--- a/test/parallel/test-dns-cache-max-ttl.js
+++ b/test/parallel/test-dns-cache-max-ttl.js
@@ -1,0 +1,82 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const dnstools = require('../common/dns');
+const dns = require('dns');
+
+for (const ctor of [dns.Resolver, dns.promises.Resolver]) {
+  for (const cacheMaxTTL of [null, true, false, '', '2', -1, 4.2]) {
+    assert.throws(() => new ctor({ cacheMaxTTL }), {
+      code: /ERR_INVALID_ARG_TYPE|ERR_OUT_OF_RANGE/,
+    });
+  }
+
+  for (const cacheMaxTTL of [0, 1, 300, 3600]) {
+    new ctor({ cacheMaxTTL });
+  }
+}
+
+function createDNSServer(address, callback) {
+  const server = dgram.createSocket('udp4');
+  let queryCount = 0;
+
+  server.on('message', (msg, rinfo) => {
+    queryCount++;
+    const parsed = dnstools.parseDNSPacket(msg);
+    const domain = parsed.questions[0].domain;
+    const response = dnstools.writeDNSPacket({
+      id: parsed.id,
+      questions: parsed.questions,
+      answers: [{
+        type: 'A',
+        domain,
+        ttl: 300,
+        address,
+      }],
+    });
+    server.send(response, rinfo.port, rinfo.address);
+  });
+
+  server.bind(0, '127.0.0.1', common.mustCall(() => {
+    callback(server, () => queryCount);
+  }));
+}
+
+createDNSServer('127.0.0.1', (server, getQueryCount) => {
+  const port = server.address().port;
+  const resolver = new dns.Resolver({ cacheMaxTTL: 300 });
+  resolver.setServers([`127.0.0.1:${port}`]);
+
+  resolver.resolve4('example.com', common.mustCall((err, addresses) => {
+    assert.ifError(err);
+    assert.deepStrictEqual(addresses, ['127.0.0.1']);
+    assert.strictEqual(getQueryCount(), 1);
+
+    resolver.resolve4('example.com', common.mustCall((err, addresses) => {
+      assert.ifError(err);
+      assert.deepStrictEqual(addresses, ['127.0.0.1']);
+      assert.strictEqual(getQueryCount(), 1);
+      server.close();
+    }));
+  }));
+});
+
+createDNSServer('127.0.0.2', (server, getQueryCount) => {
+  const port = server.address().port;
+  const resolver = new dns.Resolver({ cacheMaxTTL: 0 });
+  resolver.setServers([`127.0.0.1:${port}`]);
+
+  resolver.resolve4('example.com', common.mustCall((err, addresses) => {
+    assert.ifError(err);
+    assert.deepStrictEqual(addresses, ['127.0.0.2']);
+    assert.strictEqual(getQueryCount(), 1);
+
+    resolver.resolve4('example.com', common.mustCall((err, addresses) => {
+      assert.ifError(err);
+      assert.deepStrictEqual(addresses, ['127.0.0.2']);
+      assert.strictEqual(getQueryCount(), 2);
+      server.close();
+    }));
+  }));
+});

--- a/test/parallel/test-dns-lookup-cares.js
+++ b/test/parallel/test-dns-lookup-cares.js
@@ -1,0 +1,47 @@
+// Flags: --experimental-dns-lookup-cares --experimental-dns-cache-max-ttl=300
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const dgram = require('dgram');
+const dnstools = require('../common/dns');
+const dns = require('dns');
+
+const server = dgram.createSocket('udp4');
+let queryCount = 0;
+
+server.on('message', (msg, rinfo) => {
+  queryCount++;
+  const parsed = dnstools.parseDNSPacket(msg);
+  const domain = parsed.questions[0].domain;
+  const response = dnstools.writeDNSPacket({
+    id: parsed.id,
+    questions: parsed.questions,
+    answers: [{
+      type: 'A',
+      domain,
+      ttl: 300,
+      address: '1.2.3.4',
+    }],
+  });
+  server.send(response, rinfo.port, rinfo.address);
+});
+
+server.bind(0, '127.0.0.1', common.mustCall(() => {
+  const port = server.address().port;
+  dns.setServers([`127.0.0.1:${port}`]);
+
+  dns.lookup('test.example.com', { family: 4 }, common.mustCall((err, address, family) => {
+    assert.ifError(err);
+    assert.strictEqual(address, '1.2.3.4');
+    assert.strictEqual(family, 4);
+    assert.strictEqual(queryCount, 1);
+
+    dns.lookup('test.example.com', { family: 4 }, common.mustCall((err, address, family) => {
+      assert.ifError(err);
+      assert.strictEqual(address, '1.2.3.4');
+      assert.strictEqual(family, 4);
+      assert.strictEqual(queryCount, 1);
+      server.close();
+    }));
+  }));
+}));


### PR DESCRIPTION
Add --experimental-dns-cache-max-ttl to expose c-ares query cache, and --experimental-dns-lookup-cares to route dns.lookup() through ares_getaddrinfo instead of libuv's blocking getaddrinfo.

Refs: https://github.com/nodejs/node/issues/57641

---

I had AI compile a record of this history of this change.

# The Two DNS Resolution Paths in Node.js: A History

## The Original Design

Node.js originally used c-ares exclusively for all DNS operations. c-ares was
the natural choice: the standard POSIX `getaddrinfo(3)` is synchronous and
blocking, fundamentally incompatible with an event-driven runtime. c-ares
provides non-blocking DNS resolution that integrates with event loops.

c-ares was part of Node.js from its earliest days, initially living inside the
libuv source tree before being moved to `deps/cares` in 2012.

## Why `dns.lookup()` Was Added

`dns.lookup()` was introduced because c-ares, as a pure DNS stub resolver,
could not replicate the full behavior of the operating system's name resolution:

- `/etc/hosts` for static name-to-IP mappings
- NSS (`/etc/nsswitch.conf`) to determine resolution order (files, dns, mdns)
- mDNS/Bonjour for local network service discovery
- LLMNR on Windows
- System-wide DNS cache configurations
- Correct `localhost` handling per the OS

As Ben Noordhuis explained in [nodejs/node#49394][49394]:

> "In the deep past node used c-ares exclusively. dns.lookup was added
> explicitly because lots of things only work with the system resolver.
> Ex. mDNS."

The workaround was to run `getaddrinfo(3)` on libuv's threadpool (default 4
threads) to simulate async behavior from JavaScript's perspective.

## The Current Split

| Feature | `dns.lookup()` | `dns.resolve*()` |
|---------|---------------|-------------------|
| Backend | libuv `getaddrinfo` (threadpool) | c-ares channel (event loop) |
| Reads `/etc/hosts` | Yes (via OS) | No |
| NSS/mDNS support | Yes | No |
| Truly async | No (threadpool) | Yes |
| DNS caching | No (delegates to OS) | Yes (c-ares qcache) |
| `dns.setServers()` effect | None | Yes |
| Used by `http`/`net` | Yes (default) | No (unless custom lookup) |

`net.connect()`, `http.request()`, and all high-level APIs use `dns.lookup()`
by default. The c-ares resolver (`dns.resolve*()`) is only used when explicitly
called or when a custom `lookup` function is provided to an HTTP agent or
socket.

## Known Problems

### Threadpool Starvation

The most critical issue, reported since 2012 ([nodejs/node-v0.x-archive#2868][2868],
[nodejs/node#8436][8436]). When DNS servers are slow or unreachable,
`getaddrinfo(3)` calls saturate libuv's shared threadpool and block unrelated
file system I/O and crypto operations.

### No DNS Caching

Node.js performs no DNS caching in `dns.lookup()`. Every call goes through
`getaddrinfo(3)` from scratch, delegating caching entirely to the OS. Many
production environments (containers, minimal Linux images) have no local DNS
cache daemon, causing unnecessary latency and load on DNS servers.

### Behavioral Inconsistency

`dns.lookup()` and `dns.resolve4()` can return different results for the same
hostname because they use entirely different resolution mechanisms. This
confuses developers. `dns.setServers()` has no effect on `dns.lookup()`.

### HTTP Timeout Does Not Cover DNS

`http.request()`'s `setTimeout` does not include the `dns.lookup()` phase. A
request with a 10ms timeout can hang for seconds during DNS resolution
([nodejs/node#8436][8436]).

## Failed Unification Attempts

### 2015: Pure JavaScript DNS Resolver ([#1843][1843])

Proposed adding a new pure JS resolver as default, relegating c-ares behind a
`--use-old-dns` flag. Closed in 2016 because the author could not match the
speed of the existing resolver from JavaScript.

### 2015: Replace c-ares with node-dns ([#1013][1013])

Discussion about replacing c-ares with Tim Fontaine's `node-dns` module. Ben
Noordhuis was in favor, but Fontaine himself concluded his own module was not
ready for core inclusion, citing technical debt and the impossibility of
faithfully implementing `dns.lookup()` behavior from userspace.

### 2017: Tracking DNS Features ([#14713][14713])

Tracked growing limitations of c-ares (no AXFR, no DNSSEC at the time, limited
TTL exposure). Considered writing a custom DNS library. Went stale.

### 2023: Global Flag for Async DNS ([#49394][49394])

Proposed a Go-like flag to globally switch `dns.lookup()` to use the async
c-ares resolver. Ben Noordhuis rejected a global flag as "probably a bad idea"
because "lots of things only work with the system resolver." His
counter-proposal was to improve libuv's threadpool scaling and add a transparent
DNS cache. Neither was implemented. The issue was closed by the stale bot.

## What Changed: `ares_getaddrinfo` (c-ares 1.16.0, 2020)

c-ares 1.16.0 introduced `ares_getaddrinfo()`, an async equivalent to POSIX
`getaddrinfo()` with:

- RFC 6724-compliant address sorting
- TTL information in results
- Alias data
- `/etc/hosts` reading (with caching since c-ares 1.22.0)
- Correct `localhost` handling per RFC 6761

The original gap between c-ares and the system resolver has significantly
narrowed. The main remaining difference is NSS plugin support (mDNS, LDAP,
NIS), which `ares_getaddrinfo` does not implement.

Bun uses `ares_getaddrinfo` as its default `dns.lookup()` backend on Linux,
demonstrating the approach is viable for a JavaScript runtime.

[49394]: https://github.com/nodejs/node/issues/49394
[2868]: https://github.com/nodejs/node-v0.x-archive/issues/2868
[8436]: https://github.com/nodejs/node/issues/8436
[1843]: https://github.com/nodejs/node/pull/1843
[1013]: https://github.com/nodejs/node/issues/1013
[14713]: https://github.com/nodejs/node/issues/14713
[8475]: https://github.com/nodejs/node-v0.x-archive/issues/8475

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
