### PR TITLE
stream: align Readable.toWeb termination with eos

### DIFF
--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -183,19 +183,6 @@ function eos(stream, options, callback) {
   } else if ((rState && stream.req && stream.aborted)) {
     immediateResult = getEosErrored(stream);
   }
-  const returnImmediately = (result) => {
-    const args = result === null ? [] : [result];
-    if (options[kEosNodeSyncronousCallback]) {
-      callback.call(stream, ...args);
-    } else {
-      if (AsyncContextFrame.current() || enabledHooksExist()) {
-        // Avoid AsyncResource.bind() because it calls ObjectDefineProperties which
-        // is a bottleneck here.
-        callback = bindAsyncResource(callback, 'STREAM_END_OF_STREAM');
-      }
-      process.nextTick(() => callback.call(stream, ...args));
-    }
-  };
   let cleanup = () => {
     callback = nop;
   };
@@ -207,22 +194,26 @@ function eos(stream, options, callback) {
         stream.removeListener('error', nop);
       };
     }
-    returnImmediately(immediateResult);
-    return cleanup;
+  } else if (options.signal?.aborted) {
+    immediateResult = new AbortError(undefined, { cause: options.signal.reason });
   }
-
-  if (options.signal?.aborted) {
-    returnImmediately(new AbortError(undefined, { cause: options.signal.reason }));
+  if (immediateResult !== undefined && options[kEosNodeSyncronousCallback]) {
+    ReflectApply(callback, stream, immediateResult === null ? [] : [immediateResult]);
     return cleanup;
   }
 
   if (AsyncContextFrame.current() || enabledHooksExist()) {
     // Avoid AsyncResource.bind() because it calls ObjectDefineProperties which
     // is a bottleneck here.
-    callback = once(bindAsyncResource(callback, 'STREAM_END_OF_STREAM'));
-  } else {
-    callback = once(callback);
+    callback = bindAsyncResource(callback, 'STREAM_END_OF_STREAM');
   }
+
+  if (immediateResult !== undefined) {
+    process.nextTick(() => ReflectApply(callback, stream, immediateResult === null ? [] : [immediateResult]));
+    return cleanup;
+  }
+
+  callback = once(callback);
 
   const onlegacyfinish = () => {
     if (!stream.writable) {

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -109,7 +109,7 @@ function getEosOnCloseError(stream, readable, readableFinished, writable, writab
 
 // Internal only: if eos() can settle immediately, invoke the callback before
 // returning cleanup. Callers must tolerate cleanup yet to be assigned.
-const kEosNodeSyncronousCallback = Symbol('kEosNodeSynchronousCallback');
+const kEosNodeSynchronousCallback = Symbol('kEosNodeSynchronousCallback');
 
 function eos(stream, options, callback) {
   if (arguments.length === 2) {
@@ -197,7 +197,7 @@ function eos(stream, options, callback) {
   } else if (options.signal?.aborted) {
     immediateResult = new AbortError(undefined, { cause: options.signal.reason });
   }
-  if (immediateResult !== undefined && options[kEosNodeSyncronousCallback]) {
+  if (immediateResult !== undefined && options[kEosNodeSynchronousCallback]) {
     ReflectApply(callback, stream, immediateResult === null ? [] : [immediateResult]);
     return cleanup;
   }
@@ -404,5 +404,5 @@ function finished(stream, opts) {
 module.exports = {
   eos,
   finished,
-  kEosNodeSyncronousCallback,
+  kEosNodeSynchronousCallback,
 };

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -7,6 +7,7 @@ const {
   Promise,
   PromisePrototypeThen,
   ReflectApply,
+  Symbol,
   SymbolDispose,
 } = primordials;
 
@@ -66,6 +67,125 @@ function bindAsyncResource(fn, type) {
   };
 }
 
+const kEosImmediateClose = Symbol('kEosImmediateClose');
+
+/**
+ * Returns the current stream error tracked by eos(), if any.
+ * @param {import('stream').Stream} stream
+ * @returns {Error | null}
+ */
+function getEosErrored(stream) {
+  const errored = isWritableErrored(stream) || isReadableErrored(stream);
+  return typeof errored !== 'boolean' && errored || null;
+}
+
+/**
+ * Returns the error eos() would report from an immediate close, including
+ * premature close detection for unfinished readable or writable sides.
+ * @param {import('stream').Stream} stream
+ * @param {boolean} readable
+ * @param {boolean | null} readableFinished
+ * @param {boolean} writable
+ * @param {boolean | null} writableFinished
+ * @returns {Error | typeof kEosImmediateClose}
+ */
+function getEosOnCloseError(stream, readable, readableFinished, writable, writableFinished) {
+  const errored = getEosErrored(stream);
+  if (errored) {
+    return errored;
+  }
+
+  if (readable && !readableFinished && isReadableNodeStream(stream, true)) {
+    if (!isReadableFinished(stream, false)) {
+      return new ERR_STREAM_PREMATURE_CLOSE();
+    }
+  }
+  if (writable && !writableFinished) {
+    if (!isWritableFinished(stream, false)) {
+      return new ERR_STREAM_PREMATURE_CLOSE();
+    }
+  }
+
+  return kEosImmediateClose;
+}
+
+function getEosInitialState(stream, options = kEmptyObject) {
+  const readable = options.readable ?? isReadableNodeStream(stream);
+  const writable = options.writable ?? isWritableNodeStream(stream);
+
+  // TODO (ronag): Improve soft detection to include core modules and
+  // common ecosystem modules that do properly emit 'close' but fail
+  // this generic check.
+  const willEmitClose = (
+    _willEmitClose(stream) &&
+    isReadableNodeStream(stream) === readable &&
+    isWritableNodeStream(stream) === writable
+  );
+
+  return {
+    readable,
+    writable,
+    willEmitClose,
+    writableFinished: isWritableFinished(stream, false),
+    readableFinished: isReadableFinished(stream, false),
+    closed: isClosed(stream),
+  };
+}
+
+/**
+ * Classifies whether eos() can synchronously determine the result for the
+ * current stream snapshot, or if it must defer to future events.
+ * @param {import('stream').Stream} stream
+ * @param {object} [options]
+ * @param {boolean} [options.readable]
+ * @param {boolean} [options.writable]
+ * @param {ReturnType<typeof getEosInitialState>} [state]
+ * @returns {Error | typeof kEosImmediateClose | null}
+ */
+function getEosImmediateResult(stream, options = kEmptyObject, state = getEosInitialState(stream, options)) {
+  const {
+    readable,
+    writable,
+    willEmitClose,
+    writableFinished,
+    readableFinished,
+    closed,
+  } = state;
+  const wState = stream._writableState;
+  const rState = stream._readableState;
+
+  if (closed) {
+    return getEosOnCloseError(
+      stream,
+      readable,
+      readableFinished,
+      writable,
+      writableFinished,
+    );
+  } else if (wState?.errorEmitted || rState?.errorEmitted) {
+    if (!willEmitClose) {
+      return getEosErrored(stream) ?? kEosImmediateClose;
+    }
+  } else if (
+    !readable &&
+    (!willEmitClose || isReadable(stream)) &&
+    (writableFinished || isWritable(stream) === false) &&
+    (wState == null || wState.pendingcb === undefined || wState.pendingcb === 0)
+  ) {
+    return getEosErrored(stream) ?? kEosImmediateClose;
+  } else if (
+    !writable &&
+    (!willEmitClose || isWritable(stream)) &&
+    (readableFinished || isReadable(stream) === false)
+  ) {
+    return getEosErrored(stream) ?? kEosImmediateClose;
+  } else if ((rState && stream.req && stream.aborted)) {
+    return getEosErrored(stream) ?? kEosImmediateClose;
+  }
+
+  return null;
+}
+
 function eos(stream, options, callback) {
   if (arguments.length === 2) {
     callback = options;
@@ -94,11 +214,8 @@ function eos(stream, options, callback) {
     throw new ERR_INVALID_ARG_TYPE('stream', ['ReadableStream', 'WritableStream', 'Stream'], stream);
   }
 
-  const readable = options.readable ?? isReadableNodeStream(stream);
-  const writable = options.writable ?? isWritableNodeStream(stream);
-
+  const eosState = getEosInitialState(stream, options);
   const wState = stream._writableState;
-  const rState = stream._readableState;
 
   const onlegacyfinish = () => {
     if (!stream.writable) {
@@ -106,16 +223,13 @@ function eos(stream, options, callback) {
     }
   };
 
-  // TODO (ronag): Improve soft detection to include core modules and
-  // common ecosystem modules that do properly emit 'close' but fail
-  // this generic check.
-  let willEmitClose = (
-    _willEmitClose(stream) &&
-    isReadableNodeStream(stream) === readable &&
-    isWritableNodeStream(stream) === writable
-  );
-
-  let writableFinished = isWritableFinished(stream, false);
+  const { readable, writable } = eosState;
+  let {
+    willEmitClose,
+    writableFinished,
+    readableFinished,
+    closed,
+  } = eosState;
   const onfinish = () => {
     writableFinished = true;
     // Stream should not be destroyed here. If it is that
@@ -134,7 +248,6 @@ function eos(stream, options, callback) {
     }
   };
 
-  let readableFinished = isReadableFinished(stream, false);
   const onend = () => {
     readableFinished = true;
     // Stream should not be destroyed here. If it is that
@@ -157,41 +270,15 @@ function eos(stream, options, callback) {
     callback.call(stream, err);
   };
 
-  let closed = isClosed(stream);
-
   const onclose = () => {
     closed = true;
 
-    const errored = isWritableErrored(stream) || isReadableErrored(stream);
-
-    if (errored && typeof errored !== 'boolean') {
-      return callback.call(stream, errored);
+    const error = getEosOnCloseError(stream, readable, readableFinished, writable, writableFinished);
+    if (error === kEosImmediateClose) {
+      callback.call(stream);
+    } else {
+      callback.call(stream, error);
     }
-
-    if (readable && !readableFinished && isReadableNodeStream(stream, true)) {
-      if (!isReadableFinished(stream, false))
-        return callback.call(stream,
-                             new ERR_STREAM_PREMATURE_CLOSE());
-    }
-    if (writable && !writableFinished) {
-      if (!isWritableFinished(stream, false))
-        return callback.call(stream,
-                             new ERR_STREAM_PREMATURE_CLOSE());
-    }
-
-    callback.call(stream);
-  };
-
-  const onclosed = () => {
-    closed = true;
-
-    const errored = isWritableErrored(stream) || isReadableErrored(stream);
-
-    if (errored && typeof errored !== 'boolean') {
-      return callback.call(stream, errored);
-    }
-
-    callback.call(stream);
   };
 
   const onrequest = () => {
@@ -225,27 +312,13 @@ function eos(stream, options, callback) {
   }
   stream.on('close', onclose);
 
-  if (closed) {
-    process.nextTick(onclose);
-  } else if (wState?.errorEmitted || rState?.errorEmitted) {
-    if (!willEmitClose) {
-      process.nextTick(onclosed);
+  const immediateResult = getEosImmediateResult(stream, options, eosState);
+  if (immediateResult !== null) {
+    if (immediateResult === kEosImmediateClose) {
+      process.nextTick(() => callback.call(stream));
+    } else {
+      process.nextTick(() => callback.call(stream, immediateResult));
     }
-  } else if (
-    !readable &&
-    (!willEmitClose || isReadable(stream)) &&
-    (writableFinished || isWritable(stream) === false) &&
-    (wState == null || wState.pendingcb === undefined || wState.pendingcb === 0)
-  ) {
-    process.nextTick(onclosed);
-  } else if (
-    !writable &&
-    (!willEmitClose || isWritable(stream)) &&
-    (readableFinished || isReadable(stream) === false)
-  ) {
-    process.nextTick(onclosed);
-  } else if ((rState && stream.req && stream.aborted)) {
-    process.nextTick(onclosed);
   }
 
   const cleanup = () => {
@@ -347,4 +420,6 @@ function finished(stream, opts) {
 module.exports = {
   eos,
   finished,
+  getEosImmediateResult,
+  kEosImmediateClose,
 };

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -67,8 +67,6 @@ function bindAsyncResource(fn, type) {
   };
 }
 
-const kEosImmediateClose = Symbol('kEosImmediateClose');
-
 /**
  * Returns the current stream error tracked by eos(), if any.
  * @param {import('stream').Stream} stream
@@ -87,7 +85,7 @@ function getEosErrored(stream) {
  * @param {boolean | null} readableFinished
  * @param {boolean} writable
  * @param {boolean | null} writableFinished
- * @returns {Error | typeof kEosImmediateClose}
+ * @returns {Error | null}
  */
 function getEosOnCloseError(stream, readable, readableFinished, writable, writableFinished) {
   const errored = getEosErrored(stream);
@@ -106,85 +104,10 @@ function getEosOnCloseError(stream, readable, readableFinished, writable, writab
     }
   }
 
-  return kEosImmediateClose;
-}
-
-function getEosInitialState(stream, options = kEmptyObject) {
-  const readable = options.readable ?? isReadableNodeStream(stream);
-  const writable = options.writable ?? isWritableNodeStream(stream);
-
-  // TODO (ronag): Improve soft detection to include core modules and
-  // common ecosystem modules that do properly emit 'close' but fail
-  // this generic check.
-  const willEmitClose = (
-    _willEmitClose(stream) &&
-    isReadableNodeStream(stream) === readable &&
-    isWritableNodeStream(stream) === writable
-  );
-
-  return {
-    readable,
-    writable,
-    willEmitClose,
-    writableFinished: isWritableFinished(stream, false),
-    readableFinished: isReadableFinished(stream, false),
-    closed: isClosed(stream),
-  };
-}
-
-/**
- * Classifies whether eos() can synchronously determine the result for the
- * current stream snapshot, or if it must defer to future events.
- * @param {import('stream').Stream} stream
- * @param {object} [options]
- * @param {boolean} [options.readable]
- * @param {boolean} [options.writable]
- * @param {ReturnType<typeof getEosInitialState>} [state]
- * @returns {Error | typeof kEosImmediateClose | null}
- */
-function getEosImmediateResult(stream, options = kEmptyObject, state = getEosInitialState(stream, options)) {
-  const {
-    readable,
-    writable,
-    willEmitClose,
-    writableFinished,
-    readableFinished,
-    closed,
-  } = state;
-  const wState = stream._writableState;
-  const rState = stream._readableState;
-
-  if (closed) {
-    return getEosOnCloseError(
-      stream,
-      readable,
-      readableFinished,
-      writable,
-      writableFinished,
-    );
-  } else if (wState?.errorEmitted || rState?.errorEmitted) {
-    if (!willEmitClose) {
-      return getEosErrored(stream) ?? kEosImmediateClose;
-    }
-  } else if (
-    !readable &&
-    (!willEmitClose || isReadable(stream)) &&
-    (writableFinished || isWritable(stream) === false) &&
-    (wState == null || wState.pendingcb === undefined || wState.pendingcb === 0)
-  ) {
-    return getEosErrored(stream) ?? kEosImmediateClose;
-  } else if (
-    !writable &&
-    (!willEmitClose || isWritable(stream)) &&
-    (readableFinished || isReadable(stream) === false)
-  ) {
-    return getEosErrored(stream) ?? kEosImmediateClose;
-  } else if ((rState && stream.req && stream.aborted)) {
-    return getEosErrored(stream) ?? kEosImmediateClose;
-  }
-
   return null;
 }
+
+const kEosNodeSyncronousCallback = Symbol('kEosNodeSynchronousCallback');
 
 function eos(stream, options, callback) {
   if (arguments.length === 2) {
@@ -198,14 +121,6 @@ function eos(stream, options, callback) {
   validateFunction(callback, 'callback');
   validateAbortSignal(options.signal, 'options.signal');
 
-  if (AsyncContextFrame.current() || enabledHooksExist()) {
-    // Avoid AsyncResource.bind() because it calls ObjectDefineProperties which
-    // is a bottleneck here.
-    callback = once(bindAsyncResource(callback, 'STREAM_END_OF_STREAM'));
-  } else {
-    callback = once(callback);
-  }
-
   if (isReadableStream(stream) || isWritableStream(stream)) {
     return eosWeb(stream, options, callback);
   }
@@ -214,8 +129,99 @@ function eos(stream, options, callback) {
     throw new ERR_INVALID_ARG_TYPE('stream', ['ReadableStream', 'WritableStream', 'Stream'], stream);
   }
 
-  const eosState = getEosInitialState(stream, options);
+  const readable = options.readable ?? isReadableNodeStream(stream);
+  const writable = options.writable ?? isWritableNodeStream(stream);
+
+  // TODO (ronag): Improve soft detection to include core modules and
+  // common ecosystem modules that do properly emit 'close' but fail
+  // this generic check.
+  let willEmitClose = (
+    _willEmitClose(stream) &&
+    isReadableNodeStream(stream) === readable &&
+    isWritableNodeStream(stream) === writable
+  );
+  let writableFinished = isWritableFinished(stream, false);
+  let readableFinished = isReadableFinished(stream, false);
+
   const wState = stream._writableState;
+  const rState = stream._readableState;
+
+  /**
+   * @type {Error | null | undefined}
+   * undefined: to be determined
+   * null: no error
+   * Error: an error occurred
+   */
+  let immediateResult;
+  if (isClosed(stream)) {
+    immediateResult = getEosOnCloseError(
+      stream,
+      readable,
+      readableFinished,
+      writable,
+      writableFinished,
+    );
+  } else if (wState?.errorEmitted || rState?.errorEmitted) {
+    if (!willEmitClose) {
+      immediateResult = getEosErrored(stream);
+    }
+  } else if (
+    !readable &&
+    (!willEmitClose || isReadable(stream)) &&
+    (writableFinished || isWritable(stream) === false) &&
+    (wState == null || wState.pendingcb === undefined || wState.pendingcb === 0)
+  ) {
+    immediateResult = getEosErrored(stream);
+  } else if (
+    !writable &&
+    (!willEmitClose || isWritable(stream)) &&
+    (readableFinished || isReadable(stream) === false)
+  ) {
+    immediateResult = getEosErrored(stream);
+  } else if ((rState && stream.req && stream.aborted)) {
+    immediateResult = getEosErrored(stream);
+  }
+  const returnImmediately = (result) => {
+    const args = result === null ? [] : [result];
+    if (options[kEosNodeSyncronousCallback]) {
+      callback.call(stream, ...args);
+    } else {
+      if (AsyncContextFrame.current() || enabledHooksExist()) {
+        // Avoid AsyncResource.bind() because it calls ObjectDefineProperties which
+        // is a bottleneck here.
+        callback = bindAsyncResource(callback, 'STREAM_END_OF_STREAM');
+      }
+      process.nextTick(() => callback.call(stream, ...args));
+    }
+  };
+  let cleanup = () => {
+    callback = nop;
+  };
+  if (immediateResult !== undefined) {
+    if (options.error !== false) {
+      const onerror = () => {};
+      stream.on('error', onerror);
+      cleanup = () => {
+        callback = nop;
+        stream.removeListener('error', onerror);
+      };
+    }
+    returnImmediately(immediateResult);
+    return cleanup;
+  }
+
+  if (options.signal?.aborted) {
+    returnImmediately(new AbortError(undefined, { cause: options.signal.reason }));
+    return cleanup;
+  }
+
+  if (AsyncContextFrame.current() || enabledHooksExist()) {
+    // Avoid AsyncResource.bind() because it calls ObjectDefineProperties which
+    // is a bottleneck here.
+    callback = once(bindAsyncResource(callback, 'STREAM_END_OF_STREAM'));
+  } else {
+    callback = once(callback);
+  }
 
   const onlegacyfinish = () => {
     if (!stream.writable) {
@@ -223,13 +229,6 @@ function eos(stream, options, callback) {
     }
   };
 
-  const { readable, writable } = eosState;
-  let {
-    willEmitClose,
-    writableFinished,
-    readableFinished,
-    closed,
-  } = eosState;
   const onfinish = () => {
     writableFinished = true;
     // Stream should not be destroyed here. If it is that
@@ -271,10 +270,8 @@ function eos(stream, options, callback) {
   };
 
   const onclose = () => {
-    closed = true;
-
     const error = getEosOnCloseError(stream, readable, readableFinished, writable, writableFinished);
-    if (error === kEosImmediateClose) {
+    if (error === null) {
       callback.call(stream);
     } else {
       callback.call(stream, error);
@@ -312,16 +309,7 @@ function eos(stream, options, callback) {
   }
   stream.on('close', onclose);
 
-  const immediateResult = getEosImmediateResult(stream, options, eosState);
-  if (immediateResult !== null) {
-    if (immediateResult === kEosImmediateClose) {
-      process.nextTick(() => callback.call(stream));
-    } else {
-      process.nextTick(() => callback.call(stream, immediateResult));
-    }
-  }
-
-  const cleanup = () => {
+  cleanup = () => {
     callback = nop;
     stream.removeListener('aborted', onclose);
     stream.removeListener('complete', onfinish);
@@ -336,7 +324,7 @@ function eos(stream, options, callback) {
     stream.removeListener('close', onclose);
   };
 
-  if (options.signal && !closed) {
+  if (options.signal) {
     const abort = () => {
       // Keep it because cleanup removes it.
       const endCallback = callback;
@@ -345,23 +333,27 @@ function eos(stream, options, callback) {
         stream,
         new AbortError(undefined, { cause: options.signal.reason }));
     };
-    if (options.signal.aborted) {
-      process.nextTick(abort);
-    } else {
-      addAbortListener ??= require('internal/events/abort_listener').addAbortListener;
-      const disposable = addAbortListener(options.signal, abort);
-      const originalCallback = callback;
-      callback = once((...args) => {
-        disposable[SymbolDispose]();
-        ReflectApply(originalCallback, stream, args);
-      });
-    }
+    addAbortListener ??= require('internal/events/abort_listener').addAbortListener;
+    const disposable = addAbortListener(options.signal, abort);
+    const originalCallback = callback;
+    callback = once((...args) => {
+      disposable[SymbolDispose]();
+      ReflectApply(originalCallback, stream, args);
+    });
   }
 
   return cleanup;
 }
 
 function eosWeb(stream, options, callback) {
+  if (AsyncContextFrame.current() || enabledHooksExist()) {
+    // Avoid AsyncResource.bind() because it calls ObjectDefineProperties which
+    // is a bottleneck here.
+    callback = once(bindAsyncResource(callback, 'STREAM_END_OF_STREAM'));
+  } else {
+    callback = once(callback);
+  }
+
   let isAborted = false;
   let abort = nop;
   if (options.signal) {
@@ -420,6 +412,5 @@ function finished(stream, opts) {
 module.exports = {
   eos,
   finished,
-  getEosImmediateResult,
-  kEosImmediateClose,
+  kEosNodeSyncronousCallback,
 };

--- a/lib/internal/streams/end-of-stream.js
+++ b/lib/internal/streams/end-of-stream.js
@@ -107,6 +107,8 @@ function getEosOnCloseError(stream, readable, readableFinished, writable, writab
   return null;
 }
 
+// Internal only: if eos() can settle immediately, invoke the callback before
+// returning cleanup. Callers must tolerate cleanup yet to be assigned.
 const kEosNodeSyncronousCallback = Symbol('kEosNodeSynchronousCallback');
 
 function eos(stream, options, callback) {
@@ -199,11 +201,10 @@ function eos(stream, options, callback) {
   };
   if (immediateResult !== undefined) {
     if (options.error !== false) {
-      const onerror = () => {};
-      stream.on('error', onerror);
+      stream.on('error', nop);
       cleanup = () => {
         callback = nop;
-        stream.removeListener('error', onerror);
+        stream.removeListener('error', nop);
       };
     }
     returnImmediately(immediateResult);

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -93,8 +93,7 @@ const {
 
 const {
   eos,
-  getEosImmediateResult,
-  kEosImmediateClose,
+  kEosNodeSyncronousCallback,
 } = require('internal/streams/end-of-stream');
 
 const { UV_EOF } = internalBinding('uv');
@@ -142,6 +141,8 @@ function handleKnownInternalErrors(cause) {
       return cause;
   }
 }
+
+const noop = () => {};
 
 /**
  * @typedef {import('../../stream').Writable} Writable
@@ -479,51 +480,13 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
   }
 
   const isBYOB = options.type === 'bytes';
-  // Keep the adapter in sync with eos()'s immediate termination semantics.
-  const immediateResult = getEosImmediateResult(streamReadable, { writable: false });
-  if (immediateResult !== null) {
-    const readableStream = new ReadableStream({
-      type: isBYOB ? 'bytes' : undefined,
-      start(controller) {
-        if (immediateResult === kEosImmediateClose) {
-          controller.close();
-        } else {
-          controller.error(handleKnownInternalErrors(immediateResult));
-        }
-      },
-    });
-    return readableStream;
-  }
-  const readable = isReadable(streamReadable);
-
-  const objectMode = streamReadable.readableObjectMode;
-  const highWaterMark = streamReadable.readableHighWaterMark;
-
   let controller;
   let wasCanceled = false;
   let strategy;
 
-  // When adapting a Duplex as a ReadableStream, readable completion should not
-  // wait for a half-open writable side to finish as well.
-  const cleanup = eos(streamReadable, { writable: false }, (error) => {
-    error = handleKnownInternalErrors(error);
-
-    cleanup();
-    // This is a protection against non-standard, legacy streams
-    // that happen to emit an error event again after finished is called.
-    streamReadable.on('error', () => {});
-    if (error)
-      return controller.error(error);
-    if (wasCanceled) {
-      return;
-    }
-    controller.close();
-    if (isBYOB)
-      controller.byobRequest?.respond(0);
-  });
-
   /** @type {UnderlyingSource} */
   const underlyingSource = {
+    __proto__: null,
     type: isBYOB ? 'bytes' : undefined,
     start(c) { controller = c; },
     cancel(reason) {
@@ -532,7 +495,50 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
     },
   };
 
+  const readable = isReadable(streamReadable);
+  const objectMode = streamReadable.readableObjectMode;
   if (readable) {
+    underlyingSource.pull = function pull() {
+      streamReadable.resume();
+    };
+
+    const highWaterMark = streamReadable.readableHighWaterMark;
+    strategy = isBYOB ? { highWaterMark } :
+      options.strategy ?? new (objectMode ? CountQueuingStrategy : ByteLengthQueuingStrategy)({ highWaterMark });
+  }
+  const readableStream = new ReadableStream(underlyingSource, strategy);
+
+  // When adapting a Duplex as a ReadableStream, readable completion should not
+  // wait for a half-open writable side to finish as well.
+  let cleanup = noop;
+  cleanup = eos(streamReadable, {
+    __proto__: null,
+    writable: false,
+    [kEosNodeSyncronousCallback]: true,
+  }, (error) => {
+    error = handleKnownInternalErrors(error);
+
+    // If eos calls the callback synchronously, cleanup is still a no-op here.
+    cleanup();
+
+    // This is a protection against non-standard, legacy streams
+    // that happen to emit an error event again after finished is called.
+    streamReadable.on('error', noop);
+    if (wasCanceled) {
+      return;
+    }
+    wasCanceled = true;
+    if (error)
+      return controller.error(error);
+    controller.close();
+    if (isBYOB)
+      controller.byobRequest?.respond(0);
+  });
+
+  if (wasCanceled) {
+    // `eos` called the callback synchronously
+    cleanup();
+  } else if (readable) {
     streamReadable.pause();
 
     streamReadable.on('data', function onData(chunk) {
@@ -543,15 +549,9 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
       if (controller.desiredSize <= 0)
         streamReadable.pause();
     });
-
-    underlyingSource.pull = function pull() {
-      streamReadable.resume();
-    };
-    strategy = isBYOB ? { highWaterMark } :
-      options.strategy ?? new (objectMode ? CountQueuingStrategy : ByteLengthQueuingStrategy)({ highWaterMark });
   }
 
-  return new ReadableStream(underlyingSource, strategy);
+  return readableStream;
 }
 
 /**

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -45,10 +45,15 @@ const {
 } = require('stream');
 
 const {
+  isClosed,
   isDestroyed,
   isReadable,
+  isReadableErrored,
+  isReadableFinished,
+  isReadableNodeStream,
   isWritable,
   isWritableEnded,
+  isWritableErrored,
 } = require('internal/streams/utils');
 
 const {
@@ -476,33 +481,26 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
 
   const isBYOB = options.type === 'bytes';
 
-  if (isDestroyed(streamReadable) || !isReadable(streamReadable)) {
-    const readable = new ReadableStream();
-    readable.cancel();
-    return readable;
+  if (!isReadable(streamReadable)) {
+    const error = isWritableErrored(streamReadable) ?? isReadableErrored(streamReadable) ?? (
+      isClosed(streamReadable) &&
+        isReadableNodeStream(streamReadable, true) &&
+        !isReadableFinished(streamReadable, false) ? new ERR_STREAM_PREMATURE_CLOSE() : null
+    );
+    return new ReadableStream({
+      type: isBYOB ? 'bytes' : undefined,
+      start(controller) {
+        if (error != null) {
+          controller.error(handleKnownInternalErrors(error));
+        } else {
+          controller.close();
+        }
+      },
+    });
   }
 
   const objectMode = streamReadable.readableObjectMode;
   const highWaterMark = streamReadable.readableHighWaterMark;
-
-  const evaluateStrategyOrFallback = (strategy) => {
-    // If the stream is BYOB, we only use highWaterMark
-    if (isBYOB)
-      return { highWaterMark };
-    // If there is a strategy available, use it
-    if (strategy)
-      return strategy;
-
-    if (objectMode) {
-      // When running in objectMode explicitly but no strategy, we just fall
-      // back to CountQueuingStrategy
-      return new CountQueuingStrategy({ highWaterMark });
-    }
-
-    return new ByteLengthQueuingStrategy({ highWaterMark });
-  };
-
-  const strategy = evaluateStrategyOrFallback(options?.strategy);
 
   let controller;
   let wasCanceled = false;
@@ -539,6 +537,10 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
   });
 
   streamReadable.on('data', onData);
+
+  const strategy =
+    isBYOB ? { highWaterMark } :
+      options.strategy ?? new (objectMode ? CountQueuingStrategy : ByteLengthQueuingStrategy)({ highWaterMark });
 
   return new ReadableStream({
     type: isBYOB ? 'bytes' : undefined,

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -45,15 +45,10 @@ const {
 } = require('stream');
 
 const {
-  isClosed,
   isDestroyed,
   isReadable,
-  isReadableErrored,
-  isReadableFinished,
-  isReadableNodeStream,
   isWritable,
   isWritableEnded,
-  isWritableErrored,
 } = require('internal/streams/utils');
 
 const {
@@ -96,7 +91,11 @@ const {
   streamBaseState,
 } = internalBinding('stream_wrap');
 
-const { eos } = require('internal/streams/end-of-stream');
+const {
+  eos,
+  getEosImmediateResult,
+  kEosImmediateClose,
+} = require('internal/streams/end-of-stream');
 
 const { UV_EOF } = internalBinding('uv');
 
@@ -480,41 +479,29 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
   }
 
   const isBYOB = options.type === 'bytes';
-
-  if (!isReadable(streamReadable)) {
-    const error = isWritableErrored(streamReadable) ?? isReadableErrored(streamReadable) ?? (
-      isClosed(streamReadable) &&
-        isReadableNodeStream(streamReadable, true) &&
-        !isReadableFinished(streamReadable, false) ? new ERR_STREAM_PREMATURE_CLOSE() : null
-    );
-    return new ReadableStream({
+  // Keep the adapter in sync with eos()'s immediate termination semantics.
+  const immediateResult = getEosImmediateResult(streamReadable, { writable: false });
+  if (immediateResult !== null) {
+    const readableStream = new ReadableStream({
       type: isBYOB ? 'bytes' : undefined,
       start(controller) {
-        if (error != null) {
-          controller.error(handleKnownInternalErrors(error));
-        } else {
+        if (immediateResult === kEosImmediateClose) {
           controller.close();
+        } else {
+          controller.error(handleKnownInternalErrors(immediateResult));
         }
       },
     });
+    return readableStream;
   }
+  const readable = isReadable(streamReadable);
 
   const objectMode = streamReadable.readableObjectMode;
   const highWaterMark = streamReadable.readableHighWaterMark;
 
   let controller;
   let wasCanceled = false;
-
-  function onData(chunk) {
-    // Copy the Buffer to detach it from the pool.
-    if (Buffer.isBuffer(chunk) && !objectMode)
-      chunk = new Uint8Array(chunk);
-    controller.enqueue(chunk);
-    if (controller.desiredSize <= 0)
-      streamReadable.pause();
-  }
-
-  streamReadable.pause();
+  let strategy;
 
   // When adapting a Duplex as a ReadableStream, readable completion should not
   // wait for a half-open writable side to finish as well.
@@ -527,7 +514,6 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
     streamReadable.on('error', () => {});
     if (error)
       return controller.error(error);
-    // Was already canceled
     if (wasCanceled) {
       return;
     }
@@ -536,23 +522,36 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
       controller.byobRequest?.respond(0);
   });
 
-  streamReadable.on('data', onData);
-
-  const strategy =
-    isBYOB ? { highWaterMark } :
-      options.strategy ?? new (objectMode ? CountQueuingStrategy : ByteLengthQueuingStrategy)({ highWaterMark });
-
-  return new ReadableStream({
+  /** @type {UnderlyingSource} */
+  const underlyingSource = {
     type: isBYOB ? 'bytes' : undefined,
     start(c) { controller = c; },
-
-    pull() { streamReadable.resume(); },
-
     cancel(reason) {
       wasCanceled = true;
       destroy(streamReadable, reason);
     },
-  }, strategy);
+  };
+
+  if (readable) {
+    streamReadable.pause();
+
+    streamReadable.on('data', function onData(chunk) {
+      // Copy the Buffer to detach it from the pool.
+      if (Buffer.isBuffer(chunk) && !objectMode)
+        chunk = new Uint8Array(chunk);
+      controller.enqueue(chunk);
+      if (controller.desiredSize <= 0)
+        streamReadable.pause();
+    });
+
+    underlyingSource.pull = function pull() {
+      streamReadable.resume();
+    };
+    strategy = isBYOB ? { highWaterMark } :
+      options.strategy ?? new (objectMode ? CountQueuingStrategy : ByteLengthQueuingStrategy)({ highWaterMark });
+  }
+
+  return new ReadableStream(underlyingSource, strategy);
 }
 
 /**

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -454,6 +454,8 @@ function newStreamWritableFromWritableStream(writableStream, options = kEmptyObj
   return writable;
 }
 
+const kErrorSentinelAttached = Symbol('kErrorSentinelAttached');
+
 /**
  * @typedef {import('./queuingstrategies').QueuingStrategy} QueuingStrategy
  * @param {Readable} streamReadable
@@ -521,9 +523,12 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
     // If eos calls the callback synchronously, cleanup is still a no-op here.
     cleanup();
 
-    // This is a protection against non-standard, legacy streams
-    // that happen to emit an error event again after finished is called.
-    streamReadable.on('error', noop);
+    if (!(kErrorSentinelAttached in streamReadable)) {
+      // This is a protection against non-standard, legacy streams
+      // that happen to emit an error event again after finished is called.
+      streamReadable.on('error', noop);
+      streamReadable[kErrorSentinelAttached] = true;
+    }
     if (wasCanceled) {
       return;
     }

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -518,7 +518,9 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
 
   streamReadable.pause();
 
-  const cleanup = eos(streamReadable, (error) => {
+  // When adapting a Duplex as a ReadableStream, readable completion should not
+  // wait for a half-open writable side to finish as well.
+  const cleanup = eos(streamReadable, { writable: false }, (error) => {
     error = handleKnownInternalErrors(error);
 
     cleanup();
@@ -532,24 +534,15 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
       return;
     }
     controller.close();
+    if (isBYOB)
+      controller.byobRequest?.respond(0);
   });
 
   streamReadable.on('data', onData);
 
   return new ReadableStream({
     type: isBYOB ? 'bytes' : undefined,
-    start(c) {
-      controller = c;
-      if (isBYOB) {
-        streamReadable.once('end', () => {
-          // close the controller
-          controller.close();
-          // And unlock the last BYOB read request
-          controller.byobRequest?.respond(0);
-          wasCanceled = true;
-        });
-      }
-    },
+    start(c) { controller = c; },
 
     pull() { streamReadable.resume(); },
 

--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -93,7 +93,7 @@ const {
 
 const {
   eos,
-  kEosNodeSyncronousCallback,
+  kEosNodeSynchronousCallback,
 } = require('internal/streams/end-of-stream');
 
 const { UV_EOF } = internalBinding('uv');
@@ -516,7 +516,7 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
   cleanup = eos(streamReadable, {
     __proto__: null,
     writable: false,
-    [kEosNodeSyncronousCallback]: true,
+    [kEosNodeSynchronousCallback]: true,
   }, (error) => {
     error = handleKnownInternalErrors(error);
 

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');
@@ -15,6 +16,7 @@ const EE = require('events');
 const fs = require('fs');
 const { promisify } = require('util');
 const http = require('http');
+const { kEosNodeSynchronousCallback } = require('internal/streams/end-of-stream');
 
 {
   const rs = new Readable({
@@ -98,21 +100,17 @@ const http = require('http');
   const signal = AbortSignal.abort();
 
   const rs = Readable.from((function* () {})());
-  finished(rs, { signal }, common.mustCall((err) => {
+  const cleanup = finished(rs, { signal }, common.mustCall((err) => {
     assert.strictEqual(err.name, 'AbortError');
+    cleanup();
   }));
-}
-
-{
-  // Check pre-cancelled when eos() must resolve from the signal path.
-  const signal = AbortSignal.abort();
-
-  const rs = new Readable({
-    read() {}
-  });
-  finished(rs, { signal }, common.mustCall((err) => {
+  const unset = Symbol('unset');
+  let cleanup2 = unset;
+  cleanup2 = finished(rs, { signal, [kEosNodeSynchronousCallback]: true }, common.mustCall((err) => {
     assert.strictEqual(err.name, 'AbortError');
+    assert.strictEqual(cleanup2, unset);
   }));
+  cleanup2();
 }
 
 {

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -95,10 +95,21 @@ const http = require('http');
 
 {
   // Check pre-cancelled
-  const signal = new EventTarget();
-  signal.aborted = true;
+  const signal = AbortSignal.abort();
 
   const rs = Readable.from((function* () {})());
+  finished(rs, { signal }, common.mustCall((err) => {
+    assert.strictEqual(err.name, 'AbortError');
+  }));
+}
+
+{
+  // Check pre-cancelled when eos() must resolve from the signal path.
+  const signal = AbortSignal.abort();
+
+  const rs = new Readable({
+    read() {}
+  });
   finished(rs, { signal }, common.mustCall((err) => {
     assert.strictEqual(err.name, 'AbortError');
   }));
@@ -160,8 +171,7 @@ const http = require('http');
   // Promisified pre-aborted works
   const finishedPromise = promisify(finished);
   async function run() {
-    const signal = new EventTarget();
-    signal.aborted = true;
+    const signal = AbortSignal.abort();
     const rs = Readable.from((function* () {})());
     await finishedPromise(rs, { signal });
   }

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -593,6 +593,18 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 }
 
 {
+  const readable = new Readable({
+    read() {}
+  });
+  readable.req = new EE();
+  readable.aborted = true;
+
+  finished(readable, common.mustCall((err) => {
+    assert.strictEqual(err, undefined);
+  }));
+}
+
+{
   const w = new Writable({
     write(chunk, encoding, callback) {
       process.nextTick(callback);

--- a/test/parallel/test-stream-finished.js
+++ b/test/parallel/test-stream-finished.js
@@ -603,14 +603,25 @@ testClosed((opts) => new Writable({ write() {}, ...opts }));
 }
 
 {
-  const readable = new Readable({
-    read() {}
-  });
-  readable.req = new EE();
-  readable.aborted = true;
-
-  finished(readable, common.mustCall((err) => {
-    assert.strictEqual(err, undefined);
+  let serverRes;
+  const server = http.createServer(common.mustCall((req, res) => {
+    serverRes = res;
+    res.write('hello');
+  })).listen(0, common.mustCall(function() {
+    http.get({ port: this.address().port }, common.mustCall((res) => {
+      res.on('aborted', common.mustCall(() => {
+        finished(res, common.mustCall((err) => {
+          assert.strictEqual(err.code, 'ECONNRESET');
+          assert.strictEqual(err.message, 'aborted');
+          server.close();
+        }));
+      }));
+      res.on('error', common.expectsError({
+        code: 'ECONNRESET',
+        message: 'aborted',
+      }));
+      serverRes.destroy();
+    })).on('error', common.mustNotCall());
   }));
 }
 

--- a/test/parallel/test-stream-readable-to-web-termination.js
+++ b/test/parallel/test-stream-readable-to-web-termination.js
@@ -1,6 +1,8 @@
 'use strict';
-require('../common');
-const { Readable } = require('stream');
+const common = require('../common');
+const assert = require('assert');
+const { Duplex, Readable } = require('stream');
+const { setTimeout: delay } = require('timers/promises');
 
 {
   const r = Readable.from([]);
@@ -9,4 +11,34 @@ const { Readable } = require('stream');
 
   const reader = Readable.toWeb(r).getReader();
   reader.read();
+}
+
+{
+  const duplex = new Duplex({
+    read() {
+      this.push(Buffer.from('x'));
+      this.push(null);
+    },
+    write(_chunk, _encoding, callback) {
+      callback();
+    },
+  });
+
+  const reader = Readable.toWeb(duplex).getReader();
+
+  (async () => {
+    const result = await reader.read();
+    assert.deepStrictEqual(result, {
+      value: new Uint8Array(Buffer.from('x')),
+      done: false,
+    });
+
+    const closeResult = await Promise.race([
+      reader.read(),
+      delay(common.platformTimeout(100)).then(() => 'timeout'),
+    ]);
+
+    assert.notStrictEqual(closeResult, 'timeout');
+    assert.deepStrictEqual(closeResult, { value: undefined, done: true });
+  })().then(common.mustCall());
 }

--- a/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
@@ -308,6 +308,27 @@ const {
 }
 
 {
+  const readable = new PassThrough();
+  const readableStream = newReadableStreamFromStreamReadable(readable, {
+    type: 'bytes',
+  });
+  const reader = readableStream.getReader({ mode: 'byob' });
+
+  (async () => {
+    const readPromise = reader.read(new Uint8Array(8));
+
+    readable.end();
+    await once(readable, 'end');
+
+    assert.deepStrictEqual(await readPromise, {
+      value: new Uint8Array(0),
+      done: true,
+    });
+    await reader.closed;
+  })().then(common.mustCall());
+}
+
+{
   const duplex = new Duplex({ readable: false });
   duplex.destroy();
   const readableStream = newReadableStreamFromStreamReadable(duplex);

--- a/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
@@ -4,6 +4,7 @@
 const common = require('../common');
 
 const assert = require('assert');
+const { once } = require('events');
 
 const {
   newReadableStreamFromStreamReadable,
@@ -11,6 +12,7 @@ const {
 
 const {
   Duplex,
+  PassThrough,
   Readable,
 } = require('stream');
 
@@ -188,11 +190,75 @@ const {
 }
 
 {
-  const readable = new Readable();
-  readable.destroy();
-  const readableStream = newReadableStreamFromStreamReadable(readable);
-  const reader = readableStream.getReader();
-  reader.closed.then(common.mustCall());
+  /**
+   * Runs the same assertion across finalize-before/after and
+   * default/BYOB adapter creation orders.
+   * @param {(readable: Readable) => void | Promise<void>} finalize
+   *   Finalizes the source stream before or after adaptation.
+   * @param {(readAndAssert: () => Promise<void>, reader: ReadableStreamReader) => Promise<void>} postAssert
+   *   Asserts the resulting web stream state for the current case.
+   */
+  function testConfluence(finalize, postAssert) {
+    const cases = [false, true].flatMap((finalizeFirst) => [false, true].map((isBYOB) => ({ finalizeFirst, isBYOB })));
+    Promise.all(cases.map(async (case_) => {
+      try {
+        const { isBYOB } = case_;
+        const readable = new PassThrough();
+        if (case_.finalizeFirst) {
+          await finalize(readable);
+        }
+        /** @type {ReadableStream} */
+        const readableStream = newReadableStreamFromStreamReadable(readable, { type: isBYOB ? 'bytes' : undefined });
+        const reader = readableStream.getReader({ mode: isBYOB ? 'byob' : undefined });
+        if (!case_.finalizeFirst) {
+          await finalize(readable);
+        }
+
+        const readAndAssert = common.mustCall(() => reader.read(isBYOB ? new Uint8Array(1) : undefined).then((result) => {
+          assert.deepStrictEqual(result, { value: isBYOB ? new Uint8Array(0) : undefined, done: true });
+        }));
+        await postAssert(readAndAssert, reader);
+      } catch (cause) {
+        throw new Error(`Case failed: ${JSON.stringify(case_)}`, { cause });
+      }
+    })).then(common.mustCall());
+  }
+  const error = new Error('boom');
+  // Ending the readable without an error => closes the readableStream without an error
+  testConfluence(
+    async (readable) => {
+      readable.resume();
+      readable.end();
+      await once(readable, 'end');
+    },
+    common.mustCall(async (readAndAssert, reader) => {
+      await readAndAssert();
+      await reader.closed;
+    }, 4)
+  );
+  // Prematurely destroying the stream.Readable without an error
+  //   => errors the ReadableStream with a premature close error
+  testConfluence(
+    (readable) => readable.destroy(),
+    common.mustCall(async (readAndAssert, reader) => {
+      const errorPredicate = { code: 'ABORT_ERR' };
+      await assert.rejects(readAndAssert(), errorPredicate);
+      await assert.rejects(reader.closed, errorPredicate);
+    }, 4)
+  );
+  // Destroying the readable with an error => errors the readableStream
+  testConfluence(
+    common.mustCall((readable) => {
+      readable.on('error', common.mustCall((reason) => {
+        assert.strictEqual(reason, error);
+      }));
+      readable.destroy(error);
+    }, 4),
+    common.mustCall(async (readAndAssert, reader) => {
+      await assert.rejects(readAndAssert(), error);
+      await assert.rejects(reader.closed, error);
+    }, 4)
+  );
 }
 
 {

--- a/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
@@ -287,6 +287,27 @@ const {
 }
 
 {
+  const readable = new PassThrough();
+  readable.end();
+  readable.destroy();
+
+  (async () => {
+    await new Promise((resolve) => readable.once('close', resolve));
+    assert.strictEqual(readable.listenerCount('error'), 0);
+
+    const readableStream = newReadableStreamFromStreamReadable(readable);
+    // Only one error listener from the adapter should be added
+    assert.strictEqual(readable.listenerCount('error'), 1);
+    newReadableStreamFromStreamReadable(readable);
+    // No duplicate listeners should be added.
+    assert.strictEqual(readable.listenerCount('error'), 1);
+
+    const readResult = await readableStream.getReader().read();
+    assert.deepStrictEqual(readResult, { value: undefined, done: true });
+  })().then(common.mustCall());
+}
+
+{
   const duplex = new Duplex({ readable: false });
   duplex.destroy();
   const readableStream = newReadableStreamFromStreamReadable(duplex);

--- a/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-readablestream.js
@@ -197,13 +197,15 @@ const {
    *   Finalizes the source stream before or after adaptation.
    * @param {(readAndAssert: () => Promise<void>, reader: ReadableStreamReader) => Promise<void>} postAssert
    *   Asserts the resulting web stream state for the current case.
+   * @param {() => Readable} [createReadable]
+   *   Creates the source stream for each case.
    */
-  function testConfluence(finalize, postAssert) {
+  function testConfluence(finalize, postAssert, createReadable = () => new PassThrough()) {
     const cases = [false, true].flatMap((finalizeFirst) => [false, true].map((isBYOB) => ({ finalizeFirst, isBYOB })));
     Promise.all(cases.map(async (case_) => {
       try {
         const { isBYOB } = case_;
-        const readable = new PassThrough();
+        const readable = createReadable();
         if (case_.finalizeFirst) {
           await finalize(readable);
         }
@@ -214,9 +216,14 @@ const {
           await finalize(readable);
         }
 
-        const readAndAssert = common.mustCall(() => reader.read(isBYOB ? new Uint8Array(1) : undefined).then((result) => {
-          assert.deepStrictEqual(result, { value: isBYOB ? new Uint8Array(0) : undefined, done: true });
-        }));
+        const readAndAssert = common.mustCall(() => {
+          return reader.read(isBYOB ? new Uint8Array(1) : undefined).then((result) => {
+            assert.deepStrictEqual(result, {
+              value: isBYOB ? new Uint8Array(0) : undefined,
+              done: true,
+            });
+          });
+        });
         await postAssert(readAndAssert, reader);
       } catch (cause) {
         throw new Error(`Case failed: ${JSON.stringify(case_)}`, { cause });
@@ -245,6 +252,24 @@ const {
       await assert.rejects(readAndAssert(), errorPredicate);
       await assert.rejects(reader.closed, errorPredicate);
     }, 4)
+  );
+  // Asynchronously destroyed readable => errors the ReadableStream with a
+  // premature close error regardless of adapter creation order.
+  class AsyncDestroyReadable extends Readable {
+    _read() {}
+
+    _destroy(error, callback) {
+      setImmediate(callback, error);
+    }
+  }
+  testConfluence(
+    (readable) => readable.destroy(),
+    common.mustCall(async (readAndAssert, reader) => {
+      const errorPredicate = { code: 'ABORT_ERR' };
+      await assert.rejects(readAndAssert(), errorPredicate);
+      await assert.rejects(reader.closed, errorPredicate);
+    }, 4),
+    () => new AsyncDestroyReadable()
   );
   // Destroying the readable with an error => errors the readableStream
   testConfluence(


### PR DESCRIPTION
This aligns `Readable.toWeb(stream)` termination handling with
`eos(stream, { writable: false })`.

Changes:
- add regression tests for half-open duplex termination
- add regression coverage for adapter creation before and after
  `end()`, `destroy()`, and `destroy(error)`
- preserve terminated `Readable` adapter state, including closed/error
  state and byte stream type, regardless of when the adapter is created
- let `Readable.toWeb()` reuse `eos()` immediate completion handling
  for already-terminated streams
- add regression coverage for the synchronous internal EOS callback
  path, including listener cleanup and BYOB termination

Tests:
- make lint
- ./configure && make -j4 test