### PR TITLE
sqlite: fix sqlite3_stmt leak in prepare create failure

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1511,6 +1511,10 @@ void DatabaseSync::Prepare(const FunctionCallbackInfo<Value>& args) {
   CHECK_ERROR_OR_THROW(env->isolate(), db, r, SQLITE_OK, void());
   BaseObjectPtr<StatementSync> stmt =
       StatementSync::Create(env, BaseObjectPtr<DatabaseSync>(db), s);
+  if (!stmt) {
+    sqlite3_finalize(s);
+    return;
+  }
   db->statements_.insert(stmt.get());
 
   if (return_arrays.has_value()) {


### PR DESCRIPTION
If `StatementSync::Create` fails to allocate a JS object (OOM), the `sqlite3_stmt` prepared by `sqlite3_prepare_v2` was leaked and a null pointer was silently inserted into `db->statements_`