### PR TITLE
test_runner: exclude BRDA entries for ignored lines in lcov output

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -193,11 +193,16 @@ class TestCoverage {
           ObjectAssign(range, mapRangeToLines(range, lines));
 
           if (isBlockCoverage) {
-            ArrayPrototypePush(branchReports, {
-              __proto__: null,
-              line: range.lines[0]?.line,
-              count: range.count,
-            });
+            // If all lines in the branch are ignored, do not include this
+            // branch in the coverage report (similar to how ignored lines
+            // are excluded from DA entries in lcov output).
+            if (range.ignoredLines !== range.lines.length) {
+              ArrayPrototypePush(branchReports, {
+                __proto__: null,
+                line: range.lines[0]?.line,
+                count: range.count,
+              });
+            }
 
             if (range.count !== 0 ||
                 range.ignoredLines === range.lines.length) {


### PR DESCRIPTION
## Description

When a line is marked with `node:coverage ignore next`, both the DA (line coverage) entry and the BRDA (branch coverage) entry for branches leading to that line should be excluded from the lcov output.

This matches the behavior of c8 and ensures that branch coverage percentages are not artificially reduced by ignored code.

## Fixes

Fixes: https://github.com/nodejs/node/issues/61586

## Type of change

- [x] Bug fix (non-breaking change which fixes an existing issue)

## Checklist

- [x] I have read the contribution guidelines
- [x] I have tested the changes (if applicable)
- [x] I have run the test suite (if applicable)