### PR TITLE
[v24.x] deps: V8: cherry-pick 33e7739c134d

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.47',
+    'v8_embedder_string': '-node.48',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/wasm/wasm-feature-flags.h
+++ b/deps/v8/src/wasm/wasm-feature-flags.h
@@ -105,11 +105,6 @@
   /* V8 side owner: jkummerow */                                               \
   V(imported_strings_utf8, "imported strings (utf8 features)", false)          \
                                                                                \
-  /* Exnref */                                                                 \
-  /* This flag enables the new exception handling proposal */                  \
-  /* V8 side owner: thibaudm */                                                \
-  V(exnref, "exnref", false)                                                   \
-                                                                               \
   /* JavaScript Promise Integration proposal. */                               \
   /* https://github.com/WebAssembly/js-promise-integration */                  \
   /* V8 side owner: thibaudm, fgm */                                           \
@@ -130,7 +125,13 @@
   /* https://github.com/WebAssembly/js-string-builtins */                      \
   /* V8 side owner: jkummerow */                                               \
   /* Shipped in v13.0 */                                                       \
-  V(imported_strings, "imported strings", true)
+  V(imported_strings, "imported strings", true)                                \
+                                                                               \
+  /* Exnref */                                                                 \
+  /* This flag enables the new exception handling proposal */                  \
+  /* V8 side owner: thibaudm */                                                \
+  /* Shipped in v13.7 */                                                       \
+  V(exnref, "exnref", true)
 
 // Combination of all available wasm feature flags.
 #define FOREACH_WASM_FEATURE_FLAG(V)        \


### PR DESCRIPTION
This cherry-picks support for the modern exception handling proposal for Wasm, which is already stable in all browsers. 

Original commit message:

```
  [wasm][exnref] Enable exnref

  R=mliedtke@chromium.org
  CC=ecmziegler@chromium.org

  Bug: 42204334
  Change-Id: I0ddf1d29c936d73f7bb7909775a6bbd9a6ec5e2f
  Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/6458423
  Commit-Queue: Thibaud Michaud <thibaudm@chromium.org>
  Reviewed-by: Matthias Liedtke <mliedtke@chromium.org>
  Cr-Commit-Position: refs/heads/main@{#99795}
```

Refs: v8/v8@33e7739c134d24c94fdda02ab631eefed6bd18df