### PR TITLE
crypto: fix use-after-free risk in ManagedX509 assignment

### DIFF
--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -59,9 +59,12 @@ ManagedX509::ManagedX509(const ManagedX509& that) {
 }
 
 ManagedX509& ManagedX509::operator=(const ManagedX509& that) {
-  cert_.reset(that.get());
-  if (cert_) [[likely]]
-    X509_up_ref(cert_.get());
+  if (this == &that) return *this;
+
+  X509* cert = that.get();
+  if (cert) [[likely]]
+    X509_up_ref(cert);
+  cert_.reset(cert);
   return *this;
 }
 


### PR DESCRIPTION
### Description
This PR resolves a potential double-free/use-after-free vulnerability identified by Coverity (Issue 367349) within `ManagedX509::operator=`.

Previously, `cert_.reset(that.get())` was destructing the underlying X509 structure prior to correctly tracking the reference count out-of-band via `X509_up_ref(cert_.get())`. If multiple [ManagedX509](cci:1://file:///media/slapi/storage/Github@Open-Source/node/src/crypto/crypto_x509.cc:56:0-58:1) instances mistakenly managed the same underlying raw pointer, it could cause the OpenSSL backing object's internal reference count to reach zero and prematurely free the memory before `up_ref` executes.

The refactored logic now ensures strict adherence to OpenSSL smart pointer semantics:
- Added a self-assignment check to return early.
- Guarantees `X509_up_ref(cert)` increments the reference limits *first* before the object acts on `.reset()`, strictly guaranteeing the memory boundary.

Fixes: [#56926](https://github.com/nodejs/node/issues/56926)