### PR TITLE
dgram: don't swallow bind errors when callback is provided

### DIFF
--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -278,7 +278,7 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
   const cb = arguments.length && arguments[arguments.length - 1];
   if (typeof cb === 'function') {
     function removeListeners() {
-      this.removeListener('error', removeListeners);
+      this.removeListener(EventEmitter.errorMonitor, removeListeners);
       this.removeListener('listening', onListening);
     }
 
@@ -287,7 +287,7 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
       FunctionPrototypeCall(cb, this);
     }
 
-    this.on('error', removeListeners);
+    this.on(EventEmitter.errorMonitor, removeListeners);
     this.on('listening', onListening);
   }
 

--- a/test/parallel/test-dgram-bind-error-callback.js
+++ b/test/parallel/test-dgram-bind-error-callback.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const assert = require('node:assert');
+const dgram = require('node:dgram');
+
+// Ensure that bind errors (e.g. EADDRINUSE) are not silently swallowed
+// when socket.bind() is called with a callback but without a user
+// 'error' handler.
+
+const socket1 = dgram.createSocket('udp4');
+
+socket1.bind(0, common.mustCall(() => {
+  const { port } = socket1.address();
+  const socket2 = dgram.createSocket('udp4');
+
+  process.on('uncaughtException', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'EADDRINUSE');
+    socket1.close();
+    socket2.close();
+  }));
+
+  socket2.bind({ port }, common.mustNotCall());
+}));


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## dgram: don't swallow bind errors when callback is provided


When `Socket.prototype.bind()` is called with a callback, the internal
cleanup listener is registered on `'error'`, which counts as an error
handler and silently swallows bind errors (e.g. `EADDRINUSE`) when no
user error handler is attached.

This switches to `EventEmitter.errorMonitor` for the cleanup listener,
matching the pattern already used in the `enqueue()` function
(`lib/dgram.js:571`). This ensures bind errors properly propagate as
unhandled errors while still performing listener cleanup.

### Setup — a socket already bound to port 5000

```js
import dgram from 'dgram';

const receiver = dgram.createSocket('udp4');

receiver.bind({ port: 5000, address: '127.0.0.1' });
```

### No callback, no `listening` event — error surfaces (correct)

```js
import dgram from 'dgram';

const socket = dgram.createSocket('udp4');

socket.bind({ port: 5000, address: '127.0.0.1' }); 
// Throws: Error: bind EADDRINUSE 127.0.0.1:5000
```

### Using `listening` event — error surfaces (correct)

```js
import dgram from 'dgram';

const socket = dgram.createSocket('udp4');

socket.on('listening', () => {
  console.log('bound');
});

socket.bind({ port: 5000, address: '127.0.0.1' });
// Throws: Error: bind EADDRINUSE 127.0.0.1:5000
```

### Using callback — error silently swallowed (bug)

```js
import dgram from 'dgram';

const socket = dgram.createSocket('udp4');

socket.bind(
  { port: 5000, address: '127.0.0.1' },
  () => { console.log('bound'); },
);
// No error, no output — process hangs
```

All three examples do the same thing — bind to a port already in use.
The first two properly throw, but the third silently swallows the error
just because a callback was passed to `bind()`.

After this fix, all three cases properly surface the error.