### PR TITLE
src: constrain MaybeStackBuffer::ToString and ToStringView to standard char types

### DIFF
--- a/src/util.h
+++ b/src/util.h
@@ -390,6 +390,14 @@ constexpr size_t strsize(const T (&)[N]) {
   return N - 1;
 }
 
+// A type that has a valid std::char_traits specialization, as required by
+// std::basic_string and std::basic_string_view.
+template <typename T>
+concept standard_char_type =
+    std::is_same_v<T, char> || std::is_same_v<T, wchar_t> ||
+    std::is_same_v<T, char8_t> || std::is_same_v<T, char16_t> ||
+    std::is_same_v<T, char32_t>;
+
 // Allocates an array of member type T. For up to kStackStorageSize items,
 // the stack is used, otherwise malloc().
 template <typename T, size_t kStackStorageSize = 1024>
@@ -503,8 +511,12 @@ class MaybeStackBuffer {
       free(buf_);
   }
 
-  inline std::basic_string<T> ToString() const { return {out(), length()}; }
-  inline std::basic_string_view<T> ToStringView() const {
+  template <standard_char_type U = T>
+  inline std::basic_string<U> ToString() const {
+    return {out(), length()};
+  }
+  template <standard_char_type U = T>
+  inline std::basic_string_view<U> ToStringView() const {
     return {out(), length()};
   }
   // This can only be used if the buffer contains path data in UTF8


### PR DESCRIPTION
On newer libc++ (shipped with macOS Xcode 16+), `std::char_traits<T>` for `T` not
equal to `char`, `wchar_t`, `char8_t`, `char16_t`, or `char32_t` is deprecated and
will be removed in a future release.

When the [MaybeStackBuffer](cci:1://file:///media/slapi/storage/Github@Open-Source/node/src/util.h:406:2-407:53) template is instantiated with `unsigned char` or `uint8_t`
(e.g., in [test/cctest/test_util.cc](cci:7://file:///media/slapi/storage/Github@Open-Source/node/test/cctest/test_util.cc:0:0-0:0)), the compiler instantiates the declarations
for all member functions. The [ToString()](cci:1://file:///media/slapi/storage/Github@Open-Source/node/test_warning2.cc:20:2-23:3) and [ToStringView()](cci:1://file:///media/slapi/storage/Github@Open-Source/node/test_warning.cc:41:2-44:3) methods historically returned
`std::basic_string<T>` and `std::basic_string_view<T>`, which triggered this
deprecation warning (`-Wdeprecated-declarations`) during class instantiation because
the return type references `std::char_traits<unsigned char>`.

### Changes
This PR resolves the warning by:
1. Extracting the list of standard character types into a reusable C++20 concept
   `standard_char_type`.
2. Converting [ToString()](cci:1://file:///media/slapi/storage/Github@Open-Source/node/test_warning2.cc:20:2-23:3) and [ToStringView()](cci:1://file:///media/slapi/storage/Github@Open-Source/node/test_warning.cc:41:2-44:3) from normal member functions into
   **member function templates** with a constrained default template parameter:
   `template <standard_char_type U = T>`.

By making these member function templates, the C++ compiler defers instantiating
the return type (`std::basic_string<U>`) until the function is actually called. Since
these methods are never actually called for `unsigned char` or `uint8_t` variants
in the Node.js codebase, the deprecated `std::char_traits<unsigned char>` is never
evaluated or instantiated, completely bypassing the warning.


Refs: https://github.com/nodejs/node/issues/62506
