### PR TITLE
doc: note non-monotonic clock in crypto.randomUUIDv7

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5843,7 +5843,9 @@ added: REPLACEME
 Generates a random [RFC 9562][] version 7 UUID. The UUID contains a millisecond
 precision Unix timestamp in the most significant 48 bits, followed by
 cryptographically secure random bits for the remaining fields, making it
-suitable for use as a database key with time-based sorting.
+suitable for use as a database key with time-based sorting. The embedded
+timestamp relies on a non-monotonic clock and is not guaranteed to be strictly
+increasing.
 
 ### `crypto.scrypt(password, salt, keylen[, options], callback)`
 


### PR DESCRIPTION
Add a note to the `crypto.randomUUIDv7()` documentation clarifying 
that the embedded timestamp relies on a non-monotonic clock and is 
not guaranteed to be strictly increasing.

Refs: https://github.com/nodejs/node/pull/62553#pullrequestreview-4057326122