### PR TITLE
repl: use vm DONT_CONTEXTIFY context

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -1132,10 +1132,10 @@ class REPLServer extends Interface {
         session.once('Runtime.executionContextCreated', ({ params }) => {
           this[kContextId] = params.context.id;
         });
-        context = vm.createContext();
+        context = vm.createContext(vm.constants.DONT_CONTEXTIFY);
         session.post('Runtime.disable');
       }, () => {
-        context = vm.createContext();
+        context = vm.createContext(vm.constants.DONT_CONTEXTIFY);
       });
       ArrayPrototypeForEach(ObjectGetOwnPropertyNames(globalThis), (name) => {
         // Only set properties that do not already exist as a global builtin.


### PR DESCRIPTION
REPL does not need interception behavior in the vm context. Creating
a `DONT_CONTEXTIFY` context to reduce the chance to be impacted by V8
interceptor API changes.

No observable behavior or tests should break. This does not fix the
behavior in `vm` with the V8 upgrade, only REPL is fixed.

Refs: https://github.com/nodejs/node/pull/61898#issuecomment-4082662242
