### PR TITLE
 doc,src,test: fix dead inspector help URL

### DIFF
--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -16,7 +16,7 @@ script to debug.
 ```console
 $ node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/621111f9-ffcb-4e82-b718-48a145fa5db8
-< For help, see: https://nodejs.org/api/inspector.html
+< For help, see: https://nodejs.org/learn/getting-started/debugging
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -45,7 +45,7 @@ setTimeout(() => {
 console.log('hello');
 $ NODE_INSPECT_RESUME_ON_START=1 node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/f1ed133e-7876-495b-83ae-c32c6fc319c2
-< For help, see: https://nodejs.org/api/inspector.html
+< For help, see: https://nodejs.org/learn/getting-started/debugging
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -131,7 +131,7 @@ is not loaded yet:
 ```console
 $ node inspect main.js
 < Debugger listening on ws://127.0.0.1:9229/48a5b28a-550c-471b-b5e1-d13dd7165df9
-< For help, see: https://nodejs.org/api/inspector.html
+< For help, see: https://nodejs.org/learn/getting-started/debugging
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -158,7 +158,7 @@ given expression evaluates to `true`:
 ```console
 $ node inspect main.js
 < Debugger listening on ws://127.0.0.1:9229/ce24daa8-3816-44d4-b8ab-8273c8a66d35
-< For help, see: https://nodejs.org/api/inspector.html
+< For help, see: https://nodejs.org/learn/getting-started/debugging
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -253,7 +253,7 @@ or break on the first line for step-by-step debugging.
 ```console
 $ node --inspect index.js
 Debugger listening on ws://127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
-For help, see: https://nodejs.org/api/inspector.html
+For help, see: https://nodejs.org/learn/getting-started/debugging
 ```
 
 (In the example above, the UUID dc9010dd-f8b8-4ac5-a510-c1a114ec7d29

--- a/doc/api/debugger.md
+++ b/doc/api/debugger.md
@@ -16,7 +16,7 @@ script to debug.
 ```console
 $ node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/621111f9-ffcb-4e82-b718-48a145fa5db8
