### PR TITLE
doc: add experimental modules lifetime policy

### DIFF
--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -54,7 +54,7 @@ The stability indexes are as follows:
 >
 > If an experimental feature has reached mainstream adoption such that breaking
 > changes are not realistically possible without ecosystem breakage, it should
-> be considered stable and promoted as soon as possible.
+> be considered stable and either be promoted or be removed after a deprecation cycle.
 
 <!-- separator -->
 

--- a/doc/api/documentation.md
+++ b/doc/api/documentation.md
@@ -47,6 +47,14 @@ The stability indexes are as follows:
 >
 > Experimental features leave the experimental status typically either by
 > graduating to stable, or are removed without a deprecation cycle.
+>
+> Collaborators who introduce experimental modules are expected to take
+> ownership and drive each experiment in a timely manner to a clear outcome:
+> either promotion to stable or removal.
+>
+> If an experimental feature has reached mainstream adoption such that breaking
+> changes are not realistically possible without ecosystem breakage, it should
+> be considered stable and promoted as soon as possible.
 
 <!-- separator -->
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -466,11 +466,10 @@ For pull requests introducing new core modules:
   and committing to a clear outcome: either promoting it to stable or removing
   it in a timely manner. Because experimental features can be vulnerable to
   security issues, the author is also expected to help assess and patch
-  vulnerabilities. If an experimental feature has reached mainstream adoption such 
-  that breaking changes are not realistically possible without ecosystem breakage, 
-  it should be considered stable and either be promoted or be removed after a 
+  vulnerabilities. If an experimental feature has reached mainstream adoption such
+  that breaking changes are not realistically possible without ecosystem breakage,
+  it should be considered stable and either be promoted or be removed after a
   deprecation cycle.
-
 
 ### Introducing new APIs on the global scope
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -462,6 +462,15 @@ For pull requests introducing new core modules:
 * Land only after sign-off from at least two TSC voting members.
 * Land with a [Stability Index][] of Experimental. The module must remain
   Experimental until a semver-major release.
+* Introducing an Experimental feature means taking ownership of the experiment
+  and committing to a clear outcome: either promoting it to stable or removing
+  it in a timely manner. Because experimental features can be vulnerable to
+  security issues, the author is also expected to help assess and patch
+  vulnerabilities. If an experimental feature has reached mainstream adoption such 
+  that breaking changes are not realistically possible without ecosystem breakage, 
+  it should be considered stable and either be promoted or be removed after a 
+  deprecation cycle.
+
 
 ### Introducing new APIs on the global scope
 

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -462,6 +462,11 @@ For pull requests introducing new core modules:
 * Land only after sign-off from at least two TSC voting members.
 * Land with a [Stability Index][] of Experimental. The module must remain
   Experimental until a semver-major release.
+* Introducing an Experimental feature means taking ownership of the experiment
+  and committing to a clear outcome: either promoting it to stable or removing
+  it in a timely manner. Because experimental features can be vulnerable to
+  security issues, the author is also expected to help assess and patch
+  vulnerabilities.
 
 ### Introducing new APIs on the global scope
 


### PR DESCRIPTION
This PR documents a new lifetime policy for experimental modules by adding guidance to the API documentation and the collaborator guide. It clarifies maintenance expectations and helps contributors apply a consistent standard when introducing or managing experimental modules.