### PR TITLE
doc: mark stream.compose stable

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3013,6 +3013,9 @@ const server = http.createServer((req, res) => {
 <!-- YAML
 added: v16.9.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62562
+    description: Marking the API stable.
   - version:
     - v21.1.0
     - v20.10.0
@@ -3025,7 +3028,7 @@ changes:
     description: Added support for webstreams.
 -->
 
-> Stability: 1 - `stream.compose` is experimental.
+> Stability: 2 - Stable
 
 * `streams` {Stream\[]|Iterable\[]|AsyncIterable\[]|Function\[]|
   ReadableStream\[]|WritableStream\[]|TransformStream\[]|Duplex\[]|Function}


### PR DESCRIPTION
Mark `stream.compose()` as stable.
