### PR TITLE
timers: prevent setTimeout from firing callback early

### DIFF
--- a/src/env.cc
+++ b/src/env.cc
@@ -1505,7 +1505,11 @@ void Environment::RequestInterruptFromV8() {
 
 void Environment::ScheduleTimer(int64_t duration_ms) {
   if (started_cleanup_) return;
-  uv_timer_start(timer_handle(), RunTimers, duration_ms, 0);
+  // Add 1ms to compensate for libuv's uv_now() truncating sub-millisecond
+  // time. Without this, timers can fire up to 1ms before the requested
+  // delay when measured with high-resolution clocks (process.hrtime(),
+  // Date.now()). See: https://github.com/nodejs/node/issues/26578
+  uv_timer_start(timer_handle(), RunTimers, duration_ms + 1, 0);
 }
 
 void Environment::ToggleTimerRef(bool ref) {

--- a/test/parallel/test-timers-no-early-fire.js
+++ b/test/parallel/test-timers-no-early-fire.js
@@ -1,0 +1,45 @@
+'use strict';
+
+// This test verifies that setTimeout never fires its callback before the
+// requested delay has elapsed, as measured by process.hrtime.bigint().
+//
+// The bug: libuv's uv_now() truncates sub-millisecond time to integer
+// milliseconds. When a timer is scheduled at real time 100.7ms, uv_now()
+// returns 100. The timer fires when uv_now() >= 100 + delay, but real
+// elapsed time is only delay - 0.7ms. The interaction with setImmediate()
+// makes this more likely to occur because it affects when uv_update_time()
+// is called.
+//
+// See: https://github.com/nodejs/node/issues/26578
+
+const common = require('../common');
+const assert = require('assert');
+
+const DELAY_MS = 100;
+const ITERATIONS = 50;
+
+let completed = 0;
+
+function test() {
+  const start = process.hrtime.bigint();
+
+  setTimeout(common.mustCall(() => {
+    const elapsed = process.hrtime.bigint() - start;
+    const elapsedMs = Number(elapsed) / 1e6;
+
+    assert(
+      elapsedMs >= DELAY_MS,
+      `setTimeout(${DELAY_MS}) fired after only ${elapsedMs.toFixed(3)}ms`
+    );
+
+    completed++;
+    if (completed < ITERATIONS) {
+      // Use setImmediate to schedule the next iteration, which is critical
+      // to reproducing the original bug (the interaction between
+      // setImmediate and setTimeout affects uv_update_time() timing).
+      setImmediate(test);
+    }
+  }), DELAY_MS);
+}
+
+test();


### PR DESCRIPTION
## Summary
- Fixes `setTimeout` occasionally firing its callback **before** the requested delay has elapsed
- Root cause: libuv's `uv_now()` truncates sub-millisecond time to integer milliseconds, causing up to 1ms of "stolen" time when scheduling timers
- Fix: add 1ms to the duration passed to `uv_timer_start()` in `Environment::ScheduleTimer`

## The Bug

When a timer is scheduled at a fractional millisecond boundary:
1. Real time: **100.7ms** → `uv_now()` returns **100** (truncated)
2. Timer fires when `uv_now() >= 100 + delay`
3. When `uv_now()` reaches `100 + delay`, real elapsed time is only **delay - 0.7ms**
4. Measured with `process.hrtime()` or `Date.now()`, the callback appears to fire early

This is especially likely when `setImmediate()` is involved (affects `uv_update_time()` timing), as [identified by @bnoordhuis](https://github.com/nodejs/node/issues/26578#issuecomment-471872419).

## The Fix

**`src/env.cc` — `Environment::ScheduleTimer`:**
```cpp
// Before
uv_timer_start(timer_handle(), RunTimers, duration_ms, 0);

// After — compensate for uv_now() truncation
uv_timer_start(timer_handle(), RunTimers, duration_ms + 1, 0);
```

This covers both scheduling paths:
- Initial scheduling from JS (`binding.scheduleTimer(msecs)` in `lib/internal/timers.js`)
- Rescheduling after timer processing (`RunTimers` in `src/env.cc`)

**Trade-off:** Up to 1ms additional latency on timers. This is acceptable because:
- The HTML spec already specifies a [4ms minimum for nested timeouts](https://html.spec.whatwg.org/multipage/timers-and-user-prompts.html#dom-settimeout)
- Timer precision was never sub-millisecond in Node.js (libuv uses ms internally)
- The guarantee that `setTimeout(fn, N)` fires after ≥N ms is more important than minimizing latency

**No compounding for `setInterval`:** Each interval resets `_idleStart` to fresh `uv_now()` (line 599/611 of `lib/internal/timers.js`), so the +1ms does not accumulate across intervals.

## Reproduction

From @Trott's [comment](https://github.com/nodejs/node/issues/26578#issuecomment-471392004):
```js
const assert = require('assert');
const timeout = (ms) => new Promise((resolve) => setTimeout(resolve, ms));

const test = async () => {
    const MS = 100;
    const start = process.hrtime();
    await timeout(MS);
    const diff = process.hrtime(start);
    const actual = ((diff[0] * 1e9) + diff[1]) / 1000000;
    assert(actual > MS, `${actual} ${MS}`);
    setImmediate(test);
};
test();
```

Fails within ~20 seconds on macOS, Windows, and Linux (confirmed across Node.js 8.x through 24.x).

Fixes: https://github.com/nodejs/node/issues/26578