### PR TITLE
src: fix dead inspector help URL

### DIFF
--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -248,7 +248,7 @@ void PrintDebuggerReadyMessage(
     }
   }
   fprintf(out, "For help, see: %s\n",
-          "https://nodejs.org/en/docs/inspector");
+          "https://nodejs.org/api/inspector.html");
   fflush(out);
 }
 


### PR DESCRIPTION
Per #62743, `node --inspect` prints "For help, see: https://nodejs.org/en/docs/inspector", which 404s. Point at the live API docs instead.

Closes #62743