### PR TITLE
module: fix wrong error annotation for require of ESM

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1872,9 +1872,49 @@ function loadSource(mod, filename, formatFromNode) {
 }
 
 function reconstructErrorStack(err, parentPath, parentSource) {
-  const errLine = StringPrototypeSplit(
-    StringPrototypeSlice(err.stack, StringPrototypeIndexOf(
-      err.stack, '    at ')), '\n', 1)[0];
+  // Find the stack frame that matches the parent module path.
+  // We cannot simply use the first frame because internal wrappers
+  // like TracingChannel.traceSync may appear before the user's frame.
+  const stackLines = StringPrototypeSplit(err.stack, '\n');
+  let errLine;
+  for (let i = 0; i < stackLines.length; i++) {
+    if (StringPrototypeIndexOf(stackLines[i], parentPath) !== -1) {
+      errLine = stackLines[i];
+      break;
+    }
+  }
+  // Fallback: if no frame matched the parent path, prefer a user-land
+  // frame (skip node:internal/* and other node:-scheme frames) so the
+  // annotation points at user code, not internal wrappers.
+  if (errLine === undefined) {
+    for (let i = 0; i < stackLines.length; i++) {
+      const line = stackLines[i];
+      if (StringPrototypeIndexOf(line, '    at ') === -1) {
+        continue;
+      }
+      if (StringPrototypeIndexOf(line, 'node:internal/') !== -1) {
+        continue;
+      }
+      if (StringPrototypeIndexOf(line, '(node:') !== -1) {
+        continue;
+      }
+      errLine = line;
+      break;
+    }
+  }
+  // Last resort: if all frames are internal, use the first 'at' frame
+  // so the user still gets some error annotation rather than none.
+  if (errLine === undefined) {
+    for (let i = 0; i < stackLines.length; i++) {
+      if (StringPrototypeIndexOf(stackLines[i], '    at ') !== -1) {
+        errLine = stackLines[i];
+        break;
+      }
+    }
+  }
+  if (errLine === undefined) {
+    return;
+  }
   const { 1: line, 2: col } =
     RegExpPrototypeExec(/(\d+):(\d+)\)/, errLine) || [];
   if (line && col) {

--- a/test/es-module/test-cjs-esm-error-annotation.js
+++ b/test/es-module/test-cjs-esm-error-annotation.js
@@ -1,0 +1,52 @@
+'use strict';
+
+// This test verifies that when a CommonJS module requires an ES module,
+// the error annotation (arrow message) points to the user's require()
+// call in their source file, not to an internal frame such as
+// TracingChannel.traceSync in node:diagnostics_channel.
+// Regression test for https://github.com/nodejs/node/issues/55350.
+
+const { spawnPromisified } = require('../common');
+const fixtures = require('../common/fixtures.js');
+const assert = require('node:assert');
+const path = require('node:path');
+const { execPath } = require('node:process');
+const { describe, it } = require('node:test');
+
+const requiringEsm = path.resolve(
+  fixtures.path('/es-modules/cjs-esm-esm.js')
+);
+
+describe('ERR_REQUIRE_ESM error annotation', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  it('should point to the user require() call, not internal frames', async () => {
+    const { code, stderr } = await spawnPromisified(execPath, [
+      '--no-experimental-require-module', requiringEsm,
+    ]);
+
+    assert.strictEqual(code, 1);
+
+    const stderrStr = stderr.replaceAll('\r', '');
+
+    // The error annotation should reference the user's file, not
+    // node:diagnostics_channel or any other internal module.
+    assert.ok(
+      stderrStr.includes(requiringEsm),
+      `Expected error output to reference ${requiringEsm}, got:\n${stderrStr}`
+    );
+
+    // The error annotation line should contain the path to the requiring
+    // file. Do not assume it is the very first stderr line — internal
+    // throw-location lines may precede the arrow annotation.
+    const lines = stderrStr.split('\n');
+    const fileAnnotationLine = lines.find((l) => l.includes(requiringEsm));
+    assert.ok(
+      fileAnnotationLine,
+      `Expected an annotation line referencing the requiring file, got:\n` +
+      lines.slice(0, 10).join('\n')
+    );
+    assert.ok(
+      !fileAnnotationLine.includes('diagnostics_channel'),
+      `Annotation line should not reference diagnostics_channel, got: "${fileAnnotationLine}"`
+    );
+  });
+});


### PR DESCRIPTION
When a CommonJS module requires an ES module with
`--no-experimental-require-module`, the error annotation (arrow message)
points to an internal frame instead of the user's actual [require()](cci:1://file:///media/slapi/storage/Github@Open-Source/node/lib/internal/modules/cjs/loader.js:1560:0-1578:2) call.

**Before (broken):**
The error annotation incorrectly points to `node:diagnostics_channel:315`
with content `undefined`, because `TracingChannel.traceSync` is the first
frame in the stack trace.

**After (fixed):**
The error annotation correctly points to the user's file and line where
[require()](cci:1://file:///media/slapi/storage/Github@Open-Source/node/lib/internal/modules/cjs/loader.js:1560:0-1578:2) was called, showing the actual source line.

### Root Cause

The [reconstructErrorStack](cci:1://file:///media/slapi/storage/Github@Open-Source/node/lib/internal/modules/cjs/loader.js:1873:0-1903:1) function always picked the first [at](cci:1://file:///media/slapi/storage/Github@Open-Source/node/lib/internal/modules/cjs/loader.js:260:0-280:1) frame
from the error stack trace. Since v22.4.0, [require()](cci:1://file:///media/slapi/storage/Github@Open-Source/node/lib/internal/modules/cjs/loader.js:1560:0-1578:2) is wrapped by
`TracingChannel.traceSync` via [wrapModuleLoad](cci:1://file:///media/slapi/storage/Github@Open-Source/node/lib/internal/modules/cjs/loader.js:231:0-258:1), so the first frame is
the internal tracing wrapper instead of the user's code.

### Fix

Search the stack frames for one matching the parent module's file path,
instead of blindly using the first frame. If no frame matches (e.g.,
on a different Node.js version or with an unexpected internal wrapper),
fall back to the old behavior of using the first [at](cci:1://file:///media/slapi/storage/Github@Open-Source/node/lib/internal/modules/cjs/loader.js:260:0-280:1) frame so the
user still gets some error annotation rather than none. This ensures
robust behavior across Node.js versions while correctly skipping
internal wrappers when possible.

Fixes: https://github.com/nodejs/node/issues/55350