### PR TITLE
tools: bump @node-core/doc-kit from 1.0.2 to 1.3.3 in /tools/doc in the doc group

### DIFF
--- a/tools/doc/package-lock.json
+++ b/tools/doc/package-lock.json
@@ -6,7 +6,7 @@
     "": {
       "name": "doc",
       "dependencies": {
-        "@node-core/doc-kit": "1.0.2"
+        "@node-core/doc-kit": "1.3.3"
       }
     },
     "node_modules/@actions/core": {
@@ -519,33 +519,33 @@
       }
     },
     "node_modules/@node-core/doc-kit": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@node-core/doc-kit/-/doc-kit-1.0.2.tgz",
-      "integrity": "sha512-dYTh29FRH7Qcbz8M1WbAu1tg2YVcmCEdt514QcDqJWsRrYJfvzg10OyDODyEPJfKZ4+OUN/VPi3knGoGfOSNkQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@node-core/doc-kit/-/doc-kit-1.3.3.tgz",
+      "integrity": "sha512-atY8Opo1vdlJmT3d5u7511bjUZ1/hW4skMnwI/4Y33V4Wb/oPzAgFtpklSM9kf5nD4SCT0G7ddAvTUQISGpALA==",
       "dependencies": {
         "@actions/core": "^3.0.0",
         "@heroicons/react": "^2.2.0",
         "@minify-html/wasm": "^0.18.1",
         "@node-core/rehype-shiki": "^1.4.1",
-        "@node-core/ui-components": "^1.6.1",
+        "@node-core/ui-components": "^1.6.3",
         "@orama/orama": "^3.1.18",
         "@orama/ui": "^1.5.4",
         "@rollup/plugin-virtual": "^3.0.2",
         "@swc/html-wasm": "^1.15.18",
         "acorn": "^8.16.0",
         "commander": "^14.0.3",
-        "dedent": "^1.7.1",
+        "dedent": "^1.7.2",
         "estree-util-to-js": "^2.0.0",
         "estree-util-visit": "^2.0.0",
         "github-slugger": "^2.0.0",
-        "globals": "^17.3.0",
+        "glob-parent": "^6.0.2",
         "hast-util-to-string": "^3.0.1",
         "hastscript": "^9.0.1",
-        "lightningcss-wasm": "^1.31.1",
+        "lightningcss-wasm": "^1.32.0",
         "mdast-util-slice-markdown": "^2.0.1",
         "piscina": "^5.1.4",
-        "preact": "^10.28.4",
-        "preact-render-to-string": "^6.6.3",
+        "preact": "^10.29.0",
+        "preact-render-to-string": "^6.6.6",
         "reading-time": "^1.5.0",
         "recma-jsx": "^1.0.1",
         "rehype-raw": "^7.0.0",
@@ -555,9 +555,9 @@
         "remark-parse": "^11.0.0",
         "remark-rehype": "^11.1.2",
         "remark-stringify": "^11.0.0",
-        "rolldown": "^1.0.0-rc.6",
+        "rolldown": "^1.0.0-rc.10",
         "semver": "^7.7.4",
-        "shiki": "^4.0.0",
+        "shiki": "^4.0.2",
         "tinyglobby": "^0.2.15",
         "unified": "^11.0.5",
         "unist-builder": "^4.0.0",
@@ -566,11 +566,22 @@
         "unist-util-remove": "^4.0.0",
         "unist-util-select": "^5.1.0",
         "unist-util-visit": "^5.1.0",
-        "vfile": "^6.0.3",
-        "yaml": "^2.8.2"
+        "yaml": "^2.8.3"
       },
       "bin": {
         "doc-kit": "bin/cli.mjs"
+      }
+    },
+    "node_modules/@node-core/doc-kit/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/@node-core/rehype-shiki": {
@@ -3448,18 +3459,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/graceful-fs": {

--- a/tools/doc/package.json
+++ b/tools/doc/package.json
@@ -2,6 +2,6 @@
   "name": "doc",
   "private": true,
   "dependencies": {
-    "@node-core/doc-kit": "1.0.2"
+    "@node-core/doc-kit": "1.3.3"
   }
 }


### PR DESCRIPTION
This bump contains a fix for the `make test-only` target on riscv64: https://github.com/nodejs/doc-kit/pull/691

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
