### PR TITLE
test: wait for reattach before initial break on restart

### DIFF
--- a/test/parallel/test-debugger-preserve-breaks.js
+++ b/test/parallel/test-debugger-preserve-breaks.js
@@ -29,6 +29,8 @@ const script = path.relative(process.cwd(), scriptFullPath);
     await cli.stepCommand('c'); // hit line 3
     assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 3 });
     await cli.command('restart');
+    await cli.waitFor(/Debugger attached\./);
+    await cli.waitForPrompt();
     await cli.waitForInitialBreak();
     assert.deepStrictEqual(cli.breakInfo, { filename: script, line: 1 });
     await cli.stepCommand('c');

--- a/test/parallel/test-debugger-run-after-quit-restart.js
+++ b/test/parallel/test-debugger-run-after-quit-restart.js
@@ -58,6 +58,8 @@ const path = require('path');
       );
     })
     .then(() => cli.command('restart'))
+    .then(() => cli.waitFor(/Debugger attached\./))
+    .then(() => cli.waitForPrompt())
     .then(() => cli.waitForInitialBreak())
     .then(() => {
       assert.deepStrictEqual(


### PR DESCRIPTION
`restart` can return to the prompt before the debugger reattaches and emits the
initial break. That leaves a race in these tests, which still flakes on macOS
unusual-path runs.

This change waits for `Debugger attached.` and the prompt before
`waitForInitialBreak()`.

CI failed logs:
- test/parallel/test-debugger-run-after-quit-restart.js:61
  - https://github.com/nodejs/node/actions/runs/23221018730
- test/parallel/test-debugger-preserve-breaks.js:32
  - https://github.com/nodejs/node/actions/runs/21915213108

Refs: https://github.com/nodejs/node/issues/61762