### PR TITLE
tools: improve backport review script

### DIFF
--- a/tools/actions/review_backport.sh
+++ b/tools/actions/review_backport.sh
@@ -2,7 +2,7 @@
 
 BACKPORT_PR=$1
 
-[ -x "$(command -v gh)" ] || {
+[ -x "$(command -v gh || true)" ] || {
     # shellcheck disable=SC2016
     echo 'Missing required `gh` dependency' >&2
     exit 1


### PR DESCRIPTION
- Print a error message when `gh` is not on the PATH
- Let the CLI argument be interpreted by `gh` instead of assuming it's always a URL (i.e. support passing only the PR number)
- Set up trap handler to properly remove the temp files
- Add a prompt to quickly approve the backport PR