### PR TITLE
tools: fix redundant conditions in v8.gyp for riscv64 and loong64

### DIFF
--- a/tools/v8_gypfiles/v8.gyp
+++ b/tools/v8_gypfiles/v8.gyp
@@ -342,12 +342,12 @@
             '<(V8_ROOT)/src/builtins/arm64/builtins-arm64.cc',
           ],
         }],
-        ['v8_target_arch=="riscv64" or v8_target_arch=="riscv64"', {
+        ['v8_target_arch=="riscv64"', {
           'sources': [
             '<(V8_ROOT)/src/builtins/riscv/builtins-riscv.cc',
           ],
         }],
-        ['v8_target_arch=="loong64" or v8_target_arch=="loong64"', {
+        ['v8_target_arch=="loong64"', {
           'sources': [
             '<(V8_ROOT)/src/builtins/loong64/builtins-loong64.cc',
           ],


### PR DESCRIPTION
The builtins conditions for riscv64 and loong64 both read `v8_target_arch=="X" or v8_target_arch=="X"`. The same value on both sides of the `or`. This was copied from the `mips64 or mips64el` pattern when riscv64 (#37980) and loong64 support were first added, but those are two different architectures and riscv64/loong64 each only have one.

Simplify both to plain `v8_target_arch=="riscv64"` / `v8_target_arch=="loong64"`, matching ppc64, s390x, and the other single-variant architectures.