### PR TITLE
src: improve url error handling for triggered assertions

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -169,7 +169,10 @@ void BindingData::PathToFileURL(const FunctionCallbackInfo<Value>& args) {
       [[unlikely]] {
     CHECK(args[2]->IsString());
     Utf8Value hostname(isolate, args[2]);
-    CHECK(out->set_hostname(hostname.ToStringView()));
+    // Ada should validate chars in hostname
+    if(!out->set_hostname(hostname.ToStringView())) {
+      return ThrowInvalidURL(realm->env(), input.ToStringView(), std::nullopt);
+    }
   }
 
   binding_data->UpdateComponents(out->get_components(), out->type);
@@ -441,7 +444,10 @@ void BindingData::Update(const FunctionCallbackInfo<Value>& args) {
 
   std::string_view new_value_view = new_value.ToStringView();
   auto out = ada::parse<ada::url_aggregator>(input.ToStringView());
-  CHECK(out);
+  // If the href cannot be re-parsed, return original url
+  if (!out) {
+    return args.GetReturnValue().Set(false);
+  }
 
   bool result{true};
 

--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -170,7 +170,7 @@ void BindingData::PathToFileURL(const FunctionCallbackInfo<Value>& args) {
     CHECK(args[2]->IsString());
     Utf8Value hostname(isolate, args[2]);
     // Ada should validate chars in hostname
-    if(!out->set_hostname(hostname.ToStringView())) {
+    if (!out->set_hostname(hostname.ToStringView())) {
       return ThrowInvalidURL(realm->env(), input.ToStringView(), std::nullopt);
     }
   }

--- a/test/parallel/test-url-format-whatwg.js
+++ b/test/parallel/test-url-format-whatwg.js
@@ -154,4 +154,6 @@ test('should not crash on URLs with invalid IDN hostnames', () => {
   const u = new URL('ws:xn-\u022B');
   // doesNotThrow
   url.format(u, { fragment: false, unicode: false, auth: false, search: false });
+  // Same problem with re-parsing
+  url.port = 80;
 });

--- a/test/parallel/test-url-pathtofileurl.js
+++ b/test/parallel/test-url-pathtofileurl.js
@@ -226,7 +226,7 @@ for (const { path, expected } of testCases) {
 
 // Regression for forbidden chars in UNC Windows
 {
-  assert.throws(() => url.pathToFileURL('\\\\%\\file', {windows : true}), {
-      code: 'ERR_INVALID_URL',
-    });
+  assert.throws(() => url.pathToFileURL('\\\\%\\file', { windows: true }), {
+    code: 'ERR_INVALID_URL',
+  });
 }

--- a/test/parallel/test-url-pathtofileurl.js
+++ b/test/parallel/test-url-pathtofileurl.js
@@ -223,3 +223,10 @@ for (const { path, expected } of testCases) {
     });
   }
 }
+
+// Regression for forbidden chars in UNC Windows
+{
+  assert.throws(() => url.pathToFileURL('\\\\%\\file', {windows : true}), {
+      code: 'ERR_INVALID_URL',
+    });
+}


### PR DESCRIPTION
Follow up https://github.com/nodejs/node/commit/dabb2f5f0c0367bf8e0e116b311b9308111ab4c7 for two assertion crashes that not considered as security issues

Lets discuss changes and make it great

