### PR TITLE
POC: Memory profiler allocation labels

### DIFF
--- a/benchmark/http/heap-profiler-labels.js
+++ b/benchmark/http/heap-profiler-labels.js
@@ -1,0 +1,88 @@
+'use strict';
+
+// Benchmark: HTTP server throughput impact of heap profiler with labels.
+//
+// Measures requests/sec across three modes:
+// - none: no profiler (baseline)
+// - sampling: profiler active, no labels
+// - sampling-with-labels: profiler active with labels via withHeapProfileLabels
+//
+// Workload per request: ~100KB V8 heap (JSON parse/stringify) + ~50KB Buffer
+// to exercise both HeapProfileLabelsCallback and ProfilingArrayBufferAllocator.
+//
+// Run with compare.js:
+//   node benchmark/compare.js --old ./out/Release/node --new ./out/Release/node \
+//     --runs 10 --filter heap-profiler-labels --set c=50 -- http
+
+const common = require('../common.js');
+const { PORT } = require('../_http-benchmarkers.js');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  mode: ['none', 'sampling', 'sampling-with-labels'],
+  c: [50],
+  duration: 10,
+});
+
+// Build a ~100KB realistic JSON payload template (API response shape).
+const items = [];
+for (let i = 0; i < 200; i++) {
+  items.push({
+    id: i,
+    name: `user-${i}`,
+    email: `user${i}@example.com`,
+    role: 'admin',
+    metadata: { created: '2024-01-01', tags: ['a', 'b', 'c'] },
+  });
+}
+const payloadTemplate = JSON.stringify({ data: items, total: 200 });
+
+function main({ mode, c, duration }) {
+  const http = require('http');
+
+  const interval = 512 * 1024; // 512KB — V8 default, production-realistic.
+
+  if (mode !== 'none') {
+    v8.startSamplingHeapProfiler(interval);
+  }
+
+  const server = http.createServer((req, res) => {
+    const handler = () => {
+      // Realistic mixed workload:
+      // 1. ~100KB V8 heap: JSON parse + stringify (simulates API response building)
+      const parsed = JSON.parse(payloadTemplate);
+      parsed.requestId = Math.random();
+      const body = JSON.stringify(parsed);
+
+      // 2. ~50KB Buffer (simulates response buffering / crypto / compression)
+      const buf = Buffer.alloc(50 * 1024, 0x42);
+
+      // Keep buf reference alive until response is sent.
+      res.writeHead(200, {
+        'Content-Type': 'application/json',
+        'Content-Length': body.length,
+        'X-Buf-Check': buf[0],
+      });
+      res.end(body);
+    };
+
+    if (mode === 'sampling-with-labels') {
+      v8.withHeapProfileLabels({ route: req.url }, handler);
+    } else {
+      handler();
+    }
+  });
+
+  server.listen(PORT, () => {
+    bench.http({
+      path: '/api/bench',
+      connections: c,
+      duration,
+    }, () => {
+      if (mode !== 'none') {
+        v8.stopSamplingHeapProfiler();
+      }
+      server.close();
+    });
+  });
+}

--- a/benchmark/http/heap-profiler-realistic.js
+++ b/benchmark/http/heap-profiler-realistic.js
@@ -1,0 +1,150 @@
+'use strict';
+
+// Benchmark: realistic app-server + DB-server heap profiler overhead.
+//
+// Architecture: wrk → [App Server :PORT] → [DB Server :PORT+1]
+//
+// The app server fetches JSON rows from the DB server, parses,
+// sums two columns over all rows, and returns the result. This exercises:
+//   - http.get (async I/O + Buffer allocation for response body)
+//   - JSON.parse of realistic DB response (V8 heap allocation)
+//   - Two iteration passes over rows (intermediate values)
+//   - ALS label propagation across async I/O boundary
+//
+// Run with compare.js for statistical significance:
+//   node benchmark/compare.js --old ./out/Release/node --new ./out/Release/node \
+//     --runs 30 --filter heap-profiler-realistic --set rows=1000 -- http
+
+const common = require('../common.js');
+const { PORT } = require('../_http-benchmarkers.js');
+const v8 = require('v8');
+const http = require('http');
+
+const DB_PORT = PORT + 1;
+
+const bench = common.createBenchmark(main, {
+  mode: ['none', 'sampling', 'sampling-with-labels'],
+  rows: [100, 1000],
+  c: [50],
+  duration: 10,
+});
+
+// --- DB Server: pre-built JSON responses keyed by row count ---
+
+function buildDBResponse(n) {
+  const categories = ['electronics', 'clothing', 'food', 'books', 'tools'];
+  const rows = [];
+  for (let i = 0; i < n; i++) {
+    rows.push({
+      id: i,
+      amount: Math.round(Math.random() * 10000) / 100,
+      quantity: Math.floor(Math.random() * 500),
+      name: `user-${String(i).padStart(6, '0')}`,
+      email: `user${i}@example.com`,
+      category: categories[i % categories.length],
+    });
+  }
+  const body = JSON.stringify({ rows, total: n });
+  return { body, len: Buffer.byteLength(body) };
+}
+
+// --- App Server helpers ---
+
+function fetchFromDB(rows) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(
+      `http://127.0.0.1:${DB_PORT}/?rows=${rows}`,
+      (res) => {
+        const chunks = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          try {
+            resolve(JSON.parse(Buffer.concat(chunks).toString()));
+          } catch (e) {
+            reject(e);
+          }
+        });
+      },
+    );
+    req.on('error', reject);
+  });
+}
+
+function processRows(data) {
+  const { rows } = data;
+  // Two passes — simulates light business logic (column aggregation).
+  let totalAmount = 0;
+  for (let i = 0; i < rows.length; i++) {
+    totalAmount += rows[i].amount;
+  }
+  let totalQuantity = 0;
+  for (let i = 0; i < rows.length; i++) {
+    totalQuantity += rows[i].quantity;
+  }
+  return {
+    totalAmount: Math.round(totalAmount * 100) / 100,
+    totalQuantity,
+    count: rows.length,
+  };
+}
+
+function main({ mode, rows, c, duration }) {
+  // Pre-build DB responses.
+  const dbResponses = {};
+  for (const n of [100, 1000]) {
+    dbResponses[n] = buildDBResponse(n);
+  }
+
+  // Start DB server.
+  const dbServer = http.createServer((req, res) => {
+    const url = new URL(req.url, `http://127.0.0.1:${DB_PORT}`);
+    const n = parseInt(url.searchParams.get('rows') || '1000', 10);
+    const resp = dbResponses[n] || dbResponses[1000];
+    res.writeHead(200, {
+      'Content-Type': 'application/json',
+      'Content-Length': resp.len,
+    });
+    res.end(resp.body);
+  });
+
+  dbServer.listen(DB_PORT, () => {
+    const interval = 512 * 1024;
+    if (mode !== 'none') {
+      v8.startSamplingHeapProfiler(interval);
+    }
+
+    // Start app server.
+    const appServer = http.createServer((req, res) => {
+      const handler = async () => {
+        const data = await fetchFromDB(rows);
+        const result = processRows(data);
+        const body = JSON.stringify(result);
+        res.writeHead(200, {
+          'Content-Type': 'application/json',
+          'Content-Length': Buffer.byteLength(body),
+        });
+        res.end(body);
+      };
+
+      if (mode === 'sampling-with-labels') {
+        v8.withHeapProfileLabels({ route: req.url }, handler);
+      } else {
+        handler();
+      }
+    });
+
+    appServer.listen(PORT, () => {
+      bench.http({
+        path: '/api/data',
+        connections: c,
+        duration,
+      }, () => {
+        if (mode !== 'none') {
+          v8.stopSamplingHeapProfiler();
+        }
+        appServer.close();
+        dbServer.close();
+      });
+    });
+  });
+}

--- a/benchmark/v8/heap-profiler-labels-resolution.js
+++ b/benchmark/v8/heap-profiler-labels-resolution.js
@@ -1,0 +1,82 @@
+'use strict';
+
+// Benchmark: cost of getAllocationProfile() label resolution.
+//
+// Builds up live samples under withHeapProfileLabels() across N unique
+// label sets, then measures wall-clock time to call getAllocationProfile()
+// repeatedly. Varying samples_per_unique_label_set exposes how resolution
+// cost scales with sample count vs. unique label sets — this is the
+// signal a per-call resolution cache (see PR #62649) should improve.
+//
+// Run standalone:
+//   node benchmark/v8/heap-profiler-labels-resolution.js
+//
+// Run with compare.js for statistical analysis:
+//   node benchmark/compare.js --old ./node-baseline --new ./node-cached \
+//     --filter heap-profiler-labels-resolution
+//
+// Memory: each retained sample corresponds to ~sampleInterval bytes of
+// live heap. With the 512 KiB default and a target of 5,000 samples the
+// workload retains ~4 GiB after compensating for the V8 sampler dropping
+// ~37% of one-sampleInterval-sized allocations. Hence
+// --max-old-space-size=6144.
+
+const common = require('../common.js');
+const v8 = require('v8');
+
+const SAMPLE_INTERVAL = 512 * 1024; // V8 default
+const RETAINED_SAMPLES_TARGET = 5000;
+// V8's sampler picks each allocation of size A with probability
+// 1 - exp(-A / sampleInterval). For A = sampleInterval that's ~63%, so
+// allocate ~1.6x as many chunks as the desired sample count.
+const SAMPLE_PROBABILITY = 1 - Math.exp(-1);
+
+const bench = common.createBenchmark(main, {
+  samples_per_unique_label_set: [1, 10, 100, 1000],
+  n: [20],
+}, {
+  flags: ['--max-old-space-size=6144'],
+});
+
+function main({ samples_per_unique_label_set: samplesPerLabel, n }) {
+  const uniqueLabelSets = Math.max(
+    1, Math.ceil(RETAINED_SAMPLES_TARGET / samplesPerLabel),
+  );
+  const chunksPerLabel = Math.max(
+    1, Math.ceil(samplesPerLabel / SAMPLE_PROBABILITY),
+  );
+  // Each chunk is one sampleInterval of JS heap (a JSArray of Smi slots).
+  // JSArray over plain strings here because String.repeat() of a single
+  // ASCII char appears to bypass the sampler's allocation observers in
+  // large-object-space, while typed JSArray allocations are reliably
+  // sampled.
+  const SLOTS_PER_CHUNK = SAMPLE_INTERVAL / 8;
+
+  v8.startSamplingHeapProfiler(SAMPLE_INTERVAL);
+
+  // The sampling profiler tracks each sample with a weak global; once
+  // the underlying object is GC'd the sample is dropped. Holding strong
+  // references in this retainer keeps samples live throughout the
+  // measurement loop below.
+  const retainer = [];
+  for (let i = 0; i < uniqueLabelSets; i++) {
+    const labels = { route: `/route-${i}`, method: 'GET' };
+    v8.withHeapProfileLabels(labels, () => {
+      for (let j = 0; j < chunksPerLabel; j++) {
+        retainer.push(new Array(SLOTS_PER_CHUNK).fill(0));
+      }
+    });
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    const profile = v8.getAllocationProfile();
+    // Defensive use of the result so the call is not eliminated.
+    if (!profile) throw new Error('profile missing');
+  }
+  bench.end(n);
+
+  v8.stopSamplingHeapProfiler();
+  // Touch retainer post-bench so it stays live across the measurement.
+  if (retainer.length === 0) throw new Error('retainer leaked');
+}

--- a/benchmark/v8/heap-profiler-labels.js
+++ b/benchmark/v8/heap-profiler-labels.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Benchmark: overhead of V8 sampling heap profiler with and without labels.
+//
+// Measures per-allocation cost across three modes:
+// - none: no profiler running (baseline)
+// - sampling: profiler active, no labels callback
+// - sampling-with-labels: profiler active with labels via withHeapProfileLabels
+//
+// Run standalone:
+//   node benchmark/v8/heap-profiler-labels.js
+//
+// Run with compare.js for statistical analysis:
+//   node benchmark/compare.js --old ./node-baseline --new ./node-with-labels \
+//     --filter heap-profiler-labels
+
+const common = require('../common.js');
+const v8 = require('v8');
+
+const bench = common.createBenchmark(main, {
+  mode: ['none', 'sampling', 'sampling-with-labels'],
+  n: [1e6],
+});
+
+function main({ mode, n }) {
+  const interval = 512 * 1024; // 512KB — V8 default, production-realistic.
+
+  if (mode === 'sampling') {
+    v8.startSamplingHeapProfiler(interval);
+  } else if (mode === 'sampling-with-labels') {
+    v8.startSamplingHeapProfiler(interval);
+  }
+
+  if (mode === 'sampling-with-labels') {
+    v8.withHeapProfileLabels({ route: '/bench' }, () => {
+      runWorkload(n);
+    });
+  } else {
+    runWorkload(n);
+  }
+
+  if (mode !== 'none') {
+    v8.stopSamplingHeapProfiler();
+  }
+}
+
+function runWorkload(n) {
+  const arr = [];
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    // Allocate objects with string properties — representative of JSON API
+    // workloads. Each object is ~100-200 bytes on the V8 heap.
+    arr.push({ id: i, name: `item-${i}`, value: Math.random() });
+    // Prevent unbounded growth — keep last 1000 to maintain GC pressure
+    // without running out of memory.
+    if (arr.length > 1000) arr.shift();
+  }
+  bench.end(n);
+}

