### PR TITLE
tools: fix cpplint false positive for v8::FastApiCallbackOptions&

### DIFF
--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -6573,6 +6573,12 @@ def CheckForNonConstReference(filename, clean_lines, linenum, nesting_state, err
         r"static_assert|COMPILE_ASSERT"
         r")\s*\("
     )
+
+    # V8 Fast API types require non-const references as part of their API
+    # contract; Node.js has no control over these signatures.
+    _V8_FAST_API_REF_TYPES = re.compile(
+        r"v8::FastApiCallbackOptions\s*&"
+    )
     if re.search(allowed_functions, line):
         return
     if not re.search(r"\S+\([^)]*$", line):
@@ -6587,7 +6593,7 @@ def CheckForNonConstReference(filename, clean_lines, linenum, nesting_state, err
     for parameter in re.findall(_RE_PATTERN_REF_PARAM, decls):
         if not re.match(_RE_PATTERN_CONST_REF_PARAM, parameter) and not re.match(
             _RE_PATTERN_REF_STREAM_PARAM, parameter
-        ):
+        ) and not _V8_FAST_API_REF_TYPES.search(parameter):
             error(
                 filename,
                 linenum,


### PR DESCRIPTION
i am trying to overcome this issue , https://github.com/nodejs/node/issues/45761

## My change Summary

cpplint's `runtime/references` rule flags non-const reference parameters
as a style violation. However, `v8::FastApiCallbackOptions&` is part of
V8's Fast API contract , its signature is defined by V8 and Node.js has
no control over it. This causes a false positive.

## Changes

Patched `CheckForNonConstReference` in `tools/cpplint.py` to recognise
`v8::FastApiCallbackOptions&` as a known V8 Fast API type that
legitimately requires a non-const reference, and skip the warning for it.

## Testing

Ran cpplint with `--filter=+runtime/references` against a test file
containing both patterns:

- `v8::FastApiCallbackOptions& options` → no warning (false positive suppressed)
- `int& value` → still flagged (rule intact for legitimate cases )
