### PR TITLE
doc: correct typo in PR contribution instructions

### DIFF
--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -187,7 +187,7 @@ A good commit message should describe what changed and why.
    `Fixes:` and `Refs:` trailers get automatically added to your commit message
    when the Pull Request lands as long as they are included in the
    Pull Request's description. If the Pull Request lands in several commits,
-   by default the trailers found in the description are added to each commits.
+   by default the trailers found in the description are added to each commit.
 
    Examples:
 


### PR DESCRIPTION
This corrects a typo in [doc/contributing/pull-requests.md](https://github.com/nodejs/node/blob/main/doc/contributing/pull-requests.md) as a test case to see if `Signed-off-by` metadata can be split across multiple lines according to https://git-scm.com/docs/git-interpret-trailers

Edit: At the moment, this does not work. Leaving this PR open as a test subject.