### PR TITLE
tools: allow triagers to queue a PR for CI until it's reviewed

### DIFF
--- a/.github/workflows/auto-start-ci.yml
+++ b/.github/workflows/auto-start-ci.yml
@@ -28,13 +28,13 @@ jobs:
       - name: Get Pull Requests
         id: get_prs_for_ci
         run: >
-          numbers=$(gh pr list \
-                  --repo ${{ github.repository }} \
+          echo "numbers=$(gh pr list \
+                  --repo "$GITHUB_REPOSITORY" \
                   --label 'request-ci' \
                   --json 'number' \
+                  --search 'review:approved' \
                   -t '{{ range . }}{{ .number }} {{ end }}' \
-                  --limit 5)
-          echo "numbers=$numbers" >> $GITHUB_OUTPUT
+                  --limit 5)" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   start-ci:


### PR DESCRIPTION
Triagers and PR authors currently have to wait until a PR has gotten an approving review before applying the https://github.com/nodejs/node/labels/request-ci label; this change allows to add the label immediately, and the CI will start once the PR is approved.

Fixes: https://github.com/nodejs/node/issues/62496

<!--
Before submitting a pull request, please read:
 
- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
