### PR TITLE
build: downgrade GCC support to experimental

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -77,6 +77,10 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      - name: Install Clang ${{ env.CLANG_VERSION }}
+        uses: ./.github/actions/install-clang
+        with:
+          clang-version: ${{ env.CLANG_VERSION }}
       - name: Set up Python ${{ env.PYTHON_VERSION }}
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
@@ -90,6 +94,9 @@ jobs:
           export DATESTRING=$(date "+%Y-%m-%d")
           export COMMIT=$(git rev-parse --short=10 "$GITHUB_SHA")
           ./configure && make tar -j4 SKIP_XZ=1
+        env:
+          CC: clang-19
+          CXX: clang++-19
       - name: Upload tarball artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -78,8 +78,8 @@ jobs:
       fail-fast: false
     runs-on: macos-15
     env:
-      CC: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'sccache' || '' }} gcc
-      CXX: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'sccache' || '' }} g++
+      CC: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'sccache' || '' }} clang
+      CXX: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'sccache' || '' }} clang++
       SCCACHE_GHA_ENABLED: ${{ github.base_ref == 'main' || github.ref_name == 'main' }}
       SCCACHE_IDLE_TIMEOUT: '0'
     steps:

--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -104,6 +104,7 @@ concurrency:
 
 env:
   FLAKY_TESTS: keep_retrying
+  CLANG_VERSION: '19'
 
 permissions:
   contents: read
@@ -119,6 +120,11 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Install Clang ${{ env.CLANG_VERSION }}
+        uses: ./.github/actions/install-clang
+        with:
+          clang-version: ${{ env.CLANG_VERSION }}
+
       - name: Make tarball
         if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
@@ -127,6 +133,8 @@ jobs:
           ./configure && make tar -j4 SKIP_XZ=1 SKIP_SHARED_DEPS=1
         env:
           DISTTYPE: nightly
+          CC: clang-19
+          CXX: clang++-19
 
       - name: Upload tarball artifact
         if: ${{ github.event_name != 'workflow_dispatch' }}

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -156,7 +156,7 @@ Depending on the host platform, the selection of toolchains may vary.
 
 | Operating System | Compiler Versions                                                   |
 | ---------------- | ------------------------------------------------------------------- |
-| Linux            | GCC >= 12.2 or Clang >= 19.1                                        |
+| Linux            | Clang >= 19.1 or GCC >= 13.2 (experimental)                         |
 | Windows          | Visual Studio 2022 or 2026 with the Windows 11 SDK on a 64-bit host |
 | macOS            | Xcode >= 16.4 (Apple LLVM >= 19)                                    |
 
@@ -238,7 +238,7 @@ Consult previous versions of this document for older versions of Node.js:
 
 #### Unix prerequisites
 
-* `gcc` and `g++` >= 12.2 or `clang` and `clang++` >= 19.1
+* `clang` and `clang++` >= 19.1 or `gcc` and `g++` >= 13.2 (experimental)
 * GNU Make 3.81 or newer
 * [A supported version of Python][Python versions]
   * For test coverage, your Python installation must include pip.
@@ -246,11 +246,11 @@ Consult previous versions of this document for older versions of Node.js:
 Installation via Linux package manager can be achieved with:
 
 * Nix, NixOS: `nix-shell`
-* Ubuntu, Debian: `sudo apt-get install python3 g++-12 gcc-12 make python3-pip`
-* Fedora: `sudo dnf install python3 gcc-c++ make python3-pip`
-* CentOS and RHEL: `sudo yum install python3 gcc-c++ make python3-pip`
-* OpenSUSE: `sudo zypper install python3 gcc-c++ make python3-pip`
-* Arch Linux, Manjaro: `sudo pacman -S python gcc make python-pip`
+* Ubuntu, Debian: `sudo apt-get install python3 clang-19 make python3-pip`
+* Fedora: `sudo dnf install python3 clang make python3-pip`
+* CentOS and RHEL: `sudo yum install python3 clang make python3-pip`
+* OpenSUSE: `sudo zypper install python3 clang make python3-pip`
+* Arch Linux, Manjaro: `sudo pacman -S python clang make python-pip`
 
 FreeBSD and OpenBSD users may also need to install `libexecinfo`.
 
@@ -660,8 +660,8 @@ need to install the latest version but not the apt version.
 
 ```bash
 sudo apt install ccache mold   # for Debian/Ubuntu, included in most Linux distros
-export CC="ccache gcc"         # add to your .profile
-export CXX="ccache g++"        # add to your .profile
+export CC="ccache clang"       # add to your .profile
+export CXX="ccache clang++"    # add to your .profile
 export LDFLAGS="-fuse-ld=mold" # add to your .profile
 ```
 

--- a/configure.py
+++ b/configure.py
@@ -19,10 +19,8 @@ os.chdir(Path(__file__).parent)
 
 original_argv = sys.argv[1:]
 
-# gcc and g++ as defaults matches what GYP's Makefile generator does,
-# except on macOS and Windows.
-CC = os.environ.get('CC', 'cc' if sys.platform == 'darwin' else 'clang' if sys.platform == 'win32' else 'gcc')
-CXX = os.environ.get('CXX', 'c++' if sys.platform == 'darwin' else 'clang' if sys.platform == 'win32' else 'g++')
+CC = os.environ.get('CC', 'clang')
+CXX = os.environ.get('CXX', 'clang' if sys.platform == 'win32' else 'clang++')
 
 tools_path = Path('tools')
 
@@ -1521,8 +1519,8 @@ def check_compiler(o):
   print_verbose(f"Detected {'Apple ' if is_apple else ''}{'clang ' if is_clang else ''}C++ compiler (CXX={CXX}) version: {version_str}")
   if not ok:
     warn(f'failed to autodetect C++ compiler version (CXX={CXX})')
-  elif ((is_apple and clang_version < (17, 0, 0)) or (not is_apple and clang_version < (19, 1, 0))) if is_clang else gcc_version < (12, 2, 0):
-    warn(f"C++ compiler (CXX={CXX}, {version_str}) too old, need g++ 12.2.0 or clang++ 19.1.0{' or Apple clang++ 17.0.0' if is_apple else ''}")
+  elif ((is_apple and clang_version < (17, 0, 0)) or (not is_apple and clang_version < (19, 1, 0))) if is_clang else gcc_version < (13, 2, 0):
+    warn(f"C++ compiler (CXX={CXX}, {version_str}) too old, need g++ 13.2.0 or clang++ 19.1.0{' or Apple clang++ 17.0.0' if is_apple else ''}")
 
   ok, is_clang, clang_version, gcc_version, is_apple = try_check_compiler(CC, 'c')
   version_str = ".".join(map(str, clang_version if is_clang else gcc_version))


### PR DESCRIPTION
Update the configure script to select Clang by default.
V8 no longer officially supports GCC and we often have problems because of it.
Also bump the expected version to 13.2 because version 12 can't compile newer V8.

/cc @nodejs/build @nodejs/tsc @nodejs/embedders @nodejs/delivery-channels @nodejs/distros 

Impacted CI systems:
- ibmi (12.4) -> /cc @nodejs/platform-ibmi
- aix (12.3) -> Being migrated to Clang (https://github.com/nodejs/build/pull/4286)
- smartos 22 (12.2) -> I'll open a PR to skip it on Node.js >=26
- smartos 23 (13.2)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
