### PR TITLE
tools: respect 7 days wait commit-queue with one approval

### DIFF
--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -45,6 +45,17 @@ for pr in "$@"; do
     continue
   fi
 
+  # Skip PR if it has only one approval and was created less than 7 days ago
+  pr_meta=$(gh pr view "$pr" --json reviews,createdAt)
+  approvals=$(echo "$pr_meta" | jq '[.reviews[] | select(.state == "APPROVED")] | unique_by(.author.login) | length')
+  created_at=$(echo "$pr_meta" | jq -r '.createdAt')
+  created_epoch=$(date -d "$created_at" +%s)
+  seven_days_ago=$(date -d "7 days ago" +%s)
+  if [ "$approvals" -le 1 ] && [ "$created_epoch" -gt "$seven_days_ago" ]; then
+    echo "pr ${pr} skipped, only one approval and created less than 7 days ago"
+    continue
+  fi
+
   # Delete the commit queue label
   gh pr edit "$pr" --remove-label "$COMMIT_QUEUE_LABEL"
 

--- a/tools/actions/commit-queue.sh
+++ b/tools/actions/commit-queue.sh
@@ -47,7 +47,7 @@ for pr in "$@"; do
 
   # Skip PR if it has only one approval and was created less than 7 days ago
   pr_meta=$(gh pr view "$pr" --json reviews,createdAt)
-  approvals=$(echo "$pr_meta" | jq '[.reviews[] | select(.state == "APPROVED")] | unique_by(.author.login) | length')
+  approvals=$(echo "$pr_meta" | jq '[.reviews[] | select(.state == "APPROVED" and .authorAssociation == "MEMBER")] | unique_by(.author.login) | length')
   created_at=$(echo "$pr_meta" | jq -r '.createdAt')
   created_epoch=$(date -d "$created_at" +%s)
   seven_days_ago=$(date -d "7 days ago" +%s)


### PR DESCRIPTION
Respect 7 days wait time for https://github.com/nodejs/node/labels/commit-queue PRs with only 1 approval.

> In order to land, a pull request needs to be reviewed and [approved][] by
at least two Node.js Collaborators (one collaborator approval is enough if the
pull request has been open for more than 7 days)

This makes it so that the CQ label can be applied even with just one review and not end up with https://github.com/nodejs/node/labels/commit-queue-failed because it lacks the second review.