### PR TITLE
build: fix bundled libffi header path for ninja

### DIFF
--- a/deps/libffi/libffi.gyp
+++ b/deps/libffi/libffi.gyp
@@ -96,6 +96,7 @@
     {
       'target_name': 'libffi',
       'type': 'static_library',
+      'hard_dependency': 1,
       'cflags': ['-fvisibility=hidden'],
       'xcode_settings': {
         'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',
@@ -106,7 +107,7 @@
       ],
       'include_dirs': [
         'include',
-        '<(INTERMEDIATE_DIR)',
+        '<(SHARED_INTERMEDIATE_DIR)/libffi',
       ],
       'sources': [
         '<@(libffi_sources)',
@@ -123,15 +124,15 @@
             'src/x86/ffitarget.h',
           ],
           'outputs': [
-            '<(INTERMEDIATE_DIR)/ffi.h',
-            '<(INTERMEDIATE_DIR)/fficonfig.h',
-            '<(INTERMEDIATE_DIR)/ffitarget.h',
+            '<(SHARED_INTERMEDIATE_DIR)/libffi/ffi.h',
+            '<(SHARED_INTERMEDIATE_DIR)/libffi/fficonfig.h',
+            '<(SHARED_INTERMEDIATE_DIR)/libffi/ffitarget.h',
           ],
           'action': [
             '<(python)',
             'generate-headers.py',
             '--output-dir',
-            '<(INTERMEDIATE_DIR)',
+            '<(SHARED_INTERMEDIATE_DIR)/libffi',
           ],
         },
       ],
@@ -146,11 +147,11 @@
                 'include/ffi_cfi.h',
                 'src/x86/asmnames.h',
                 'src/x86/win64_intel.S',
-                '<(INTERMEDIATE_DIR)/ffi.h',
-                '<(INTERMEDIATE_DIR)/fficonfig.h',
+                '<(SHARED_INTERMEDIATE_DIR)/libffi/ffi.h',
+                '<(SHARED_INTERMEDIATE_DIR)/libffi/fficonfig.h',
               ],
               'outputs': [
-                '<(INTERMEDIATE_DIR)/win64_intel.asm',
+                '<(SHARED_INTERMEDIATE_DIR)/libffi/win64_intel.asm',
               ],
               'action': [
                 '<(python)',
@@ -172,7 +173,7 @@
         ['OS == "win" and target_arch == "arm64"', {
           # Link the prebuilt object file directly
           'libraries': [
-            '<(INTERMEDIATE_DIR)/win64_armasm.obj',
+            '<(SHARED_INTERMEDIATE_DIR)/libffi/win64_armasm.obj',
           ],
           'actions': [
             {
@@ -183,11 +184,11 @@
                 'include/ffi_cfi.h',
                 'src/aarch64/internal.h',
                 'src/aarch64/win64_armasm.S',
-                '<(INTERMEDIATE_DIR)/ffi.h',
-                '<(INTERMEDIATE_DIR)/fficonfig.h',
+                '<(SHARED_INTERMEDIATE_DIR)/libffi/ffi.h',
+                '<(SHARED_INTERMEDIATE_DIR)/libffi/fficonfig.h',
               ],
               'outputs': [
-                '<(INTERMEDIATE_DIR)/win64_armasm.obj',
+                '<(SHARED_INTERMEDIATE_DIR)/libffi/win64_armasm.obj',
               ],
               'action': [
                 '<(python)',
@@ -195,7 +196,7 @@
                 '--input',
                 'src/aarch64/win64_armasm.S',
                 '--output',
-                '<(INTERMEDIATE_DIR)/win64_armasm.asm',
+                '<(SHARED_INTERMEDIATE_DIR)/libffi/win64_armasm.asm',
                 '--include-dir',
                 'include',
                 '--include-dir',
@@ -212,7 +213,7 @@
       'direct_dependent_settings': {
         'include_dirs': [
           'include',
-          '<(INTERMEDIATE_DIR)',
+          '<(SHARED_INTERMEDIATE_DIR)/libffi',
         ],
         'defines': [
           'FFI_STATIC_BUILD',

--- a/node.gyp
+++ b/node.gyp
@@ -1010,17 +1010,6 @@
               'dependencies': [
                 'deps/libffi/libffi.gyp:libffi',
               ],
-              'conditions': [
-                [ 'OS=="win"', {
-                  'include_dirs': [
-                    '<(PRODUCT_DIR)/obj/libffi',
-                  ],
-                }, {
-                  'include_dirs': [
-                    '<(PRODUCT_DIR)/obj.target/libffi/geni',
-                  ],
-                }],
-              ],
             }],
           ],
         }],
@@ -1087,17 +1076,6 @@
             [ 'node_shared_ffi=="false"', {
               'dependencies': [
                 'deps/libffi/libffi.gyp:libffi',
-              ],
-              'conditions': [
-                [ 'OS=="win"', {
-                  'include_dirs': [
-                    '<(PRODUCT_DIR)/obj/libffi',
-                  ],
-                }, {
-                  'include_dirs': [
-                    '<(PRODUCT_DIR)/obj.target/libffi/geni',
-                  ],
-                }],
               ],
             }],
           ],


### PR DESCRIPTION
Hello, yesterday I tried building with `--ninja` and got this error. Refs: https://github.com/nodejs/node/issues/62735

I removed the static path from node.gyp and fixed it in deps/libffi/libffi.gyp

I tested this commands and get a succes build.

`./configure && make -j12`
`./configure --ninja && ninja -C out/Release`
