### PR TITLE
test_runner: exclude ignored branches from BRDA in lcov output

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -193,14 +193,20 @@ class TestCoverage {
           ObjectAssign(range, mapRangeToLines(range, lines));
 
           if (isBlockCoverage) {
+            // Skip branches where all lines are ignored by coverage
+            // comments. This is consistent with how ignored lines are
+            // excluded from line reports (DA entries in lcov).
+            if (range.ignoredLines === range.lines.length) {
+              continue;
+            }
+
             ArrayPrototypePush(branchReports, {
               __proto__: null,
               line: range.lines[0]?.line,
               count: range.count,
             });
 
-            if (range.count !== 0 ||
-                range.ignoredLines === range.lines.length) {
+            if (range.count !== 0) {
               branchesCovered++;
             }
 


### PR DESCRIPTION
## Summary

When using \/* node:coverage ignore next */\ comments, line coverage (DA entries) is correctly excluded from the lcov output, but branch coverage (BRDA entries) for branches pointing to ignored lines still appears as uncovered. This causes branch coverage percentages to be incorrectly low (e.g. 66.67% instead of 100%).

## Changes

In \lib/internal/test_runner/coverage.js\, when processing branch coverage:

1. **Skip branches entirely** when all their lines are ignored by coverage comments (\ange.ignoredLines === range.lines.length\). Previously these branches were still added to \ranchReports\ and counted toward \	otalBranches\.
2. **Simplify the covered branch condition** — since fully-ignored branches are now skipped, the \ranchesCovered\ check only needs \ange.count !== 0\.

This makes branch coverage handling consistent with how ignored lines are already excluded from line reports (DA entries in lcov).

## Before

\\\
BRDA:4,2,0,0    <-- Branch to ignored line still reported as uncovered
BRF:3
BRH:2           <-- 66.67% branch coverage
\\\

## After

\\\
BRF:2           <-- Ignored branch excluded
BRH:2           <-- 100% branch coverage
\\\

Fixes: https://github.com/nodejs/node/issues/61586