### PR TITLE
fs: expose frsize field in statfs results

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7899,7 +7899,8 @@ StatFs {
   bfree: 61058895,
   bavail: 61058895,
   files: 999,
-  ffree: 1000000
+  ffree: 1000000,
+  frsize: 4096
 }
 ```
 
@@ -7913,7 +7914,8 @@ StatFs {
   bfree: 61058895n,
   bavail: 61058895n,
   files: 999n,
-  ffree: 1000000n
+  ffree: 1000000n,
+  frsize: 4096n
 }
 ```
 
@@ -7988,6 +7990,20 @@ added:
 * Type: {number|bigint}
 
 Total file nodes in file system.
+
+#### `statfs.frsize`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {number|bigint}
+
+Fundamental file system block size. This is the unit in which `blocks`,
+`bfree`, and `bavail` are counted. On most file systems this equals `bsize`,
+but on FUSE mounts (e.g. Docker Desktop on macOS using VirtioFS) they can
+differ. Use `frsize` (not `bsize`) when calculating disk space from block
+counts.
 
 #### `statfs.type`
 

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -571,7 +571,7 @@ function getStatsFromBinding(stats, offset = 0) {
 }
 
 class StatFs {
-  constructor(type, bsize, blocks, bfree, bavail, files, ffree) {
+  constructor(type, bsize, blocks, bfree, bavail, files, ffree, frsize) {
     this.type = type;
     this.bsize = bsize;
     this.blocks = blocks;
@@ -579,12 +579,14 @@ class StatFs {
     this.bavail = bavail;
     this.files = files;
     this.ffree = ffree;
+    this.frsize = frsize;
   }
 }
 
 function getStatFsFromBinding(stats) {
   return new StatFs(
     stats[0], stats[1], stats[2], stats[3], stats[4], stats[5], stats[6],
+    stats[7],
   );
 }
 

--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -158,6 +158,7 @@ void FillStatFsArray(AliasedBufferBase<NativeT, V8T>* fields,
   SET_FIELD(kBAvail, s->f_bavail);
   SET_FIELD(kFiles, s->f_files);
   SET_FIELD(kFFree, s->f_ffree);
+  SET_FIELD(kFrSize, s->f_frsize);
 
 #undef SET_FIELD
 }

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -49,6 +49,7 @@ enum class FsStatFsOffset {
   kBAvail,
   kFiles,
   kFFree,
+  kFrSize,
   kFsStatFsFieldsNumber
 };
 

--- a/test/parallel/test-fs-promises.js
+++ b/test/parallel/test-fs-promises.js
@@ -94,6 +94,7 @@ function verifyStatFsObject(stat, isBigint = false) {
   assert.strictEqual(typeof stat.bavail, valueType);
   assert.strictEqual(typeof stat.files, valueType);
   assert.strictEqual(typeof stat.ffree, valueType);
+  assert.strictEqual(typeof stat.frsize, valueType);
 }
 
 async function getHandle(dest) {

--- a/test/parallel/test-fs-statfs.js
+++ b/test/parallel/test-fs-statfs.js
@@ -7,7 +7,7 @@ function verifyStatFsObject(statfs, isBigint = false) {
   const valueType = isBigint ? 'bigint' : 'number';
 
   [
-    'type', 'bsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree',
+    'type', 'bsize', 'blocks', 'bfree', 'bavail', 'files', 'ffree', 'frsize',
   ].forEach((k) => {
     assert.ok(Object.hasOwn(statfs, k));
     assert.strictEqual(typeof statfs[k], valueType,


### PR DESCRIPTION
## Description

`fs.statfs()` exposes `bsize` (optimal I/O block size) but not `frsize` (fundamental filesystem block size). Per POSIX, block counts (`blocks`, `bfree`, `bavail`) are in units of `frsize`, not `bsize`. libuv already reads `f_frsize` from the kernel and stores it in `uv_statfs_t` — it was simply never mapped to JavaScript.

On most native filesystems `bsize == frsize`, so the omission was harmless. However, on FUSE mounts (e.g. Docker Desktop on macOS with VirtioFS or gRPC FUSE), they can diverge by orders of magnitude:

| Field | Value | `* blocks` result |
|-------|-------|-------------------|
| `bsize` | 2,097,152 (2 MiB) | **1.82 PiB** ❌ |
| `frsize` | 16,384 (16 KiB) | **14.9 TiB** ✅ |

This causes any application computing disk space as `bsize * blocks` to report wildly inflated values. Real-world example: [Immich photo manager shows "602 TiB of 1.8 PiB"](https://github.com/immich-app/immich/issues/4318) on a 15 TB disk when running in Docker on macOS.

### Changes

Adds the `frsize` property to the `StatFs` object returned by `fs.statfs()`, `fs.statfsSync()`, and `fsPromises.statfs()`, in both normal and bigint modes.

**Files changed:**
- `src/node_file.h` — add `kFrSize` to `FsStatFsOffset` enum
- `src/node_file-inl.h` — map `s->f_frsize` in `FillStatFsArray()`
- `lib/internal/fs/utils.js` — add `frsize` to `StatFs` class and binding
- `doc/api/fs.md` — document the new field
- `test/parallel/test-fs-statfs.js` — include `frsize` in property checks
- `test/parallel/test-fs-promises.js` — include `frsize` in type assertions

### Notes

- On Linux, libuv sets `f_frsize` from the kernel's `statfs.f_frsize`
- On non-Linux (macOS, etc.), libuv falls back to `f_frsize = f_bsize`, so this is always populated
- This is a semver-minor addition (new property on existing object)