### PR TITLE
sea: add test and update docs for import() with code cache

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -216,8 +216,6 @@ executable application is launched, instead of compiling the `main` script from
 scratch, Node.js would use the code cache to speed up the compilation, then
 execute the script, which would improve the startup performance.
 
-**Note:** `import()` does not work when `useCodeCache` is `true`.
-
 ### Execution arguments
 
 The `execArgv` field can be used to specify Node.js-specific
@@ -451,8 +449,9 @@ injected main script with the following properties:
 
 <!-- TODO(joyeecheung): support and document module.registerHooks -->
 
-When using `"mainFormat": "module"`, `import()` can be used to dynamically
-load built-in modules. Attempting to use `import()` to load modules from
+`import()` can be used to dynamically load built-in modules in both
+CommonJS and ESM (`"mainFormat": "module"`) single executable applications.
+Attempting to use `import()` to load modules from
 the file system will throw an error.
 
 ### Using native addons in the injected main script

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -666,12 +666,6 @@ std::optional<std::string> GenerateCodeCache(std::string_view main_path,
     Local<UnboundModuleScript> unbound = module->GetUnboundModuleScript();
     cache.reset(ScriptCompiler::CreateCodeCache(unbound));
   } else {
-    // TODO(RaisinTen): Using the V8 code cache prevents us from using
-    // `import()` in the SEA code. Support it. Refs:
-    // https://github.com/nodejs/node/pull/48191#discussion_r1213271430
-    // TODO(joyeecheung): this likely has been fixed by
-    // https://chromium-review.googlesource.com/c/v8/v8/+/5401780 - add a test
-    // and update docs.
     LocalVector<String> parameters(
         isolate,
         {

--- a/test/fixtures/sea/use-code-cache-dynamic-import/sea-config.json
+++ b/test/fixtures/sea/use-code-cache-dynamic-import/sea-config.json
@@ -1,0 +1,6 @@
+{
+  "main": "sea.js",
+  "output": "sea",
+  "useCodeCache": true,
+  "disableExperimentalSEAWarning": true
+}

--- a/test/fixtures/sea/use-code-cache-dynamic-import/sea.js
+++ b/test/fixtures/sea/use-code-cache-dynamic-import/sea.js
@@ -1,0 +1,13 @@
+(async () => {
+  const assert = require('node:assert');
+
+  // Dynamic import of a built-in module should work even with code cache.
+  const { strictEqual } = await import('node:assert');
+  assert.strictEqual(strictEqual, assert.strictEqual);
+
+  // Dynamic import of another built-in module.
+  const { join } = await import('node:path');
+  assert.strictEqual(typeof join, 'function');
+
+  console.log('dynamic import with code cache works');
+})();

--- a/test/sea/test-single-executable-application-use-code-cache-dynamic-import.js
+++ b/test/sea/test-single-executable-application-use-code-cache-dynamic-import.js
@@ -1,0 +1,36 @@
+'use strict';
+
+// This tests that import() works in a CJS single executable application
+// when useCodeCache is true. A V8 fix (https://chromium-review.googlesource.com
+// /c/v8/v8/+/5401780) resolved the issue where code cache serialization
+// wiped host-defined options needed by HostImportModuleDynamically.
+
+require('../common');
+
+const {
+  buildSEA,
+  skipIfBuildSEAIsNotSupported,
+} = require('../common/sea');
+
+skipIfBuildSEAIsNotSupported();
+
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndAssert } = require('../common/child_process');
+
+tmpdir.refresh();
+
+const outputFile = buildSEA(fixtures.path('sea', 'use-code-cache-dynamic-import'));
+
+spawnSyncAndAssert(
+  outputFile,
+  [],
+  {
+    env: {
+      NODE_DEBUG_NATIVE: 'SEA',
+      ...process.env,
+    },
+  },
+  {
+    stdout: 'dynamic import with code cache works\n',
+  });

--- a/test/sea/test-single-executable-application-use-code-cache-dynamic-import.js
+++ b/test/sea/test-single-executable-application-use-code-cache-dynamic-import.js
@@ -1,9 +1,7 @@
 'use strict';
 
 // This tests that import() works in a CJS single executable application
-// when useCodeCache is true. A V8 fix (https://chromium-review.googlesource.com
-// /c/v8/v8/+/5401780) resolved the issue where code cache serialization
-// wiped host-defined options needed by HostImportModuleDynamically.
+// when useCodeCache is true.
 
 require('../common');
 


### PR DESCRIPTION
- Remove the `**Note:** import() does not work when useCodeCache is true.` restriction from the API documentation.

Assisted by: Claude Opus 4.6


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
