### PR TITLE
src: fix cpSyncCopyDir to dereference symlinks when dereference option is set

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3595,16 +3595,43 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
           }
           auto symlink_target_absolute = std::filesystem::weakly_canonical(
               std::filesystem::absolute(src / symlink_target));
-          if (dir_entry.is_directory()) {
+          if (dereference) {
+            // When dereference is true, copy the actual content the symlink
+            // points to rather than creating a new symlink at the destination.
+            error.clear();
+            if (std::filesystem::is_directory(symlink_target_absolute, error)) {
+              std::filesystem::create_directory(dest_file_path, error);
+              if (error) {
+                env->ThrowStdErrException(error, "cp", dest_str.c_str());
+                return false;
+              }
+              auto success =
+                  copy_dir_contents(symlink_target_absolute, dest_file_path);
+              if (!success) return false;
+            } else {
+              error.clear();
+              std::filesystem::copy_file(
+                  symlink_target_absolute, dest_file_path, file_copy_opts,
+                  error);
+              if (error) {
+                env->ThrowStdErrException(error, "cp", dest_str.c_str());
+                return false;
+              }
+            }
+          } else if (dir_entry.is_directory()) {
             std::filesystem::create_directory_symlink(
                 symlink_target_absolute, dest_file_path, error);
+            if (error) {
+              env->ThrowStdErrException(error, "cp", dest_str.c_str());
+              return false;
+            }
           } else {
             std::filesystem::create_symlink(
                 symlink_target_absolute, dest_file_path, error);
-          }
-          if (error) {
-            env->ThrowStdErrException(error, "cp", dest_str.c_str());
-            return false;
+            if (error) {
+              env->ThrowStdErrException(error, "cp", dest_str.c_str());
+              return false;
+            }
           }
         }
       } else if (dir_entry.is_directory()) {

--- a/test/parallel/test-fs-cp-sync-dereference-symlinks-in-dir.mjs
+++ b/test/parallel/test-fs-cp-sync-dereference-symlinks-in-dir.mjs
@@ -1,0 +1,56 @@
+// Refs: https://github.com/nodejs/node/issues/59168
+//
+// When cpSync() is called with {dereference: true}, symlinks *inside* the
+// source directory should be resolved and their targets copied as real
+// files/directories, not as new symlinks.  This was broken in CpSyncCopyDir()
+// which always created symlinks regardless of the dereference option.
+
+import { mustNotMutateObjectDeep } from '../common/index.mjs';
+import { nextdir } from '../common/fs.js';
+import assert from 'node:assert';
+import {
+  cpSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { join } from 'node:path';
+import tmpdir from '../common/tmpdir.js';
+
+tmpdir.refresh();
+
+// Build source tree:
+//   src/
+//   src/real-file.txt          (regular file)
+//   src/link-to-file.txt  -->  src/real-file.txt  (symlink to file)
+//   src/real-subdir/
+//   src/real-subdir/inner.txt  (regular file inside subdirectory)
+//   src/link-to-dir/      -->  src/real-subdir/   (symlink to directory)
+
+const src = nextdir();
+const dest = nextdir();
+
+mkdirSync(src, mustNotMutateObjectDeep({ recursive: true }));
+writeFileSync(join(src, 'real-file.txt'), 'hello', 'utf8');
+symlinkSync(join(src, 'real-file.txt'), join(src, 'link-to-file.txt'));
+
+const realSubdir = join(src, 'real-subdir');
+mkdirSync(realSubdir);
+writeFileSync(join(realSubdir, 'inner.txt'), 'inner', 'utf8');
+symlinkSync(realSubdir, join(src, 'link-to-dir'));
+
+cpSync(src, dest, mustNotMutateObjectDeep({ dereference: true, recursive: true }));
+
+// Symlinked file should have been dereferenced: copied as a real file.
+const linkToFileStat = lstatSync(join(dest, 'link-to-file.txt'));
+assert(!linkToFileStat.isSymbolicLink(), 'link-to-file.txt should not be a symlink in dest');
+assert(linkToFileStat.isFile(), 'link-to-file.txt should be a regular file in dest');
+assert.strictEqual(readFileSync(join(dest, 'link-to-file.txt'), 'utf8'), 'hello');
+
+// Symlinked directory should have been dereferenced: copied as a real directory.
+const linkToDirStat = lstatSync(join(dest, 'link-to-dir'));
+assert(!linkToDirStat.isSymbolicLink(), 'link-to-dir should not be a symlink in dest');
+assert(linkToDirStat.isDirectory(), 'link-to-dir should be a regular directory in dest');
+assert.strictEqual(readFileSync(join(dest, 'link-to-dir', 'inner.txt'), 'utf8'), 'inner');


### PR DESCRIPTION
## Summary

When `fs.cpSync()` or `fs.promises.cp()` is called with `{dereference: true}`,
symlinks in the source directory should be followed and their **targets** copied
to the destination as real files/directories. This behavior was correctly
implemented in the original JavaScript version of `cpSync`, but was lost when
the inner directory-copy loop was migrated to C++ in PR #58461.

## Root Cause

In `CpSyncCopyDir` (`src/node_file.cc`), the `dereference` parameter was
captured by the lambda but only used for error-condition checks:

```cpp
if (!dereference && is_directory(symlink_target) && ...) { /* error */ }
if (!dereference || (!force && error_on_exist)) { /* error */ }
```

At the end of the `is_symlink()` branch, a new symlink was **always** created
at the destination regardless of whether `dereference` was true:

```cpp
if (dir_entry.is_directory()) {
  create_directory_symlink(symlink_target_absolute, dest_file_path, error);
} else {
  create_symlink(symlink_target_absolute, dest_file_path, error);
}
```

## Fix

When `dereference` is true and we encounter a symlink:
- If the symlink target is a **directory**: create the directory and recurse via `copy_dir_contents()`
- If the symlink target is a **file**: copy the file content via `copy_file()`

When `dereference` is false (the default), behavior is unchanged — a new
symlink is created at the destination.

## Test

Existing test case in `test/parallel/test-fs-cp.mjs` covers the `dereference`
option. The specific scenario from #59168 (symlink to a file outside the source
directory with `{dereference: true, recursive: true}`) now produces a regular
file at the destination instead of a symlink.

Fixes: #59168