### PR TITLE
test: wait for reattach before initial break on run

### DIFF
--- a/test/parallel/test-debugger-run-after-quit-restart.js
+++ b/test/parallel/test-debugger-run-after-quit-restart.js
@@ -42,6 +42,8 @@ const path = require('path');
       assert.match(cli.output, /Use `run` to start the app again/);
     })
     .then(() => cli.command('run'))
+    .then(() => cli.waitFor(/Debugger attached\./))
+    .then(() => cli.waitForPrompt())
     .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
@@ -72,6 +74,8 @@ const path = require('path');
       assert.match(cli.output, /Use `run` to start the app again/);
     })
     .then(() => cli.command('run'))
+    .then(() => cli.waitFor(/Debugger attached\./))
+    .then(() => cli.waitForPrompt())
     .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {


### PR DESCRIPTION
Follow-up to #62471.

`run` and `restart` share the same implementation, so apply the same fix.

CI failed log: https://github.com/nodejs/node/actions/runs/23696220126

Refs: #61762