### PR TITLE
module: add requireStack to ESM exports resolution errors

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -625,9 +625,10 @@ function trySelfParentPath(parent) {
  * @param {string} parentPath The path of the parent module
  * @param {string} request The module request to resolve
  * @param {unknown} conditions
+ * @param {Module} [parent] The module that issued the require() call
  * @returns {false|string}
  */
-function trySelf(parentPath, request, conditions) {
+function trySelf(parentPath, request, conditions, parent) {
   if (!parentPath) { return false; }
 
   const pkg = packageJsonReader.getNearestParentPackageJSON(parentPath);
@@ -648,10 +649,10 @@ function trySelf(parentPath, request, conditions) {
     const { packageExportsResolve } = require('internal/modules/esm/resolve');
     return finalizeEsmResolution(packageExportsResolve(
       pathToFileURL(pkg.path), expansion, pkg.data,
-      pathToFileURL(parentPath), conditions), parentPath, pkg.path);
+      pathToFileURL(parentPath), conditions), parentPath, pkg.path, parent);
   } catch (e) {
     if (e.code === 'ERR_MODULE_NOT_FOUND') {
-      throw createEsmNotFoundErr(request, pkg.path);
+      throw createEsmNotFoundErr(request, pkg.path, parent);
     }
     throw e;
   }
@@ -671,7 +672,7 @@ const EXPORTS_PATTERN = /^((?:@[^/\\%]+\/)?[^./\\%][^/\\%]*)(\/.*)?$/;
  * @param {Set<string>} conditions The conditions to use for resolution.
  * @returns {undefined|string}
  */
-function resolveExports(nmPath, request, conditions) {
+function resolveExports(nmPath, request, conditions, parent) {
   // The implementation's behavior is meant to mirror resolution in ESM.
   const { 1: name, 2: expansion = '' } =
     RegExpPrototypeExec(EXPORTS_PATTERN, request) || kEmptyObject;
@@ -683,10 +684,10 @@ function resolveExports(nmPath, request, conditions) {
       const { packageExportsResolve } = require('internal/modules/esm/resolve');
       return finalizeEsmResolution(packageExportsResolve(
         pathToFileURL(pkgPath + '/package.json'), '.' + expansion, pkg, null,
-        conditions), null, pkgPath);
+        conditions), null, pkgPath, parent);
     } catch (e) {
       if (e.code === 'ERR_MODULE_NOT_FOUND') {
-        throw createEsmNotFoundErr(request, pkgPath + '/package.json');
+        throw createEsmNotFoundErr(request, pkgPath + '/package.json', parent);
       }
       throw e;
     }
@@ -698,9 +699,11 @@ function resolveExports(nmPath, request, conditions) {
  * @param {string} request Relative or absolute file path
  * @param {Array<string>} paths Folders to search as file paths
  * @param {boolean} isMain Whether the request is the main app entry point
+ * @param {Set<string>} [conditions] The conditions to use for resolution
+ * @param {Module} [parent] The module that issued the require() call
  * @returns {string | false}
  */
-Module._findPath = function(request, paths, isMain, conditions = getCjsConditions()) {
+Module._findPath = function(request, paths, isMain, conditions = getCjsConditions(), parent) {
   const absoluteRequest = path.isAbsolute(request);
   if (absoluteRequest) {
     paths = [''];
@@ -748,7 +751,7 @@ Module._findPath = function(request, paths, isMain, conditions = getCjsCondition
     }
 
     if (!absoluteRequest) {
-      const exportsResolved = resolveExports(curPath, request, conditions);
+      const exportsResolved = resolveExports(curPath, request, conditions, parent);
       if (exportsResolved) {
         return exportsResolved;
       }
@@ -1436,10 +1439,11 @@ Module._resolveFilename = function(request, parent, isMain, options) {
           packageImportsResolve(request, pathToFileURL(parentPath), conditions),
           parentPath,
           pkg.path,
+          parent,
         );
       } catch (e) {
         if (e.code === 'ERR_MODULE_NOT_FOUND') {
-          throw createEsmNotFoundErr(request);
+          throw createEsmNotFoundErr(request, undefined, parent);
         }
         throw e;
       }
@@ -1448,7 +1452,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
 
   // Try module self resolution first
   const parentPath = trySelfParentPath(parent);
-  const selfResolved = trySelf(parentPath, request, conditions);
+  const selfResolved = trySelf(parentPath, request, conditions, parent);
   if (selfResolved) {
     const cacheKey = request + '\x00' +
          (paths.length === 1 ? paths[0] : ArrayPrototypeJoin(paths, '\x00'));
@@ -1457,7 +1461,7 @@ Module._resolveFilename = function(request, parent, isMain, options) {
   }
 
   // Look up the filename first, since that's the cache key.
-  const filename = Module._findPath(request, paths, isMain, conditions);
+  const filename = Module._findPath(request, paths, isMain, conditions, parent);
   if (filename) { return filename; }
   const requireStack = [];
   for (let cursor = parent;
@@ -1483,11 +1487,12 @@ Module._resolveFilename = function(request, parent, isMain, options) {
  * @param {string} resolved The resolved module specifier
  * @param {string} parentPath The path of the parent module
  * @param {string} pkgPath The path of the package.json file
+ * @param {Module} [parent] The module that issued the require() call
  * @throws {ERR_INVALID_MODULE_SPECIFIER} If the resolved module specifier contains encoded `/` or `\\` characters
  * @throws {Error} If the module cannot be found
  * @returns {void|string|undefined}
  */
-function finalizeEsmResolution(resolved, parentPath, pkgPath) {
+function finalizeEsmResolution(resolved, parentPath, pkgPath, parent) {
   const { encodedSepRegEx } = require('internal/modules/esm/resolve');
   if (RegExpPrototypeExec(encodedSepRegEx, resolved) !== null) {
     throw new ERR_INVALID_MODULE_SPECIFIER(
@@ -1498,23 +1503,37 @@ function finalizeEsmResolution(resolved, parentPath, pkgPath) {
   if (actual) {
     return actual;
   }
-  throw createEsmNotFoundErr(filename, pkgPath);
+  throw createEsmNotFoundErr(filename, pkgPath, parent);
 }
 
 /**
  * Creates an error object for when a requested ES module cannot be found.
  * @param {string} request The name of the requested module
  * @param {string} [path] The path to the requested module
+ * @param {Module} [parent] The module that issued the require() call
  * @returns {Error}
  */
-function createEsmNotFoundErr(request, path) {
+function createEsmNotFoundErr(request, path, parent) {
+  const requireStack = [];
+  for (let cursor = parent;
+    cursor;
+    cursor = cursor[kLastModuleParent]) {
+    ArrayPrototypePush(requireStack, cursor.filename || cursor.id);
+  }
+  let message = `Cannot find module '${request}'`;
+  if (requireStack.length > 0) {
+    message = message + '\nRequire stack:\n- ' +
+              ArrayPrototypeJoin(requireStack, '\n- ');
+  }
   // eslint-disable-next-line no-restricted-syntax
-  const err = new Error(`Cannot find module '${request}'`);
+  const err = new Error(message);
   err.code = 'MODULE_NOT_FOUND';
   if (path) {
     err.path = path;
   }
-  // TODO(BridgeAR): Add the requireStack as well.
+  if (requireStack.length > 0) {
+    err.requireStack = requireStack;
+  }
   return err;
 }
 

--- a/test/fixtures/node_modules/pkgexports-esm-require-stack/package.json
+++ b/test/fixtures/node_modules/pkgexports-esm-require-stack/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "pkgexports-esm-require-stack",
+  "exports": {
+    "./missing": "./missing.js"
+  }
+}

--- a/test/parallel/test-require-esm-not-found-require-stack.js
+++ b/test/parallel/test-require-esm-not-found-require-stack.js
@@ -1,0 +1,78 @@
+// Tests that MODULE_NOT_FOUND errors thrown from the ESM exports resolution
+// path include the requireStack property and message, matching the behaviour
+// of the CJS resolution path.
+// Fixes the TODO(BridgeAR) in lib/internal/modules/cjs/loader.js.
+'use strict';
+require('../common');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const { createRequire } = require('module');
+const fs = require('fs');
+
+// --- Scenario 1: single-level require via createRequire ---
+// createRequire creates a fake module at the given path. When the exports
+// resolution fails, the fake module's path appears in requireStack.
+const requireFixture = createRequire(fixtures.path('node_modules/'));
+assert.throws(
+  () => {
+    requireFixture('pkgexports-esm-require-stack/missing');
+  },
+  (err) => {
+    assert.strictEqual(err.code, 'MODULE_NOT_FOUND');
+
+    // requireStack must be present and non-empty (previously it was undefined).
+    assert(Array.isArray(err.requireStack),
+           `expected err.requireStack to be an array, got ${err.requireStack}`);
+    assert(err.requireStack.length > 0, 'expected err.requireStack to be non-empty');
+
+    // The human-readable message must include the require stack section.
+    assert(
+      err.message.includes('Require stack:'),
+      `expected error message to include "Require stack:", got:\n${err.message}`,
+    );
+    return true;
+  },
+);
+
+// --- Scenario 2: multi-level require propagates the full requireStack ---
+// When an intermediate module (inner) requires the missing export,
+// requireStack must list inner first and outer second (nearest caller first).
+//
+// inner.js lives in test/fixtures/ so Node's normal node_modules lookup finds
+// test/fixtures/node_modules/pkgexports-esm-require-stack automatically.
+const innerFixture = fixtures.path('require-esm-not-found-inner.js');
+const outerFixture = fixtures.path('require-esm-not-found-outer.js');
+
+if (!fs.existsSync(innerFixture)) {
+  fs.writeFileSync(
+    innerFixture,
+    // Uses plain require — test/fixtures/node_modules is in the search path.
+    `'use strict';\nrequire('pkgexports-esm-require-stack/missing');\n`,
+  );
+}
+if (!fs.existsSync(outerFixture)) {
+  fs.writeFileSync(
+    outerFixture,
+    `'use strict';\nrequire(${JSON.stringify(innerFixture)});\n`,
+  );
+}
+
+assert.throws(
+  () => { require(outerFixture); },
+  (err) => {
+    assert.strictEqual(err.code, 'MODULE_NOT_FOUND');
+    assert(Array.isArray(err.requireStack));
+
+    // The inner module (direct caller of the failing require) is first.
+    assert.strictEqual(err.requireStack[0], innerFixture,
+                       `requireStack[0] should be ${innerFixture}, got ${err.requireStack[0]}`);
+    // The outer module appears next.
+    assert.strictEqual(err.requireStack[1], outerFixture,
+                       `requireStack[1] should be ${outerFixture}, got ${err.requireStack[1]}`);
+
+    // Both paths appear in the human-readable message.
+    assert(err.message.includes(innerFixture));
+    assert(err.message.includes(outerFixture));
+    return true;
+  },
+);


### PR DESCRIPTION
## Summary

When `require()` fails via the ESM exports resolution path (e.g. `require('pkg/subpath')` where `pkg` has a `package.json` `exports` field), the thrown `MODULE_NOT_FOUND` error was missing the `requireStack` property and the `"Require stack:"` section in the message — even though the CJS resolution path has included this information for years.

This was acknowledged in a `TODO(BridgeAR)` comment in `lib/internal/modules/cjs/loader.js`.

### Changes

- **`createEsmNotFoundErr`** — accepts an optional `parent` Module and builds `requireStack` + message using the same pattern as the CJS path. Removes the TODO comment.
- **`finalizeEsmResolution`** — threads `parent` through to `createEsmNotFoundErr`.
- **`resolveExports`** — threads `parent` through. Covers the most common case: `require('pkg/subpath')` with an `exports` field.
- **`Module._findPath`** — accepts optional 5th arg `parent` (fully backward-compatible) and passes it to `resolveExports`.
- **`trySelf`** — threads `parent` through. Covers self-referencing packages.
- **`Module._resolveFilename`** — passes `parent` at all three ESM call sites.

### Before

```
Error: Cannot find module 'my-pkg/missing'
```

### After

```
Error: Cannot find module 'my-pkg/missing'
Require stack:
- /app/src/utils.js
- /app/src/index.js
```

## Test plan

- Added `test/fixtures/node_modules/pkgexports-esm-require-stack/` — a fixture package whose `exports` map points to a non-existent file.
- Added `test/parallel/test-require-esm-not-found-require-stack.js` with two scenarios:
  - Single-level: verifies `err.requireStack` is present and `err.message` includes `"Require stack:"`.
  - Multi-level: verifies the full caller chain appears in `requireStack` in the correct order (nearest caller first).