### PR TITLE
build: fix stray debug string in LIEF defines

### DIFF
--- a/deps/LIEF/lief.gyp
+++ b/deps/LIEF/lief.gyp
@@ -443,7 +443,6 @@
       },
       'defines': [
         'LIEF_STATIC',
-        'testtttt'
         'MBEDTLS_CONFIG_FILE="config/mbedtls/config.h"',
         'MBEDTLS_NO_PLATFORM_ENTROPY',
         'SPDLOG_DISABLE_DEFAULT_LOGGER',


### PR DESCRIPTION
A stray debug string `'testtttt'` in [lief.gyp](cci:7://file:///media/slapi/storage/Github@Open-Source/node/deps/LIEF/lief.gyp:0:0-0:0)'s defines list was missing
a trailing comma, causing it to be concatenated with the adjacent
`MBEDTLS_CONFIG_FILE` define via GYP's implicit string concatenation.

**Current (broken):** `-DtestttttMBEDTLS_CONFIG_FILE="config/mbedtls/config.h"`

**Expected (fixed):** `-DMBEDTLS_CONFIG_FILE="config/mbedtls/config.h"`

This means mbedtls was never receiving its intended config file path. Remove
the stray string so `MBEDTLS_CONFIG_FILE` is defined correctly.

### Risk
Fixing this define may change mbedtls behavior if it was previously falling
back to a default config. Reviewers should verify that
`config/mbedtls/config.h` is the correct config path and that LIEF's mbedtls
usage works correctly with it.

**Related:** PR #62682 addresses the duplicate C++ standard flags in the same file.

Refs: https://github.com/nodejs/node/issues/62129