### PR TITLE
﻿build: enable Maglev for riscv64

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -55,7 +55,7 @@ valid_mips_fpu = ('fp32', 'fp64', 'fpxx')
 valid_mips_float_abi = ('soft', 'hard')
 valid_intl_modes = ('none', 'small-icu', 'full-icu', 'system-icu')
 icu_versions = json.loads((tools_path / 'icu' / 'icu_versions.json').read_text(encoding='utf-8'))
-maglev_enabled_architectures = ('x64', 'arm', 'arm64', 'ppc64', 's390x')
+maglev_enabled_architectures = ('x64', 'arm', 'arm64', 'ppc64', 's390x', 'riscv64')
 
 # builtins may be removed later if they have been disabled by options
 shareable_builtins = {'undici/undici': 'deps/undici/undici.js',

--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -671,6 +671,11 @@
                   '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"v8_internal_headers\\".*?v8_enable_maglev.*?v8_current_cpu == \\"ppc64\\".*?sources \\+= ")',
                 ],
               }],
+              ['v8_target_arch=="riscv64"', {
+                'sources': [
+                  '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "v8_header_set.\\"v8_internal_headers\\".*?v8_enable_maglev.*?v8_current_cpu == \\"riscv64\\".*?sources \\+= ")',
+                ],
+              }],
             ],
           }],
           ['v8_enable_webassembly==1', {
@@ -1135,6 +1140,11 @@
             ['v8_target_arch=="ppc64"', {
               'sources': [
                 '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_base_without_compiler.*?v8_enable_maglev.*?v8_current_cpu == \\"ppc64\\".*?sources \\+= ")',
+              ],
+            }],
+            ['v8_target_arch=="riscv64"', {
+              'sources': [
+                '<!@pymod_do_main(GN-scraper "<(V8_ROOT)/BUILD.gn"  "\\"v8_base_without_compiler.*?v8_enable_maglev.*?v8_current_cpu == \\"riscv64\\".*?sources \\+= ")',
               ],
             }],
           ],


### PR DESCRIPTION
﻿V8's BUILD.gn has listed riscv64 as a Maglev-supported architecture since V8 14.0, and the source files exist in `deps/v8/src/maglev/riscv/`. But Node.js never wired it up on its side:

  - configure.py didn't include riscv64 in maglev_enabled_architectures
  - tools/v8_gypfiles/v8.gyp had no GN-scraper conditions for riscv64 in the two Maglev source blocks (it had arm, arm64, x64, s390x, ppc64, just not riscv64)

This adds riscv64 to both, following the same approach as #60863 which did this for s390x.

 Refs: https://github.com/nodejs/build/issues/4099