### PR TITLE
path: canonicalize Windows namespaced paths

### DIFF
--- a/src/path.cc
+++ b/src/path.cc
@@ -98,6 +98,75 @@ constexpr bool IsWindowsDeviceRoot(const char c) noexcept {
   return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z');
 }
 
+enum class WindowsNamespacedPathType {
+  kNotNamespaced,
+  kDriveAbsolutePath,
+  kUNCPath,
+  kOtherNamespacedPath,
+};
+
+static WindowsNamespacedPathType ClassifyWindowsNamespacedPath(
+    std::string_view path) {
+  if (!(path.size() >= 4 && path[0] == '\\' && path[1] == '\\' &&
+        path[2] == '?' && path[3] == '\\')) {
+    return WindowsNamespacedPathType::kNotNamespaced;
+  }
+
+  if (path.size() >= 7 && IsWindowsDeviceRoot(path[4]) && path[5] == ':' &&
+      IsPathSeparator(path[6])) {
+    return WindowsNamespacedPathType::kDriveAbsolutePath;
+  }
+
+  if (path.size() >= 8 && ToLower(path[4]) == 'u' && ToLower(path[5]) == 'n' &&
+      ToLower(path[6]) == 'c' && path[7] == '\\') {
+    size_t i = 8;
+    const size_t server_start = i;
+    while (i < path.size() && !IsPathSeparator(path[i])) {
+      i++;
+    }
+    if (i == server_start || i == path.size()) {
+      return WindowsNamespacedPathType::kOtherNamespacedPath;
+    }
+
+    while (i < path.size() && IsPathSeparator(path[i])) {
+      i++;
+    }
+    const size_t share_start = i;
+    while (i < path.size() && !IsPathSeparator(path[i])) {
+      i++;
+    }
+    if (i == share_start) {
+      return WindowsNamespacedPathType::kOtherNamespacedPath;
+    }
+
+    return WindowsNamespacedPathType::kUNCPath;
+  }
+
+  return WindowsNamespacedPathType::kOtherNamespacedPath;
+}
+
+static void StripExtendedPathPrefixForPathResolve(std::string& path) {
+  // PathResolve() is an internal filesystem identity resolver, not the public
+  // path.win32.resolve() API. For valid namespaced filesystem paths, the
+  // namespace prefix does not identify a different file or directory:
+  //   \\?\C:\foo                 -> C:\foo
+  //   \\?\UNC\server\share\foo   -> \\server\share\foo
+  // Keep all other namespaced forms intact. For example,
+  // \\?\PHYSICALDRIVE0 is not a drive-absolute filesystem path, and
+  // \\?\C:foo is drive-relative rather than drive-absolute.
+  switch (ClassifyWindowsNamespacedPath(path)) {
+    case WindowsNamespacedPathType::kDriveAbsolutePath:
+      path = path.substr(4);
+      return;
+    case WindowsNamespacedPathType::kUNCPath:
+      path = "\\\\" + path.substr(8);
+      return;
+    case WindowsNamespacedPathType::kNotNamespaced:
+    case WindowsNamespacedPathType::kOtherNamespacedPath:
+      return;
+  }
+}
+
 std::string PathResolve(Environment* env,
                         const std::vector<std::string_view>& paths) {
   std::string resolvedDevice = "";
@@ -131,6 +200,8 @@ std::string PathResolve(Environment* env,
         path = resolvedDevice + "\\";
       }
     }
+
+    StripExtendedPathPrefixForPathResolve(path);
 
     const size_t len = path.length();
     int rootEnd = 0;
