### PR TITLE
stream: deprecate legacy prependListener fallback

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4548,6 +4548,22 @@ that have proven unresolveable. See [caveats of asynchronous customization hooks
 `module.registerHooks()` as soon as possible as `module.register()` will be
 removed in a future version of Node.js.
 
+### DEP0206: Piping to emitters without `prependListener`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62435
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+Piping to an EventEmitter that does not have a `prependListener` method is
+deprecated. The `prependListener` method has been available on EventEmitter
+since Node.js v6.0.0. The internal fallback code that manually manipulates
+the `_events` object will be removed in a future version.
+
 [DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/lib/internal/streams/legacy.js
+++ b/lib/internal/streams/legacy.js
@@ -105,6 +105,8 @@ Stream.prototype.eventNames = function eventNames() {
   return names;
 };
 
+let emittedPrependListenerDeprecation = false;
+
 function prependListener(emitter, event, fn) {
   // Sadly this is not cacheable as some libraries bundle their own
   // event emitter implementation with them.
@@ -115,6 +117,15 @@ function prependListener(emitter, event, fn) {
   // userland ones.  NEVER DO THIS. This is here only because this code needs
   // to continue to work with older versions of Node.js that do not include
   // the prependListener() method. The goal is to eventually remove this hack.
+  if (!emittedPrependListenerDeprecation) {
+    process.emitWarning(
+      'Piping to an EventEmitter without a prependListener method is deprecated. ' +
+      'The emitter should have a prependListener method.',
+      'DeprecationWarning',
+      'DEP0206',
+    );
+    emittedPrependListenerDeprecation = true;
+  }
   if (!emitter._events || !emitter._events[event])
     emitter.on(event, fn);
   else if (ArrayIsArray(emitter._events[event]))

--- a/test/parallel/test-event-emitter-prepend.js
+++ b/test/parallel/test-event-emitter-prepend.js
@@ -37,6 +37,14 @@ function Readable() {
 Object.setPrototypeOf(Readable.prototype, stream.Stream.prototype);
 Object.setPrototypeOf(Readable, stream.Stream);
 
+// Expect deprecation warning when using fallback path
+common.expectWarning(
+  'DeprecationWarning',
+  'Piping to an EventEmitter without a prependListener method is deprecated. ' +
+  'The emitter should have a prependListener method.',
+  'DEP0206',
+);
+
 const w = new Writable();
 const r = new Readable();
 r.pipe(w);

--- a/test/parallel/test-stream-events-prepend.js
+++ b/test/parallel/test-stream-events-prepend.js
@@ -19,6 +19,14 @@ class Readable extends stream.Readable {
   }
 }
 
+// Expect deprecation warning when using fallback path
+common.expectWarning(
+  'DeprecationWarning',
+  'Piping to an EventEmitter without a prependListener method is deprecated. ' +
+  'The emitter should have a prependListener method.',
+  'DEP0206',
+);
+
 const w = new Writable();
 w.on('pipe', common.mustCall());
 


### PR DESCRIPTION
The prependListener method has been available on EventEmitter since Node.js v6.0.0 (April 2016). The fallback code that manipulated the internal _events object is no longer necessary.

This also removes tests that explicitly tested the fallback behavior.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
