### PR TITLE
child_process: use module.exports.spawn in fork and execFile

### DIFF
--- a/lib/child_process.js
+++ b/lib/child_process.js
@@ -171,7 +171,7 @@ function fork(modulePath, args = [], options) {
     throw new ERR_CHILD_PROCESS_IPC_REQUIRED('options.stdio');
   }
 
-  return spawn(options.execPath, args, options);
+  return module.exports.spawn(options.execPath, args, options);
 }
 
 function _forkChild(fd, serializationMode) {
@@ -346,7 +346,7 @@ function execFile(file, args, options, callback) {
 
   options.killSignal = sanitizeKillSignal(options.killSignal);
 
-  const child = spawn(file, args, {
+  const child = module.exports.spawn(file, args, {
     cwd: options.cwd,
     env: options.env,
     gid: options.gid,

--- a/test/parallel/test-child-process-spawn-module-exports.js
+++ b/test/parallel/test-child-process-spawn-module-exports.js
@@ -1,0 +1,33 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const cp = require('child_process');
+
+// Verify that fork() and execFile() call spawn through module.exports
+// so that user-level wrapping of child_process.spawn works correctly.
+// This is consistent with exec() which already uses module.exports.execFile().
+
+if (process.argv[2] === 'child') {
+  process.exit(0);
+}
+
+const originalSpawn = cp.spawn;
+
+// Test that fork() uses module.exports.spawn.
+cp.spawn = common.mustCall(function(...args) {
+  cp.spawn = originalSpawn;
+  return originalSpawn.apply(this, args);
+});
+
+const child = cp.fork(__filename, ['child']);
+child.on('exit', common.mustCall((code) => {
+  assert.strictEqual(code, 0);
+
+  // Test that execFile() uses module.exports.spawn.
+  cp.spawn = common.mustCall(function(...args) {
+    cp.spawn = originalSpawn;
+    return originalSpawn.apply(this, args);
+  });
+
+  cp.execFile(process.execPath, ['--version'], common.mustSucceed());
+}));


### PR DESCRIPTION
`fork()` and `execFile()` call the locally-scoped `spawn()` function
directly, bypassing any wrapping applied to `child_process.spawn` via
module exports.

This is inconsistent with `exec()`, which correctly uses
`module.exports.execFile()` (see [lib/child_process.js:236](https://github.com/nodejs/node/blob/main/lib/child_process.js#L236)).

### The problem

APM tools (New Relic, Datadog), security monitors, and testing
frameworks commonly wrap `child_process.spawn` on exports to intercept
child process creation. With the current code, processes spawned
through `fork()` and `execFile()` silently bypass these wrappers, while
`exec()` correctly goes through them.

```js
const cp = require('child_process');
const originalSpawn = cp.spawn;

cp.spawn = function (...args) {
  console.log('spawn intercepted');
  return originalSpawn.apply(this, args);
};

cp.exec('echo hi');       // intercepted (exec → module.exports.execFile → ... → spawn)
cp.fork('./worker.js');   // NOT intercepted (fork → local spawn)
cp.execFile('ls', []);    // NOT intercepted (execFile → local spawn)
```

### The fix

Change `fork()` and `execFile()` to call `module.exports.spawn()`
instead of the locally-scoped `spawn()`, consistent with the pattern
already used by `exec()`.

Refs: https://github.com/yao-pkg/pkg/issues/231