### PR TITLE
util: honor breakLength Infinity with unlimited depth

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2660,7 +2660,10 @@ function reduceToSingleString(
       // Consolidate all entries of the local most inner depth up to
       // `ctx.compact`, as long as the properties are smaller than
       // `ctx.breakLength`.
-      if (ctx.currentDepth - recurseTimes < ctx.compact &&
+      if (((ctx.breakLength === Infinity &&
+            (ctx.depth === Infinity || ctx.depth === null) &&
+            ctx.compact === 3) ||
+           ctx.currentDepth - recurseTimes < ctx.compact) &&
           entries === output.length) {
         // Line up all entries on a single line in case the entries do not
         // exceed `breakLength`. Add 10 as constant to start next to all other

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -1615,6 +1615,36 @@ if (typeof Symbol !== 'undefined') {
   assert.strictEqual(twoLines, "{\n  foo: 'abc',\n  bar: 'xyz'\n}");
 }
 
+{
+  const obj = {
+    a: {
+      b: {
+        c: {
+          d: 1,
+        },
+      },
+    },
+  };
+
+  assert.strictEqual(
+    util.inspect(obj, { breakLength: Infinity, depth: Infinity }),
+    '{ a: { b: { c: { d: 1 } } } }',
+  );
+  assert.strictEqual(
+    util.inspect(obj, { breakLength: Infinity, depth: null }),
+    '{ a: { b: { c: { d: 1 } } } }',
+  );
+  assert.strictEqual(
+    util.inspect(obj, { breakLength: Infinity, depth: Infinity, compact: 3 }),
+    '{ a: { b: { c: { d: 1 } } } }',
+  );
+
+  assert.strictEqual(
+    util.inspect(obj, { breakLength: Infinity, depth: Infinity, compact: 1 }),
+    '{\n  a: {\n    b: {\n      c: { d: 1 }\n    }\n  }\n}',
+  );
+}
+
 // util.inspect.defaultOptions tests.
 {
   const arr = new Array(101).fill();
@@ -1631,6 +1661,12 @@ if (typeof Symbol !== 'undefined') {
   assert.doesNotMatch(util.inspect(obj), /Object/);
   util.inspect.defaultOptions.depth = oldOptions.depth;
   assert.match(util.inspect(obj), /Object/);
+  util.inspect.defaultOptions.compact = 1;
+  assert.strictEqual(
+    util.inspect(obj, { breakLength: Infinity, depth: Infinity }),
+    '{\n  a: {\n    a: {\n      a: { a: 1 }\n    }\n  }\n}',
+  );
+  util.inspect.defaultOptions.compact = oldOptions.compact;
   assert.strictEqual(
     JSON.stringify(util.inspect.defaultOptions),
     JSON.stringify(oldOptions)


### PR DESCRIPTION
Restore single-line `util.inspect()` output when `breakLength` is `Infinity`
and depth is unlimited. This covers both `depth: Infinity` and `depth: null`.

Keep existing behavior for explicit non-default `compact` settings and for
customized `util.inspect.defaultOptions.compact`, so the fix only applies to
the default `compact: 3` formatting behavior.

Add regression coverage for:
- `depth: Infinity`
- `depth: null`
- explicit `compact: 3`
- explicit `compact: 1`
- customized `util.inspect.defaultOptions.compact`

Validation:
- `make -j8 node`
- `python3 tools/test.py test/parallel/test-util-inspect.js`
- `make lint`

Fixes: https://github.com/nodejs/node/issues/60475

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
