### PR TITLE
vm: DONT_CONTEXTIFY when no contextObject set

### DIFF
--- a/lib/vm.js
+++ b/lib/vm.js
@@ -222,7 +222,7 @@ function getContextOptions(options) {
 }
 
 let defaultContextNameIndex = 1;
-function createContext(contextObject = {}, options = kEmptyObject) {
+function createContext(contextObject = vm_context_no_contextify, options = kEmptyObject) {
   if (contextObject !== vm_context_no_contextify && isContext(contextObject)) {
     return contextObject;
   }

--- a/test/known_issues/test-vm-function-declaration-uses-define.js
+++ b/test/known_issues/test-vm-function-declaration-uses-define.js
@@ -9,7 +9,7 @@ const common = require('../common');
 const vm = require('vm');
 const assert = require('assert');
 
-const ctx = vm.createContext();
+const ctx = vm.createContext({});
 Object.defineProperty(ctx, 'x', {
   enumerable: true,
   configurable: true,

--- a/test/parallel/test-vm-strict-define.js
+++ b/test/parallel/test-vm-strict-define.js
@@ -1,0 +1,51 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const vm = require('vm');
+
+// Declared with `var`.
+{
+  const ctx = vm.createContext();
+  vm.runInContext(`"use strict"; var x; x = 42;`, ctx);
+  assert.strictEqual(ctx.x, 42);
+}
+
+// Define on `globalThis`.
+{
+  const ctx = vm.createContext();
+  vm.runInContext(`
+    "use strict";
+    Object.defineProperty(globalThis, "x", {
+      configurable: true,
+      value: 42,
+    });
+  `, ctx);
+  const ret = vm.runInContext(`"use strict"; x`, ctx);
+  assert.strictEqual(ret, 42);
+  assert.strictEqual(ctx.x, 42);
+}
+
+// Set on globalThis.
+{
+  const ctx = vm.createContext();
+  vm.runInContext(`"use strict"; globalThis.x = 42`, ctx);
+  const ret = vm.runInContext(`"use strict"; x`, ctx);
+  assert.strictEqual(ret, 42);
+  assert.strictEqual(ctx.x, 42);
+}
+
+// Set on context.
+// Should throw a ReferenceError when a variable is not defined in strict-mode.
+assert.throws(() => vm.runInNewContext(`"use strict"; x = 42`),
+              /ReferenceError: x is not defined/);
+
+// Known issue since V8 14.6.
+// When the context is a "contextified" object, ReferenceError can not be thrown.
+// TODO(legendecas): https://github.com/nodejs/node/pull/61898#issuecomment-4142811603
+// Refs: https://chromium-review.googlesource.com/c/v8/v8/+/7474608
+{
+  const ctx = vm.createContext({});
+  assert.throws(() => vm.runInContext(`"use strict"; x = 42`, ctx),
+                /ReferenceError: x is not defined/);
+}


### PR DESCRIPTION
When `contextObject` is not passed in `vm.createContext`, do not
contextify by default. This reduces the chance that the script semantics
are broken by the interceptors.

It's getting harder to maintain a spec-compliant behavior in a
vm contextified context. Hopefully this could reduce the breakage where
the `contextObject` is not set, like a simple `vm.createContext()`
usage.

Refs: https://github.com/nodejs/node/pull/61898#issuecomment-4142811603