### PR TITLE
doc: clarify Backport-PR-URL metadata added automatically

### DIFF
--- a/doc/contributing/backporting-to-release-lines.md
+++ b/doc/contributing/backporting-to-release-lines.md
@@ -75,8 +75,8 @@ line.
 5. Resolve conflicts using `git add` and `git cherry-pick --continue`.
 
 6. Leave the commit message as is. If you think it should be modified, comment
-   in the pull request. The `Backport-PR-URL` metadata does need to be added to
-   the commit, but this will be done later.
+   in the pull request. Do not manually add a `Backport-PR-URL` metadata entry.
+   This is automatically added later.
 
 7. Verify that `make -j4 test` passes.
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/61955
Refs: https://github.com/nodejs/node/pull/61840#issuecomment-3944761331

Clarifies in [How to backport a pull request to a release line > Manual process](https://github.com/nodejs/node/blob/main/doc/contributing/backporting-to-release-lines.md#manual-process) document section, that the `Backport-PR-URL` is added automatically. Currently the document says:

> The `Backport-PR-URL` metadata does need to be added to the commit, but this will be done later.

which has been incorrectly interpreted as meaning that the submitter needs to add it.