### PR TITLE
test: fix flaky https tests on windows

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -35,6 +35,7 @@ const {
   NumberParseInt,
   ObjectDefineProperty,
   ObjectSetPrototypeOf,
+  SafeSet,
   Symbol,
   SymbolAsyncDispose,
   SymbolDispose,
@@ -912,6 +913,7 @@ Socket.prototype._destroy = function(exception, cb) {
   if (this._server) {
     debug('has server');
     this._server._connections--;
+    this._server._connectionSockets?.delete(this);
     if (this._server._emitCloseIfDrained) {
       this._server._emitCloseIfDrained();
     }
@@ -1867,6 +1869,7 @@ function Server(options, connectionListener) {
   }
 
   this._connections = 0;
+  this._connectionSockets = new SafeSet();
 
   this[async_id_symbol] = -1;
   this._handle = null;
@@ -2365,6 +2368,7 @@ function onconnection(err, clientHandle) {
   }
 
   self._connections++;
+  self._connectionSockets.add(socket);
   socket.server = self;
   socket._server = self;
   self.emit('connection', socket);
@@ -2434,6 +2438,22 @@ Server.prototype.close = function(cb) {
   if (this._handle) {
     this._handle.close();
     this._handle = null;
+  }
+
+  // Register a beforeExit handler to destroy any remaining connections
+  // before the process exits. This ensures connections are torn down
+  // during normal JS execution rather than during environment cleanup,
+  // where on Windows the IOCP completion processing can race with
+  // handle teardown.
+  if (this._connectionSockets.size > 0) {
+    const connections = this._connectionSockets;
+    const onBeforeExit = () => {
+      process.removeListener('beforeExit', onBeforeExit);
+      for (const socket of connections) {
+        socket.destroy();
+      }
+    };
+    process.on('beforeExit', onBeforeExit);
   }
 
   if (this._usingWorkers) {


### PR DESCRIPTION
The test-https-server-options-incoming-message and
test-https-server-options-server-response tests can
be flaky on Windows.

Opencode/Opus is helping figure out why.

If this PR makes the tests non-flaky it's just a bandaid. There appears to be a race condition on cleanup on windows where shutting down connections races with shutting down the server. We'd still need to identify specifically where that race is occurring and where to fix it specifically. Right now, however, my goal is to unblock CI flakes.

The flakiness does seem generalized to *any* `test-http(s)-*` and `test-net-*` or `test-tls-*`, not just one... which makes me strongly suspect the race is quite low in the stack, possibly even in libuv but that's yet to be determined precisely.

This PR adds a pre-exit hook that will force open connections to be destroyed when the process is exiting, short-circuiting the race condition that's causing the process to crash on windows.