-< For help, see: https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/api/inspector.html
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -45,7 +45,7 @@ setTimeout(() => {
 console.log('hello');
 $ NODE_INSPECT_RESUME_ON_START=1 node inspect myscript.js
 < Debugger listening on ws://127.0.0.1:9229/f1ed133e-7876-495b-83ae-c32c6fc319c2
-< For help, see: https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/api/inspector.html
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -131,7 +131,7 @@ is not loaded yet:
 ```console
 $ node inspect main.js
 < Debugger listening on ws://127.0.0.1:9229/48a5b28a-550c-471b-b5e1-d13dd7165df9
-< For help, see: https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/api/inspector.html
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -158,7 +158,7 @@ given expression evaluates to `true`:
 ```console
 $ node inspect main.js
 < Debugger listening on ws://127.0.0.1:9229/ce24daa8-3816-44d4-b8ab-8273c8a66d35
-< For help, see: https://nodejs.org/en/docs/inspector
+< For help, see: https://nodejs.org/api/inspector.html
 <
 connecting to 127.0.0.1:9229 ... ok
 < Debugger attached.
@@ -253,7 +253,7 @@ or break on the first line for step-by-step debugging.
 ```console
 $ node --inspect index.js
 Debugger listening on ws://127.0.0.1:9229/dc9010dd-f8b8-4ac5-a510-c1a114ec7d29
-For help, see: https://nodejs.org/en/docs/inspector
+For help, see: https://nodejs.org/api/inspector.html
 ```
 
 (In the example above, the UUID dc9010dd-f8b8-4ac5-a510-c1a114ec7d29

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -465,12 +465,12 @@ Return the URL of the active inspector, or `undefined` if there is none.
 ```console
 $ node --inspect -p 'inspector.url()'
 Debugger listening on ws://127.0.0.1:9229/166e272e-7a30-4d09-97ce-f1c012b43c34
-For help, see: https://nodejs.org/en/docs/inspector
+For help, see: https://nodejs.org/api/inspector.html
 ws://127.0.0.1:9229/166e272e-7a30-4d09-97ce-f1c012b43c34
 
 $ node --inspect=localhost:3000 -p 'inspector.url()'
 Debugger listening on ws://localhost:3000/51cf8d0e-3c36-4c59-8efd-54519839e56a
-For help, see: https://nodejs.org/en/docs/inspector
+For help, see: https://nodejs.org/api/inspector.html
 ws://localhost:3000/51cf8d0e-3c36-4c59-8efd-54519839e56a
 
 $ node -p 'inspector.url()'

--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -465,12 +465,12 @@ Return the URL of the active inspector, or `undefined` if there is none.
 ```console
 $ node --inspect -p 'inspector.url()'
 Debugger listening on ws://127.0.0.1:9229/166e272e-7a30-4d09-97ce-f1c012b43c34
-For help, see: https://nodejs.org/api/inspector.html
+For help, see: https://nodejs.org/learn/getting-started/debugging
 ws://127.0.0.1:9229/166e272e-7a30-4d09-97ce-f1c012b43c34
 
 $ node --inspect=localhost:3000 -p 'inspector.url()'
 Debugger listening on ws://localhost:3000/51cf8d0e-3c36-4c59-8efd-54519839e56a
-For help, see: https://nodejs.org/api/inspector.html
+For help, see: https://nodejs.org/learn/getting-started/debugging
 ws://localhost:3000/51cf8d0e-3c36-4c59-8efd-54519839e56a
 
 $ node -p 'inspector.url()'

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -247,7 +247,8 @@ void PrintDebuggerReadyMessage(
               FormatWsAddress(host, server_socket->port(), id, true).c_str());
     }
   }
-  fprintf(out, "For help, see: %s\n",
+  fprintf(out,
+          "For help, see: %s\n",
           "https://nodejs.org/learn/getting-started/debugging");
   fflush(out);
 }

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -247,7 +247,8 @@ void PrintDebuggerReadyMessage(
               FormatWsAddress(host, server_socket->port(), id, true).c_str());
     }
   }
-  fprintf(out, "For help, see: %s\n", "https://nodejs.org/api/inspector.html");
+  fprintf(out, "For help, see: %s\n",
+          "https://nodejs.org/learn/getting-started/debugging");
   fflush(out);
 }
 

--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -247,8 +247,7 @@ void PrintDebuggerReadyMessage(
               FormatWsAddress(host, server_socket->port(), id, true).c_str());
     }
   }
-  fprintf(out, "For help, see: %s\n",
-          "https://nodejs.org/en/docs/inspector");
+  fprintf(out, "For help, see: %s\n", "https://nodejs.org/api/inspector.html");
   fflush(out);
 }
 

--- a/test/internet/test-inspector-help-page.js
+++ b/test/internet/test-inspector-help-page.js
@@ -28,7 +28,7 @@ function check(url, cb) {
     });
 
     res.on('end', common.mustCall(() => {
-      assert.match(result, />Debugging Node\.js</);
+      assert.match(result, /<title>Inspector \| Node\.js/);
       cb();
     }));
   })).on('error', common.mustNotCall);

--- a/test/internet/test-inspector-help-page.js
+++ b/test/internet/test-inspector-help-page.js
@@ -28,7 +28,7 @@ function check(url, cb) {
     });
 
     res.on('end', common.mustCall(() => {
-      assert.match(result, /<title>Inspector \| Node\.js/);
+      assert.match(result, />Debugging Node\.js</);
       cb();
     }));
   })).on('error', common.mustNotCall);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

  The inspector help message pointed to https://nodejs.org/en/docs/inspector
  which returns a 404. Updated to https://nodejs.org/api/inspector.html.

  - src: update URL in inspector_socket_server.cc
  - doc: update example output in inspector.md and debugger.md
  - test: update response pattern in test-inspector-help-page.js

  Fixes: https://github.com/nodejs/node/issues/62743