### PR TITLE
stream: refactor duplexify to be less suceptible to prototype pollution

### DIFF
--- a/lib/internal/streams/duplexify.js
+++ b/lib/internal/streams/duplexify.js
@@ -63,23 +63,23 @@ module.exports = function duplexify(body, name) {
   }
 
   if (isReadableNodeStream(body)) {
-    return _duplexify({ readable: body });
+    return _duplexify({ __proto__: null, readable: body });
   }
 
   if (isWritableNodeStream(body)) {
-    return _duplexify({ writable: body });
+    return _duplexify({ __proto__: null, writable: body });
   }
 
   if (isNodeStream(body)) {
-    return _duplexify({ writable: false, readable: false });
+    return _duplexify({ __proto__: null, writable: false, readable: false });
   }
 
   if (isReadableStream(body)) {
-    return _duplexify({ readable: Readable.fromWeb(body) });
+    return _duplexify({ __proto__: null, readable: Readable.fromWeb(body) });
   }
 
   if (isWritableStream(body)) {
-    return _duplexify({ writable: Writable.fromWeb(body) });
+    return _duplexify({ __proto__: null, writable: Writable.fromWeb(body) });
   }
 
   if (typeof body === 'function') {
@@ -173,7 +173,7 @@ module.exports = function duplexify(body, name) {
         duplexify(body.writable) :
       undefined;
 
-    return _duplexify({ readable, writable });
+    return _duplexify({ __proto__: null, readable, writable });
   }
 
   const then = body?.then;
@@ -231,12 +231,12 @@ function fromAsyncGen(fn) {
     write(chunk, encoding, cb) {
       const _resolve = resolve;
       resolve = null;
-      _resolve({ chunk, done: false, cb });
+      _resolve({ __proto__: null, chunk, done: false, cb });
     },
     final(cb) {
       const _resolve = resolve;
       resolve = null;
-      _resolve({ done: true, cb });
+      _resolve({ __proto__: null, done: true, cb });
     },
     destroy(err, cb) {
       ac.abort();


### PR DESCRIPTION
With the `__proto__: null`, the JS engine has to look into e.g. `%Object.prototype%.then` when trying to resolve the promise

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
