### PR TITLE
module: doc-deprecate `module.register()`

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4517,6 +4517,20 @@ Type: Documentation-only
 Passing a non-extractable [`CryptoKey`][] to [`KeyObject.from()`][] is
 deprecated and will throw an error in a future version.
 
+### DEP0205: `module.register()`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62395
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+[`module.register()`][] is deprecated. Use [`module.registerHooks()`][]
+instead.
+
 [DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3
@@ -4621,6 +4635,8 @@ deprecated and will throw an error in a future version.
 [`message.trailersDistinct`]: http.md#messagetrailersdistinct
 [`message.trailers`]: http.md#messagetrailers
 [`module.createRequire()`]: module.md#modulecreaterequirefilename
+[`module.register()`]: module.md#moduleregisterspecifier-parenturl-options
+[`module.registerHooks()`]: module.md#moduleregisterhooksoptions
 [`os.networkInterfaces()`]: os.md#osnetworkinterfaces
 [`os.tmpdir()`]: os.md#ostmpdir
 [`process.env`]: process.md#processenv

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -178,7 +178,12 @@ isBuiltin('wss'); // false
 added:
   - v20.6.0
   - v18.19.0
+deprecated: REPLACEME
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62395
+    description: Documentation-only deprecation (DEP0205). Use
+                 `module.registerHooks()` instead.
   - version:
     - v23.6.1
     - v22.13.1
@@ -193,7 +198,7 @@ changes:
     description: Add support for WHATWG URL instances.
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 0 - Deprecated: Use [`module.registerHooks()`][] instead.
 
 * `specifier` {string|URL} Customization hooks to be registered; this should be
   the same string that would be passed to `import()`, except that if it is

--- a/test/doctool/test-doc-api-json.mjs
+++ b/test/doctool/test-doc-api-json.mjs
@@ -159,5 +159,5 @@ for await (const dirent of await fs.opendir(new URL('../../out/doc/api/', import
   assert.partialDeepStrictEqual(allExpectedKeys, findAllKeys(json));
 }
 
-assert.strictEqual(numberOfDeprecatedSections, 44); // Increase this number every time a new API is deprecated.
+assert.strictEqual(numberOfDeprecatedSections, 45); // Increase this number every time a new API is deprecated.
 assert.strictEqual(numberOfRemovedAPIs, 46); // Increase this number every time a section is marked as removed.


### PR DESCRIPTION
This PR doc-deprecates `module.register()` in favor of `module.registerHooks()`.

In discussion with @joyeecheung we were thinking of landing this now so it can go out in 25 and 26, and then a runtime deprecation can go out in 26. cc @nodejs/loaders @nodejs/releasers 

The `module.registerHooks` API is nearing stability; at the very least it’s already much more stable than `module.register`, and lacks the [unresolvable issues](https://github.com/nodejs/node/pull/55698) that plagued `module.register`.