### PR TITLE
fs: fix always return promise from `fs.openAsBlob`

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -36,6 +36,7 @@ const {
   ObjectDefineProperty,
   Promise,
   PromisePrototypeThen,
+  PromiseReject,
   PromiseResolve,
   ReflectApply,
   SafeMap,
@@ -568,17 +569,17 @@ function openSync(path, flags, mode) {
  * @returns {Promise<Blob>}
  */
 function openAsBlob(path, options = kEmptyObject) {
-  validateObject(options, 'options');
-  const type = options.type || '';
-  validateString(type, 'options.type');
-  // The underlying implementation here returns the Blob synchronously for now.
-  // To give ourselves flexibility to maybe return the Blob asynchronously,
-  // this API returns a Promise.
   try {
+    validateObject(options, 'options');
+    const type = options.type || '';
+    validateString(type, 'options.type');
+    // The underlying implementation here returns the Blob synchronously for now.
+    // To give ourselves flexibility to maybe return the Blob asynchronously,
+    // this API returns a Promise.
     path = getValidatedPath(path);
     return PromiseResolve(createBlobFromFilePath(path, { type }));
   } catch (error) {
-    return Promise.reject(error);
+    return PromiseReject(error);
   }
 }
 

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -574,8 +574,12 @@ function openAsBlob(path, options = kEmptyObject) {
   // The underlying implementation here returns the Blob synchronously for now.
   // To give ourselves flexibility to maybe return the Blob asynchronously,
   // this API returns a Promise.
-  path = getValidatedPath(path);
-  return PromiseResolve(createBlobFromFilePath(path, { type }));
+  try {
+    path = getValidatedPath(path);
+    return PromiseResolve(createBlobFromFilePath(path, { type }));
+  } catch (error) {
+    return Promise.reject(error);
+  }
 }
 
 /**

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -569,13 +569,13 @@ function openSync(path, flags, mode) {
  * @returns {Promise<Blob>}
  */
 function openAsBlob(path, options = kEmptyObject) {
+  validateObject(options, 'options');
+  const type = options.type || '';
+  validateString(type, 'options.type');
+  // The underlying implementation here returns the Blob synchronously for now.
+  // To give ourselves flexibility to maybe return the Blob asynchronously,
+  // this API returns a Promise.
   try {
-    validateObject(options, 'options');
-    const type = options.type || '';
-    validateString(type, 'options.type');
-    // The underlying implementation here returns the Blob synchronously for now.
-    // To give ourselves flexibility to maybe return the Blob asynchronously,
-    // this API returns a Promise.
     path = getValidatedPath(path);
     return PromiseResolve(createBlobFromFilePath(path, { type }));
   } catch (error) {

--- a/test/parallel/test-fs-openasblob-promise-contract.js
+++ b/test/parallel/test-fs-openasblob-promise-contract.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+
+// Verify invalid paths throw synchronously and return a Promise
+(async () => {
+  let promise;
+  assert.doesNotThrow(() => { promise = fs.openAsBlob('does-not-exist'); });
+  assert.strictEqual(typeof promise?.then, 'function');
+  await assert.rejects(promise, { code: 'ERR_INVALID_ARG_VALUE' });
+})();
+
+
+// Verify that invalid arguments throw synchronously and return a Promise
+(async () => {
+  let promise;
+  assert.doesNotThrow(() => { promise = fs.openAsBlob(123); });
+  assert.strictEqual(typeof promise?.then, 'function');
+  await assert.rejects(promise, { code: 'ERR_INVALID_ARG_TYPE' });
+})();


### PR DESCRIPTION
**Summary**: Ensure `fs.openAsBlob` always returns a Promise by converting synchronous validation/creation errors into Promise rejections so error handling is consistent.

**Motivation**: The issue reported that openAsBlob can throw synchronously (for invalid paths), which bypasses `await/.catch`. This aligns behaviour with the Promise-based API contract.

**Changes**: Wrap getValidatedPath and createBlobFromFilePath in `try/catch` and return Promise.reject on failure.

Fixes: https://github.com/nodejs/node/issues/62418

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
