### PR TITLE
inspector: coerce key and value to string in webstorage events

### DIFF
--- a/lib/internal/inspector/webstorage.js
+++ b/lib/internal/inspector/webstorage.js
@@ -7,6 +7,8 @@ const { getOptionValue } = require('internal/options');
 
 class InspectorLocalStorage extends Storage {
   setItem(key, value) {
+    key = `${key}`;
+    value = `${value}`;
     const oldValue = this.getItem(key);
     super.setItem(key, value);
     if (oldValue == null) {
@@ -17,6 +19,7 @@ class InspectorLocalStorage extends Storage {
   }
 
   removeItem(key) {
+    key = `${key}`;
     super.removeItem(key);
     itemRemoved(key, true);
   }
@@ -29,6 +32,8 @@ class InspectorLocalStorage extends Storage {
 
 const InspectorSessionStorage = class extends Storage {
   setItem(key, value) {
+    key = `${key}`;
+    value = `${value}`;
     const oldValue = this.getItem(key);
     super.setItem(key, value);
     if (oldValue == null) {
@@ -39,6 +44,7 @@ const InspectorSessionStorage = class extends Storage {
   }
 
   removeItem(key) {
+    key = `${key}`;
     super.removeItem(key);
     itemRemoved(key, false);
   }


### PR DESCRIPTION
it's this test is failing everywhere, I can also produce this on local
[test-inspector-dom-storage](https://ci.nodejs.org/job/node-test-commit-linuxone/nodes=rhel9-s390x/54584/testReport/(root)/parallel/test_inspector_dom_storage/)
[parallel](https://ci.nodejs.org/job/node-test-commit-linuxone/nodes=rhel9-s390x/54584/testReport/(root)/parallel/test_inspector_dom_storage/)

---
duration_ms: 86.899
exitcode: 1
severity: fail
stack: |-
  Debugger listening on ws://127.0.0.1:35101/9a738d12-0f90-4667-8875-1f17ef781521
  For help, see: https://nodejs.org/en/docs/inspector
  node:inspector:212
    emitProtocolEvent(eventName, params);
    ^

  TypeError: Missing newValue in event
      at broadcastToFrontend (node:inspector:212:3)
      at Object.domStorageItemAdded (node:inspector:233:36)
      at itemAdded (node:internal/inspector/webstorage:53:14)
      at InspectorLocalStorage.setItem (node:internal/inspector/webstorage:13:7)
      at test (/home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-inspector-dom-storage.js:75:16)
      at async testGetData (/home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-inspector-dom-storage.js:62:3)
      at async test (/home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-inspector-dom-storage.js:167:3)

Refs: https://github.com/nodejs/node/pull/62145
Refs: https://github.com/nodejs/node/pull/62162

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
