### PR TITLE
meta: ignore AI assistants files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,10 @@ cmake_install.cmake
 install_manifest.txt
 *.cbp
 
+# === Rules for AI assistants ===
+CLAUDE.md
+AGENTS.md
+
 # === Global Rules ===
 # Keep last to avoid being excluded
 *.pyc

--- a/Makefile
+++ b/Makefile
@@ -1442,7 +1442,7 @@ else
 LINT_MD_NEWER = -newer tools/.mdlintstamp
 endif
 
-LINT_MD_TARGETS = doc src lib benchmark test tools/doc tools/icu $(wildcard *.md)
+LINT_MD_TARGETS = doc src lib benchmark test tools/doc tools/icu $(filter-out CLAUDE.md AGENTS.md,$(wildcard *.md))
 LINT_MD_FILES = $(shell $(FIND) $(LINT_MD_TARGETS) -type f \
 	! -path '*node_modules*' ! -path 'test/fixtures/*' -name '*.md' \
 	$(LINT_MD_NEWER))

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -395,6 +395,7 @@ export default [
   // #region markdown config
   {
     files: ['**/*.md'],
+    ignores: ['CLAUDE.md', 'AGENTS.md'],
     plugins: {
       markdown,
     },


### PR DESCRIPTION
- Add `CLAUDE.md` and `AGENTS.md` to `.gitignore` under a new AI assistants section
- Exclude them from markdown linting in `Makefile` via `$(filter-out ...)`
- Exclude them from ESLint markdown processing in eslint.config.mjs