### PR TITLE
[wontfix] deps: ignore loopback interface in c-ares on Windows

### DIFF
--- a/deps/cares/src/lib/ares_sysconfig_win.c
+++ b/deps/cares/src/lib/ares_sysconfig_win.c
@@ -54,6 +54,10 @@
 
 #include "ares_inet_net_pton.h"
 
+#ifndef IF_TYPE_SOFTWARE_LOOPBACK
+#define IF_TYPE_SOFTWARE_LOOPBACK 24
+#endif
+
 #if defined(USE_WINSOCK)
 
 #  define WIN_NS_9X     "System\\CurrentControlSet\\Services\\VxD\\MSTCP"
@@ -366,6 +370,9 @@ static ares_bool_t get_DNS_Windows(char **outptr)
 
   for (ipaaEntry = ipaa; ipaaEntry; ipaaEntry = ipaaEntry->Next) {
     if (ipaaEntry->OperStatus != IfOperStatusUp) {
+      continue;
+    }
+    if (ipaaEntry->IfType == IF_TYPE_SOFTWARE_LOOPBACK) {
       continue;
     }
 


### PR DESCRIPTION
This PR modifies `deps/cares` to ignore DNS servers reported by the loopback interface on Windows.
This prevents `dns.getServers()` from returning `127.0.0.1` when it is not explicitly configured on a physical interface.

Fixes: https://github.com/nodejs/node/issues/62347

For code changes:
- [ ] Include tests for any bug fixes or new features.
- [ ] Update documentation if relevant.
- [x] Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.