### PR TITLE
doc: fix 'transfered' typo in quic.md

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -519,7 +519,7 @@ added: v23.8.0
 
 Sends an unreliable datagram to the remote peer, returning the datagram ID.
 If the datagram payload is specified as an `ArrayBufferView`, then ownership of
-that view will be transfered to the underlying stream.
+that view will be transferred to the underlying stream.
 
 ### `session.stats`
 


### PR DESCRIPTION
Fixed a typo: `transfered` → `transferred` in `doc/api/quic.md` (session.datagramWrite).

```
- that view will be transfered to the underlying stream.
+ that view will be transferred to the underlying stream.
```