@@ -330,11 +401,16 @@ void ToNamespacedPath(Environment* env, BufferValue* path) {
 // namespace-prefixed path.
 void FromNamespacedPath(std::string* path) {
 #ifdef _WIN32
-  if (path->starts_with("\\\\?\\UNC\\")) {
-    *path = path->substr(8);
-    path->insert(0, "\\\\");
-  } else if (path->starts_with("\\\\?\\")) {
-    *path = path->substr(4);
+  switch (ClassifyWindowsNamespacedPath(*path)) {
+    case WindowsNamespacedPathType::kUNCPath:
+      *path = "\\\\" + path->substr(8);
+      return;
+    case WindowsNamespacedPathType::kDriveAbsolutePath:
+      *path = path->substr(4);
+      return;
+    case WindowsNamespacedPathType::kNotNamespaced:
+    case WindowsNamespacedPathType::kOtherNamespacedPath:
+      return;
   }
 #endif
 }

--- a/test/cctest/test_path.cc
+++ b/test/cctest/test_path.cc
@@ -8,6 +8,7 @@
 #include "v8.h"
 
 using node::BufferValue;
+using node::FromNamespacedPath;
 using node::PathResolve;
 using node::ToNamespacedPath;
 
@@ -43,6 +44,13 @@ TEST_F(PathTest, PathResolve) {
             "\\\\.\\PHYSICALDRIVE0");
   EXPECT_EQ(PathResolve(*env, {"\\\\?\\PHYSICALDRIVE0"}),
             "\\\\?\\PHYSICALDRIVE0");
+  EXPECT_EQ(PathResolve(*env, {"\\\\?\\C:\\foo"}), "C:\\foo");
+  EXPECT_EQ(PathResolve(*env, {"\\\\?\\C:\\"}), "C:\\");
+  EXPECT_EQ(PathResolve(*env, {"\\\\?\\UNC\\server\\share"}),
+            "\\\\server\\share\\");
+  EXPECT_EQ(PathResolve(*env, {"\\\\?\\UNC\\server\\share\\dir"}),
+            "\\\\server\\share\\dir");
+  EXPECT_EQ(PathResolve(*env, {"\\\\?\\C:foo"}), "\\\\?\\C:foo");
 #else
   EXPECT_EQ(PathResolve(*env, {"/var/lib", "../", "file/"}), "/var/file");
   EXPECT_EQ(PathResolve(*env, {"/var/lib", "/../", "file/"}), "/file");
@@ -85,11 +93,36 @@ TEST_F(PathTest, ToNamespacedPath) {
           .ToLocalChecked());
   ToNamespacedPath(*env, &data_4);
   EXPECT_EQ(data_4.ToStringView(), "\\\\?\\c:\\Windows\\System");
+  BufferValue data_5(
+      isolate_,
+      v8::String::NewFromUtf8(isolate_, "\\\\?\\C:\\").ToLocalChecked());
+  ToNamespacedPath(*env, &data_5);
+  EXPECT_EQ(data_5.ToStringView(), "\\\\?\\C:\\");
 #else
   BufferValue data(
       isolate_,
       v8::String::NewFromUtf8(isolate_, "hello world").ToLocalChecked());
   ToNamespacedPath(*env, &data);
   EXPECT_EQ(data.ToStringView(), "hello world");  // Input should not be mutated
+#endif
+}
+
+TEST_F(PathTest, FromNamespacedPath) {
+#ifdef _WIN32
+  std::string drive_absolute = "\\\\?\\C:\\foo";
+  FromNamespacedPath(&drive_absolute);
+  EXPECT_EQ(drive_absolute, "C:\\foo");
+
+  std::string unc_absolute = "\\\\?\\UNC\\server\\share\\dir";
+  FromNamespacedPath(&unc_absolute);
+  EXPECT_EQ(unc_absolute, "\\\\server\\share\\dir");
+
+  std::string device_path = "\\\\?\\PHYSICALDRIVE0";
+  FromNamespacedPath(&device_path);
+  EXPECT_EQ(device_path, "\\\\?\\PHYSICALDRIVE0");
+
+  std::string drive_relative = "\\\\?\\C:foo";
+  FromNamespacedPath(&drive_relative);
+  EXPECT_EQ(drive_relative, "\\\\?\\C:foo");
 #endif
 }

--- a/test/es-module/test-esm-long-path-win.js
+++ b/test/es-module/test-esm-long-path-win.js
@@ -47,6 +47,28 @@ describe('long path on Windows', () => {
     tmpdir.refresh();
   });
 
+  it('check extended-length path in executeUserEntryPoint', async () => {
+    const packageDirPath = tmpdir.resolve('issue-62446');
+    const mainJsFilePath = path.resolve(packageDirPath, 'main.js');
+    const namespacedMainJsPath = path.toNamespacedPath(mainJsFilePath);
+
+    tmpdir.refresh();
+
+    fs.mkdirSync(packageDirPath);
+    fs.writeFileSync(mainJsFilePath, 'console.log("hello world");');
+
+    const { code, signal, stderr, stdout } = await spawnPromisified(
+      execPath,
+      [namespacedMainJsPath],
+    );
+    assert.strictEqual(stderr.trim(), '');
+    assert.strictEqual(stdout.trim(), 'hello world');
+    assert.strictEqual(code, 0);
+    assert.strictEqual(signal, null);
+
+    tmpdir.refresh();
+  });
+
   it('check long path in LegacyMainResolve - 1', () => {
     // Module layout will be the following:
     //  package.json

--- a/test/parallel/test-compile-cache-namespaced-path-win.js
+++ b/test/parallel/test-compile-cache-namespaced-path-win.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// This tests NODE_COMPILE_CACHE works with a Windows namespaced path.
+
+const common = require('../common');
+if (!common.isWindows) {
+  common.skip('this test is Windows-specific.');
+}
+
+const { spawnSyncAndAssert } = require('../common/child_process');
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
+const tmpdir = require('../common/tmpdir');
+const fs = require('fs');
+const path = require('path');
+
+{
+  tmpdir.refresh();
+  const cacheDir = tmpdir.resolve('.compile_cache_dir');
+  const namespacedCacheDir = path.toNamespacedPath(cacheDir);
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [fixtures.path('empty.js')],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: namespacedCacheDir,
+      },
+      cwd: tmpdir.path,
+    },
+    {
+      stderr(output) {
+        assert.match(output, /writing cache for .*empty\.js.*success/);
+        return true;
+      },
+    });
+
+  const topEntries = fs.readdirSync(cacheDir);
+  assert.strictEqual(topEntries.length, 1);
+  const cacheEntries = fs.readdirSync(path.join(cacheDir, topEntries[0]));
+  assert.strictEqual(cacheEntries.length, 1);
+
+  spawnSyncAndAssert(
+    process.execPath,
+    [fixtures.path('empty.js')],
+    {
+      env: {
+        ...process.env,
+        NODE_DEBUG_NATIVE: 'COMPILE_CACHE',
+        NODE_COMPILE_CACHE: namespacedCacheDir,
+      },
+      cwd: tmpdir.path,
+    },
+    {
+      stderr(output) {
+        assert.match(output, /cache for .*empty\.js was accepted/);
+        return true;
+      },
+    });
+}

