### PR TITLE
deps: fix ast-value-factory build without shared RO heap

### DIFF
--- a/deps/v8/src/ast/ast-value-factory.cc
+++ b/deps/v8/src/ast/ast-value-factory.cc
@@ -32,7 +32,8 @@
 #include "src/common/globals.h"
 #include "src/heap/factory-inl.h"
 #include "src/heap/local-factory-inl.h"
-#include "src/objects/string.h"
+#include "src/objects/string-inl.h"
+#include "src/roots/roots.h"
 #include "src/strings/string-hasher.h"
 #include "src/utils/utils-inl.h"
 
@@ -83,7 +84,7 @@ bool AstRawString::AsArrayIndex(uint32_t* index) const {
   if (!IsIntegerIndex()) return false;
   if (length() <= Name::kMaxCachedArrayIndexLength) {
     *index = StringHasher::DecodeArrayIndexFromHashField(
-        raw_hash_field_, HashSeed(ReadOnlyHeap::GetReadOnlyRoots()));
+        raw_hash_field_, HashSeed(GetReadOnlyRoots()));
     return true;
   }
   // Might be an index, but too big to cache it. Do the slow conversion. This


### PR DESCRIPTION
## Summary

This fixes a V8 build regression on the `v22.x` line when Node is configured with `--disable-shared-readonly-heap`.

## Problem

Building Node 22.22.2 without `V8_SHARED_RO_HEAP` fails in `deps/v8/src/ast/ast-value-factory.cc` because the code tries to retrieve read-only roots with a shared-RO-heap accessor that is not available in that configuration.

## Root cause

The backported V8 change switched `AstRawString::AsArrayIndex()` to decode cached array indexes using a hash seed from read-only roots, but this call site used the wrong accessor for non-shared-readonly-heap builds.

## Fix

- align `deps/v8/src/ast/ast-value-factory.cc` with the current `main` branch implementation
- use `HashSeed(GetReadOnlyRoots())` at the call site
- update the include list accordingly

## Testing

- `git diff --check`
- manual inspection against the current `main` branch implementation

Fixes: #62631
