### PR TITLE
http: deprecate CRLF constant from _http_common

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4517,6 +4517,20 @@ Type: Documentation-only
 Passing a non-extractable [`CryptoKey`][] to [`KeyObject.from()`][] is
 deprecated and will throw an error in a future version.
 
+### DEP0205: `CRLF` constant from `_http_common`
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62464
+    description: Runtime deprecation.
+-->
+
+Type: Runtime
+
+The `CRLF` constant exported from the internal `_http_common` module is
+deprecated. Use the string `'\r\n'` directly instead.
+
 [DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3

--- a/lib/_http_common.js
+++ b/lib/_http_common.js
@@ -23,6 +23,7 @@
 
 const {
   MathMin,
+  ObjectDefineProperty,
   Symbol,
   Uint8Array,
 } = primordials;
@@ -300,12 +301,13 @@ function isLenient() {
   return insecureHTTPParser;
 }
 
+let warnedCRLF = false;
+
 module.exports = {
   _checkInvalidHeaderChar: checkInvalidHeaderChar,
   _checkIsHttpToken: checkIsHttpToken,
   chunkExpression: /(?:^|\W)chunked(?:$|\W)/i,
   continueExpression: /(?:^|\W)100-continue(?:$|\W)/i,
-  CRLF: '\r\n', // TODO: Deprecate this.
   freeParser,
   methods,
   parsers,
@@ -315,3 +317,21 @@ module.exports = {
   prepareError,
   kSkipPendingData,
 };
+
+ObjectDefineProperty(module.exports, 'CRLF', {
+  __proto__: null,
+  configurable: true,
+  enumerable: true,
+  get() {
+    if (!warnedCRLF) {
+      warnedCRLF = true;
+      process.emitWarning(
+        "The CRLF constant from '_http_common' is deprecated. " +
+        "Use '\\r\\n' directly instead.",
+        'DeprecationWarning',
+        'DEP0205',
+      );
+    }
+    return '\r\n';
+  },
+});

--- a/test/parallel/test-http-common-crlf-deprecation.js
+++ b/test/parallel/test-http-common-crlf-deprecation.js
@@ -1,0 +1,19 @@
+// Flags: --no-warnings
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+common.expectWarning(
+  'DeprecationWarning',
+  "The CRLF constant from '_http_common' is deprecated. " +
+  "Use '\\r\\n' directly instead.",
+  'DEP0205',
+);
+
+const { CRLF } = require('_http_common');
+
+assert.strictEqual(CRLF, '\r\n');
+
+// Accessing CRLF again should not emit another warning
+assert.strictEqual(CRLF, '\r\n');


### PR DESCRIPTION
The CRLF constant exported from '_http_common' is deprecated (DEP0206). Users should use the string '\r\n' directly instead.

This addresses the TODO comment added in nodejs/node#40101.

PR-URL: https://github.com/nodejs/node/pull/62464

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
