### PR TITLE
test: wait for prompt before initial break in debugger tests

### DIFF
--- a/test/parallel/test-debugger-backtrace.js
+++ b/test/parallel/test-debugger-backtrace.js
@@ -17,6 +17,7 @@ const path = require('path');
 
   async function runTest() {
     try {
+      await cli.waitForPrompt();
       await cli.waitForInitialBreak();
       await cli.waitForPrompt();
       await cli.stepCommand('c');

--- a/test/parallel/test-debugger-break.js
+++ b/test/parallel/test-debugger-break.js
@@ -14,6 +14,7 @@ const script = path.relative(process.cwd(), scriptFullPath);
 const cli = startCLI([script]);
 
 (async () => {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   assert.deepStrictEqual(

--- a/test/parallel/test-debugger-clear-breakpoints.js
+++ b/test/parallel/test-debugger-clear-breakpoints.js
@@ -20,7 +20,8 @@ const path = require('path');
     throw error;
   }
 
-  return cli.waitForInitialBreak()
+  return cli.waitForPrompt()
+    .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => cli.command('sb("break.js", 3)'))
     .then(() => cli.command('sb("break.js", 9)'))

--- a/test/parallel/test-debugger-sb-before-load.js
+++ b/test/parallel/test-debugger-sb-before-load.js
@@ -20,6 +20,7 @@ const otherScript = path.relative(process.cwd(), otherScriptFullPath);
 const cli = startCLI([script]);
 
 (async () => {
+  await cli.waitForPrompt();
   await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('sb("other.js", 2)');


### PR DESCRIPTION
This fixes flakiness around `waitForInitialBreak()` in debugger tests.

`waitForInitialBreak()` can be flaky during startup because the CLI may already attach and print `debug>` before the initial `break ... in` output arrives. 

Example CI log: https://github.com/nodejs/node/actions/runs/23657399006
```
    '< For help, see: https://nodejs.org/en/docs/inspector\n' +
    '< \n' +
    'connecting to 127.0.0.1:54872 ...\n' +
    ' ok\n' +
    '\n' +
    '\n' +
    '< Debugger attached.\n' +
    '< \n' +
    '\n' +
    'debug> '
```

In some CI runs, tests end up waiting on that break message while startup output is still racing.
There are similar flakes in other tests, but this PR focuses on the failures seen in the past week.

#### Recent CI failures:
- test/parallel/test-debugger-backtrace.js:20
  - https://github.com/nodejs/node/actions/runs/23657399006
- test/parallel/test-debugger-break.js:17
  - https://github.com/nodejs/node/actions/runs/23689423627
- test/parallel/test-debugger-clear-breakpoints.js:23
  - https://github.com/nodejs/node/actions/runs/23675940885
- test/parallel/test-debugger-sb-before-load.js:23
  - https://github.com/nodejs/node/actions/runs/23697732704

Refs: https://github.com/nodejs/node/issues/61762