### PR TITLE
doc: fix article usage before vowel-sound acronyms

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -6645,7 +6645,7 @@ See the [list of SSL OP Flags][] for details.
   </tr>
   <tr>
     <td><code>SSL_OP_DONT_INSERT_EMPTY_FRAGMENTS</code></td>
-    <td>Instructs OpenSSL to disable a SSL 3.0/TLS 1.0 vulnerability
+    <td>Instructs OpenSSL to disable an SSL 3.0/TLS 1.0 vulnerability
     workaround added in OpenSSL 0.9.6d.</td>
   </tr>
   <tr>

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1517,7 +1517,7 @@ changes:
   - version: v12.0.0
     pr-url: https://github.com/nodejs/node/pull/25605
     description: The default behavior will return a 431 Request Header
-                 Fields Too Large if a HPE_HEADER_OVERFLOW error occurs.
+                 Fields Too Large if an HPE_HEADER_OVERFLOW error occurs.
   - version: v9.4.0
     pr-url: https://github.com/nodejs/node/pull/17672
     description: The `rawPacket` is the current buffer that just parsed. Adding
@@ -1543,8 +1543,8 @@ This event is guaranteed to be passed an instance of the {net.Socket} class,
 a subclass of {stream.Duplex}, unless the user specifies a socket
 type other than {net.Socket}.
 
-Default behavior is to try close the socket with a HTTP '400 Bad Request',
-or a HTTP '431 Request Header Fields Too Large' in the case of a
+Default behavior is to try close the socket with an HTTP '400 Bad Request',
+or an HTTP '431 Request Header Fields Too Large' in the case of an
 [`HPE_HEADER_OVERFLOW`][] error. If the socket is not writable or headers
 of the current attached [`http.ServerResponse`][] has been sent, it is
 immediately destroyed.
@@ -2703,7 +2703,7 @@ will result in a [`TypeError`][] being thrown.
 added: v10.0.0
 -->
 
-Sends a HTTP/1.1 102 Processing message to the client, indicating that
+Sends an HTTP/1.1 102 Processing message to the client, indicating that
 the request body should be sent.
 
 ## Class: `http.IncomingMessage`
@@ -3690,7 +3690,7 @@ changes:
     `readableHighWaterMark` and `writableHighWaterMark`. This affects
     `highWaterMark` property of both `IncomingMessage` and `ServerResponse`.
     **Default:** See [`stream.getDefaultHighWaterMark()`][].
-  * `insecureHTTPParser` {boolean} If set to `true`, it will use a HTTP parser
+  * `insecureHTTPParser` {boolean} If set to `true`, it will use an HTTP parser
     with leniency flags enabled. Using the insecure parser should be avoided.
     See [`--insecure-http-parser`][] for more information.
     **Default:** `false`.
@@ -4001,7 +4001,7 @@ changes:
     request to. **Default:** `'localhost'`.
   * `hostname` {string} Alias for `host`. To support [`url.parse()`][],
     `hostname` will be used if both `host` and `hostname` are specified.
-  * `insecureHTTPParser` {boolean} If set to `true`, it will use a HTTP parser
+  * `insecureHTTPParser` {boolean} If set to `true`, it will use an HTTP parser
     with leniency flags enabled. Using the insecure parser should be avoided.
     See [`--insecure-http-parser`][] for more information.
     **Default:** `false`

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -3966,7 +3966,7 @@ const server = createSecureServer(
 ).listen(8000);
 
 function onRequest(req, res) {
-  // Detects if it is a HTTPS request or HTTP/2
+  // Detects if it is an HTTPS request or HTTP/2
   const { socket: { alpnProtocol } } = req.httpVersion === '2.0' ?
     req.stream.session : req;
   res.writeHead(200, { 'content-type': 'application/json' });
@@ -3990,7 +3990,7 @@ const server = createSecureServer(
 ).listen(4443);
 
 function onRequest(req, res) {
-  // Detects if it is a HTTPS request or HTTP/2
+  // Detects if it is an HTTPS request or HTTP/2
   const { socket: { alpnProtocol } } = req.httpVersion === '2.0' ?
     req.stream.session : req;
   res.writeHead(200, { 'content-type': 'application/json' });

--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -364,7 +364,7 @@ changes:
 
 The module compile cache can be enabled either using the [`module.enableCompileCache()`][]
 method or the [`NODE_COMPILE_CACHE=dir`][] environment variable. After it is enabled,
-whenever Node.js compiles a CommonJS, a ECMAScript Module, or a TypeScript module, it will
+whenever Node.js compiles a CommonJS, an ECMAScript Module, or a TypeScript module, it will
 use on-disk [V8 code cache][] persisted in the specified directory to speed up the compilation.
 This may slow down the first load of a module graph, but subsequent loads of the same module
 graph may get a significant speedup if the contents of the modules do not change.

--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1212,7 +1212,7 @@ added: v9.9.0
 -->
 
 * Returns: {Buffer|undefined} The latest `Finished` message that has been
-  sent to the socket as part of a SSL/TLS handshake, or `undefined` if
+  sent to the socket as part of an SSL/TLS handshake, or `undefined` if
   no `Finished` message has been sent yet.
 
 As the `Finished` messages are message digests of the complete handshake
@@ -1355,7 +1355,7 @@ added: v9.9.0
 -->
 
 * Returns: {Buffer|undefined} The latest `Finished` message that is expected
-  or has actually been received from the socket as part of a SSL/TLS handshake,
+  or has actually been received from the socket as part of an SSL/TLS handshake,
   or `undefined` if there is no `Finished` message so far.
 
 As the `Finished` messages are message digests of the complete handshake


### PR DESCRIPTION
### Doc change

Several prose references across the API docs use the article `a` where the following acronym starts with a **vowel sound** and should take `an` instead. The rule is based on pronunciation, not spelling:

| Acronym | Pronounced | Correct article |
| --- | --- | --- |
| HTTP | aitch-tee-tee-pee | an HTTP |
| HTTPS | aitch-tee-tee-pee-ess | an HTTPS |
| SSL | ess-es-el | an SSL |
| HPE_HEADER_OVERFLOW | aitch-pee-ee... | an HPE_... |
| ECMAScript | ek-mah-script | an ECMAScript |

### Affected occurrences

13 instances across 5 files:

- `doc/api/crypto.md` — 1: "Instructs OpenSSL to disable `a SSL 3.0/TLS 1.0` vulnerability"
- `doc/api/http.md` — 7: five `a HTTP` (one `HTTP/1.1`, two `HTTP parser`, two `HTTP '4xx'`) plus two `a HPE_HEADER_OVERFLOW error`
- `doc/api/http2.md` — 2: two code-sample comments reading `// Detects if it is a HTTPS request or HTTP/2`
- `doc/api/module.md` — 1: `compiles a CommonJS, a ECMAScript Module, or a TypeScript module` — only the middle article changes; `a CommonJS` and `a TypeScript` are already correct
- `doc/api/tls.md` — 2: both `getFinished()` and `getPeerFinished()` describe data "sent/received as part of `a SSL/TLS` handshake"

### Not in scope

- `errors.md:2043` — "The syntax of a MIME is not valid." — MIME is typically spoken as a word ("mime", rhymes with "time"), consonant start, so `a MIME` is already correct.
- `a TLS ...` occurrences — TLS is "tee-el-es", consonant start, already correct.

### Verification

Docs-only change. No code, build, or behavior impact.

<!-- Ref: https://en.wiktionary.org/wiki/Appendix:English_articles#Distinction_between_a_and_an -->