### PR TITLE
test: check contextify contextual store behavior in strict mode

### DIFF
--- a/test/parallel/test-vm-global-contextual-store.js
+++ b/test/parallel/test-vm-global-contextual-store.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const vm = require('vm');
+
+const ctx = vm.createContext({ x: 0 });
+
+// Global properties should be intercepted in strict mode
+vm.runInContext('"use strict"; x = 42', ctx);
+assert.strictEqual(ctx.x, 42);
+
+// Contextual store should only be intercepted in non-strict mode
+vm.runInContext('y = 42', ctx);
+assert.strictEqual(ctx.y, 42);
+
+assert.throws(() => vm.runInContext('"use strict"; z = 42', ctx),
+              /ReferenceError: z is not defined/);
+assert.strictEqual(Object.hasOwn(ctx, 'z'), false);


### PR DESCRIPTION
Previously, this behaviour was tested indirectly by the REPL tests. However, REPL now uses DONT\_CONTEXTIFY for its VM context, so the interceptor behaviour is no longer covered.

Refs: https://github.com/nodejs/node/pull/61898#issuecomment-4056324938
Refs: #62371