### PR TITLE
build: use `CARGO` environment variable if set

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1452,7 +1452,9 @@ def get_cargo_version(cargo):
   except OSError:
     error('''No acceptable cargo found!
 
-       Please make sure you have cargo installed on your system.''')
+       Please make sure you have cargo installed on your system and/or
+       consider adjusting the CARGO environment variable if you have installed
+       it in a non-standard prefix.''')
 
   with proc:
     cargo_ret = to_utf8(proc.communicate()[0])
@@ -1540,8 +1542,9 @@ def check_compiler(o):
     # Minimum cargo and rustc versions should match values in BUILDING.md.
     min_cargo_ver_tuple = (1, 82)
     min_rustc_ver_tuple = (1, 82)
-    cargo_ver = get_cargo_version('cargo')
-    print_verbose(f'Detected cargo: {cargo_ver}')
+    cargo = os.environ.get('CARGO', 'cargo')
+    cargo_ver = get_cargo_version(cargo)
+    print_verbose(f'Detected cargo (CARGO={cargo}): {cargo_ver}')
     cargo_ver_tuple = tuple(map(int, cargo_ver.split('.')))
     if cargo_ver_tuple < min_cargo_ver_tuple:
       warn(f'cargo {cargo_ver} too old, need cargo {".".join(map(str, min_cargo_ver_tuple))}')
@@ -2750,6 +2753,11 @@ if flavor == 'win' and python.lower().endswith('.exe'):
 # Always set 'python' variable, otherwise environments that only have python3
 # will fail to run python scripts.
 gyp_args += ['-Dpython=' + python]
+
+if options.v8_enable_temporal_support and not options.shared_temporal_capi:
+  cargo = os.environ.get('CARGO')
+  if cargo:
+    gyp_args += ['-Dcargo=' + cargo]
 
 if options.use_ninja:
   gyp_args += ['-f', 'ninja-' + flavor]

--- a/deps/crates/crates.gyp
+++ b/deps/crates/crates.gyp
@@ -1,5 +1,6 @@
 {
   'variables': {
+    'cargo%': 'cargo',
     'cargo_vendor_dir': './vendor',
   },
   'conditions': [
@@ -48,7 +49,7 @@
             '<(node_crates_libpath)'
           ],
           'action': [
-            'cargo',
+            '<(cargo)',
             'rustc',
             '<@(cargo_build_flags)',
             '--frozen',


### PR DESCRIPTION
When enabling support for Temporal, check for the `CARGO` environment variable to locate the `cargo` binary (defaulting to `cargo` if not set) and use this to build `deps/crates`.

This will allow using Cargo on systems where the Cargo binary name is suffixed with the version, e.g. `cargo-1.82` on Ubuntu 24.04.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
