### PR TITLE
src: use stack allocation for small string encoding

### DIFF
--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -550,14 +550,15 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
   MaybeLocal<String> val;
 
   switch (encoding) {
-    case BUFFER: {
-      auto maybe_buf = Buffer::Copy(isolate, buf, buflen);
-      Local<v8::Object> buf;
-      if (!maybe_buf.ToLocal(&buf)) {
-        isolate->ThrowException(node::ERR_MEMORY_ALLOCATION_FAILED(isolate));
+    case BUFFER:
+      {
+        auto maybe_buf = Buffer::Copy(isolate, buf, buflen);
+        Local<v8::Object> buf;
+        if (!maybe_buf.ToLocal(&buf)) {
+          isolate->ThrowException(node::ERR_MEMORY_ALLOCATION_FAILED(isolate));
+        }
+        return buf;
       }
-      return buf;
-    }
 
     case ASCII:
       buflen = keep_buflen_in_range(buflen);


### PR DESCRIPTION
- Introduce `EncodeOneByteString` / `EncodeTwoByteString` helper templates in `StringBytes::Encode()` that use a 512 byte (256-char for two-byte) stack buffer for small inputs, falling back to heap allocation + `ExternString` for larger ones.
- Covers all encoding paths: ASCII, HEX, BASE64, BASE64URL, UTF8 (two-byte), and UCS2.

Refs: https://github.com/nodejs/performance/issues/194


```
                                                                       confidence improvement accuracy (*)   (**)  (***)
buffers/buffer-base64-encode.js n=32 len=67108864                                      1.82 %       ±2.53% ±3.38% ±4.42%
buffers/buffer-base64url-encode.js n=32 len=67108864                            *     -1.70 %       ±1.39% ±1.86% ±2.42%
buffers/buffer-tostring.js n=1000000 len=1 args=0 encoding=''                 ***      3.71 %       ±1.67% ±2.23% ±2.91%
buffers/buffer-tostring.js n=1000000 len=1 args=1 encoding='ascii'                     0.21 %       ±2.08% ±2.78% ±3.65%
buffers/buffer-tostring.js n=1000000 len=1 args=1 encoding='hex'              ***     40.34 %       ±4.17% ±5.60% ±7.39%
buffers/buffer-tostring.js n=1000000 len=1 args=1 encoding='latin1'           ***      2.52 %       ±1.15% ±1.53% ±1.99%
buffers/buffer-tostring.js n=1000000 len=1 args=1 encoding='UCS-2'            ***      3.33 %       ±1.26% ±1.68% ±2.19%
buffers/buffer-tostring.js n=1000000 len=1 args=1 encoding='utf8'             ***      2.03 %       ±0.90% ±1.19% ±1.55%
buffers/buffer-tostring.js n=1000000 len=1 args=3 encoding='ascii'              *      3.00 %       ±2.83% ±3.80% ±5.02%
buffers/buffer-tostring.js n=1000000 len=1 args=3 encoding='hex'              ***     40.40 %       ±3.23% ±4.30% ±5.59%
buffers/buffer-tostring.js n=1000000 len=1 args=3 encoding='latin1'            **      2.93 %       ±2.04% ±2.73% ±3.58%
buffers/buffer-tostring.js n=1000000 len=1 args=3 encoding='UCS-2'            ***      4.55 %       ±1.17% ±1.56% ±2.04%
buffers/buffer-tostring.js n=1000000 len=1 args=3 encoding='utf8'             ***      2.52 %       ±0.88% ±1.17% ±1.52%
buffers/buffer-tostring.js n=1000000 len=1024 args=0 encoding=''                      -0.48 %       ±1.75% ±2.35% ±3.09%
buffers/buffer-tostring.js n=1000000 len=1024 args=1 encoding='ascii'                  2.68 %       ±3.68% ±4.91% ±6.44%
buffers/buffer-tostring.js n=1000000 len=1024 args=1 encoding='hex'                   -0.05 %       ±1.47% ±1.96% ±2.55%
buffers/buffer-tostring.js n=1000000 len=1024 args=1 encoding='latin1'          *      2.53 %       ±1.94% ±2.60% ±3.41%
buffers/buffer-tostring.js n=1000000 len=1024 args=1 encoding='UCS-2'                  0.75 %       ±1.80% ±2.40% ±3.13%
buffers/buffer-tostring.js n=1000000 len=1024 args=1 encoding='utf8'            *      3.19 %       ±2.47% ±3.33% ±4.40%
buffers/buffer-tostring.js n=1000000 len=1024 args=3 encoding='ascii'                  0.01 %       ±2.15% ±2.86% ±3.72%
buffers/buffer-tostring.js n=1000000 len=1024 args=3 encoding='hex'                    0.40 %       ±1.31% ±1.74% ±2.26%
buffers/buffer-tostring.js n=1000000 len=1024 args=3 encoding='latin1'          *      1.96 %       ±1.86% ±2.48% ±3.23%
buffers/buffer-tostring.js n=1000000 len=1024 args=3 encoding='UCS-2'                  0.54 %       ±1.99% ±2.65% ±3.46%
buffers/buffer-tostring.js n=1000000 len=1024 args=3 encoding='utf8'                   1.05 %       ±1.11% ±1.48% ±1.93%
buffers/buffer-tostring.js n=1000000 len=64 args=0 encoding=''                        -0.37 %       ±1.28% ±1.72% ±2.26%
buffers/buffer-tostring.js n=1000000 len=64 args=1 encoding='ascii'                   -1.33 %       ±2.21% ±2.97% ±3.92%
buffers/buffer-tostring.js n=1000000 len=64 args=1 encoding='hex'             ***     41.64 %       ±2.07% ±2.76% ±3.62%
buffers/buffer-tostring.js n=1000000 len=64 args=1 encoding='latin1'            *      1.98 %       ±1.86% ±2.48% ±3.25%
buffers/buffer-tostring.js n=1000000 len=64 args=1 encoding='UCS-2'                   -0.38 %       ±2.76% ±3.68% ±4.80%
buffers/buffer-tostring.js n=1000000 len=64 args=1 encoding='utf8'                     0.64 %       ±0.88% ±1.18% ±1.53%
buffers/buffer-tostring.js n=1000000 len=64 args=3 encoding='ascii'                    0.35 %       ±2.91% ±3.88% ±5.07%
buffers/buffer-tostring.js n=1000000 len=64 args=3 encoding='hex'             ***     40.54 %       ±1.43% ±1.90% ±2.48%
buffers/buffer-tostring.js n=1000000 len=64 args=3 encoding='latin1'                   1.67 %       ±2.47% ±3.30% ±4.31%
buffers/buffer-tostring.js n=1000000 len=64 args=3 encoding='UCS-2'                    0.32 %       ±1.93% ±2.57% ±3.35%
buffers/buffer-tostring.js n=1000000 len=64 args=3 encoding='utf8'                     0.56 %       ±0.91% ±1.21% ±1.58%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 35 comparisons, you can thus
expect the following amount of false-positive results:
  1.75 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.35 false positives, when considering a   1% risk acceptance (**, ***),
  0.04 false positives, when considering a 0.1% risk acceptance (***)
thisalihassan@Alis-MacBook-Pro node % 
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
