### PR TITLE
build: remove redundant -fuse-linker-plugin from GCC LTO flags

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -189,7 +189,7 @@
             ['clang==1', {
               'lto': ' -flto ', # Clang
             }, {
-              'lto': ' -flto=4 -fuse-linker-plugin -ffat-lto-objects ', # GCC
+              'lto': ' -flto=4 -ffat-lto-objects ', # GCC
             }],
           ],
         },


### PR DESCRIPTION
The `-fuse-linker-plugin` flag has been automatically enabled by GCC
since version 5 when LTO is active, making the explicit flag
redundant. Since Node.js requires GCC >= 13.2, this flag serves no
purpose.

Removing it also improves portability with alternative linkers (mold,
lld) that may not support GCC's linker plugin interface, avoiding
build failures when these linkers are used with GCC LTO builds.

Refs: https://github.com/yao-pkg/pkg/issues/231