### PR TITLE
internal: improve formatting for network errors with IPv6 addresses

### DIFF
--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -698,7 +698,8 @@ class UVExceptionWithHostPort extends Error {
     let details = '';
 
     if (port && port > 0) {
-      details = ` ${address}:${port}`;
+      const host = address.includes(':') ? `[${address}]` : address; // RFC 5952 Section 6
+      details = ` ${host}:${port}`;
     } else if (address) {
       details = ` ${address}`;
     }

--- a/test/parallel/test-net-autoselectfamily-commandline-option.js
+++ b/test/parallel/test-net-autoselectfamily-commandline-option.js
@@ -32,14 +32,14 @@ const { createConnection, createServer } = require('net');
 
       if (common.hasIPv6) {
         assert.strictEqual(error.code, 'ECONNREFUSED');
-        assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
+        assert.strictEqual(error.message, `connect ECONNREFUSED [::1]:${port}`);
       } else if (error.code === 'EAFNOSUPPORT') {
-        assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
+        assert.strictEqual(error.message, `connect EAFNOSUPPORT [::1]:${port} - Local (undefined:undefined)`);
       } else if (error.code === 'EUNATCH') {
-        assert.strictEqual(error.message, `connect EUNATCH ::1:${port} - Local (:::0)`);
+        assert.strictEqual(error.message, `connect EUNATCH [::1]:${port} - Local ([::]:0)`);
       } else {
         assert.strictEqual(error.code, 'EADDRNOTAVAIL');
-        assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
+        assert.strictEqual(error.message, `connect EADDRNOTAVAIL [::1]:${port} - Local ([::]:0)`);
       }
 
       ipv4Server.close();

--- a/test/parallel/test-net-autoselectfamily-default.js
+++ b/test/parallel/test-net-autoselectfamily-default.js
@@ -67,14 +67,14 @@ const autoSelectFamilyAttemptTimeout = common.defaultAutoSelectFamilyAttemptTime
     connection.on('error', common.mustCall((error) => {
       if (common.hasIPv6) {
         assert.strictEqual(error.code, 'ECONNREFUSED');
-        assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
+        assert.strictEqual(error.message, `connect ECONNREFUSED [::1]:${port}`);
       } else if (error.code === 'EAFNOSUPPORT') {
-        assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
+        assert.strictEqual(error.message, `connect EAFNOSUPPORT [::1]:${port} - Local (undefined:undefined)`);
       } else if (error.code === 'EUNATCH') {
-        assert.strictEqual(error.message, `connect EUNATCH ::1:${port} - Local (:::0)`);
+        assert.strictEqual(error.message, `connect EUNATCH [::1]:${port} - Local ([::]:0)`);
       } else {
         assert.strictEqual(error.code, 'EADDRNOTAVAIL');
-        assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
+        assert.strictEqual(error.message, `connect EADDRNOTAVAIL [::1]:${port} - Local ([::]:0)`);
       }
 
       ipv4Server.close();

--- a/test/parallel/test-net-autoselectfamily.js
+++ b/test/parallel/test-net-autoselectfamily.js
@@ -177,7 +177,7 @@ if (common.hasIPv6) {
     assert.ok(errors.includes('connect ECONNREFUSED 127.0.0.1:10'));
 
     if (common.hasIPv6) {
-      assert.ok(errors.includes('connect ECONNREFUSED ::1:10'));
+      assert.ok(errors.includes('connect ECONNREFUSED [::1]:10'));
     }
   }));
 }
@@ -207,14 +207,14 @@ if (common.hasIPv6) {
 
       if (common.hasIPv6) {
         assert.strictEqual(error.code, 'ECONNREFUSED');
-        assert.strictEqual(error.message, `connect ECONNREFUSED ::1:${port}`);
+        assert.strictEqual(error.message, `connect ECONNREFUSED [::1]:${port}`);
       } else if (error.code === 'EAFNOSUPPORT') {
-        assert.strictEqual(error.message, `connect EAFNOSUPPORT ::1:${port} - Local (undefined:undefined)`);
+        assert.strictEqual(error.message, `connect EAFNOSUPPORT [::1]:${port} - Local (undefined:undefined)`);
       } else if (error.code === 'EUNATCH') {
-        assert.strictEqual(error.message, `connect EUNATCH ::1:${port} - Local (:::0)`);
+        assert.strictEqual(error.message, `connect EUNATCH [::1]:${port} - Local ([::]:0)`);
       } else {
         assert.strictEqual(error.code, 'EADDRNOTAVAIL');
-        assert.strictEqual(error.message, `connect EADDRNOTAVAIL ::1:${port} - Local (:::0)`);
+        assert.strictEqual(error.message, `connect EADDRNOTAVAIL [::1]:${port} - Local ([::]:0)`);
       }
 
       ipv4Server.close();


### PR DESCRIPTION
This is an attempt to improve readability of network errors using IPv6 addresses.

Changes error messages for network errors such as "Connection refused" from this:

```
connect ECONNREFUSED 2001:db8::1337:443
```

to this:

```
connect ECONNREFUSED [2001:db8::1337]:443
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