--- a/deps/v8/include/v8-profiler.h
+++ b/deps/v8/include/v8-profiler.h
@@ -1330,6 +1330,16 @@ class V8_EXPORT HeapProfiler {
    * Pass an empty handle to clear.
    */
   void SetHeapProfileSampleLabelsKey(Local<Value> key);
+
+  /**
+   * Extracts the ALS value from a CPED (ContinuationPreservedEmbedderData)
+   * Map using the stored ALS key (set via SetHeapProfileSampleLabelsKey).
+   *
+   * Uses OrderedHashMap::FindEntry internally — zero-allocation, GC-safe.
+   * Returns an empty MaybeLocal if the CPED is not a Map, no ALS key is set,
+   * or the key is not found in the Map.
+   */
+  MaybeLocal<Value> LookupAlsValue(Local<Value> cped);
 #endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 
   /**

--- a/deps/v8/include/v8-profiler.h
+++ b/deps/v8/include/v8-profiler.h
@@ -11,6 +11,11 @@
 #include <unordered_set>
 #include <vector>
 
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+#include <string>
+#include <utility>
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+
 #include "cppgc/common.h"          // NOLINT(build/include_directory)
 #include "v8-local-handle.h"       // NOLINT(build/include_directory)
 #include "v8-message.h"            // NOLINT(build/include_directory)
@@ -791,26 +796,42 @@ class V8_EXPORT AllocationProfile {
    * Represent a single sample recorded for an allocation.
    */
   struct Sample {
-    /**
-     * id of the node in the profile tree.
-     */
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+    Sample(uint32_t node_id, size_t size, unsigned int count,
+           uint64_t sample_id,
+           std::vector<std::pair<std::string, std::string>> labels = {})
+        : node_id(node_id),
+          size(size),
+          count(count),
+          sample_id(sample_id),
+          labels(std::move(labels)) {}
+#else
+    Sample(uint32_t node_id, size_t size, unsigned int count,
+           uint64_t sample_id)
+        : node_id(node_id), size(size), count(count), sample_id(sample_id) {}
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+
+    /** id of the node in the profile tree. */
     uint32_t node_id;
-
-    /**
-     * Size of the sampled allocation object.
-     */
+    /** Size of the sampled allocation object. */
     size_t size;
-
-    /**
-     * The number of objects of such size that were sampled.
-     */
+    /** The number of objects of such size that were sampled. */
     unsigned int count;
-
     /**
      * Unique time-ordered id of the allocation sample. Can be used to track
      * what samples were added or removed between two snapshots.
      */
     uint64_t sample_id;
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+    /**
+     * Embedder-provided labels resolved by the HeapProfileSampleLabelsCallback
+     * during GetAllocationProfile(). The ALS value is captured at allocation
+     * time; labels are parsed from it when the profile is read. Each pair is
+     * (key, value). Empty if no callback is registered or the callback
+     * returned no labels for this sample.
+     */
+    std::vector<std::pair<std::string, std::string>> labels;
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
   };
 
   /**
@@ -1000,6 +1021,31 @@ class V8_EXPORT HeapProfiler {
   using GetDetachednessCallback = EmbedderGraph::Node::Detachedness (*)(
       v8::Isolate* isolate, const v8::Local<v8::Value>& v8_value,
       uint16_t class_id, void* data);
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  /**
+   * Callback invoked during GetAllocationProfile() to resolve labels from
+   * the ALS value captured at allocation time.
+   *
+   * |data| is the opaque pointer passed to SetHeapProfileSampleLabelsCallback.
+   * |context| is the ALS value (e.g. a flat [key, val, ...] array) that was
+   * extracted from the ContinuationPreservedEmbedderData (CPED) Map at
+   * allocation time using the ALS key set via SetHeapProfileSampleLabelsKey.
+   * The extraction uses OrderedHashMap::FindEntry (zero-allocation, GC-safe).
+   * The callback parses this value directly to produce labels — no Map lookup
+   * is needed at callback time.
+   *
+   * Only invoked for samples that had an ALS value at allocation time (i.e.
+   * the ALS key was found in the CPED Map).
+   *
+   * Write labels to |out_labels| and return true, or return false if no
+   * labels apply. The caller provides a stack-local vector; returning false
+   * avoids any heap allocation on the hot path.
+   */
+  using HeapProfileSampleLabelsCallback = bool (*)(
+      void* data, v8::Local<v8::Value> context,
+      std::vector<std::pair<std::string, std::string>>* out_labels);
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 
   /** Returns the number of snapshots taken. */
   int GetSnapshotCount();
@@ -1260,6 +1306,31 @@ class V8_EXPORT HeapProfiler {
                                         void* data);
 
   void SetGetDetachednessCallback(GetDetachednessCallback callback, void* data);
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  /**
+   * Registers a callback invoked during GetAllocationProfile() to resolve
+   * embedder-defined labels from the ALS value extracted at allocation time.
+   * The labels are stored on AllocationProfile::Sample::labels.
+   *
+   * Pass nullptr to clear the callback.
+   */
+  void SetHeapProfileSampleLabelsCallback(
+      HeapProfileSampleLabelsCallback callback, void* data = nullptr);
+
+  /**
+   * Sets the AsyncLocalStorage (ALS) key used to extract the label value
+   * from the ContinuationPreservedEmbedderData (CPED) Map at allocation
+   * time.  When a heap sample is taken, SampleObject uses this key with
+   * OrderedHashMap::FindEntry to look up the corresponding ALS value and
+   * store it on the sample.  The stored value is later passed to the
+   * HeapProfileSampleLabelsCallback as the |context| parameter.
+   *
+   * Must be called before starting the sampling profiler.
+   * Pass an empty handle to clear.
+   */
+  void SetHeapProfileSampleLabelsKey(Local<Value> key);
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 
   /**
    * Returns whether the heap profiler is currently taking a snapshot.

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -11829,6 +11829,19 @@ void HeapProfiler::SetGetDetachednessCallback(GetDetachednessCallback callback,
                                                                        data);
 }
 
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+void HeapProfiler::SetHeapProfileSampleLabelsCallback(
+    HeapProfileSampleLabelsCallback callback, void* data) {
+  reinterpret_cast<i::HeapProfiler*>(this)
+      ->SetHeapProfileSampleLabelsCallback(callback, data);
+}
+
+void HeapProfiler::SetHeapProfileSampleLabelsKey(Local<Value> key) {
+  reinterpret_cast<i::HeapProfiler*>(this)
+      ->SetHeapProfileSampleLabelsKey(key);
+}
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+
 bool HeapProfiler::IsTakingSnapshot() {
   return reinterpret_cast<i::HeapProfiler*>(this)->IsTakingSnapshot();
 }

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -11840,6 +11840,10 @@ void HeapProfiler::SetHeapProfileSampleLabelsKey(Local<Value> key) {
   reinterpret_cast<i::HeapProfiler*>(this)
       ->SetHeapProfileSampleLabelsKey(key);
 }
+
+MaybeLocal<Value> HeapProfiler::LookupAlsValue(Local<Value> cped) {
+  return reinterpret_cast<i::HeapProfiler*>(this)->LookupAlsValue(cped);
+}
 #endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 
 bool HeapProfiler::IsTakingSnapshot() {

--- a/deps/v8/src/profiler/heap-profiler.cc
+++ b/deps/v8/src/profiler/heap-profiler.cc
@@ -18,6 +18,8 @@
 #include "src/heap/heap.h"
 #include "src/objects/cpp-heap-object-wrapper-inl.h"
 #include "src/objects/js-array-buffer-inl.h"
+#include "src/objects/js-collection-inl.h"
+#include "src/objects/ordered-hash-table.h"
 #include "src/profiler/allocation-tracker.h"
 #include "src/profiler/heap-snapshot-generator-inl.h"
 #include "src/profiler/sampling-heap-profiler.h"
@@ -404,5 +406,28 @@ void HeapProfiler::QueryObjects(DirectHandle<Context> context,
     }
   });
 }
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+v8::MaybeLocal<v8::Value> HeapProfiler::LookupAlsValue(
+    v8::Local<v8::Value> cped) {
+  if (sample_labels_als_key_.IsEmpty() || cped.IsEmpty()) {
+    return v8::MaybeLocal<v8::Value>();
+  }
+  Tagged<Object> cped_obj = *Utils::OpenDirectHandle(*cped);
+  if (!IsJSMap(cped_obj)) return v8::MaybeLocal<v8::Value>();
+
+  Tagged<JSMap> js_map = Cast<JSMap>(cped_obj);
+  Tagged<OrderedHashMap> table = Cast<OrderedHashMap>(js_map->table());
+
+  v8::Isolate* v8_isolate = reinterpret_cast<v8::Isolate*>(isolate());
+  v8::Local<v8::Value> als_key_local = sample_labels_als_key_.Get(v8_isolate);
+  Tagged<Object> key_obj = *Utils::OpenDirectHandle(*als_key_local);
+  InternalIndex entry = table->FindEntry(isolate(), key_obj);
+  if (!entry.is_found()) return v8::MaybeLocal<v8::Value>();
+
+  Tagged<Object> value = table->ValueAt(entry);
+  return Utils::ToLocal(direct_handle(value, isolate()));
+}
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 
 }  // namespace v8::internal

--- a/deps/v8/src/profiler/heap-profiler.h
+++ b/deps/v8/src/profiler/heap-profiler.h
@@ -105,6 +105,10 @@ class HeapProfiler : public HeapObjectAllocationTracker {
   const v8::Global<v8::Value>& sample_labels_als_key() const {
     return sample_labels_als_key_;
   }
+
+  // Extracts the ALS value from a CPED Map using the stored ALS key.
+  // Uses OrderedHashMap::FindEntry — zero-allocation, GC-safe.
+  v8::MaybeLocal<v8::Value> LookupAlsValue(v8::Local<v8::Value> cped);
 #endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 
   void StartHeapObjectsTracking(bool track_allocations);

--- a/deps/v8/src/profiler/heap-profiler.h
+++ b/deps/v8/src/profiler/heap-profiler.h
@@ -79,6 +79,34 @@ class HeapProfiler : public HeapObjectAllocationTracker {
   bool is_sampling_allocations() { return !!sampling_heap_profiler_; }
   AllocationProfile* GetAllocationProfile();
 
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  void SetHeapProfileSampleLabelsCallback(
+      v8::HeapProfiler::HeapProfileSampleLabelsCallback callback,
+      void* data) {
+    sample_labels_callback_ = callback;
+    sample_labels_data_ = data;
+  }
+
+  void SetHeapProfileSampleLabelsKey(v8::Local<v8::Value> key) {
+    if (key.IsEmpty()) {
+      sample_labels_als_key_.Reset();
+    } else {
+      sample_labels_als_key_.Reset(
+          reinterpret_cast<v8::Isolate*>(isolate()), key);
+    }
+  }
+
+  v8::HeapProfiler::HeapProfileSampleLabelsCallback
+  sample_labels_callback() const {
+    return sample_labels_callback_;
+  }
+  void* sample_labels_data() const { return sample_labels_data_; }
+
+  const v8::Global<v8::Value>& sample_labels_als_key() const {
+    return sample_labels_als_key_;
+  }
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+
   void StartHeapObjectsTracking(bool track_allocations);
   void StopHeapObjectsTracking();
   AllocationTracker* allocation_tracker() const {
@@ -176,6 +204,18 @@ class HeapProfiler : public HeapObjectAllocationTracker {
   std::pair<v8::HeapProfiler::GetDetachednessCallback, void*>
       get_detachedness_callback_;
   std::unique_ptr<HeapProfilerNativeMoveListener> native_move_listener_;
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  // All three fields are written only from the main thread via
+  // SetHeapProfileSampleLabelsCallback() / SetHeapProfileSampleLabelsKey()
+  // and read during GetAllocationProfile() or SampleObject() (also main
+  // thread).  No cross-thread access, so no synchronization is required.
+  v8::HeapProfiler::HeapProfileSampleLabelsCallback sample_labels_callback_ =
+      nullptr;
+  void* sample_labels_data_ = nullptr;
+  // The ALS key used at allocation time to extract the label value from
+  // the CPED Map via OrderedHashMap::FindEntry.
+  v8::Global<v8::Value> sample_labels_als_key_;
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 };
 
 }  // namespace internal

--- a/deps/v8/src/profiler/sampling-heap-profiler.cc
+++ b/deps/v8/src/profiler/sampling-heap-profiler.cc
@@ -15,6 +15,9 @@
 #include "src/execution/isolate.h"
 #include "src/heap/heap-layout-inl.h"
 #include "src/heap/heap.h"
+#include "src/objects/js-collection-inl.h"
+#include "src/objects/ordered-hash-table.h"
+#include "src/profiler/heap-profiler.h"
 #include "src/profiler/strings-storage.h"
 
 namespace v8 {
@@ -96,6 +99,47 @@ void SamplingHeapProfiler::SampleObject(Address soon_object, size_t size) {
   node->allocations_[size]++;
   auto sample =
       std::make_unique<Sample>(size, node, loc, this, next_sample_id());
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  // Extract the ALS value from the CPED Map at allocation time.
+  // The CPED (ContinuationPreservedEmbedderData) is a JSMap containing
+  // ALL ALS stores.  We look up only our ALS key via
+  // OrderedHashMap::FindEntry (zero-allocation, GC-safe) and store just
+  // the resulting value (the flat label array).  This avoids retaining
+  // the entire CPED for the lifetime of each sample.
+  // Global::Reset is safe inside DisallowGC (uses malloc, not V8 heap).
+  {
+    HeapProfiler* hp = isolate_->heap()->heap_profiler();
+    if (hp->sample_labels_callback()) {
+      const v8::Global<v8::Value>& als_key_global =
+          hp->sample_labels_als_key();
+      if (!als_key_global.IsEmpty()) {
+        v8::Isolate* v8_isolate = reinterpret_cast<v8::Isolate*>(isolate_);
+        v8::Local<v8::Value> context =
+            v8_isolate->GetContinuationPreservedEmbedderData();
+        if (!context.IsEmpty() && !context->IsUndefined()) {
+          Tagged<Object> cped_obj = *Utils::OpenDirectHandle(*context);
+          if (IsJSMap(cped_obj)) {
+            Tagged<JSMap> js_map = Cast<JSMap>(cped_obj);
+            Tagged<OrderedHashMap> table =
+                Cast<OrderedHashMap>(js_map->table());
+            v8::Local<v8::Value> als_key_local =
+                als_key_global.Get(v8_isolate);
+            Tagged<Object> key_obj = *Utils::OpenDirectHandle(*als_key_local);
+            InternalIndex entry = table->FindEntry(isolate_, key_obj);
+            if (entry.is_found()) {
+              Tagged<Object> value = table->ValueAt(entry);
+              v8::Local<v8::Value> value_local =
+                  Utils::ToLocal(direct_handle(value, isolate_));
+              sample->label_value.Reset(v8_isolate, value_local);
+            }
+          }
+        }
+      }
+    }
+  }
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+
   sample->global.SetWeak(sample.get(), OnWeakCallback,
                          WeakCallbackType::kParameter);
   samples_.emplace(sample.get(), std::move(sample));
@@ -299,22 +343,103 @@ v8::AllocationProfile* SamplingHeapProfiler::GetAllocationProfile() {
       scripts[script->id()] = handle(script, isolate_);
     }
   }
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  // Pre-resolve labels while GC is still allowed.
+  // The labels callback may allocate on the V8 heap. These MUST NOT run
+  // during BuildSamples() iteration — GC would fire weak callbacks that
+  // erase from samples_, causing iterator invalidation / UAF.
+  //
+  // Two-phase approach:
+  //   Phase 1: snapshot sample IDs and ALS values (Global::Get + Global
+  //            ctor use malloc, not V8 heap — no GC risk during iteration).
+  //   Phase 2: invoke the callback for each snapshot entry. GC may fire
+  //            here but we iterate our snapshot vector, not samples_.
+  ResolvedLabelsMap resolved_labels;
+  {
+    HeapProfiler* hp = heap_->heap_profiler();
+    auto callback = hp->sample_labels_callback();
+    void* callback_data = hp->sample_labels_data();
+    if (callback) {
+      v8::Isolate* v8_isolate = reinterpret_cast<v8::Isolate*>(isolate_);
+
+      // Phase 1: snapshot ALS values keyed by sample_id.
+      // Global ctor (GlobalizeReference) and Global::Get use global handle
+      // storage (malloc), not the V8 heap — safe under DisallowGarbageCollection.
+      // Locals from Get() are immediately consumed by Global ctor, so a single
+      // HandleScope outside the loop suffices (no per-iteration scope churn).
+      struct LabelValueSnapshot {
+        uint64_t sample_id;
+        v8::Global<v8::Value> label_value;
+      };
+      std::vector<LabelValueSnapshot> snapshot;
+      snapshot.reserve(samples_.size());
+      {
+        HandleScope handle_scope(isolate_);
+        DisallowGarbageCollection no_gc;
+        for (const auto& [ptr, sample] : samples_) {
+          if (!sample->label_value.IsEmpty()) {
+            snapshot.push_back(
+                {sample->sample_id,
+                 v8::Global<v8::Value>(
+                     v8_isolate, sample->label_value.Get(v8_isolate))});
+          }
+        }
+      }
+
+      // Phase 2: resolve labels via callback (GC allowed).
+      // The callback receives the ALS value (flat label array) directly —
+      // the CPED Map lookup was already done at allocation time.
+      for (auto& entry : snapshot) {
+        HandleScope scope(isolate_);
+        v8::Local<v8::Value> value_local = entry.label_value.Get(v8_isolate);
+        std::vector<std::pair<std::string, std::string>> labels;
+        if (callback(callback_data, value_local, &labels) && !labels.empty()) {
+          resolved_labels[entry.sample_id] = std::move(labels);
+        }
+      }
+    }
+  }
+#endif
+
   auto profile = new v8::internal::AllocationProfile();
   TranslateAllocationNode(profile, &profile_root_, scripts);
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  profile->samples_ = BuildSamples(std::move(resolved_labels));
+#else
   profile->samples_ = BuildSamples();
+#endif
 
   return profile;
 }
 
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+const std::vector<v8::AllocationProfile::Sample>
+SamplingHeapProfiler::BuildSamples(ResolvedLabelsMap resolved_labels) const {
+#else
 const std::vector<v8::AllocationProfile::Sample>
 SamplingHeapProfiler::BuildSamples() const {
+#endif
   std::vector<v8::AllocationProfile::Sample> samples;
   samples.reserve(samples_.size());
+
   for (const auto& it : samples_) {
     const Sample* sample = it.second.get();
-    samples.emplace_back(v8::AllocationProfile::Sample{
-        sample->owner->id_, sample->size, ScaleSample(sample->size, 1).count,
-        sample->sample_id});
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+    std::vector<std::pair<std::string, std::string>> labels;
+    auto label_it = resolved_labels.find(sample->sample_id);
+    if (label_it != resolved_labels.end()) {
+      labels = std::move(label_it->second);
+    }
+    samples.emplace_back(sample->owner->id_, sample->size,
+                         ScaleSample(sample->size, 1).count,
+                         sample->sample_id, std::move(labels));
+#else
+    samples.emplace_back(sample->owner->id_, sample->size,
+                         ScaleSample(sample->size, 1).count,
+                         sample->sample_id);
+#endif
   }
   return samples;
 }

--- a/deps/v8/src/profiler/sampling-heap-profiler.cc
+++ b/deps/v8/src/profiler/sampling-heap-profiler.cc
@@ -390,12 +390,32 @@ v8::AllocationProfile* SamplingHeapProfiler::GetAllocationProfile() {
       // Phase 2: resolve labels via callback (GC allowed).
       // The callback receives the ALS value (flat label array) directly —
       // the CPED Map lookup was already done at allocation time.
+      //
+      // Per-call cache: samples sharing the same ALS value (e.g. all
+      // allocations under one withHeapProfileLabels scope) resolve to the
+      // same labels, so we dedup callback invocations within this call.
+      // Key: raw object Address (cheap identity check). If GC moves the
+      // object between iterations we get a cache miss and re-call the
+      // callback — correctness preserved, just less optimal. Negative
+      // results (callback returned false or empty labels) are also cached
+      // so we don't re-call for ALS values that resolve to nothing.
+      std::unordered_map<Address,
+                         std::vector<std::pair<std::string, std::string>>>
+          label_cache;
       for (auto& entry : snapshot) {
         HandleScope scope(isolate_);
         v8::Local<v8::Value> value_local = entry.label_value.Get(v8_isolate);
-        std::vector<std::pair<std::string, std::string>> labels;
-        if (callback(callback_data, value_local, &labels) && !labels.empty()) {
-          resolved_labels[entry.sample_id] = std::move(labels);
+        Address key = (*Utils::OpenDirectHandle(*value_local)).ptr();
+        auto [cache_it, inserted] = label_cache.try_emplace(key);
+        if (inserted) {
+          std::vector<std::pair<std::string, std::string>> labels;
+          if (callback(callback_data, value_local, &labels) &&
+              !labels.empty()) {
+            cache_it->second = std::move(labels);
+          }
+        }
+        if (!cache_it->second.empty()) {
+          resolved_labels[entry.sample_id] = cache_it->second;
         }
       }
     }

--- a/deps/v8/src/profiler/sampling-heap-profiler.h
+++ b/deps/v8/src/profiler/sampling-heap-profiler.h
@@ -114,6 +114,14 @@ class SamplingHeapProfiler {
     Global<Value> global;
     SamplingHeapProfiler* const profiler;
     const uint64_t sample_id;
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+    // ALS value extracted from the CPED Map at allocation time via
+    // OrderedHashMap::FindEntry.  Storing only the ALS value (the flat
+    // label array) instead of the full CPED avoids retaining all ALS
+    // stores for the lifetime of the sample.  Labels are resolved from
+    // this at read time (in GetAllocationProfile) via the callback.
+    Global<Value> label_value;
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
   };
 
   SamplingHeapProfiler(Heap* heap, StringsStorage* names, uint64_t rate,
@@ -160,7 +168,14 @@ class SamplingHeapProfiler {
 
   void SampleObject(Address soon_object, size_t size);
 
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  using ResolvedLabelsMap = std::unordered_map<
+      uint64_t, std::vector<std::pair<std::string, std::string>>>;
+  const std::vector<v8::AllocationProfile::Sample> BuildSamples(
+      ResolvedLabelsMap resolved_labels) const;
+#else
   const std::vector<v8::AllocationProfile::Sample> BuildSamples() const;
+#endif
 
   AllocationNode* FindOrAddChildNode(AllocationNode* parent, const char* name,
                                      int script_id, int start_position);

--- a/deps/v8/test/cctest/test-heap-profiler.cc
+++ b/deps/v8/test/cctest/test-heap-profiler.cc
@@ -4854,3 +4854,355 @@ TEST(HeapSnapshotWithWasmInstance) {
 #endif  // V8_ENABLE_SANDBOX
 }
 #endif  // V8_ENABLE_WEBASSEMBLY
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+
+// --- Tests for HeapProfileSampleLabelsCallback ---
+
+// Helper: a label callback that writes fixed labels via output parameter.
+static bool FixedLabelsCallback(
+    void* data, v8::Local<v8::Value> context,
+    std::vector<std::pair<std::string, std::string>>* out_labels) {
+  auto* labels =
+      static_cast<std::vector<std::pair<std::string, std::string>>*>(data);
+  *out_labels = *labels;
+  return true;
+}
+
+// Helper: a label callback that returns false (no labels).
+static bool EmptyLabelsCallback(
+    void* data, v8::Local<v8::Value> context,
+    std::vector<std::pair<std::string, std::string>>* out_labels) {
+  return false;
+}
+
+// Helper: a label callback that returns different labels based on CPED value.
+struct MultiLabelState {
+  std::string first_cped;
+  std::vector<std::pair<std::string, std::string>> first;
+  std::string second_cped;
+  std::vector<std::pair<std::string, std::string>> second;
+};
+
+static bool MultiLabelsCallback(
+    void* data, v8::Local<v8::Value> context,
+    std::vector<std::pair<std::string, std::string>>* out_labels) {
+  auto* state = static_cast<MultiLabelState*>(data);
+  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  v8::String::Utf8Value cped_str(isolate, context);
+  std::string cped(*cped_str, cped_str.length());
+  if (cped == state->first_cped) {
+    *out_labels = state->first;
+  } else if (cped == state->second_cped) {
+    *out_labels = state->second;
+  }
+  return true;
+}
+
+TEST(SamplingHeapProfilerLabelsCallback) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HeapProfiler* heap_profiler = isolate->GetHeapProfiler();
+
+  i::v8_flags.sampling_heap_profiler_suppress_randomness = true;
+
+  std::vector<std::pair<std::string, std::string>> labels = {
+      {"route", "/api/test"}};
+
+  // Set CPED so the callback gets invoked (non-empty context required).
+  {
+    v8::HandleScope inner(isolate);
+    isolate->SetContinuationPreservedEmbedderData(
+        v8::String::NewFromUtf8Literal(isolate, "test-context"));
+  }
+
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  // Allocate enough objects to get samples.
+  for (int i = 0; i < 8 * 1024; ++i) v8::Object::New(isolate);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  CHECK(profile);
+
+  // Verify at least one sample has the expected labels.
+  bool found_labeled = false;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      CHECK_EQ(sample.labels.size(), 1);
+      CHECK_EQ(sample.labels[0].first, "route");
+      CHECK_EQ(sample.labels[0].second, "/api/test");
+      found_labeled = true;
+    }
+  }
+  CHECK(found_labeled);
+
+  heap_profiler->StopSamplingHeapProfiler();
+
+  // Clear callback.
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+TEST(SamplingHeapProfilerNoLabelsCallback) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HeapProfiler* heap_profiler = isolate->GetHeapProfiler();
+
+  i::v8_flags.sampling_heap_profiler_suppress_randomness = true;
+
+  // No callback registered — samples should have empty labels.
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  for (int i = 0; i < 8 * 1024; ++i) v8::Object::New(isolate);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  CHECK(profile);
+
+  for (const auto& sample : profile->GetSamples()) {
+    CHECK(sample.labels.empty());
+  }
+
+  heap_profiler->StopSamplingHeapProfiler();
+}
+
+TEST(SamplingHeapProfilerEmptyLabelsCallback) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HeapProfiler* heap_profiler = isolate->GetHeapProfiler();
+
+  i::v8_flags.sampling_heap_profiler_suppress_randomness = true;
+
+  // Set CPED so callback is invoked.
+  isolate->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate, "test-context"));
+
+  // Callback returns empty vector — samples should have empty labels.
+  heap_profiler->SetHeapProfileSampleLabelsCallback(EmptyLabelsCallback,
+                                                    nullptr);
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  for (int i = 0; i < 8 * 1024; ++i) v8::Object::New(isolate);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  CHECK(profile);
+
+  for (const auto& sample : profile->GetSamples()) {
+    CHECK(sample.labels.empty());
+  }
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+TEST(SamplingHeapProfilerMultipleLabels) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HeapProfiler* heap_profiler = isolate->GetHeapProfiler();
+
+  i::v8_flags.sampling_heap_profiler_suppress_randomness = true;
+
+  MultiLabelState state;
+  state.first_cped = "context-first";
+  state.first = {{"route", "/api/first"}};
+  state.second_cped = "context-second";
+  state.second = {{"route", "/api/second"}};
+
+  heap_profiler->SetHeapProfileSampleLabelsCallback(MultiLabelsCallback,
+                                                    &state);
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  // Set first CPED and allocate.
+  isolate->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate, "context-first"));
+  for (int i = 0; i < 4 * 1024; ++i) v8::Object::New(isolate);
+
+  // Set second CPED and allocate.
+  isolate->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate, "context-second"));
+  for (int i = 0; i < 4 * 1024; ++i) v8::Object::New(isolate);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  CHECK(profile);
+
+  bool found_first = false;
+  bool found_second = false;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      CHECK_EQ(sample.labels.size(), 1);
+      CHECK_EQ(sample.labels[0].first, "route");
+      if (sample.labels[0].second == "/api/first") found_first = true;
+      if (sample.labels[0].second == "/api/second") found_second = true;
+    }
+  }
+  CHECK(found_first);
+  CHECK(found_second);
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+TEST(SamplingHeapProfilerLabelsWithGCRetain) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HeapProfiler* heap_profiler = isolate->GetHeapProfiler();
+
+  i::v8_flags.sampling_heap_profiler_suppress_randomness = true;
+
+  // Set CPED so callback is invoked.
+  isolate->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate, "test-context"));
+
+  std::vector<std::pair<std::string, std::string>> labels = {
+      {"route", "/api/gc-test"}};
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  // Start with GC retain flags — GC'd samples should survive.
+  heap_profiler->StartSamplingHeapProfiler(
+      256, 128,
+      v8::HeapProfiler::kSamplingIncludeObjectsCollectedByMajorGC |
+          v8::HeapProfiler::kSamplingIncludeObjectsCollectedByMinorGC);
+
+  // Allocate short-lived objects (no reference retained).
+  CompileRun(
+      "for (var i = 0; i < 4096; i++) {"
+      "  new Array(64);"
+      "}");
+
+  // Force GC to collect the short-lived objects.
+  i::heap::InvokeMajorGC(CcTest::heap());
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  CHECK(profile);
+
+  // With GC retain flags, samples for collected objects should still exist
+  // with their labels intact.
+  bool found_labeled = false;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      CHECK_EQ(sample.labels[0].first, "route");
+      CHECK_EQ(sample.labels[0].second, "/api/gc-test");
+      found_labeled = true;
+    }
+  }
+  CHECK(found_labeled);
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+TEST(SamplingHeapProfilerLabelsRemovedByGC) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HeapProfiler* heap_profiler = isolate->GetHeapProfiler();
+
+  i::v8_flags.sampling_heap_profiler_suppress_randomness = true;
+
+  // Set CPED so callback is invoked.
+  isolate->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate, "test-context"));
+
+  std::vector<std::pair<std::string, std::string>> labels = {
+      {"route", "/api/gc-remove"}};
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  // Start WITHOUT GC retain flags — GC'd samples should be removed.
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  // Allocate short-lived objects (no reference retained).
+  CompileRun(
+      "for (var i = 0; i < 4096; i++) {"
+      "  new Array(64);"
+      "}");
+
+  // Force GC to collect the short-lived objects.
+  i::heap::InvokeMajorGC(CcTest::heap());
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  CHECK(profile);
+
+  // Without GC retain flags, most/all short-lived samples should be gone.
+  // Count remaining labeled samples — should be significantly fewer than
+  // what was allocated (many were collected by GC).
+  size_t labeled_count = 0;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      labeled_count++;
+    }
+  }
+  // We can't assert zero because some objects may survive GC, but the count
+  // should be much smaller than the retained case. Just verify the profile
+  // is valid and doesn't crash.
+  CHECK(profile->GetRootNode());
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+TEST(SamplingHeapProfilerUnregisterCallback) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Isolate* isolate = env->GetIsolate();
+  v8::HeapProfiler* heap_profiler = isolate->GetHeapProfiler();
+
+  i::v8_flags.sampling_heap_profiler_suppress_randomness = true;
+
+  // Set CPED so callback is invoked.
+  isolate->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate, "test-context"));
+
+  std::vector<std::pair<std::string, std::string>> labels = {
+      {"route", "/api/before-unregister"}};
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  // Allocate with callback active.
+  for (int i = 0; i < 4 * 1024; ++i) v8::Object::New(isolate);
+
+  // Unregister callback (pass nullptr).
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+
+  // Allocate more — these should have no labels.
+  for (int i = 0; i < 4 * 1024; ++i) v8::Object::New(isolate);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  CHECK(profile);
+
+  // Should have some labeled samples (from before unregister) and some
+  // unlabeled (from after). Verify at least one labeled exists.
+  bool found_labeled = false;
+  bool found_unlabeled = false;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      found_labeled = true;
+    } else {
+      found_unlabeled = true;
+    }
+  }
+  CHECK(found_labeled);
+  CHECK(found_unlabeled);
+
+  heap_profiler->StopSamplingHeapProfiler();
+}
+
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1503,12 +1503,17 @@ not running.
   "samples": [
     { "nodeId": 1, "size": 128, "count": 4, "sampleId": 42,
       "labels": { "route": "/users/:id" } }
+  ],
+  "externalBytes": [
+    { "labels": { "route": "/users/:id" }, "bytes": 1048576 }
   ]
 }
 ```
 
 * `samples[].labels` — key-value string pairs from the active label context
   at allocation time. Empty object if no labels were active.
+* `externalBytes[]` — live `Buffer`/`ArrayBuffer` backing-store bytes per
+  label context. Complements heap samples which only see the JS wrapper.
 
 ### `v8.withHeapProfileLabels(labels, fn)`
 
@@ -1551,9 +1556,9 @@ Prefer [`v8.withHeapProfileLabels()`][] when possible for automatic cleanup.
 ### Limitations — what is measured
 
 Heap samples cover V8 heap allocations (JS objects, strings, closures).
+`externalBytes` covers `Buffer`/`ArrayBuffer` backing stores.
 
-Not measured: `Buffer`/`ArrayBuffer` backing stores, native addon memory,
-JIT code space, OS-level allocations.
+Not measured: native addon memory, JIT code space, OS-level allocations.
 
 ## Class: `v8.GCProfiler`
 

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1453,6 +1453,108 @@ added:
 
 Returns true if the Node.js instance is run to build a snapshot.
 
+## Heap profile labels
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+Attach string labels to V8 sampling heap profiler allocation samples.
+Combined with [`AsyncLocalStorage`][], labels propagate through `await`
+boundaries for per-context memory attribution (e.g., per-HTTP-route).
+
+### `v8.startSamplingHeapProfiler([sampleInterval[, stackDepth[, options]]])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `sampleInterval` {number} Average interval in bytes. **Default:** `524288`.
+* `stackDepth` {number} Maximum call stack depth. **Default:** `16`.
+* `options` {Object}
+  * `includeCollectedObjects` {boolean} Retain samples for GC'd objects.
+    **Default:** `false`.
+
+Starts the V8 sampling heap profiler.
+
+### `v8.stopSamplingHeapProfiler()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Stops the sampling heap profiler and clears all registered label entries.
+
+### `v8.getAllocationProfile()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Returns: {Object | undefined}
+
+Returns the current allocation profile, or `undefined` if the profiler is
+not running.
+
+```json
+{
+  "samples": [
+    { "nodeId": 1, "size": 128, "count": 4, "sampleId": 42,
+      "labels": { "route": "/users/:id" } }
+  ]
+}
+```
+
+* `samples[].labels` — key-value string pairs from the active label context
+  at allocation time. Empty object if no labels were active.
+
+### `v8.withHeapProfileLabels(labels, fn)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `labels` {Object} Key-value string pairs (e.g., `{ route: '/users/:id' }`).
+* `fn` {Function} May be `async`.
+* Returns: {*} Return value of `fn`.
+
+Runs `fn` with the given labels active. If `fn` returns a promise, labels
+remain active until the promise settles.
+
+```js
+v8.startSamplingHeapProfiler(64);
+
+await v8.withHeapProfileLabels({ route: '/users' }, async () => {
+  const data = await fetchUsers();
+  return processData(data);
+});
+
+const profile = v8.getAllocationProfile();
+v8.stopSamplingHeapProfiler();
+```
+
+### `v8.setHeapProfileLabels(labels)`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `labels` {Object} Key-value string pairs.
+
+Sets labels for the current async scope using `enterWith` semantics.
+Useful for frameworks where the handler runs after the extension returns.
+
+Prefer [`v8.withHeapProfileLabels()`][] when possible for automatic cleanup.
+
+### Limitations — what is measured
+
+Heap samples cover V8 heap allocations (JS objects, strings, closures).
+
+Not measured: `Buffer`/`ArrayBuffer` backing stores, native addon memory,
+JIT code space, OS-level allocations.
+
 ## Class: `v8.GCProfiler`
 
 <!-- YAML
@@ -1798,7 +1900,10 @@ console.log(profile);
 [`serializer.transferArrayBuffer()`]: #serializertransferarraybufferid-arraybuffer
 [`serializer.writeRawBytes()`]: #serializerwriterawbytesbuffer
 [`settled` callback]: #settledpromise
+[`v8.setHeapProfileLabels()`]: #v8setheapprofilelabelslabels
 [`v8.stopCoverage()`]: #v8stopcoverage
 [`v8.takeCoverage()`]: #v8takecoverage
+[`v8.withHeapProfileLabels()`]: #v8withheapprofilelabelslabels-fn
+[Limitations — what is measured]: #limitations--what-is-measured
 [`vm.Script`]: vm.md#new-vmscriptcode-options
 [worker threads]: worker_threads.md

--- a/lib/v8.js
+++ b/lib/v8.js
@@ -26,7 +26,9 @@ const {
   Int32Array,
   Int8Array,
   JSONParse,
+  ObjectKeys,
   ObjectPrototypeToString,
+  ReflectGet,
   SymbolDispose,
   Uint16Array,
   Uint32Array,
@@ -39,6 +41,8 @@ const {
 
 const { Buffer } = require('buffer');
 const {
+  validateFunction,
+  validateObject,
   validateString,
   validateUint32,
   validateOneOf,
@@ -156,6 +160,11 @@ const {
   heapSpaceStatisticsBuffer,
   getCppHeapStatistics: _getCppHeapStatistics,
   detailLevel,
+
+  startSamplingHeapProfiler: _startSamplingHeapProfiler,
+  stopSamplingHeapProfiler: _stopSamplingHeapProfiler,
+  getAllocationProfile: _getAllocationProfile,
+  setHeapProfileLabelsStore: _setHeapProfileLabelsStore,
 } = binding;
 
 const kNumberOfHeapSpaces = kHeapSpaces.length;
@@ -494,6 +503,109 @@ class GCProfiler {
   }
 }
 
+// --- Heap profile labels API ---
+// Internal AsyncLocalStorage for propagating labels through async context.
+// Requires --experimental-async-context-frame (Node 22) or Node 24+.
+// Lazily initialized on first use so processes that never use heap profiling
+// pay zero cost (no ALS instance, no async_hooks require).
+let _heapProfileLabelsALS;
+
+function ensureHeapProfileLabelsALS() {
+  if (_heapProfileLabelsALS === undefined) {
+    // When V8_HEAP_PROFILER_SAMPLE_LABELS is compiled out, the C++ binding
+    // for _setHeapProfileLabelsStore is not registered — labels are a no-op.
+    if (typeof _setHeapProfileLabelsStore !== 'function') return;
+    const { AsyncLocalStorage } = require('async_hooks');
+    _heapProfileLabelsALS = new AsyncLocalStorage();
+    // The ALS instance is passed to C++ as the key used to look up labels in
+    // the AsyncContextFrame map (via ContinuationPreservedEmbedderData).
+    // This relies on the async-context-frame implementation storing ALS
+    // instances as Map keys — if that internal representation changes, the
+    // C++ label-resolution code in node_v8.cc must be updated to match.
+    _setHeapProfileLabelsStore(_heapProfileLabelsALS);
+  }
+  return _heapProfileLabelsALS;
+}
+
+/**
+ * Convert a labels object to a flat array [key1, val1, key2, val2, ...].
+ * Pre-flattened at label-set time (not per allocation/sample) because the
+ * C++ callback runs in GetAllocationProfile() BEFORE BuildSamples() where
+ * it resolves labels from CPED captured at allocation time.
+ * @param {Record<string, string>} labels
+ * @returns {string[]}
+ */
+function labelsToFlat(labels) {
+  const keys = ObjectKeys(labels);
+  const len = keys.length;
+  const flat = new Array(len * 2);
+  for (let i = 0; i < len; i++) {
+    const key = keys[i];
+    const val = ReflectGet(labels, key);
+    validateString(val, `labels.${key}`);
+    flat[i * 2] = key;
+    flat[i * 2 + 1] = val;
+  }
+  return flat;
+}
+
+/**
+ * Starts the V8 sampling heap profiler.
+ * @param {number} [sampleInterval] - Average bytes between samples (default 512 KB).
+ * @param {number} [stackDepth] - Maximum stack depth for samples (default 16).
+ * @param {object} [options] - Options object.
+ * @param {boolean} [options.includeCollectedObjects] - If true, retain
+ *   samples for objects collected by GC (allocation-rate mode).
+ */
+function startSamplingHeapProfiler(sampleInterval, stackDepth, options) {
+  if (sampleInterval !== undefined) validateUint32(sampleInterval, 'sampleInterval', true);
+  if (stackDepth !== undefined) validateUint32(stackDepth, 'stackDepth');
+  if (options !== undefined) validateObject(options, 'options');
+  return _startSamplingHeapProfiler(sampleInterval, stackDepth, options);
+}
+
+/**
+ * Runs `fn` with the given heap profile labels active. Labels propagate
+ * across `await` boundaries via AsyncLocalStorage. If `fn` returns a
+ * Promise, labels remain active until the Promise settles.
+ *
+ * @param {Record<string, string>} labels
+ * @param {Function} fn
+ * @returns {*} The return value of `fn`.
+ */
+function withHeapProfileLabels(labels, fn) {
+  validateObject(labels, 'labels');
+  validateFunction(fn, 'fn');
+  // Store the flat [key1, val1, key2, val2, ...] array in ALS.
+  // Conversion happens once at label-set time (not per allocation).
+  // The C++ callback resolves labels from CPED in GetAllocationProfile()
+  // before BuildSamples() — pre-flattening avoids V8 Object property
+  // access during label resolution.
+  const flat = labelsToFlat(labels);
+  const als = ensureHeapProfileLabelsALS();
+  // When labels are compiled out, still run the callback — just without
+  // label tracking.
+  if (als === undefined) return fn();
+  return als.run(flat, fn);
+}
+
+/**
+ * Sets heap profile labels for the current async scope using
+ * `enterWith` semantics. Labels persist until overwritten or the
+ * async scope ends. Useful for frameworks (e.g. Hapi) where the
+ * handler runs after the extension returns.
+ *
+ * @param {Record<string, string>} labels
+ */
+function setHeapProfileLabels(labels) {
+  validateObject(labels, 'labels');
+  const flat = labelsToFlat(labels);
+  const als = ensureHeapProfileLabelsALS();
+  // When labels are compiled out, setHeapProfileLabels is a no-op.
+  if (als === undefined) return;
+  als.enterWith(flat);
+}
+
 module.exports = {
   cachedDataVersionTag,
   getHeapSnapshot,
@@ -518,4 +630,9 @@ module.exports = {
   GCProfiler,
   isStringOneByteRepresentation,
   startCpuProfile,
+  startSamplingHeapProfiler,
+  stopSamplingHeapProfiler: _stopSamplingHeapProfiler,
+  getAllocationProfile: _getAllocationProfile,
+  withHeapProfileLabels,
+  setHeapProfileLabels,
 };

--- a/node.gyp
+++ b/node.gyp
@@ -4,6 +4,9 @@
     'v8_trace_maps%': 0,
     'v8_enable_pointer_compression%': 0,
     'v8_enable_31bit_smis_on_64bit_arch%': 0,
+    # Matches V8 default (BUILD.gn); must be declared here for GYP conditions
+    # that gate V8_HEAP_PROFILER_SAMPLE_LABELS below.
+    'v8_enable_continuation_preserved_embedder_data%': 1,
     'force_dynamic_crt%': 0,
     'node_builtin_modules_path%': '',
     'node_core_target_name%': 'node',
@@ -937,6 +940,12 @@
       'msvs_disabled_warnings!': [4244],
 
       'conditions': [
+        [ 'v8_enable_continuation_preserved_embedder_data==1', {
+          'defines': [
+            # Enable heap profiler sample labels when CPED is available.
+            'V8_HEAP_PROFILER_SAMPLE_LABELS',
+          ],
+        }],
         [ 'openssl_default_cipher_list!=""', {
           'defines': [
             'NODE_OPENSSL_DEFAULT_CIPHER_LIST="<(openssl_default_cipher_list)"'
@@ -1322,6 +1331,11 @@
       'sources': [ '<@(node_cctest_sources)' ],
 
       'conditions': [
+        [ 'v8_enable_continuation_preserved_embedder_data==1', {
+          'defines': [
+            'V8_HEAP_PROFILER_SAMPLE_LABELS',
+          ],
+        }],
         [ 'node_shared_gtest=="false"', {
           'dependencies': [
             'deps/googletest/googletest.gyp:gtest',

--- a/src/api/environment.cc
+++ b/src/api/environment.cc
@@ -15,7 +15,9 @@
 #include "node_realm-inl.h"
 #include "node_shadow_realm.h"
 #include "node_snapshot_builder.h"
+#include "node_v8.h"
 #include "node_v8_platform-inl.h"
+#include "v8-profiler.h"
 #include "node_wasm_web_api.h"
 #include "uv.h"
 #ifdef NODE_ENABLE_VTUNE_PROFILING
@@ -117,6 +119,10 @@ void* NodeArrayBufferAllocator::Allocate(size_t size) {
   ret = allocator_->Allocate(size);
   if (ret != nullptr) [[likely]] {
     total_mem_usage_.fetch_add(size, std::memory_order_relaxed);
+    auto* pa = profiling_allocator_.load(std::memory_order_acquire);
+    if (pa != nullptr) [[unlikely]] {
+      pa->TrackAllocate(ret, size);
+    }
   }
   return ret;
 }
@@ -126,13 +132,36 @@ void* NodeArrayBufferAllocator::AllocateUninitialized(size_t size) {
   void* ret = allocator_->AllocateUninitialized(size);
   if (ret != nullptr) [[likely]] {
     total_mem_usage_.fetch_add(size, std::memory_order_relaxed);
+    auto* pa = profiling_allocator_.load(std::memory_order_acquire);
+    if (pa != nullptr) [[unlikely]] {
+      pa->TrackAllocate(ret, size);
+    }
   }
   return ret;
 }
 
 void NodeArrayBufferAllocator::Free(void* data, size_t size) {
+  auto* pa = profiling_allocator_.load(std::memory_order_acquire);
+  if (pa != nullptr) [[unlikely]] {
+    pa->TrackFree(data);
+  }
   total_mem_usage_.fetch_sub(size, std::memory_order_relaxed);
   allocator_->Free(data, size);
+}
+
+ProfilingArrayBufferAllocator*
+NodeArrayBufferAllocator::CreateProfilingAllocator() {
+  if (!owned_profiling_allocator_) {
+    owned_profiling_allocator_ =
+        std::make_unique<ProfilingArrayBufferAllocator>();
+  }
+  auto* pa = owned_profiling_allocator_.get();
+  profiling_allocator_.store(pa, std::memory_order_release);
+  return pa;
+}
+
+void NodeArrayBufferAllocator::ClearProfilingAllocator() {
+  profiling_allocator_.store(nullptr, std::memory_order_release);
 }
 
 DebuggingArrayBufferAllocator::~DebuggingArrayBufferAllocator() {
@@ -191,11 +220,154 @@ void DebuggingArrayBufferAllocator::RegisterPointerInternal(void* data,
   allocations_[data] = size;
 }
 
+void ProfilingArrayBufferAllocator::TrackAllocate(void* data, size_t size) {
+  // GC safety: this runs inside the ArrayBuffer allocator where V8 may
+  // prohibit heap allocation and JS execution (e.g. BackingStore::Allocate
+  // inside the ArrayBuffer constructor).  Extract only the ALS value
+  // from the CPED at allocation time via HeapProfiler::LookupAlsValue(),
+  // which uses OrderedHashMap::FindEntry (zero-allocation, GC-safe).
+  // HandleScope, GetContinuationPreservedEmbedderData, Global::Reset,
+  // and OrderedHashMap::FindEntry use the handle-scope stack / malloc,
+  // not the V8 heap.
+  v8::Isolate* isolate = isolate_.load(std::memory_order_relaxed);
+  if (std::this_thread::get_id() != main_thread_id_ ||
+      isolate == nullptr) {
+    return;
+  }
+  v8::HandleScope handle_scope(isolate);
+  v8::Local<v8::Value> cped =
+      isolate->GetContinuationPreservedEmbedderData();
+  if (!cped.IsEmpty() && cped->IsMap()) {
+    v8::HeapProfiler* profiler = isolate->GetHeapProfiler();
+    v8::Local<v8::Value> als_value;
+    if (profiler->LookupAlsValue(cped).ToLocal(&als_value)) {
+      Mutex::ScopedLock lock(mutex_);
+      auto& entry = allocations_[data];
+      entry.label_value.Reset(isolate, als_value);
+      entry.size = size;
+    }
+  }
+}
+
+void ProfilingArrayBufferAllocator::TrackFree(void* data) {
+  Mutex::ScopedLock lock(mutex_);
+  allocations_.erase(data);
+}
+
+void ProfilingArrayBufferAllocator::Enable(v8::Isolate* isolate) {
+  // Synchronization strategy: isolate_ serves as the "enabled" sentinel.
+  // TrackAllocate() and GetPerLabelBytes() check isolate_ == nullptr without
+  // holding the mutex as an early-exit guard.  We set isolate_ LAST here so
+  // that by the time any reader sees non-null isolate_, main_thread_id_ is
+  // already valid.  The corresponding Disable() sets isolate_ FIRST (to
+  // nullptr) before clearing other fields.  All accesses to isolate_ outside
+  // the mutex happen on the main thread, so relaxed memory ordering
+  // suffices — std::atomic prevents compiler reordering and torn reads.
+  Mutex::ScopedLock lock(mutex_);
+  main_thread_id_ = std::this_thread::get_id();
+  isolate_.store(isolate, std::memory_order_relaxed);
+}
+
+void ProfilingArrayBufferAllocator::Disable() {
+  // Clear isolate_ FIRST — it is the "enabled" sentinel checked by
+  // TrackAllocate() and GetPerLabelBytes() without holding the mutex.
+  // Setting it to nullptr before clearing other state ensures any
+  // re-entrant call (e.g., if allocations_.clear() triggers a Global
+  // destructor → GC → allocation → TrackAllocate on the same thread)
+  // will see null and exit early.
+  isolate_.store(nullptr, std::memory_order_relaxed);
+  Mutex::ScopedLock lock(mutex_);
+  allocations_.clear();
+}
+
+std::vector<ProfilingArrayBufferAllocator::LabeledBytes>
+ProfilingArrayBufferAllocator::GetPerLabelBytes() const {
+  v8::Isolate* isolate = isolate_.load(std::memory_order_relaxed);
+  if (isolate == nullptr) {
+    return {};
+  }
+
+  v8::HandleScope handle_scope(isolate);
+
+  // Snapshot: convert stored Globals to Locals under the lock, then release
+  // the lock before doing V8 API calls that may trigger GC.  If GC fires
+  // weak callbacks that call Free(), they acquire the lock independently
+  // without deadlocking.
+  struct SnapshotEntry {
+    v8::Local<v8::Value> label_value;
+    size_t size;
+  };
+  std::vector<SnapshotEntry> snapshot;
+  {
+    Mutex::ScopedLock lock(mutex_);
+    snapshot.reserve(allocations_.size());
+    for (const auto& [ptr, entry] : allocations_) {
+      if (!entry.label_value.IsEmpty()) {
+        snapshot.push_back({entry.label_value.Get(isolate), entry.size});
+      }
+    }
+  }
+
+  // Resolve labels outside the lock.  Array::Get() and String::Utf8Value
+  // may allocate on the V8 heap — safe here because GetPerLabelBytes is
+  // called from GetAllocationProfile (a JS callback) where GC is allowed.
+  // The stored values are ALS values (flat [key, val, ...] arrays) extracted
+  // at allocation time — no Map lookup needed.
+  v8::Local<v8::Context> v8_context = isolate->GetCurrentContext();
+  std::unordered_map<std::string, LabeledBytes> aggregated;
+  for (const auto& snap : snapshot) {
+    if (!snap.label_value->IsArray()) continue;
+    v8::Local<v8::Array> flat = snap.label_value.As<v8::Array>();
+    uint32_t len = flat->Length();
+    LabelPairs labels;
+    for (uint32_t j = 0; j + 1 < len; j += 2) {
+      v8::Local<v8::Value> k, v;
+      if (!flat->Get(v8_context, j).ToLocal(&k)) continue;
+      if (!flat->Get(v8_context, j + 1).ToLocal(&v)) continue;
+      v8::String::Utf8Value key_str(isolate, k);
+      v8::String::Utf8Value val_str(isolate, v);
+      if (*key_str == nullptr || *val_str == nullptr) continue;
+      labels.emplace_back(*key_str, *val_str);
+    }
+    if (labels.empty()) continue;
+    std::string key = SerializeLabels(labels);
+    auto& agg = aggregated[key];
+    if (agg.labels.empty()) agg.labels = std::move(labels);
+    agg.bytes += static_cast<int64_t>(snap.size);
+  }
+
+  std::vector<LabeledBytes> result;
+  result.reserve(aggregated.size());
+  for (auto& [key, entry] : aggregated) {
+    if (entry.bytes > 0) {
+      result.push_back(std::move(entry));
+    }
+  }
+  return result;
+}
+
+std::string ProfilingArrayBufferAllocator::SerializeLabels(
+    const LabelPairs& labels) {
+  std::string key;
+  for (const auto& [k, v] : labels) {
+    if (!key.empty()) key += '\0';
+    key += k;
+    key += '\0';
+    key += v;
+  }
+  return key;
+}
+
 std::unique_ptr<ArrayBufferAllocator> ArrayBufferAllocator::Create(bool debug) {
   if (debug || per_process::cli_options->debug_arraybuffer_allocations)
     return std::make_unique<DebuggingArrayBufferAllocator>();
-  else
-    return std::make_unique<NodeArrayBufferAllocator>();
+  // Use the plain NodeArrayBufferAllocator by default.  When heap profiling
+  // with labels is started (v8.startSamplingHeapProfiler), a
+  // ProfilingArrayBufferAllocator tracker is created on demand and installed
+  // as a delegate — see NodeArrayBufferAllocator::CreateProfilingAllocator().
+  // This ensures ZERO per-allocation overhead when profiling is not active:
+  // no atomic load, no virtual dispatch change, just a predicted null-branch.
+  return std::make_unique<NodeArrayBufferAllocator>();
 }
 
 ArrayBufferAllocator* CreateArrayBufferAllocator() {

--- a/src/node_internals.h
+++ b/src/node_internals.h
@@ -123,9 +123,11 @@ v8::Maybe<void> InitializePrimordials(v8::Local<v8::Context> context,
 v8::MaybeLocal<v8::Object> InitializePrivateSymbols(
     v8::Local<v8::Context> context, IsolateData* isolate_data);
 
+class ProfilingArrayBufferAllocator;  // Forward declaration.
+
 class NodeArrayBufferAllocator : public ArrayBufferAllocator {
  public:
-  void* Allocate(size_t size) override;  // Defined in src/node.cc
+  void* Allocate(size_t size) override;
   void* AllocateUninitialized(size_t size) override;
   void Free(void* data, size_t size) override;
   virtual void RegisterPointer(void* data, size_t size) {
@@ -136,6 +138,17 @@ class NodeArrayBufferAllocator : public ArrayBufferAllocator {
   }
 
   NodeArrayBufferAllocator* GetImpl() final { return this; }
+  // Returns the profiling tracker if active, nullptr otherwise.
+  ProfilingArrayBufferAllocator* GetProfilingAllocator() {
+    return profiling_allocator_.load(std::memory_order_acquire);
+  }
+  // Lazily create and install a ProfilingArrayBufferAllocator.  Returns the
+  // tracker (reuses existing one if already created).
+  ProfilingArrayBufferAllocator* CreateProfilingAllocator();
+  // Disconnect the profiling allocator so Allocate/Free no longer delegate.
+  // The tracker object stays alive for thread safety and is reused on next
+  // CreateProfilingAllocator() call.
+  void ClearProfilingAllocator();
   inline uint64_t total_mem_usage() const {
     return total_mem_usage_.load(std::memory_order_relaxed);
   }
@@ -146,6 +159,15 @@ class NodeArrayBufferAllocator : public ArrayBufferAllocator {
   // Delegate to V8's allocator for compatibility with the V8 memory cage.
   std::unique_ptr<v8::ArrayBuffer::Allocator> allocator_{
       v8::ArrayBuffer::Allocator::NewDefaultAllocator()};
+
+  // Owned profiling tracker — created lazily on first profiling start.
+  std::unique_ptr<ProfilingArrayBufferAllocator> owned_profiling_allocator_;
+  // Atomic pointer for fast null-check on the allocation hot path.
+  // Points into owned_profiling_allocator_ when profiling is active, nullptr
+  // otherwise.  Uses acquire/release ordering to pair with the release store
+  // in CreateProfilingAllocator/ClearProfilingAllocator — ensures Free()
+  // (called from GC threads) sees the fully constructed object.
+  std::atomic<ProfilingArrayBufferAllocator*> profiling_allocator_{nullptr};
 };
 
 class DebuggingArrayBufferAllocator final : public NodeArrayBufferAllocator {
@@ -162,6 +184,64 @@ class DebuggingArrayBufferAllocator final : public NodeArrayBufferAllocator {
   void UnregisterPointerInternal(void* data, size_t size);
   Mutex mutex_;
   std::unordered_map<void*, size_t> allocations_;
+};
+
+// Tracks per-label external memory (Buffer/ArrayBuffer backing stores) when
+// heap profiling with labels is active.  NOT an allocator itself — installed
+// as a delegate on NodeArrayBufferAllocator via CreateProfilingAllocator().
+// When inactive, there is zero overhead on the allocation path because
+// NodeArrayBufferAllocator skips delegation when the pointer is null.
+//
+// Synchronization model:
+//   isolate_ serves as the "enabled" sentinel.  TrackAllocate() and
+//   GetPerLabelBytes() check isolate_ == nullptr as the first guard,
+//   WITHOUT holding the mutex (they only lock to access allocations_).
+//   Enable() sets isolate_ LAST (after main_thread_id_); Disable()
+//   sets isolate_ FIRST (to nullptr, before clearing other state and
+//   locking).  This ordering ensures any re-entrant call that reads
+//   isolate_ either sees null (exits early) or sees a fully initialized
+//   state.  All reads/writes of isolate_ happen on the main thread,
+//   so relaxed memory ordering suffices, but isolate_ is std::atomic
+//   to prevent compiler reordering and torn reads.  The mutex protects
+//   allocations_ which is accessed cross-thread (main thread writes,
+//   GC threads call Free).
+class ProfilingArrayBufferAllocator {
+ public:
+  using LabelPairs = std::vector<std::pair<std::string, std::string>>;
+
+  struct LabeledBytes {
+    LabelPairs labels;
+    int64_t bytes = 0;
+  };
+
+  // Called from NodeArrayBufferAllocator::Allocate/AllocateUninitialized
+  // when the profiling delegate is active.
+  void TrackAllocate(void* data, size_t size);
+  // Called from NodeArrayBufferAllocator::Free.
+  void TrackFree(void* data);
+
+  // Called from StartSamplingHeapProfiler/StopSamplingHeapProfiler.
+  void Enable(v8::Isolate* isolate);
+  void Disable();
+
+  // Returns per-label live external bytes (for getAllocationProfile).
+  std::vector<LabeledBytes> GetPerLabelBytes() const;
+
+ private:
+  static std::string SerializeLabels(const LabelPairs& labels);
+
+  std::atomic<v8::Isolate*> isolate_{nullptr};
+
+  std::thread::id main_thread_id_ = std::this_thread::get_id();
+
+  mutable Mutex mutex_;
+  // Maps allocation pointer to the ALS value (flat label array) extracted
+  // at allocation time and the allocation size.
+  struct AllocationEntry {
+    v8::Global<v8::Value> label_value;
+    size_t size;
+  };
+  std::unordered_map<void*, AllocationEntry> allocations_;
 };
 
 namespace Buffer {

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -25,6 +25,7 @@
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
 #include "node.h"
+#include "node_internals.h"
 #include "node_external_reference.h"
 #include "util-inl.h"
 #include "v8-container.h"
@@ -778,10 +779,13 @@ void GCProfiler::Stop(const FunctionCallbackInfo<v8::Value>& args) {
 // dangling by the time this hook fires.
 struct HeapProfilingCleanup {
   Isolate* isolate;
+  NodeArrayBufferAllocator* node_allocator;
+  ProfilingArrayBufferAllocator* profiling_allocator;
   bool cleaned_up = false;
 
-  // Idempotent: stops the sampling profiler and clears the labels callback.
-  // Safe to call multiple times — only the first call has effect.
+  // Idempotent: stops the sampling profiler, clears the labels callback,
+  // and disables the allocator tracker.  Safe to call multiple times —
+  // only the first call has effect.
   void DoCleanup() {
     if (cleaned_up) return;
     cleaned_up = true;
@@ -792,7 +796,15 @@ struct HeapProfilingCleanup {
     profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
     profiler->SetHeapProfileSampleLabelsKey(Local<Value>());
 #endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+    if (node_allocator != nullptr) {
+      node_allocator->ClearProfilingAllocator();
+    }
+    if (profiling_allocator != nullptr) {
+      profiling_allocator->Disable();
+    }
     isolate = nullptr;
+    node_allocator = nullptr;
+    profiling_allocator = nullptr;
   }
 };
 
@@ -842,18 +854,31 @@ void StartSamplingHeapProfiler(const FunctionCallbackInfo<Value>& args) {
   }
   profiler->StartSamplingHeapProfiler(interval, stack_depth, flags);
 
+  // Enable external memory tracking on the allocator.  The profiling tracker
+  // is created lazily on first use — when profiling is not active there is
+  // zero overhead on every Allocate/Free call (no atomic load, no vtable
+  // change, just a predicted null-branch in NodeArrayBufferAllocator).
+  Environment* env = Environment::GetCurrent(args);
+  auto* node_allocator = env->isolate_data()->node_allocator();
+  ProfilingArrayBufferAllocator* profiling_allocator = nullptr;
+  if (node_allocator != nullptr) {
+    profiling_allocator = node_allocator->CreateProfilingAllocator();
+    profiling_allocator->Enable(isolate);
+  }
+
   // Register a cleanup hook so that if the Environment is torn down while
   // profiling is active (e.g. a worker thread is terminated), V8's callback
-  // pointer into the now-destroyed BindingData is cleared.  Remove any prior
-  // hook first (handles repeated Start calls without an intervening Stop).
-  Environment* env = Environment::GetCurrent(args);
+  // pointer into the now-destroyed BindingData is cleared and the allocator
+  // tracking is disabled.  Remove any prior hook first (handles repeated
+  // Start calls without an intervening Stop).
   if (binding_data->heap_profiling_cleanup_ != nullptr) {
     binding_data->heap_profiling_cleanup_->DoCleanup();
     env->RemoveCleanupHook(
         CleanupHeapProfiling, binding_data->heap_profiling_cleanup_);
     delete binding_data->heap_profiling_cleanup_;
   }
-  auto* cleanup = new HeapProfilingCleanup{isolate};
+  auto* cleanup = new HeapProfilingCleanup{
+      isolate, node_allocator, profiling_allocator};
   env->AddCleanupHook(CleanupHeapProfiling, cleanup);
   binding_data->heap_profiling_cleanup_ = cleanup;
 }
@@ -932,6 +957,48 @@ void GetAllocationProfile(const FunctionCallbackInfo<Value>& args) {
   if (result->Set(context,
                   FIXED_ONE_BYTE_STRING(isolate, "samples"),
                   js_samples).IsNothing()) return;
+
+  // Include per-label external memory (Buffer/ArrayBuffer) if profiling
+  // allocator is active. Each entry has { labels: { key: val, ... }, bytes: N }
+  // matching the labels structure used in heap samples.
+  Environment* env = Environment::GetCurrent(args);
+  auto* node_allocator = env->isolate_data()->node_allocator();
+  auto* profiling_allocator = node_allocator != nullptr
+      ? node_allocator->GetProfilingAllocator() : nullptr;
+  if (profiling_allocator != nullptr) {
+    auto per_label = profiling_allocator->GetPerLabelBytes();
+    if (!per_label.empty()) {
+      Local<Array> js_external = Array::New(isolate, per_label.size());
+      for (size_t idx = 0; idx < per_label.size(); idx++) {
+        const auto& entry = per_label[idx];
+        Local<Object> js_entry = Object::New(isolate);
+        Local<Object> js_labels = Object::New(isolate);
+        for (const auto& [lk, lv] : entry.labels) {
+          Local<String> key;
+          if (!String::NewFromUtf8(isolate, lk.c_str(),
+                                   v8::NewStringType::kNormal)
+                   .ToLocal(&key)) return;
+          Local<String> value;
+          if (!String::NewFromUtf8(isolate, lv.c_str(),
+                                   v8::NewStringType::kNormal)
+                   .ToLocal(&value)) return;
+          if (js_labels->Set(context, key, value).IsNothing()) return;
+        }
+        if (js_entry->Set(context,
+                          FIXED_ONE_BYTE_STRING(isolate, "labels"),
+                          js_labels).IsNothing()) return;
+        if (js_entry->Set(context,
+                          FIXED_ONE_BYTE_STRING(isolate, "bytes"),
+                          Number::New(isolate,
+                                      static_cast<double>(entry.bytes)))
+                .IsNothing()) return;
+        if (js_external->Set(context, idx, js_entry).IsNothing()) return;
+      }
+      if (result->Set(context,
+                      FIXED_ONE_BYTE_STRING(isolate, "externalBytes"),
+                      js_external).IsNothing()) return;
+    }
+  }
 
   args.GetReturnValue().Set(result);
 }

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -27,11 +27,16 @@
 #include "node.h"
 #include "node_external_reference.h"
 #include "util-inl.h"
+#include "v8-container.h"
 #include "v8-profiler.h"
 #include "v8.h"
 
 namespace node {
 namespace v8_utils {
+
+// V8's default sampling interval for the sampling heap profiler (512 KB).
+static constexpr uint64_t kDefaultSamplingInterval = 512 * 1024;
+using v8::AllocationProfile;
 using v8::Array;
 using v8::BigInt;
 using v8::CFunction;
@@ -44,12 +49,14 @@ using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
 using v8::HandleScope;
 using v8::HeapCodeStatistics;
+using v8::HeapProfiler;
 using v8::HeapSpaceStatistics;
 using v8::HeapStatistics;
 using v8::Integer;
 using v8::Isolate;
 using v8::Local;
 using v8::LocalVector;
+using v8::Map;
 using v8::MaybeLocal;
 using v8::Number;
 using v8::Object;
@@ -58,6 +65,63 @@ using v8::String;
 using v8::Uint32;
 using v8::V8;
 using v8::Value;
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+// V8 callback invoked at profile-read time (BuildSamples) for each sample
+// that has a stored CPED. Receives the CPED (AsyncContextFrame = JS Map),
+// looks up the heap profile labels ALS store value, and converts the
+// pre-flattened [key1, val1, key2, val2, ...] array to string pairs.
+//
+// GC safety: this callback is invoked from GetAllocationProfile() BEFORE
+// BuildSamples() iteration, in a context where GC is allowed. The caller
+// iterates a snapshot of ALS values (not the live samples_ map), so
+// GC-triggered weak callbacks that erase from samples_ cannot cause
+// iterator invalidation. Array::Get() may allocate on the V8 heap — that
+// is safe in this pre-resolution phase.
+//
+// The |context| parameter is the ALS value (flat [key1, val1, key2, val2, ...]
+// array) extracted by V8 at allocation time via OrderedHashMap::FindEntry.
+// If no ALS value was found for a sample, context will be empty or undefined.
+static bool HeapProfileLabelsCallback(
+    void* data, v8::Local<v8::Value> context,
+    std::vector<std::pair<std::string, std::string>>* out_labels) {
+  auto* binding_data = static_cast<BindingData*>(data);
+  if (!binding_data) return false;
+
+  // context is the ALS value (flat label array) — no Map lookup needed.
+  if (context.IsEmpty() || !context->IsArray()) return false;
+
+  Isolate* isolate = binding_data->env()->isolate();
+  HandleScope handle_scope(isolate);
+  Local<v8::Context> v8_context = isolate->GetCurrentContext();
+
+  // Convert flat [key1, val1, key2, val2, ...] array to string pairs.
+  Local<Array> flat = context.As<Array>();
+  uint32_t len = flat->Length();
+  std::vector<std::pair<std::string, std::string>> result;
+  for (uint32_t j = 0; j + 1 < len; j += 2) {
+    Local<Value> k, v;
+    if (!flat->Get(v8_context, j).ToLocal(&k)) return false;
+    if (!flat->Get(v8_context, j + 1).ToLocal(&v)) return false;
+    String::Utf8Value key_str(isolate, k);
+    String::Utf8Value val_str(isolate, v);
+    if (*key_str == nullptr || *val_str == nullptr) continue;
+    result.emplace_back(*key_str, *val_str);
+  }
+
+  *out_labels = std::move(result);
+  return !out_labels->empty();
+}
+
+// C++ binding: store the AsyncLocalStorage instance used for heap profile
+// labels. V8 uses this key at allocation time to extract the ALS value from
+// the CPED (AsyncContextFrame) via OrderedHashMap::FindEntry.
+void SetHeapProfileLabelsStore(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
+  binding_data->heap_profile_labels_als_key.Reset(isolate, args[0]);
+}
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 
 #define HEAP_STATISTICS_PROPERTIES(V)                                          \
   V(0, total_heap_size, kTotalHeapSizeIndex)                                   \
@@ -103,6 +167,9 @@ static const size_t kHeapCodeStatisticsPropertiesCount =
     HEAP_CODE_STATISTICS_PROPERTIES(V);
 #undef V
 
+// Forward declaration for the env cleanup hook (used by ~BindingData).
+static void CleanupHeapProfiling(void* data);
+
 BindingData::BindingData(Realm* realm,
                          Local<Object> obj,
                          InternalFieldInfo* info)
@@ -142,6 +209,25 @@ BindingData::BindingData(Realm* realm,
   heap_statistics_buffer.MakeWeak();
   heap_space_statistics_buffer.MakeWeak();
   heap_code_statistics_buffer.MakeWeak();
+}
+
+BindingData::~BindingData() {
+  // BindingData is destroyed during Realm::RunCleanup() (via
+  // binding_data_store_.reset()), which runs BEFORE the environment cleanup
+  // queue is drained.  At this point the Isolate and Environment are
+  // guaranteed to still be alive (Realm::RunCleanup runs inside
+  // Environment::RunCleanup, before the Environment is deleted and long
+  // before the Isolate is disposed).
+  //
+  // If profiling was active, DoCleanup() stops the sampler, clears V8's
+  // callback pointer into this (about-to-be-destroyed) BindingData, and
+  // disables the allocator tracker — preventing use-after-free.
+  if (heap_profiling_cleanup_ != nullptr) {
+    heap_profiling_cleanup_->DoCleanup();
+    env()->RemoveCleanupHook(CleanupHeapProfiling, heap_profiling_cleanup_);
+    delete heap_profiling_cleanup_;
+    heap_profiling_cleanup_ = nullptr;
+  }
 }
 
 bool BindingData::PrepareForSerialization(Local<Context> context,
@@ -186,6 +272,9 @@ void BindingData::MemoryInfo(MemoryTracker* tracker) const {
                       heap_space_statistics_buffer);
   tracker->TrackField("heap_code_statistics_buffer",
                       heap_code_statistics_buffer);
+  tracker->TrackFieldWithSize("heap_profile_labels_als_key",
+                              heap_profile_labels_als_key.IsEmpty() ? 0 :
+                                  sizeof(v8::Global<v8::Value>));
 }
 
 void CachedDataVersionTag(const FunctionCallbackInfo<Value>& args) {
@@ -673,6 +762,180 @@ void GCProfiler::Stop(const FunctionCallbackInfo<v8::Value>& args) {
   }
 }
 
+// Data captured when heap profiling starts, used by the cleanup hook to
+// safely tear down profiler state if the Environment is destroyed while
+// profiling is still active (e.g. worker thread termination).
+//
+// Raw pointers are safe here because Environment cleanup hooks are
+// guaranteed to run before the Isolate is disposed: FreeEnvironment()
+// calls env->RunCleanup() (which drains the cleanup queue) while still
+// inside Isolate::Scope, and the ArrayBufferAllocator that owns
+// ProfilingArrayBufferAllocator outlives the Isolate.
+//
+// We intentionally do NOT store a BindingData* here — Realm::RunCleanup()
+// destroys BindingData (via binding_data_store_.reset()) before the
+// environment cleanup queue is drained, so any BindingData* would be
+// dangling by the time this hook fires.
+struct HeapProfilingCleanup {
+  Isolate* isolate;
+  bool cleaned_up = false;
+
+  // Idempotent: stops the sampling profiler and clears the labels callback.
+  // Safe to call multiple times — only the first call has effect.
+  void DoCleanup() {
+    if (cleaned_up) return;
+    cleaned_up = true;
+
+    HeapProfiler* profiler = isolate->GetHeapProfiler();
+    profiler->StopSamplingHeapProfiler();
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+    profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+    profiler->SetHeapProfileSampleLabelsKey(Local<Value>());
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+    isolate = nullptr;
+  }
+};
+
+static void CleanupHeapProfiling(void* data) {
+  auto* ctx = static_cast<HeapProfilingCleanup*>(data);
+  ctx->DoCleanup();
+  delete ctx;
+}
+
+void StartSamplingHeapProfiler(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  Local<Context> context = isolate->GetCurrentContext();
+  HeapProfiler* profiler = isolate->GetHeapProfiler();
+  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
+  uint64_t interval = kDefaultSamplingInterval;
+  if (args.Length() > 0 && args[0]->IsNumber()) {
+    interval = static_cast<uint64_t>(args[0].As<Number>()->Value());
+  }
+  int stack_depth = 16;  // Default stack depth
+  if (args.Length() > 1 && args[1]->IsNumber()) {
+    stack_depth = static_cast<int>(args[1].As<Number>()->Value());
+  }
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  profiler->SetHeapProfileSampleLabelsCallback(
+      HeapProfileLabelsCallback, binding_data);
+  if (!binding_data->heap_profile_labels_als_key.IsEmpty()) {
+    profiler->SetHeapProfileSampleLabelsKey(
+        binding_data->heap_profile_labels_als_key.Get(isolate));
+  }
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+  // By default, GC'd samples are removed from the profile (live-memory mode).
+  // When includeCollectedObjects is true, retain GC'd samples so allocation
+  // attribution reflects total allocations (allocation-rate mode).
+  v8::HeapProfiler::SamplingFlags flags =
+      static_cast<v8::HeapProfiler::SamplingFlags>(
+          v8::HeapProfiler::kSamplingNoFlags);
+  if (args.Length() > 2 && args[2]->IsObject()) {
+    Local<Object> options = args[2].As<Object>();
+    Local<String> key = String::NewFromUtf8Literal(isolate,
+                                                    "includeCollectedObjects");
+    Local<Value> val;
+    if (options->Get(context, key).ToLocal(&val) && val->IsTrue()) {
+      flags = static_cast<v8::HeapProfiler::SamplingFlags>(
+          v8::HeapProfiler::kSamplingIncludeObjectsCollectedByMajorGC |
+          v8::HeapProfiler::kSamplingIncludeObjectsCollectedByMinorGC);
+    }
+  }
+  profiler->StartSamplingHeapProfiler(interval, stack_depth, flags);
+
+  // Register a cleanup hook so that if the Environment is torn down while
+  // profiling is active (e.g. a worker thread is terminated), V8's callback
+  // pointer into the now-destroyed BindingData is cleared.  Remove any prior
+  // hook first (handles repeated Start calls without an intervening Stop).
+  Environment* env = Environment::GetCurrent(args);
+  if (binding_data->heap_profiling_cleanup_ != nullptr) {
+    binding_data->heap_profiling_cleanup_->DoCleanup();
+    env->RemoveCleanupHook(
+        CleanupHeapProfiling, binding_data->heap_profiling_cleanup_);
+    delete binding_data->heap_profiling_cleanup_;
+  }
+  auto* cleanup = new HeapProfilingCleanup{isolate};
+  env->AddCleanupHook(CleanupHeapProfiling, cleanup);
+  binding_data->heap_profiling_cleanup_ = cleanup;
+}
+
+void StopSamplingHeapProfiler(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
+
+  if (binding_data->heap_profiling_cleanup_ != nullptr) {
+    binding_data->heap_profiling_cleanup_->DoCleanup();
+    env->RemoveCleanupHook(
+        CleanupHeapProfiling, binding_data->heap_profiling_cleanup_);
+    delete binding_data->heap_profiling_cleanup_;
+    binding_data->heap_profiling_cleanup_ = nullptr;
+  }
+}
+
+void GetAllocationProfile(const FunctionCallbackInfo<Value>& args) {
+  Isolate* isolate = args.GetIsolate();
+  HeapProfiler* profiler = isolate->GetHeapProfiler();
+  HandleScope scope(isolate);
+  Local<Context> context = isolate->GetCurrentContext();
+
+  std::unique_ptr<AllocationProfile> profile(profiler->GetAllocationProfile());
+  if (!profile) {
+    return;  // Returns undefined if profiler not started
+  }
+
+  const std::vector<AllocationProfile::Sample>& samples = profile->GetSamples();
+  Local<Array> js_samples = Array::New(isolate, samples.size());
+
+  for (size_t i = 0; i < samples.size(); i++) {
+    const AllocationProfile::Sample& sample = samples[i];
+    Local<Object> js_sample = Object::New(isolate);
+
+    if (js_sample->Set(context,
+                       FIXED_ONE_BYTE_STRING(isolate, "nodeId"),
+                       Integer::NewFromUnsigned(isolate, sample.node_id))
+            .IsNothing()) return;
+    if (js_sample->Set(context,
+                       FIXED_ONE_BYTE_STRING(isolate, "size"),
+                       Number::New(isolate, static_cast<double>(sample.size)))
+            .IsNothing()) return;
+    if (js_sample->Set(context,
+                       FIXED_ONE_BYTE_STRING(isolate, "count"),
+                       Integer::NewFromUnsigned(isolate, sample.count))
+            .IsNothing()) return;
+    if (js_sample->Set(context,
+                       FIXED_ONE_BYTE_STRING(isolate, "sampleId"),
+                       Number::New(isolate, static_cast<double>(sample.sample_id)))
+            .IsNothing()) return;
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+    // Always emit labels field (empty {} when no labels captured)
+    Local<Object> js_labels = Object::New(isolate);
+    for (const auto& label : sample.labels) {
+      Local<String> key;
+      if (!String::NewFromUtf8(isolate, label.first.c_str(),
+                               v8::NewStringType::kNormal)
+               .ToLocal(&key)) return;
+      Local<String> value;
+      if (!String::NewFromUtf8(isolate, label.second.c_str(),
+                               v8::NewStringType::kNormal)
+               .ToLocal(&value)) return;
+      if (js_labels->Set(context, key, value).IsNothing()) return;
+    }
+    if (js_sample->Set(context,
+                       FIXED_ONE_BYTE_STRING(isolate, "labels"),
+                       js_labels).IsNothing()) return;
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+
+    if (js_samples->Set(context, i, js_sample).IsNothing()) return;
+  }
+
+  Local<Object> result = Object::New(isolate);
+  if (result->Set(context,
+                  FIXED_ONE_BYTE_STRING(isolate, "samples"),
+                  js_samples).IsNothing()) return;
+
+  args.GetReturnValue().Set(result);
+}
+
 void Initialize(Local<Object> target,
                 Local<Value> unused,
                 Local<Context> context,
@@ -741,6 +1004,18 @@ void Initialize(Local<Object> target,
   SetMethod(context, target, "startCpuProfile", StartCpuProfile);
   SetMethod(context, target, "stopCpuProfile", StopCpuProfile);
 
+  // Sampling heap profiler with context support
+  SetMethod(context, target, "startSamplingHeapProfiler",
+            StartSamplingHeapProfiler);
+  SetMethod(context, target, "stopSamplingHeapProfiler",
+            StopSamplingHeapProfiler);
+  SetMethod(context, target, "getAllocationProfile",
+            GetAllocationProfile);
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  SetMethod(context, target, "setHeapProfileLabelsStore",
+            SetHeapProfileLabelsStore);
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+
   // Export symbols used by v8.isStringOneByteRepresentation()
   SetFastMethodNoSideEffect(context,
                             target,
@@ -787,6 +1062,12 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(fast_is_string_one_byte_representation_);
   registry->Register(StartCpuProfile);
   registry->Register(StopCpuProfile);
+  registry->Register(StartSamplingHeapProfiler);
+  registry->Register(StopSamplingHeapProfiler);
+  registry->Register(GetAllocationProfile);
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+  registry->Register(SetHeapProfileLabelsStore);
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 }
 
 }  // namespace v8_utils

--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -117,10 +117,16 @@ static bool HeapProfileLabelsCallback(
 // C++ binding: store the AsyncLocalStorage instance used for heap profile
 // labels. V8 uses this key at allocation time to extract the ALS value from
 // the CPED (AsyncContextFrame) via OrderedHashMap::FindEntry.
+//
+// Propagates to the V8 HeapProfiler immediately so that callers who set the
+// store after StartSamplingHeapProfiler() (the common JS path:
+// withHeapProfileLabels lazily creates the ALS on first use) still have
+// labels captured by SampleObject().
 void SetHeapProfileLabelsStore(const FunctionCallbackInfo<Value>& args) {
   Isolate* isolate = args.GetIsolate();
   BindingData* binding_data = Realm::GetBindingData<BindingData>(args);
   binding_data->heap_profile_labels_als_key.Reset(isolate, args[0]);
+  isolate->GetHeapProfiler()->SetHeapProfileSampleLabelsKey(args[0]);
 }
 #endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
 
@@ -210,6 +216,60 @@ BindingData::BindingData(Realm* realm,
   heap_statistics_buffer.MakeWeak();
   heap_space_statistics_buffer.MakeWeak();
   heap_code_statistics_buffer.MakeWeak();
+}
+
+// Data captured when heap profiling starts, used by the cleanup hook to
+// safely tear down profiler state if the Environment is destroyed while
+// profiling is still active (e.g. worker thread termination).
+//
+// Raw pointers are safe here because Environment cleanup hooks are
+// guaranteed to run before the Isolate is disposed: FreeEnvironment()
+// calls env->RunCleanup() (which drains the cleanup queue) while still
+// inside Isolate::Scope, and the ArrayBufferAllocator that owns
+// ProfilingArrayBufferAllocator outlives the Isolate.
+//
+// We intentionally do NOT store a BindingData* here — Realm::RunCleanup()
+// destroys BindingData (via binding_data_store_.reset()) before the
+// environment cleanup queue is drained, so any BindingData* would be
+// dangling by the time this hook fires.
+//
+// Defined before BindingData::~BindingData() because the destructor calls
+// DoCleanup() and deletes this struct, which requires the complete type.
+struct HeapProfilingCleanup {
+  Isolate* isolate;
+  NodeArrayBufferAllocator* node_allocator;
+  ProfilingArrayBufferAllocator* profiling_allocator;
+  bool cleaned_up = false;
+
+  // Idempotent: stops the sampling profiler, clears the labels callback,
+  // and disables the allocator tracker.  Safe to call multiple times —
+  // only the first call has effect.
+  void DoCleanup() {
+    if (cleaned_up) return;
+    cleaned_up = true;
+
+    HeapProfiler* profiler = isolate->GetHeapProfiler();
+    profiler->StopSamplingHeapProfiler();
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+    profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+    profiler->SetHeapProfileSampleLabelsKey(Local<Value>());
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
+    if (node_allocator != nullptr) {
+      node_allocator->ClearProfilingAllocator();
+    }
+    if (profiling_allocator != nullptr) {
+      profiling_allocator->Disable();
+    }
+    isolate = nullptr;
+    node_allocator = nullptr;
+    profiling_allocator = nullptr;
+  }
+};
+
+static void CleanupHeapProfiling(void* data) {
+  auto* ctx = static_cast<HeapProfilingCleanup*>(data);
+  ctx->DoCleanup();
+  delete ctx;
 }
 
 BindingData::~BindingData() {
@@ -761,57 +821,6 @@ void GCProfiler::Stop(const FunctionCallbackInfo<v8::Value>& args) {
   if (ToV8Value(env->context(), string, env->isolate()).ToLocal(&ret)) {
     args.GetReturnValue().Set(ret);
   }
-}
-
-// Data captured when heap profiling starts, used by the cleanup hook to
-// safely tear down profiler state if the Environment is destroyed while
-// profiling is still active (e.g. worker thread termination).
-//
-// Raw pointers are safe here because Environment cleanup hooks are
-// guaranteed to run before the Isolate is disposed: FreeEnvironment()
-// calls env->RunCleanup() (which drains the cleanup queue) while still
-// inside Isolate::Scope, and the ArrayBufferAllocator that owns
-// ProfilingArrayBufferAllocator outlives the Isolate.
-//
-// We intentionally do NOT store a BindingData* here — Realm::RunCleanup()
-// destroys BindingData (via binding_data_store_.reset()) before the
-// environment cleanup queue is drained, so any BindingData* would be
-// dangling by the time this hook fires.
-struct HeapProfilingCleanup {
-  Isolate* isolate;
-  NodeArrayBufferAllocator* node_allocator;
-  ProfilingArrayBufferAllocator* profiling_allocator;
-  bool cleaned_up = false;
-
-  // Idempotent: stops the sampling profiler, clears the labels callback,
-  // and disables the allocator tracker.  Safe to call multiple times —
-  // only the first call has effect.
-  void DoCleanup() {
-    if (cleaned_up) return;
-    cleaned_up = true;
-
-    HeapProfiler* profiler = isolate->GetHeapProfiler();
-    profiler->StopSamplingHeapProfiler();
-#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
-    profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
-    profiler->SetHeapProfileSampleLabelsKey(Local<Value>());
-#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS
-    if (node_allocator != nullptr) {
-      node_allocator->ClearProfilingAllocator();
-    }
-    if (profiling_allocator != nullptr) {
-      profiling_allocator->Disable();
-    }
-    isolate = nullptr;
-    node_allocator = nullptr;
-    profiling_allocator = nullptr;
-  }
-};
-
-static void CleanupHeapProfiling(void* data) {
-  auto* ctx = static_cast<HeapProfilingCleanup*>(data);
-  ctx->DoCleanup();
-  delete ctx;
 }
 
 void StartSamplingHeapProfiler(const FunctionCallbackInfo<Value>& args) {

--- a/src/node_v8.h
+++ b/src/node_v8.h
@@ -4,6 +4,7 @@
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 #include <sstream>
+#include <string>
 #include "aliased_buffer.h"
 #include "base_object.h"
 #include "json_utils.h"
@@ -17,6 +18,9 @@ class Environment;
 struct InternalFieldInfoBase;
 
 namespace v8_utils {
+
+struct HeapProfilingCleanup;
+
 class BindingData : public SnapshotableObject {
  public:
   struct InternalFieldInfo : public node::InternalFieldInfoBase {
@@ -27,6 +31,7 @@ class BindingData : public SnapshotableObject {
   BindingData(Realm* realm,
               v8::Local<v8::Object> obj,
               InternalFieldInfo* info = nullptr);
+  ~BindingData() override;
 
   SERIALIZABLE_OBJECT_METHODS()
   SET_BINDING_ID(v8_binding_data)
@@ -34,6 +39,36 @@ class BindingData : public SnapshotableObject {
   AliasedFloat64Array heap_statistics_buffer;
   AliasedFloat64Array heap_space_statistics_buffer;
   AliasedFloat64Array heap_code_statistics_buffer;
+
+  // Reference to the JS AsyncLocalStorage instance used by
+  // withHeapProfileLabels/setHeapProfileLabels. The V8 callback uses this
+  // as the key to look up label values in the stored CPED (AsyncContextFrame
+  // Map) at profile-read time.
+  v8::Global<v8::Value> heap_profile_labels_als_key;
+
+  // Typed pointer to HeapProfilingCleanup state registered with
+  // AddCleanupHook when profiling is active.
+  //
+  // Lifetime contract — three paths may trigger cleanup, all on the
+  // main thread:
+  //
+  //  1. StopSamplingHeapProfiler (explicit user call):
+  //     Calls DoCleanup(), removes the env cleanup hook, deletes
+  //     the struct, and nulls this pointer.
+  //
+  //  2. ~BindingData (Realm teardown — runs BEFORE env cleanup hooks):
+  //     Calls DoCleanup(), removes the env cleanup hook, deletes
+  //     the struct, and nulls this pointer.
+  //
+  //  3. CleanupHeapProfiling (env cleanup hook):
+  //     Fires only if neither (1) nor (2) removed the hook first.
+  //     Calls DoCleanup() and deletes the struct.
+  //
+  // DoCleanup() is idempotent (guarded by cleaned_up flag), so
+  // multiple paths calling it is safe.  The first path that runs
+  // removes the hook and deletes the struct; subsequent paths see
+  // nullptr and skip.
+  HeapProfilingCleanup* heap_profiling_cleanup_ = nullptr;
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_SELF_SIZE(BindingData)

--- a/test/cctest/test_heap_profile_labels.cc
+++ b/test/cctest/test_heap_profile_labels.cc
@@ -1,0 +1,358 @@
+// Tests for V8 HeapProfileSampleLabelsCallback API.
+// Validates the label callback feature at the V8 public API level.
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "node_test_fixture.h"
+#include "v8-profiler.h"
+#include "v8.h"
+
+#ifdef V8_HEAP_PROFILER_SAMPLE_LABELS
+
+// Helper: a label callback that writes fixed labels via output parameter.
+static bool FixedLabelsCallback(
+    void* data, v8::Local<v8::Value> context,
+    std::vector<std::pair<std::string, std::string>>* out_labels) {
+  auto* labels =
+      static_cast<std::vector<std::pair<std::string, std::string>>*>(data);
+  *out_labels = *labels;
+  return true;
+}
+
+// Helper: a label callback that returns false (no labels).
+static bool EmptyLabelsCallback(
+    void* data, v8::Local<v8::Value> context,
+    std::vector<std::pair<std::string, std::string>>* out_labels) {
+  return false;
+}
+
+// Helper: a label callback that resolves labels based on the CPED string value.
+// Used to verify that different CPED values produce different labels.
+struct ContextLabelState {
+  v8::Isolate* isolate;
+};
+
+static bool ContextBasedLabelsCallback(
+    void* data, v8::Local<v8::Value> context,
+    std::vector<std::pair<std::string, std::string>>* out_labels) {
+  if (context.IsEmpty() || !context->IsString()) return false;
+  auto* state = static_cast<ContextLabelState*>(data);
+  v8::String::Utf8Value utf8(state->isolate, context);
+  std::string cped_str(*utf8, utf8.length());
+  if (cped_str == "first") {
+    out_labels->push_back({"route", "/api/first"});
+  } else if (cped_str == "second") {
+    out_labels->push_back({"route", "/api/second"});
+  }
+  return !out_labels->empty();
+}
+
+class HeapProfileLabelsTest : public NodeTestFixture {};
+
+// Test: register callback, allocate, verify labels on samples.
+TEST_F(HeapProfileLabelsTest, CallbackReturnsLabels) {
+  const v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+
+  v8::HeapProfiler* heap_profiler = isolate_->GetHeapProfiler();
+
+  std::vector<std::pair<std::string, std::string>> labels = {
+      {"route", "/api/test"}};
+
+  // Set CPED so the callback gets invoked (requires non-empty context).
+  isolate_->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate_, "test-context"));
+
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  // Allocate enough objects to get samples.
+  for (int i = 0; i < 8 * 1024; ++i) v8::Object::New(isolate_);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  ASSERT_NE(profile, nullptr);
+
+  bool found_labeled = false;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      EXPECT_EQ(sample.labels.size(), 1u);
+      EXPECT_EQ(sample.labels[0].first, "route");
+      EXPECT_EQ(sample.labels[0].second, "/api/test");
+      found_labeled = true;
+    }
+  }
+  EXPECT_TRUE(found_labeled);
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+// Test: no callback registered — samples have empty labels.
+TEST_F(HeapProfileLabelsTest, NoCallbackEmptyLabels) {
+  const v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+
+  v8::HeapProfiler* heap_profiler = isolate_->GetHeapProfiler();
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  for (int i = 0; i < 8 * 1024; ++i) v8::Object::New(isolate_);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  ASSERT_NE(profile, nullptr);
+
+  for (const auto& sample : profile->GetSamples()) {
+    EXPECT_TRUE(sample.labels.empty());
+  }
+
+  heap_profiler->StopSamplingHeapProfiler();
+}
+
+// Test: callback returns empty vector — samples have empty labels.
+TEST_F(HeapProfileLabelsTest, EmptyCallbackEmptyLabels) {
+  const v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+
+  v8::HeapProfiler* heap_profiler = isolate_->GetHeapProfiler();
+
+  // Set CPED so callback is invoked.
+  isolate_->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate_, "test-context"));
+
+  heap_profiler->SetHeapProfileSampleLabelsCallback(EmptyLabelsCallback,
+                                                    nullptr);
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  for (int i = 0; i < 8 * 1024; ++i) v8::Object::New(isolate_);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  ASSERT_NE(profile, nullptr);
+
+  for (const auto& sample : profile->GetSamples()) {
+    EXPECT_TRUE(sample.labels.empty());
+  }
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+// Test: multiple distinct label sets resolved from different CPED values.
+// Labels are resolved at read time (BuildSamples) from stored CPED.
+TEST_F(HeapProfileLabelsTest, MultipleDistinctLabels) {
+  const v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+
+  v8::HeapProfiler* heap_profiler = isolate_->GetHeapProfiler();
+
+  ContextLabelState state{isolate_};
+  heap_profiler->SetHeapProfileSampleLabelsCallback(ContextBasedLabelsCallback,
+                                                    &state);
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  // Allocate with first CPED value.
+  isolate_->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate_, "first"));
+  for (int i = 0; i < 4 * 1024; ++i) v8::Object::New(isolate_);
+
+  // Switch to second CPED value.
+  isolate_->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate_, "second"));
+  for (int i = 0; i < 4 * 1024; ++i) v8::Object::New(isolate_);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  ASSERT_NE(profile, nullptr);
+
+  bool found_first = false;
+  bool found_second = false;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      EXPECT_EQ(sample.labels.size(), 1u);
+      EXPECT_EQ(sample.labels[0].first, "route");
+      if (sample.labels[0].second == "/api/first") found_first = true;
+      if (sample.labels[0].second == "/api/second") found_second = true;
+    }
+  }
+  EXPECT_TRUE(found_first);
+  EXPECT_TRUE(found_second);
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+// Test: labels survive GC when kSamplingIncludeObjectsCollectedByMajorGC enabled.
+TEST_F(HeapProfileLabelsTest, LabelsSurviveGCWithRetainFlags) {
+  const v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+
+  v8::HeapProfiler* heap_profiler = isolate_->GetHeapProfiler();
+
+  // Set CPED so callback is invoked.
+  isolate_->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate_, "test-context"));
+
+  std::vector<std::pair<std::string, std::string>> labels = {
+      {"route", "/api/gc-test"}};
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  // Start with GC retain flags — GC'd samples should survive.
+  heap_profiler->StartSamplingHeapProfiler(
+      256, 128,
+      static_cast<v8::HeapProfiler::SamplingFlags>(
+          v8::HeapProfiler::kSamplingIncludeObjectsCollectedByMajorGC |
+          v8::HeapProfiler::kSamplingIncludeObjectsCollectedByMinorGC));
+
+  // Allocate short-lived objects via JS (no reference retained).
+  v8::Local<v8::String> source =
+      v8::String::NewFromUtf8Literal(isolate_,
+          "for (var i = 0; i < 4096; i++) { new Array(64); }");
+  v8::Local<v8::Script> script =
+      v8::Script::Compile(context, source).ToLocalChecked();
+  script->Run(context).ToLocalChecked();
+
+  // Force GC to collect the short-lived objects.
+  v8::V8::SetFlagsFromString("--expose-gc");
+  isolate_->RequestGarbageCollectionForTesting(
+      v8::Isolate::kFullGarbageCollection);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  ASSERT_NE(profile, nullptr);
+
+  // With GC retain flags, samples for collected objects should still exist
+  // with their labels intact.
+  bool found_labeled = false;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      EXPECT_EQ(sample.labels[0].first, "route");
+      EXPECT_EQ(sample.labels[0].second, "/api/gc-test");
+      found_labeled = true;
+    }
+  }
+  EXPECT_TRUE(found_labeled);
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+// Test: labels removed with samples when GC flags disabled and objects collected.
+TEST_F(HeapProfileLabelsTest, SamplesRemovedByGCWithoutFlags) {
+  const v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+
+  v8::HeapProfiler* heap_profiler = isolate_->GetHeapProfiler();
+
+  // Set CPED so callback is invoked.
+  isolate_->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate_, "test-context"));
+
+  std::vector<std::pair<std::string, std::string>> labels = {
+      {"route", "/api/gc-remove"}};
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  // Start WITHOUT GC retain flags — GC'd samples should be removed.
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  // Allocate short-lived objects via JS (no reference retained).
+  v8::Local<v8::String> source =
+      v8::String::NewFromUtf8Literal(isolate_,
+          "for (var i = 0; i < 4096; i++) { new Array(64); }");
+  v8::Local<v8::Script> script =
+      v8::Script::Compile(context, source).ToLocalChecked();
+  script->Run(context).ToLocalChecked();
+
+  // Force GC to collect the short-lived objects.
+  v8::V8::SetFlagsFromString("--expose-gc");
+  isolate_->RequestGarbageCollectionForTesting(
+      v8::Isolate::kFullGarbageCollection);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  ASSERT_NE(profile, nullptr);
+
+  // Without GC retain flags, samples for collected objects should be removed.
+  // The profile should still be valid (no crash).
+  EXPECT_NE(profile->GetRootNode(), nullptr);
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+// Test: unregister callback — samples allocated after have no stored CPED.
+// In the new architecture, CPED is only captured when a callback is registered
+// at allocation time. Labels are resolved at read time. Samples without CPED
+// get no labels even when the callback is re-registered for reading.
+TEST_F(HeapProfileLabelsTest, UnregisterCallbackStopsLabels) {
+  const v8::HandleScope handle_scope(isolate_);
+  v8::Local<v8::Context> context = v8::Context::New(isolate_);
+  v8::Context::Scope context_scope(context);
+
+  v8::HeapProfiler* heap_profiler = isolate_->GetHeapProfiler();
+
+  // Set CPED so it's available during allocation.
+  isolate_->SetContinuationPreservedEmbedderData(
+      v8::String::NewFromUtf8Literal(isolate_, "test-context"));
+
+  std::vector<std::pair<std::string, std::string>> labels = {
+      {"route", "/api/before-unregister"}};
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  heap_profiler->StartSamplingHeapProfiler(256);
+
+  // Allocate with callback active — CPED is captured on these samples.
+  for (int i = 0; i < 4 * 1024; ++i) v8::Object::New(isolate_);
+
+  // Unregister callback — new samples won't have CPED captured.
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+
+  // Allocate more — no CPED captured since callback is null at allocation time.
+  for (int i = 0; i < 4 * 1024; ++i) v8::Object::New(isolate_);
+
+  // Re-register callback before reading profile. Labels are resolved at
+  // read time, so only samples with stored CPED will get labels.
+  heap_profiler->SetHeapProfileSampleLabelsCallback(FixedLabelsCallback,
+                                                    &labels);
+
+  std::unique_ptr<v8::AllocationProfile> profile(
+      heap_profiler->GetAllocationProfile());
+  ASSERT_NE(profile, nullptr);
+
+  // Should have labeled samples (CPED captured before unregister) and
+  // unlabeled samples (no CPED captured after unregister).
+  bool found_labeled = false;
+  bool found_unlabeled = false;
+  for (const auto& sample : profile->GetSamples()) {
+    if (!sample.labels.empty()) {
+      found_labeled = true;
+    } else {
+      found_unlabeled = true;
+    }
+  }
+  EXPECT_TRUE(found_labeled);
+  EXPECT_TRUE(found_unlabeled);
+
+  heap_profiler->StopSamplingHeapProfiler();
+  heap_profiler->SetHeapProfileSampleLabelsCallback(nullptr, nullptr);
+}
+
+#endif  // V8_HEAP_PROFILER_SAMPLE_LABELS

--- a/test/parallel/test-v8-heap-profile-external.js
+++ b/test/parallel/test-v8-heap-profile-external.js
@@ -1,0 +1,257 @@
+// Flags: --expose-gc
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+
+// Helper: find an externalBytes entry whose labels match a predicate.
+function findExternal(profile, predicate) {
+  if (!Array.isArray(profile.externalBytes)) return undefined;
+  return profile.externalBytes.find(predicate);
+}
+
+// Helper: find an externalBytes entry by a single label key-value pair.
+function findByLabel(profile, key, value) {
+  return findExternal(profile, (e) => e.labels[key] === value);
+}
+
+// Test 1: Buffer.alloc() inside withHeapProfileLabels is attributed to the
+// correct label in externalBytes.
+{
+  v8.startSamplingHeapProfiler(512 * 1024);  // 512KB interval (default)
+
+  // Allocate 10MB Buffer inside a labeled context.
+  const buf = v8.withHeapProfileLabels({ route: '/heavy' }, () => {
+    const b = Buffer.alloc(10 * 1024 * 1024);
+    // Keep buf alive.
+    assert.strictEqual(b.length, 10 * 1024 * 1024);
+    return b;
+  });
+
+  const profile = v8.getAllocationProfile();
+  assert.ok(profile, 'profile should exist');
+
+  assert.ok(Array.isArray(profile.externalBytes),
+    'externalBytes should be an array (ProfilingArrayBufferAllocator active)');
+  {
+    const entry = findByLabel(profile, 'route', '/heavy');
+    assert.ok(entry, 'Expected entry for route=/heavy in externalBytes');
+    assert.ok(entry.bytes > 0,
+      `Expected /heavy external bytes > 0, got ${entry.bytes}`);
+    // The 10MB Buffer should show up (allow some tolerance for overhead).
+    assert.ok(entry.bytes >= 9 * 1024 * 1024,
+      `Expected /heavy >= 9MB, got ${entry.bytes}`);
+  }
+
+  // Keep buf alive until after profile is read.
+  assert.ok(buf.length > 0);
+  v8.stopSamplingHeapProfiler();
+}
+
+// Test 2: Buffer.alloc() outside any label context is not tracked.
+{
+  v8.startSamplingHeapProfiler(512 * 1024);
+
+  // Allocate outside any label context.
+  const buf = Buffer.alloc(5 * 1024 * 1024);
+  assert.strictEqual(buf.length, 5 * 1024 * 1024);
+
+  const profile = v8.getAllocationProfile();
+  assert.ok(profile, 'profile should exist');
+
+  // externalBytes should be empty or have zero bytes (no labeled allocations).
+  if (Array.isArray(profile.externalBytes)) {
+    const totalLabeled = profile.externalBytes
+      .reduce((a, e) => a + e.bytes, 0);
+    assert.strictEqual(totalLabeled, 0,
+      `Expected 0 labeled external bytes, got ${totalLabeled}`);
+  }
+
+  v8.stopSamplingHeapProfiler();
+}
+
+// Test 3: After dropping Buffer references and forcing GC, per-label bytes
+// decrease (Free is called).
+{
+  v8.startSamplingHeapProfiler(512 * 1024);
+
+  let profile;
+
+  v8.withHeapProfileLabels({ route: '/gc-test' }, () => {
+    // Create a Buffer, then let it be GC'd.
+    let buf = Buffer.alloc(8 * 1024 * 1024);
+    assert.strictEqual(buf.length, 8 * 1024 * 1024);
+
+    profile = v8.getAllocationProfile();
+    assert.ok(Array.isArray(profile.externalBytes),
+    'externalBytes should be an array (ProfilingArrayBufferAllocator active)');
+  {
+      const entry = findByLabel(profile, 'route', '/gc-test');
+      if (entry) {
+        assert.ok(entry.bytes >= 7 * 1024 * 1024,
+          `Expected /gc-test >= 7MB before GC, got ${entry.bytes}`);
+      }
+    }
+
+    // Drop reference and force GC.
+    buf = null;
+  });
+
+  global.gc();
+  global.gc();
+
+  profile = v8.getAllocationProfile();
+  // After GC, externalBytes may be absent if all labeled allocations were freed.
+  {
+    const entry = Array.isArray(profile.externalBytes)
+      ? findByLabel(profile, 'route', '/gc-test') : undefined;
+    const afterGC = entry ? entry.bytes : 0;
+    // After GC, the buffer should be freed and the count should decrease.
+    // It may not go to exactly 0 due to other small allocations.
+    assert.ok(afterGC < 8 * 1024 * 1024,
+      `Expected /gc-test < 8MB after GC, got ${afterGC}`);
+  }
+
+  v8.stopSamplingHeapProfiler();
+}
+
+// Test 4: Multiple labels — allocate Buffers with different labels, verify
+// externalBytes shows correct per-label totals.
+{
+  v8.startSamplingHeapProfiler(512 * 1024);
+
+  const bufs = [];
+  v8.withHeapProfileLabels({ route: '/api/users' }, () => {
+    bufs.push(Buffer.alloc(4 * 1024 * 1024));
+  });
+
+  v8.withHeapProfileLabels({ route: '/api/orders' }, () => {
+    bufs.push(Buffer.alloc(6 * 1024 * 1024));
+  });
+
+  const profile = v8.getAllocationProfile();
+  assert.ok(profile, 'profile should exist');
+
+  assert.ok(Array.isArray(profile.externalBytes),
+    'externalBytes should be an array (ProfilingArrayBufferAllocator active)');
+  {
+    const usersEntry = findByLabel(profile, 'route', '/api/users');
+    const ordersEntry = findByLabel(profile, 'route', '/api/orders');
+    const usersBytes = usersEntry ? usersEntry.bytes : 0;
+    const ordersBytes = ordersEntry ? ordersEntry.bytes : 0;
+    assert.ok(usersBytes >= 3 * 1024 * 1024,
+      `Expected /api/users >= 3MB, got ${usersBytes}`);
+    assert.ok(ordersBytes >= 5 * 1024 * 1024,
+      `Expected /api/orders >= 5MB, got ${ordersBytes}`);
+    // Orders should have more external memory than users.
+    assert.ok(ordersBytes > usersBytes,
+      `Expected /api/orders (${ordersBytes}) > /api/users (${usersBytes})`);
+  }
+
+  // Keep bufs alive.
+  assert.ok(bufs.length === 2);
+  v8.stopSamplingHeapProfiler();
+}
+
+// Test 5: JSON serialization of the profile includes externalBytes.
+{
+  v8.startSamplingHeapProfiler(512 * 1024);
+
+  const buf = v8.withHeapProfileLabels({ route: '/json-test' }, () => {
+    return Buffer.alloc(2 * 1024 * 1024);
+  });
+
+  const profile = v8.getAllocationProfile();
+  const json = JSON.stringify(profile);
+  const parsed = JSON.parse(json);
+
+  assert.ok(Array.isArray(parsed.samples), 'samples should be an array');
+  if (Array.isArray(parsed.externalBytes)) {
+    const entry = parsed.externalBytes.find(
+      (e) => e.labels && e.labels.route === '/json-test'
+    );
+    assert.ok(entry, 'Expected /json-test in serialized externalBytes');
+    assert.ok(entry.bytes > 0,
+      `Expected /json-test bytes > 0, got ${entry.bytes}`);
+  }
+
+  // Keep buf alive.
+  assert.ok(buf.length > 0);
+  v8.stopSamplingHeapProfiler();
+}
+
+// Test 6: Multi-label context — both key-value pairs appear in externalBytes.
+{
+  v8.startSamplingHeapProfiler(512 * 1024);
+
+  const buf = v8.withHeapProfileLabels(
+    { route: '/foo', handler: 'bar' }, () => {
+      return Buffer.alloc(3 * 1024 * 1024);
+    });
+
+  const profile = v8.getAllocationProfile();
+  assert.ok(profile, 'profile should exist');
+
+  assert.ok(Array.isArray(profile.externalBytes),
+    'externalBytes should be an array (ProfilingArrayBufferAllocator active)');
+  {
+    const entry = findExternal(profile,
+      (e) => e.labels.route === '/foo' && e.labels.handler === 'bar');
+    assert.ok(entry,
+      'Expected entry with both route=/foo and handler=bar');
+    assert.ok(entry.bytes >= 2 * 1024 * 1024,
+      `Expected multi-label entry >= 2MB, got ${entry.bytes}`);
+    // Verify both keys are present.
+    assert.strictEqual(entry.labels.route, '/foo');
+    assert.strictEqual(entry.labels.handler, 'bar');
+  }
+
+  // Keep buf alive.
+  assert.ok(buf.length > 0);
+  v8.stopSamplingHeapProfiler();
+}
+
+// Test 7: externalBytes labels match heap sample labels for same context.
+{
+  v8.startSamplingHeapProfiler(64);  // Small interval to increase sample hits
+
+  const buf = v8.withHeapProfileLabels({ route: '/match-test' }, () => {
+    // Allocate both heap objects and a Buffer in the same label context.
+    const arr = [];
+    for (let i = 0; i < 1000; i++) {
+      arr.push({ data: new Array(100).fill(i) });
+    }
+    const b = Buffer.alloc(5 * 1024 * 1024);
+    // Keep arr alive.
+    assert.ok(arr.length > 0);
+    return b;
+  });
+
+  const profile = v8.getAllocationProfile();
+
+  // Find heap samples with matching labels.
+  const labeledSamples = profile.samples.filter(
+    (s) => s.labels && s.labels.route === '/match-test'
+  );
+
+  // Find externalBytes entry with matching labels.
+  assert.ok(Array.isArray(profile.externalBytes),
+    'externalBytes should be an array (ProfilingArrayBufferAllocator active)');
+  {
+    const extEntry = findByLabel(profile, 'route', '/match-test');
+    if (extEntry && labeledSamples.length > 0) {
+      // The label keys should match between heap samples and externalBytes.
+      const sampleLabelKeys = Object.keys(labeledSamples[0].labels).sort();
+      const extLabelKeys = Object.keys(extEntry.labels).sort();
+      assert.deepStrictEqual(extLabelKeys, sampleLabelKeys,
+        'externalBytes label keys should match heap sample label keys');
+    }
+  }
+
+  // Keep buf alive.
+  assert.ok(buf.length > 0);
+  v8.stopSamplingHeapProfiler();
+}
+
+console.log('All external memory tracking tests passed.');

--- a/test/parallel/test-v8-heap-profile-labels-async.js
+++ b/test/parallel/test-v8-heap-profile-labels-async.js
@@ -1,0 +1,154 @@
+// Heap profile labels require async-context-frame (enabled by default in
+// Node.js 24+; use --experimental-async-context-frame on Node.js 22).
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+
+// Test: labels survive await boundaries
+async function testAwaitBoundary() {
+  v8.startSamplingHeapProfiler(64);
+
+  await v8.withHeapProfileLabels({ route: '/async' }, async () => {
+    // Allocate before await
+    const before = [];
+    for (let i = 0; i < 2000; i++) before.push({ pre: i });
+
+    // Yield to event loop
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // Allocate after await — labels should still be active
+    const after = [];
+    for (let i = 0; i < 2000; i++) after.push({ post: i });
+  });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const labeled = profile.samples.filter(
+    (s) => s.labels.route === '/async'
+  );
+  assert.ok(
+    labeled.length > 0,
+    'Labels should survive await boundaries'
+  );
+}
+
+// Test: concurrent async contexts with different labels
+async function testConcurrentContexts() {
+  v8.startSamplingHeapProfiler(64);
+
+  const task = async (route, count) => {
+    await v8.withHeapProfileLabels({ route }, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      const arr = [];
+      for (let i = 0; i < count; i++) arr.push({ data: i, route });
+    });
+  };
+
+  // Run multiple concurrent labeled tasks
+  await Promise.all([
+    task('/users', 5000),
+    task('/products', 5000),
+    task('/orders', 5000),
+  ]);
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const users = profile.samples.filter((s) => s.labels.route === '/users');
+  const products = profile.samples.filter(
+    (s) => s.labels.route === '/products'
+  );
+  const orders = profile.samples.filter((s) => s.labels.route === '/orders');
+
+  // At least some of the three routes should have samples
+  const totalLabeled = users.length + products.length + orders.length;
+  assert.ok(
+    totalLabeled > 0,
+    'Concurrent contexts should produce labeled samples'
+  );
+}
+
+// Test: setHeapProfileLabels with async work
+async function testSetLabelsAsync() {
+  v8.startSamplingHeapProfiler(64);
+
+  // Simulate Hapi-style: set labels, then do async work
+  v8.setHeapProfileLabels({ route: '/hapi-style' });
+
+  await new Promise((resolve) => setTimeout(resolve, 10));
+
+  const arr = [];
+  for (let i = 0; i < 5000; i++) arr.push({ hapi: i });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const labeled = profile.samples.filter(
+    (s) => s.labels.route === '/hapi-style'
+  );
+  assert.ok(
+    labeled.length > 0,
+    'setHeapProfileLabels should work with async code'
+  );
+}
+
+// Test: withHeapProfileLabels handles async errors
+async function testAsyncError() {
+  v8.startSamplingHeapProfiler(64);
+
+  await assert.rejects(
+    () => v8.withHeapProfileLabels({ route: '/error' }, async () => {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      throw new Error('test error');
+    }),
+    { message: 'test error' }
+  );
+
+  // Profiler should still work after error
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+  assert.ok(profile);
+}
+
+// Test: nested withHeapProfileLabels
+async function testNestedLabels() {
+  v8.startSamplingHeapProfiler(64);
+
+  await v8.withHeapProfileLabels({ route: '/outer' }, async () => {
+    const outer = [];
+    for (let i = 0; i < 2000; i++) outer.push({ outer: i });
+
+    await v8.withHeapProfileLabels({ route: '/inner' }, async () => {
+      const inner = [];
+      for (let i = 0; i < 2000; i++) inner.push({ inner: i });
+    });
+  });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const outerSamples = profile.samples.filter(
+    (s) => s.labels.route === '/outer'
+  );
+  const innerSamples = profile.samples.filter(
+    (s) => s.labels.route === '/inner'
+  );
+
+  // Both outer and inner should have some samples
+  assert.ok(
+    outerSamples.length + innerSamples.length > 0,
+    'Nested labels should produce labeled samples'
+  );
+}
+
+async function main() {
+  await testAwaitBoundary();
+  await testConcurrentContexts();
+  await testSetLabelsAsync();
+  await testAsyncError();
+  await testNestedLabels();
+}
+
+main().then(common.mustCall());

--- a/test/parallel/test-v8-heap-profile-labels-worker.js
+++ b/test/parallel/test-v8-heap-profile-labels-worker.js
@@ -1,0 +1,96 @@
+// Heap profile labels require async-context-frame (enabled by default in
+// Node.js 24+; use --experimental-async-context-frame on Node.js 22).
+'use strict';
+// Test that terminating a worker thread while heap profiling is active
+// does not crash.  The cleanup hook in node_v8.cc must clear the V8
+// HeapProfiler callback and disable allocator tracking before the
+// Isolate is disposed.
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+// Test 1: Worker starts profiling, is terminated without stopping profiler.
+{
+  const worker = new Worker(`
+    const v8 = require('v8');
+    const { parentPort } = require('worker_threads');
+
+    v8.startSamplingHeapProfiler(64);
+
+    // Allocate some objects to generate samples
+    const arr = [];
+    for (let i = 0; i < 500; i++) arr.push({ x: i });
+
+    // Signal that profiling is active
+    parentPort.postMessage('profiling');
+
+    // Keep worker alive until terminated
+    setTimeout(() => {}, 60000);
+  `, { eval: true });
+
+  worker.on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg, 'profiling');
+    // Terminate the worker while profiling is still active
+    worker.terminate();
+  }));
+
+  worker.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 1);
+  }));
+}
+
+// Test 2: Worker starts profiling with labels, is terminated.
+{
+  const worker = new Worker(`
+    const v8 = require('v8');
+    const { parentPort } = require('worker_threads');
+
+    v8.startSamplingHeapProfiler(64);
+
+    v8.withHeapProfileLabels({ route: '/worker' }, () => {
+      const arr = [];
+      for (let i = 0; i < 500; i++) arr.push({ x: i });
+
+      // Signal that labeled profiling is active
+      parentPort.postMessage('labeled');
+
+      // Keep worker alive until terminated
+      setTimeout(() => {}, 60000);
+    });
+  `, { eval: true });
+
+  worker.on('message', common.mustCall((msg) => {
+    assert.strictEqual(msg, 'labeled');
+    worker.terminate();
+  }));
+
+  worker.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 1);
+  }));
+}
+
+// Test 3: Worker starts and stops profiling normally, then exits.
+{
+  const worker = new Worker(`
+    const v8 = require('v8');
+    const { parentPort } = require('worker_threads');
+
+    v8.startSamplingHeapProfiler(64);
+    const arr = [];
+    for (let i = 0; i < 500; i++) arr.push({ x: i });
+    const profile = v8.getAllocationProfile();
+    v8.stopSamplingHeapProfiler();
+
+    parentPort.postMessage({
+      hasSamples: profile && profile.samples && profile.samples.length > 0
+    });
+  `, { eval: true });
+
+  worker.on('message', common.mustCall((msg) => {
+    assert.ok(msg.hasSamples, 'Worker profiling should produce samples');
+  }));
+
+  worker.on('exit', common.mustCall((code) => {
+    assert.strictEqual(code, 0);
+  }));
+}

--- a/test/parallel/test-v8-heap-profile-labels.js
+++ b/test/parallel/test-v8-heap-profile-labels.js
@@ -1,0 +1,353 @@
+// Flags: --expose-gc
+// Heap profile labels require async-context-frame (enabled by default in
+// Node.js 24+; use --experimental-async-context-frame on Node.js 22).
+'use strict';
+require('../common');
+const assert = require('assert');
+const v8 = require('v8');
+
+// Test: API functions are exported
+assert.strictEqual(typeof v8.startSamplingHeapProfiler, 'function');
+assert.strictEqual(typeof v8.stopSamplingHeapProfiler, 'function');
+assert.strictEqual(typeof v8.getAllocationProfile, 'function');
+assert.strictEqual(typeof v8.withHeapProfileLabels, 'function');
+assert.strictEqual(typeof v8.setHeapProfileLabels, 'function');
+
+// Test: getAllocationProfile returns undefined when profiler not started
+assert.strictEqual(v8.getAllocationProfile(), undefined);
+
+// Test: basic profiling without labels
+{
+  v8.startSamplingHeapProfiler(64);
+  const arr = [];
+  for (let i = 0; i < 1000; i++) arr.push({ x: i });
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  assert.ok(profile);
+  assert.ok(Array.isArray(profile.samples));
+  assert.ok(profile.samples.length > 0);
+
+  // Every sample should have a labels field (empty object when unlabeled)
+  for (const sample of profile.samples) {
+    assert.strictEqual(typeof sample.nodeId, 'number');
+    assert.strictEqual(typeof sample.size, 'number');
+    assert.strictEqual(typeof sample.count, 'number');
+    assert.strictEqual(typeof sample.sampleId, 'number');
+    assert.strictEqual(typeof sample.labels, 'object');
+    assert.ok(sample.labels !== null);
+  }
+}
+
+// Test: withHeapProfileLabels captures labels on samples
+{
+  v8.startSamplingHeapProfiler(64);
+
+  v8.withHeapProfileLabels({ route: '/test' }, () => {
+    const arr = [];
+    for (let i = 0; i < 5000; i++) arr.push({ data: i });
+  });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const labeled = profile.samples.filter(
+    (s) => s.labels.route === '/test'
+  );
+  assert.ok(labeled.length > 0, 'Should have samples labeled with /test');
+}
+
+// Test: distinct labels are attributed correctly
+{
+  v8.startSamplingHeapProfiler(64);
+
+  v8.withHeapProfileLabels({ route: '/heavy' }, () => {
+    const arr = [];
+    for (let i = 0; i < 10000; i++) arr.push(new Array(100));
+  });
+
+  v8.withHeapProfileLabels({ route: '/light' }, () => {
+    const arr = [];
+    for (let i = 0; i < 100; i++) arr.push({ x: i });
+  });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const heavy = profile.samples.filter((s) => s.labels.route === '/heavy');
+  const light = profile.samples.filter((s) => s.labels.route === '/light');
+  assert.ok(heavy.length > 0, 'Should have /heavy samples');
+  // /light may have zero samples due to sampling — that's acceptable
+  // The key assertion is that /heavy has samples and they are attributed
+}
+
+// Test: multi-key labels
+{
+  v8.startSamplingHeapProfiler(64);
+
+  v8.withHeapProfileLabels({ route: '/api', method: 'GET' }, () => {
+    const arr = [];
+    for (let i = 0; i < 5000; i++) arr.push({ data: i });
+  });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const labeled = profile.samples.filter(
+    (s) => s.labels.route === '/api' && s.labels.method === 'GET'
+  );
+  assert.ok(labeled.length > 0, 'Should have multi-key labeled samples');
+}
+
+// Test: JSON.stringify round-trip
+{
+  v8.startSamplingHeapProfiler(64);
+
+  v8.withHeapProfileLabels({ route: '/json' }, () => {
+    const arr = [];
+    for (let i = 0; i < 5000; i++) arr.push({ data: i });
+  });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const json = JSON.stringify(profile);
+  const parsed = JSON.parse(json);
+  assert.ok(Array.isArray(parsed.samples));
+  const labeled = parsed.samples.filter((s) => s.labels.route === '/json');
+  assert.ok(labeled.length > 0, 'Labels survive JSON round-trip');
+}
+
+// Test: startSamplingHeapProfiler(0) throws RangeError (0 hits CHECK_GT in V8)
+assert.throws(() => v8.startSamplingHeapProfiler(0), {
+  code: 'ERR_OUT_OF_RANGE',
+  name: 'RangeError',
+});
+
+// Test: withHeapProfileLabels validates arguments
+assert.throws(() => v8.withHeapProfileLabels('bad', () => {}), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+assert.throws(() => v8.withHeapProfileLabels({}, 'bad'), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// Test: setHeapProfileLabels validates arguments
+assert.throws(() => v8.setHeapProfileLabels('bad'), {
+  code: 'ERR_INVALID_ARG_TYPE',
+});
+
+// Test: repeated start/stop cycles work
+{
+  for (let cycle = 0; cycle < 3; cycle++) {
+    v8.startSamplingHeapProfiler(64);
+    v8.withHeapProfileLabels({ route: `/cycle${cycle}` }, () => {
+      const arr = [];
+      for (let i = 0; i < 1000; i++) arr.push({ x: i });
+    });
+    const profile = v8.getAllocationProfile();
+    v8.stopSamplingHeapProfiler();
+    assert.ok(profile);
+    assert.ok(profile.samples.length > 0);
+  }
+}
+
+// Test: GC'd samples are retained with includeCollectedObjects: true
+{
+  v8.startSamplingHeapProfiler(64, 16, { includeCollectedObjects: true });
+
+  v8.withHeapProfileLabels({ route: '/heavy-gc' }, () => {
+    for (let i = 0; i < 500; i++) {
+      // Allocate ~100KB arrays that become garbage immediately
+      new Array(25000).fill(i);
+    }
+  });
+
+  v8.withHeapProfileLabels({ route: '/light-gc' }, () => {
+    const arr = [];
+    for (let i = 0; i < 10; i++) arr.push({ x: i });
+  });
+
+  // Force garbage collection to remove unreferenced objects
+  global.gc();
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const heavy = profile.samples.filter((s) => s.labels.route === '/heavy-gc');
+  assert.ok(
+    heavy.length > 0,
+    'GC\'d samples should still be present with includeCollectedObjects: true'
+  );
+
+  // Heavy route allocated ~50MB, light route ~trivial — ratio should be high
+  const heavyBytes = heavy.reduce((sum, s) => sum + s.size * s.count, 0);
+  const light = profile.samples.filter((s) => s.labels.route === '/light-gc');
+  const lightBytes = light.reduce((sum, s) => sum + s.size * s.count, 0);
+  if (lightBytes > 0) {
+    const ratio = heavyBytes / lightBytes;
+    assert.ok(
+      ratio > 50,
+      `Heavy/light ratio should be >50 after GC, got ${ratio.toFixed(1)}`
+    );
+  }
+}
+
+// Test: GC'd samples are removed without includeCollectedObjects (default)
+{
+  v8.startSamplingHeapProfiler(64);
+
+  v8.withHeapProfileLabels({ route: '/gc-default' }, () => {
+    for (let i = 0; i < 500; i++) {
+      // Allocate ~100KB arrays that become garbage immediately
+      new Array(25000).fill(i);
+    }
+  });
+
+  // Force garbage collection — without includeCollectedObjects, samples are
+  // removed from the profile via V8's OnWeakCallback
+  global.gc();
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const samples = profile.samples.filter(
+    (s) => s.labels.route === '/gc-default'
+  );
+  const totalBytes = samples.reduce((sum, s) => sum + s.size * s.count, 0);
+  // After GC, most or all samples should be gone. The total bytes retained
+  // should be much less than what was allocated (~50MB).
+  assert.ok(
+    totalBytes < 5 * 1024 * 1024,
+    `Without includeCollectedObjects, GC'd samples should mostly be removed ` +
+    `(got ${(totalBytes / 1024 / 1024).toFixed(1)}MB)`
+  );
+}
+
+// Test: includeCollectedObjects: true retains samples, false does not
+{
+  // Start WITH includeCollectedObjects
+  v8.startSamplingHeapProfiler(64, 16, { includeCollectedObjects: true });
+  v8.withHeapProfileLabels({ route: '/retained' }, () => {
+    for (let i = 0; i < 200; i++) new Array(25000).fill(i);
+  });
+  global.gc();
+  const withProfile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const withSamples = withProfile.samples.filter(
+    (s) => s.labels.route === '/retained'
+  );
+  const withBytes = withSamples.reduce((sum, s) => sum + s.size * s.count, 0);
+
+  // Start WITHOUT includeCollectedObjects
+  v8.startSamplingHeapProfiler(64);
+  v8.withHeapProfileLabels({ route: '/removed' }, () => {
+    for (let i = 0; i < 200; i++) new Array(25000).fill(i);
+  });
+  global.gc();
+  const withoutProfile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const withoutSamples = withoutProfile.samples.filter(
+    (s) => s.labels.route === '/removed'
+  );
+  const withoutBytes = withoutSamples.reduce(
+    (sum, s) => sum + s.size * s.count, 0
+  );
+
+  // With includeCollectedObjects should retain significantly more bytes.
+  // withBytes must be positive to avoid vacuous pass when both are 0.
+  assert.ok(withBytes > 0,
+    `includeCollectedObjects should retain samples: withBytes=${withBytes}`);
+  assert.ok(
+    withBytes > withoutBytes * 5,
+    `includeCollectedObjects should retain more samples: ` +
+    `with=${(withBytes / 1024).toFixed(0)}KB, ` +
+    `without=${(withoutBytes / 1024).toFixed(0)}KB`
+  );
+}
+
+// Test: setHeapProfileLabels doesn't leak entries when called repeatedly
+// Each enterWith() creates a new AsyncContextFrame (CPED). Without cleanup,
+// old entries accumulate in the label map. The fix calls unregister before
+// enterWith so the old CPED entry is removed.
+{
+  v8.startSamplingHeapProfiler(64);
+
+  // Call setHeapProfileLabels 100 times — only the last label should matter
+  for (let i = 0; i < 100; i++) {
+    v8.setHeapProfileLabels({ route: `/iter${i}` });
+  }
+
+  // Allocate under the final label
+  const arr = [];
+  for (let i = 0; i < 5000; i++) arr.push({ data: i });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  // The final label should be present on samples
+  const finalLabeled = profile.samples.filter(
+    (s) => s.labels.route === '/iter99'
+  );
+  assert.ok(
+    finalLabeled.length > 0,
+    'Should have samples labeled with final /iter99'
+  );
+
+  // Old labels should NOT appear on the post-loop allocations
+  // (they may appear on allocations made during the loop itself, which is fine)
+  // The key check: only /iter99 should appear on samples from the bulk alloc
+  const allRoutes = new Set(
+    profile.samples
+      .filter((s) => s.labels.route)
+      .map((s) => s.labels.route)
+  );
+  // With the fix, old entries are cleaned up before enterWith. Intermediate
+  // labels may still appear (allocations during the loop), but the entry
+  // count should not grow — verified by no crash or OOM under heavy use.
+  assert.ok(allRoutes.has('/iter99'), 'Final label must be present');
+}
+
+// Test: labels survive when another ALS store changes the CPED address.
+// Regression test for nodejs/node#62649: CPED is a shared AsyncContextFrame
+// Map. Its identity (address) changes when ANY ALS store changes, not just the
+// heap profile labels store. The old address-based lookup would fail because
+// the CPED address at allocation time differs from the one registered with
+// withHeapProfileLabels. The CPED-storage approach stores the full CPED value
+// on each sample at allocation time and resolves labels at profile-read time
+// via Map lookup — immune to address changes.
+{
+  const { AsyncLocalStorage } = require('async_hooks');
+  const otherALS = new AsyncLocalStorage();
+
+  v8.startSamplingHeapProfiler(64);
+
+  v8.withHeapProfileLabels({ route: '/cped-identity' }, () => {
+    // Allocate before changing other ALS (CPED address is X)
+    const before = [];
+    for (let i = 0; i < 2000; i++) before.push({ pre: i });
+
+    // Change a DIFFERENT ALS store — this creates a new AsyncContextFrame,
+    // changing the CPED address to Y. The heap profile labels ALS store is
+    // still set (it was inherited into the new frame).
+    otherALS.enterWith({ unrelated: 'data' });
+
+    // Allocate after the other ALS change (CPED address is now Y, not X)
+    const after = [];
+    for (let i = 0; i < 2000; i++) after.push({ post: i });
+  });
+
+  const profile = v8.getAllocationProfile();
+  v8.stopSamplingHeapProfiler();
+
+  const labeled = profile.samples.filter(
+    (s) => s.labels.route === '/cped-identity'
+  );
+  assert.ok(
+    labeled.length > 0,
+    'Labels must survive when another ALS store changes the CPED address ' +
+    '(nodejs/node#62649 regression)'
+  );
+}

--- a/tools/v8_gypfiles/features.gypi
+++ b/tools/v8_gypfiles/features.gypi
@@ -523,7 +523,12 @@
         'defines': ['V8_ENABLE_JAVASCRIPT_PROMISE_HOOKS',],
       }],
       ['v8_enable_continuation_preserved_embedder_data==1', {
-        'defines': ['V8_ENABLE_CONTINUATION_PRESERVED_EMBEDDER_DATA',],
+        'defines': [
+          'V8_ENABLE_CONTINUATION_PRESERVED_EMBEDDER_DATA',
+          # Enable heap profiler sample labels for per-context memory
+          # attribution when CPED is available.
+          'V8_HEAP_PROFILER_SAMPLE_LABELS',
+        ],
       }],
       ['v8_enable_allocation_folding==1', {
         'defines': ['V8_ALLOCATION_FOLDING',],


### PR DESCRIPTION
This is a POC for initial feedback. If we can get alignment within Node.js I could try to contribute the V8 changes upstream.

# Summary

Adds the ability to tag sampling heap profiler allocations with string labels that propagate through async context (via CPED). This enables attributing memory usage to specific HTTP routes, tenants, or operations.

# V8 changes

The V8 surface is intentionally minimal and avoids committing to string types.

- `AllocationProfile::Sample::label_id` (uint32_t, behind `V8_HEAP_PROFILER_SAMPLE_LABELS`) — a compact 4-byte identifier instead of a `vector<pair<string,string>>`. `Sample` remains a plain aggregate.
- `LabelInternTable` — process-wide intern table mapping `Global<Value>` to `uint32_t` label_id with refcount. One reference per sample; the table releases the `Global` when the last sample referencing it is collected.
- `HeapProfiler::SetHeapProfileSampleLabelsKey` — the on/off switch and the CPED Map lookup key. When unset, zero cost in the allocation path.
- `HeapProfiler::InternLabelValue` / `ReleaseLabelValue` / `ResolveLabelValue` — embedder API for allocation trackers that need to share the intern table.

No callback registration. The design associates any JS value (not just string pairs) with each sample and lets the profile consumer interpret it. The same mechanism is reusable for CPU profile samples (Szegedi's v8-dev proposal targets that use-case).

Attila Szegedi proposed a similar label mechanism for CPU profiling on [v8-dev](https://www.mail-archive.com/v8-dev@googlegroups.com/msg162591.html) (July 2025). V8 team (Leszek Swirski) indicated they would review non-invasive patches behind `#ifdef`s.

# Node.js changes

- `v8.withHeapProfileLabels(labels, fn)` — runs fn with labels propagating across `await`
- `v8.setHeapProfileLabels(labels)` — sets labels for the current async scope (for framework middleware patterns)
- `v8.getAllocationProfile()` returns `samples[].labels` (frozen, shared across samples with the same label set) and per-label `externalBytes`.
- `ProfilingArrayBufferAllocator` tracks external allocations per `label_id` (one atomic null-check per allocation/free when disabled, predicted not-taken).

The JS-facing API is **unchanged**. Label resolution (label_id to flat array to labels object) happens in the Node.js binding with a per-call cache, not in V8.

nodejs/node#62273 landed the SyncHeapProfileHandle API with Symbol.dispose support. The labels API proposed here is complementary.

# Motivation

In multi-tenant or multi-route Node.js servers, a memory spike today tells you how much memory grew but not what caused it. With labeled heap/external memory profiling, you can answer "route /api/search accounts for 400 MB of the 1.2 GB heap" directly from production telemetry (e.g. via OTel).

This mirrors Go's `pprof.Labels` capability.

# Read-time performance

The label_id design moves `getAllocationProfile()` from O(total samples) to O(distinct label sets): each unique label_id is resolved once and the frozen object is shared across all samples with that id. Benchmark results (5000 retained samples, n=5 calls per run):

| samples/unique set | unique sets | pre-label_id ops/s | label_id ops/s | speedup |
|:---:|:---:|---:|---:|---:|
| 1 | 5000 | 115 | 160 | 1.4x |
| 10 | 500 | 213 | 326 | 1.5x |
| 100 | 50 | 225 | 383 | 1.7x |
| 1000 | 5 | 223 | 376 | 1.7x |

# Overhead

20-run benchmark (two-server realistic HTTP workload):
- Sampling profiler alone: 0.6% (not statistically significant)
- Sampling + labels: 2.2% total (p<0.01)
- When disabled: one atomic null-check per Allocate/Free (predicted not-taken)

# Test plan

- V8 cctests: label internment, dedup, refcount lifecycle, concurrent release
- Node.js cctests: label resolution, GC interaction
- JS tests: label propagation across await, concurrent contexts, setHeapProfileLabels, external memory tracking, GC cleanup, HTTP regression
- Benchmarks: benchmark/v8/heap-profiler-labels-resolution.js, benchmark/http/heap-profiler-realistic.js