### PR TITLE
doc: clarify fs.StatFs property descriptions

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7929,7 +7929,8 @@ added:
 
 * Type: {number|bigint}
 
-Free blocks available to unprivileged users.
+Free blocks available to unprivileged users. To calculate the available
+space in bytes, multiply `statfs.bavail` by `statfs.frsize`.
 
 #### `statfs.bfree`
 
@@ -7941,7 +7942,8 @@ added:
 
 * Type: {number|bigint}
 
-Free blocks in file system.
+Free blocks in file system. To calculate the free space in bytes,
+multiply `statfs.bfree` by `statfs.frsize`.
 
 #### `statfs.blocks`
 
@@ -7965,7 +7967,7 @@ added:
 
 * Type: {number|bigint}
 
-Optimal transfer block size.
+Optimal transfer block size, in bytes.
 
 #### `statfs.frsize`
 
@@ -7975,7 +7977,8 @@ added: REPLACEME
 
 * Type: {number|bigint}
 
-Fundamental file system block size.
+Fundamental file system block size, in bytes. This is the unit used
+for block counts (`statfs.blocks`, `statfs.bfree`, `statfs.bavail`).
 
 #### `statfs.ffree`
 
@@ -8011,7 +8014,9 @@ added:
 
 * Type: {number|bigint}
 
-Type of file system.
+Type of file system. This is a numeric identifier corresponding to the
+file system type (e.g., `0xEF53` for ext4, `0x01021997` for tmpfs on Linux).
+On Windows, this value is not meaningful.
 
 ### Class: `fs.Utf8Stream`
 


### PR DESCRIPTION
## Summary

Improves the documentation for the `fs.StatFs` class properties.

**Changes:**
- `statfs.bsize`: Specify that the unit is bytes
- `statfs.frsize`: Clarify that this is the unit used for block counts (`blocks`, `bfree`, `bavail`)
- `statfs.bavail`: Add note on how to calculate available space in bytes (`bavail * frsize`)
- `statfs.bfree`: Add note on how to calculate free space in bytes (`bfree * frsize`)
- `statfs.type`: Explain the numeric file system type identifier with examples, note platform differences

Fixes: https://github.com/nodejs/node/issues/50749