### PR TITLE
aix: add required changes to build with clang

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.17',
+    'v8_embedder_string': '-node.18',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -591,6 +591,18 @@
           '-maix64',
         ],
         'conditions': [
+          [ 'clang==1', {
+            'cflags': [
+              '-fno-integrated-as',
+              '-fno-xl-pragma-pack',
+              '-mcpu=power9',
+            ],
+            'cflags_cc': [
+              '-fno-integrated-as',
+              '-fno-xl-pragma-pack',
+              '-mcpu=power9',
+            ],
+          }],
           [ '"<(aix_variant_name)"=="OS400"', {            # a.k.a. `IBM i`
             'ldflags': [
               '-Wl,-blibpath:/QOpenSys/pkgs/lib:/QOpenSys/usr/lib',

--- a/deps/openssl/openssl/crypto/bio/bss_dgram.c
+++ b/deps/openssl/openssl/crypto/bio/bss_dgram.c
@@ -68,8 +68,8 @@
 #undef NO_RECVMMSG
 #define NO_RECVMMSG
 #endif
-#if defined(_AIX) && !defined(_AIX72)
-/* AIX >= 7.2 provides sendmmsg() and recvmmsg(). */
+#if defined(_AIX)
+/* Force fallback to sndmsg and recvmsg */
 #undef NO_RECVMMSG
 #define NO_RECVMMSG
 #endif

--- a/deps/v8/BUILD.gn
+++ b/deps/v8/BUILD.gn
@@ -1583,7 +1583,7 @@ config("toolchain") {
   if (v8_current_cpu == "ppc64") {
     defines += [ "V8_TARGET_ARCH_PPC64" ]
     cflags += [ "-ffp-contract=off" ]
-    if (current_os == "aix") {
+    if (current_os == "aix" and !is_clang) {
       cflags += [
         # Work around AIX ceil, trunc and round oddities.
         "-mcpu=power5+",

--- a/deps/v8/src/builtins/ppc/builtins-ppc.cc
+++ b/deps/v8/src/builtins/ppc/builtins-ppc.cc
@@ -4219,6 +4219,19 @@ void Builtins::Generate_CEntry(MacroAssembler* masm, int result_size,
 
   // If return value is on the stack, pop it to registers.
   if (needs_return_buffer) {
+    Label done;
+    if (switch_to_central_stack) {
+      Label no_stack_change;
+      __ CmpU64(kOldSPRegister, Operand(0), r0);
+      __ beq(&no_stack_change);
+      __ addi(r3, kOldSPRegister,
+              Operand((kStackFrameExtraParamSlot + 1) * kSystemPointerSize));
+      __ b(&done);
+      __ bind(&no_stack_change);
+    }
+    __ addi(r3, sp,
+            Operand((kStackFrameExtraParamSlot + 1) * kSystemPointerSize));
+    __ bind(&done);
     __ LoadU64(r4, MemOperand(r3, kSystemPointerSize));
     __ LoadU64(r3, MemOperand(r3));
   }

--- a/deps/v8/src/compiler/turboshaft/operations.h
+++ b/deps/v8/src/compiler/turboshaft/operations.h
@@ -526,7 +526,7 @@ class InputsRepFactory {
   };
 };
 
-struct EffectDimensions {
+struct __attribute__((packed))  EffectDimensions {
   // Produced by loads, consumed by operations that should not move before loads
   // because they change memory.
   bool load_heap_memory : 1;
@@ -621,7 +621,7 @@ static_assert(sizeof(EffectDimensions) == sizeof(EffectDimensions::Bits));
 // they become more restricted in their movement. Note that calls are not the
 // most side-effectful operations, as they do not leave the heap in an
 // inconsistent state, so they do not need to be marked as raw heap access.
-struct OpEffects {
+struct __attribute__((packed)) OpEffects {
   EffectDimensions produces;
   EffectDimensions consumes;
 
@@ -2878,7 +2878,7 @@ struct ConstantOp : FixedArityOperationT<0, ConstantOp> {
 // When result_rep is RegisterRepresentation::Compressed(), then the load does
 // not decompress the value.
 struct LoadOp : OperationT<LoadOp> {
-  struct Kind {
+  struct __attribute__((packed)) Kind {
     // The `base` input is a tagged pointer to a HeapObject.
     bool tagged_base : 1;
     // The effective address might be unaligned. This is only set to true if

--- a/deps/v8/src/trap-handler/handler-shared.cc
+++ b/deps/v8/src/trap-handler/handler-shared.cc
@@ -24,7 +24,11 @@ namespace v8 {
 namespace internal {
 namespace trap_handler {
 
+#if defined(V8_OS_AIX)
+__thread bool TrapHandlerGuard::is_active_ = 0;
+#else
 thread_local bool TrapHandlerGuard::is_active_ = 0;
+#endif
 
 size_t gNumCodeObjects = 0;
 CodeProtectionInfoListEntry* gCodeObjects = nullptr;

--- a/tools/create_expfile.sh
+++ b/tools/create_expfile.sh
@@ -34,18 +34,35 @@
 # Symbols for the gtest libraries are excluded as
 # they are not linked into the node executable.
 #
+set -x
 echo "Searching $1 to write out expfile to $2"
 
 # This special sequence must be at the start of the exp file.
 echo "#!." > "$2.tmp"
 
 # Pull the symbols from the .a files.
-find "$1" -name "*.a" | grep -v gtest \
-  | xargs nm -Xany -BCpg \
-  | awk '{
-      if ((($2 == "T") || ($2 == "D") || ($2 == "B")) &&
-          (substr($3,1,1) != ".")) { print $3 }
-    }' \
-  | sort -u >> "$2.tmp"
+# Use dump -tov to get visibility information and exclude HIDDEN symbols
+# This prevents AIX linker error 0711-407 when addons try to import symbols
+# with visibility attributes.
+find "$1" -name "*.a" | grep -v gtest | while read f; do
+    dump -tov -X 32_64 "$f" 2>/dev/null | \
+    awk '
+        BEGIN {
+            V["EXPORTED"]=" export"
+            V["PROTECTED"]=" protected"
+            V["HIDDEN"]=" hidden"
+        }
+        /^\[[0-9]+\]\tm +[^ ]+ +\.(text|data|tdata|bss) +[^ ]+ +(extern|weak) +(EXPORTED|PROTECTED|HIDDEN| ) / {
+            # Exclude symbols starting with dot, __sinit, __sterm, __[0-9]+__
+            # Also exclude HIDDEN symbols to avoid visibility attribute issues
+            if (!match($NF,/^(\.|__sinit|__sterm|__[0-9]+__)/)) {
+                visibility = $(NF-1)
+                if (visibility != "HIDDEN") {
+                    print $NF
+                }
+            }
+        }
+    '
+done | sort -u >> "$2.tmp"
 
 mv -f "$2.tmp" "$2"

--- a/tools/create_expfile.sh
+++ b/tools/create_expfile.sh
@@ -62,7 +62,7 @@ echo "#!." > "$2.tmp"
 # any key in V[], the lookup returns an empty string, which is perfect for
 # handling the variable field positions caused by the blank visibility column.
 #
-find "$1" -name "*.a" | grep -v gtest | while read f; do
+find "$1" -name "*.a" | grep -v gtest | while read -r f; do
     dump -tov -X 32_64 "$f" 2>/dev/null | \
     awk '
         BEGIN {

--- a/tools/create_expfile.sh
+++ b/tools/create_expfile.sh
@@ -5,45 +5,63 @@
 # specifically for export so that they can be used
 # by native add-ons.
 #
-# The raw symbol data is obtained by using nm on
+# The raw symbol data is obtained by using dump -tov on
 # the .a files which make up the node executable.
 #
-# -Xany processes symbols for both 32-bit and
-# 64-bit (the default is for 32-bit only).
+# dump -tov flags:
+# -t: Display symbol table entries
+# -o: Display object file headers
+# -v: Display visibility information (HIDDEN/EXPORTED/PROTECTED)
+# -X 32_64: Process both 32-bit and 64-bit symbols
 #
-# -g selects only exported symbols.
+# This approach is similar to CMake's ExportImportList module for AIX:
+# https://github.com/Kitware/CMake/blob/45f4742cbfe6c25c7c801e3806c8af04a2c4b09b/Modules/Platform/AIX/ExportImportList#L67-L80
 #
-# -C, -B and -p ensure that the output is in a
-# format that can be easily parsed and converted
-# into the required symbol.
-#
-# -C suppresses the demangling of C++ names.
-# -B writes the output in BSD format.
-# -p displays the info in a standard portable
-#    output format.
-#
-# Only include symbols if they are of the following
-# types and don't start with a dot.
-#
-# T - Global text symbol.
-# D - Global data symbol.
-# B - Global bss symbol.
+# We filter for symbols in .text, .data, .tdata, and .bss sections
+# with extern or weak linkage, excluding:
+# - Symbols starting with dot (internal/local symbols)
+# - __sinit/__sterm (static initialization/termination)
+# - __[0-9]+__ (compiler-generated symbols)
+# - HIDDEN visibility symbols (to avoid linker error 0711-407)
 #
 # The final sort allows removal of any duplicates.
 #
 # Symbols for the gtest libraries are excluded as
 # they are not linked into the node executable.
 #
-set -x
 echo "Searching $1 to write out expfile to $2"
 
 # This special sequence must be at the start of the exp file.
 echo "#!." > "$2.tmp"
 
 # Pull the symbols from the .a files.
-# Use dump -tov to get visibility information and exclude HIDDEN symbols
+# Use dump -tov to get visibility information and exclude HIDDEN symbols.
 # This prevents AIX linker error 0711-407 when addons try to import symbols
 # with visibility attributes.
+#
+# IMPORTANT: AIX dump -tov output has a visibility column that contains either
+# a visibility keyword (HIDDEN/EXPORTED/PROTECTED) or blank spaces when no
+# visibility attribute is set. Since AWK splits fields on whitespace, this
+# results in different field counts:
+#
+# With visibility keyword (8 fields after AWK splits):
+#   [137] m 0x00003290 .text 1 weak HIDDEN ._ZNKSt3__1...
+#    $1  $2    $3      $4   $5  $6    $7        $8
+#                              |     |         └─ Symbol name
+#                              |     └─ Visibility (HIDDEN/EXPORTED/PROTECTED)
+#                              └─ Linkage (weak/extern)
+#
+# Without visibility keyword (7 fields after AWK splits, spaces collapsed):
+#   [77] m 0x00000000 .text 1 weak ._ZN8simdjson...
+#    $1 $2    $3      $4   $5  $6       $7
+#                             |         └─ Symbol name
+#                             └─ Linkage (weak/extern)
+#
+# The awk script handles both cases by using an associative array V[]
+# to map field values to their export suffixes. For fields that don't match
+# any key in V[], the lookup returns an empty string, which is perfect for
+# handling the variable field positions caused by the blank visibility column.
+#
 find "$1" -name "*.a" | grep -v gtest | while read f; do
     dump -tov -X 32_64 "$f" 2>/dev/null | \
     awk '
@@ -51,14 +69,15 @@ find "$1" -name "*.a" | grep -v gtest | while read f; do
             V["EXPORTED"]=" export"
             V["PROTECTED"]=" protected"
             V["HIDDEN"]=" hidden"
+            V["weak"]=" weak"
         }
-        /^\[[0-9]+\]\tm +[^ ]+ +\.(text|data|tdata|bss) +[^ ]+ +(extern|weak) +(EXPORTED|PROTECTED|HIDDEN| ) / {
+        /^\[[0-9]+\]\tm +[^ ]+ +\.(text|data|tdata|bss) +[^ ]+ +(extern|weak)( +(EXPORTED|PROTECTED|HIDDEN))?/ {
             # Exclude symbols starting with dot, __sinit, __sterm, __[0-9]+__
             # Also exclude HIDDEN symbols to avoid visibility attribute issues
             if (!match($NF,/^(\.|__sinit|__sterm|__[0-9]+__)/)) {
-                visibility = $(NF-1)
-                if (visibility != "HIDDEN") {
-                    print $NF
+                # Skip if HIDDEN visibility (can be at $(NF-1) or $(NF-2))
+                if ($(NF-1) != "HIDDEN" && $(NF-2) != "HIDDEN") {
+                    print $NF V[$(NF-1)] V[$(NF-2)]
                 }
             }
         }

--- a/tools/v8_gypfiles/toolchain.gypi
+++ b/tools/v8_gypfiles/toolchain.gypi
@@ -330,11 +330,20 @@
         'conditions': [
           ['OS=="aix" or OS=="os400"', {
             # Work around AIX ceil, trunc and round oddities.
-            'cflags': [ '-mcpu=power9 -mfprnd' ],
+            'cflags': [ '-mcpu=power9' ],
+            'conditions': [
+              ['clang==0', {
+                'cflags': [ '-mfprnd' ],
+              }],
+            ],
           }],
           ['OS=="aix" or OS=="os400"', {
-            # Work around AIX assembler popcntb bug.
-            'cflags': [ '-mno-popcntb' ],
+            'conditions': [
+              ['clang==0', {
+                # Work around AIX assembler popcntb bug.
+                'cflags': [ '-mno-popcntb' ],
+              }],
+            ],
           }],
         ],
       }],  # ppc64
@@ -593,8 +602,13 @@
           '_ALL_SOURCE=1'],
         'conditions': [
           [ 'v8_target_arch=="ppc64"', {
-            'cflags': [ '-maix64', '-fdollars-in-identifiers', '-fno-extern-tls-init' ],
+            'cflags': [ '-maix64', '-fdollars-in-identifiers' ],
             'ldflags': [ '-maix64 -Wl,-bbigtoc' ],
+            'conditions': [
+              ['clang==0', {
+                'cflags': [ '-fno-extern-tls-init' ],
+              }],
+            ],
           }],
         ],
       }],


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
This PR enables building Node.js on AIX with Clang by addressing several issues.

The game plan I have in mind to get AIX building with clang:


1. Confirm the changes in this PR doesn't break gcc builds (Node.js 24, 22, 20 still use it), then merge this PR

2. After this PR gets merged, update select compiler to use clang for Node.js 26+ builds
   (I have a draft PR for that here: https://github.com/nodejs/build/pull/4286)


## Changes

### 1. Add conditional flags for Clang builds

Some GCC flags don't work on Clang:
- `-mfprnd`
- `-mno-popcntb`
- `-fno-extern-tls-init`

These are now conditionally added only when Clang is not enabled.

For Clang builds, we need additional flags:
- `-fno-integrated-as`
- `-fno-xl-pragma-pack`

These flags are discussed in: https://chromium-review.googlesource.com/c/chromium/src/+/7120638

### 2. Fix OpenSSL implicit declaration errors

AIX header files don't ship declarations for `sendmmsg` and related functions, despite documentation showing they should be included. This appears to be a bug in AIX header files.

GCC tolerates implicit function declarations, but Clang 16+ treats them as errors:
https://www.redhat.com/en/blog/new-warnings-and-errors-clang-16

example:

```c
16:55:13 ../deps/openssl/openssl/crypto/bio/bss_dgram.c: In function 'dgram_sendmmsg':
16:55:13 ../deps/openssl/openssl/crypto/bio/bss_dgram.c:1416:11: warning: implicit declaration of function 'sendmmsg'; did you mean 'sendmsg'? [-Wimplicit-function-declaration]
16:55:14  1416 |     ret = sendmmsg(b->num, mh, num_msg, sysflags);
16:55:14       |           ^~~~~~~~
16:55:14       |           sendmsg
16:55:14 ../deps/openssl/openssl/crypto/bio/bss_dgram.c: In function 'dgram_recvmmsg':
16:55:14 ../deps/openssl/openssl/crypto/bio/bss_dgram.c:1609:11: warning: implicit declaration of function 'recvmmsg'; did you mean 'recvmsg'? [-Wimplicit-function-declaration]
16:55:14  1609 |     ret = recvmmsg(b->num, mh, num_msg, sysflags, NULL);
16:55:14       |           ^~~~~~~~
16:55:14       |           recvmsg
```
ref: https://ci.nodejs.org/job/node-test-commit-aix/nodes=aix72-power9/62022/consoleFull
For now, we claim to not have these functions. The actual functions are available in libc, so an alternative would be to declare them ourselves for AIX 7.2+.

Ref: https://www.ibm.com/docs/en/aix/7.2.0?topic=s-sendmmsg-subroutine

### 3. Cherry-pick V8 commit for AIX Clang support

Cherry-picked V8 commit 7107287 which adds required changes to build V8 with Clang on AIX.

Original commit: https://chromium-review.googlesource.com/c/v8/v8/+/7107287

### 4. Filter hidden visibility symbols from export script

Without filtering HIDDEN symbols, AIX Clang builds fail with linker errors:

```text
ld: 0711-407 ERROR: Symbol [SYMBOL_NAME]
        Visibility is not allowed on a reference to an imported symbol.
```

Not including hidden symbols in the export files matches the recommendation by XLC documentation:

> When using export lists, it is not recommended to put symbols with hidden visibility in the lists.

Ref: https://www.ibm.com/docs/en/openxl-c-and-cpp-aix/17.1.4?topic=libraries-symbol-exports-visibilities


### 5. Add weak symbol detection in create_expfile.sh

AIX export files support the `weak` keyword to mark weak symbols. According to IBM documentation:

> Each line within an import or export file contains the name of a symbol, optionally followed by an address or a keyword. Primary keywords are svc, svc32, svc3264, svc64, syscall, syscall32, syscall3264, syscall64, symbolic, nosymbolic, nosymbolic-, list, cm, bss, internal, hidden, protected, and export. A few more keywords are weak and required, which can be used along with another keyword.

ref: https://www.ibm.com/docs/en/aix/7.2.0?topic=l-ld-command#ld__a3119106d

This helps preserve C++ weak symbol semantics and preventing potential linker conflicts.