### PR TITLE
deps: V8: cherry-pick cf1bce40a5ef

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.16',
+    'v8_embedder_string': '-node.17',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/wasm/constant-expression-interface.cc
+++ b/deps/v8/src/wasm/constant-expression-interface.cc
@@ -40,7 +40,17 @@ void ConstantExpressionInterface::S128Const(FullDecoder* decoder,
                                             const Simd128Immediate& imm,
                                             Value* result) {
   if (!generate_value()) return;
+#if V8_TARGET_BIG_ENDIAN
+  // Globals are not little endian enforced, they use native byte order and we
+  // need to reverse the bytes on big endian platforms.
+  uint8_t value[kSimd128Size];
+  for (int i = 0; i < kSimd128Size; i++) {
+    value[i] = imm.value[kSimd128Size - 1 - i];
+  }
+  result->runtime_value = WasmValue(value, kWasmS128);
+#else
   result->runtime_value = WasmValue(imm.value, kWasmS128);
+#endif
 }
 
 void ConstantExpressionInterface::UnOp(FullDecoder* decoder, WasmOpcode opcode,


### PR DESCRIPTION
Original commit message:

    [wasm] Fix S128Const on big endian

    Since http://crrev.com/c/2944437 globals are no longer little endian
    enforced.

    S128Const handling in the initializer needs to take this into account
    and byte reverse values which are hard coded in little endian order.

    This is currently causing failures on Node.js upstream:
    https://github.com/nodejs/node/pull/59034#issuecomment-4129144461

    Change-Id: Ifcc9ade93ee51565ab19b16e9dadf0ff5752f7a6
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7704213
    Commit-Queue: Milad Farazmand <mfarazma@ibm.com>
    Reviewed-by: Manos Koukoutos <manoskouk@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#106082}

Refs: https://github.com/v8/v8/commit/cf1bce40a5ef4c7c1da351754f5bf526c0c96463
Refs: https://github.com/nodejs/node/pull/59034#issuecomment-4136524324
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