--- a/test/parallel/test-fs-realpath.js
+++ b/test/parallel/test-fs-realpath.js
@@ -558,6 +558,22 @@ function test_root_with_null_options(realpath, realpathSync, cb) {
   }));
 }
 
+function test_windows_namespaced_path(realpath, realpathSync, cb) {
+  if (!common.isWindows) {
+    cb();
+    return;
+  }
+
+  const entry = tmp('issue-62446-entry.js');
+  fs.writeFileSync(entry, 'console.log("ok");');
+  const namespacedEntry = path.toNamespacedPath(entry);
+
+  assertEqualPath(realpathSync(namespacedEntry), path.resolve(entry));
+  asynctest(realpath, [namespacedEntry], cb, function(err, result) {
+    assertEqualPath(result, path.resolve(entry));
+  });
+}
+
 // ----------------------------------------------------------------------------
 
 const tests = [
@@ -579,6 +595,7 @@ const tests = [
   test_up_multiple_with_null_options,
   test_root,
   test_root_with_null_options,
+  test_windows_namespaced_path,
 ];
 const numtests = tests.length;
 let testsRun = 0;


### PR DESCRIPTION
Canonicalize valid Windows namespaced drive and UNC filesystem paths by stripping the prefix in these 2 kinds

```
\\?\C:\foo
\\?\UNC\server\share\foo
```

This is safe for ToNamespacedPath() because it resolves to the regular drive or UNC spelling before adding the namespace prefix back for Windows filesystem calls.

Fixes: https://github.com/nodejs/node/issues/62446

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
