### PR TITLE
add several build flags to avoid unnecessary warnings

### DIFF
--- a/deps/uv/uv.gyp
+++ b/deps/uv/uv.gyp
@@ -188,6 +188,9 @@
           '-Wall',
           '-Wextra',
           '-Wno-unused-parameter',
+          # `uv_cpu_info_t.model` is exposed as `const char*`, but libuv frees
+          # the owned buffer internally via `uv__free(void*)`.
+          '-Wno-incompatible-pointer-types-discards-qualifiers',
           '-Wstrict-prototypes',
         ],
         'OTHER_CFLAGS': [ '-g', '--std=gnu11' ],

--- a/tools/gyp/pylib/gyp/mac_tool.py
+++ b/tools/gyp/pylib/gyp/mac_tool.py
@@ -254,8 +254,13 @@ class MacTool:
     def ExecFilterLibtool(self, *cmd_list):
         """Calls libtool and filters out '/path/to/libtool: file: foo.o has no
         symbols'."""
-        libtool_re = re.compile(
+        libtool_no_symbols_re = re.compile(
             r"^.*libtool: (?:for architecture: \S* )?file: .* has no symbols$"
+        )
+        # Newer Apple cctools emits the same warning as:
+        #   libtool: warning: 'foo.o' has no symbols
+        libtool_no_symbols_warning_re = re.compile(
+            r"^.*libtool: warning: '.*' has no symbols$"
         )
         libtool_re5 = re.compile(
             r"^.*libtool: warning for library: "
@@ -271,7 +276,11 @@ class MacTool:
         libtoolout = subprocess.Popen(cmd_list, stderr=subprocess.PIPE, env=env)
         err = libtoolout.communicate()[1].decode("utf-8")
         for line in err.splitlines():
-            if not libtool_re.match(line) and not libtool_re5.match(line):
+            if (
+                not libtool_no_symbols_re.match(line)
+                and not libtool_no_symbols_warning_re.match(line)
+                and not libtool_re5.match(line)
+            ):
                 print(line, file=sys.stderr)
         # Unconditionally touch the output .a file on the command line if present
         # and the command succeeded. A bit hacky.

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -2421,6 +2421,9 @@
         ],
       },
       'include_dirs': ['.'],
+      # Keep the GYP target aligned with third_party/simdutf/BUILD.gn, which
+      # suppresses this warning for the amalgamated translation unit.
+      'cflags_cc': [ '-Wno-unused-function' ],
       'sources': [
         '<(V8_ROOT)/third_party/simdutf/simdutf.cpp',
       ],


### PR DESCRIPTION
Whenever I build Node.js on my macOS machine, I always see this unnecessary warnings. Since they're dependencies, we can just ignore warnings.

cc @nodejs/build