### PR TITLE
cli: add --enable-all-experimentals build flag

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -15,6 +15,7 @@
     'python%': 'python',
 
     'node_shared%': 'false',
+    'node_enable_experimentals%': 'false',
     'force_dynamic_crt%': 0,
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
@@ -437,6 +438,9 @@
       }],
       # The defines bellow must include all things from the external_v8_defines
       # list in v8/BUILD.gn.
+      ['node_enable_experimentals == "true"', {
+        'defines': ['EXPERIMENTALS_DEFAULT_VALUE=true'],
+      }],
       ['v8_enable_v8_checks == 1', {
         'defines': ['V8_ENABLE_CHECKS'],
       }],

--- a/common.gypi
+++ b/common.gypi
@@ -15,6 +15,7 @@
     'python%': 'python',
 
     'node_shared%': 'false',
+    'node_enable_experimentals%': 0,
     'force_dynamic_crt%': 0,
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
@@ -437,6 +438,9 @@
       }],
       # The defines bellow must include all things from the external_v8_defines
       # list in v8/BUILD.gn.
+      ['node_enable_experimentals==1', {
+        'defines': ['NODE_ENABLE_EXPERIMENTALS'],
+      }],
       ['v8_enable_v8_checks == 1', {
         'defines': ['V8_ENABLE_CHECKS'],
       }],

--- a/common.gypi
+++ b/common.gypi
@@ -15,7 +15,7 @@
     'python%': 'python',
 
     'node_shared%': 'false',
-    'node_enable_experimentals%': 0,
+    'node_enable_experimentals%': 'false',
     'force_dynamic_crt%': 0,
     'node_use_v8_platform%': 'true',
     'node_use_bundled_v8%': 'true',
@@ -438,8 +438,8 @@
       }],
       # The defines bellow must include all things from the external_v8_defines
       # list in v8/BUILD.gn.
-      ['node_enable_experimentals==1', {
-        'defines': ['NODE_ENABLE_EXPERIMENTALS'],
+      ['node_enable_experimentals == "true"', {
+        'defines': ['EXPERIMENTALS_DEFAULT_VALUE=true'],
       }],
       ['v8_enable_v8_checks == 1', {
         'defines': ['V8_ENABLE_CHECKS'],

--- a/configure.py
+++ b/configure.py
@@ -797,6 +797,12 @@ parser.add_argument('--enable-trace-maps',
     default=None,
     help='Enable the --trace-maps flag in V8 (use at your own risk)')
 
+parser.add_argument('--enable-all-experimentals',
+    action='store_true',
+    dest='enable_all_experimentals',
+    default=None,
+    help='Enable all experimental features by default')
+
 parser.add_argument('--experimental-enable-pointer-compression',
     action='store_true',
     dest='enable_pointer_compression',
@@ -1803,6 +1809,7 @@ def configure_node_cctest_sources(o):
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
+  o['variables']['node_enable_experimentals'] = b(options.enable_all_experimentals)
   o['variables']['node_prefix'] = options.prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['variables']['node_install_corepack'] = b(options.with_corepack)

--- a/configure.py
+++ b/configure.py
@@ -1809,7 +1809,7 @@ def configure_node_cctest_sources(o):
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
-  o['variables']['node_enable_experimentals'] = B(options.enable_all_experimentals)
+  o['variables']['node_enable_experimentals'] = b(options.enable_all_experimentals)
   o['variables']['node_prefix'] = options.prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['variables']['node_install_corepack'] = b(options.with_corepack)

--- a/configure.py
+++ b/configure.py
@@ -797,6 +797,12 @@ parser.add_argument('--enable-trace-maps',
     default=None,
     help='Enable the --trace-maps flag in V8 (use at your own risk)')
 
+parser.add_argument('--enable-all-experimentals',
+    action='store_true',
+    dest='enable_all_experimentals',
+    default=None,
+    help='Enable all experimental features by default')
+
 parser.add_argument('--experimental-enable-pointer-compression',
     action='store_true',
     dest='enable_pointer_compression',
@@ -1803,6 +1809,7 @@ def configure_node_cctest_sources(o):
 def configure_node(o):
   if options.dest_os == 'android':
     o['variables']['OS'] = 'android'
+  o['variables']['node_enable_experimentals'] = B(options.enable_all_experimentals)
   o['variables']['node_prefix'] = options.prefix
   o['variables']['node_install_npm'] = b(not options.without_npm)
   o['variables']['node_install_corepack'] = b(options.with_corepack)

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -112,6 +112,10 @@ class DebugOptions : public Options {
                     std::vector<std::string>* argv) override;
 };
 
+#ifndef EXPERIMENTALS_DEFAULT_VALUE
+#define EXPERIMENTALS_DEFAULT_VALUE false
+#endif
+
 class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
@@ -122,18 +126,18 @@ class EnvironmentOptions : public Options {
   bool require_module = true;
   std::string dns_result_order;
   bool enable_source_maps = false;
-  bool experimental_addon_modules = false;
-  bool experimental_eventsource = false;
-  bool experimental_ffi = false;
+  bool experimental_addon_modules = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_eventsource = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_ffi = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_websocket = true;
   bool experimental_sqlite = HAVE_SQLITE;
-  bool experimental_stream_iter = false;
+  bool experimental_stream_iter = EXPERIMENTALS_DEFAULT_VALUE;
   bool webstorage = HAVE_SQLITE;
-  bool experimental_quic = false;
+  bool experimental_quic = EXPERIMENTALS_DEFAULT_VALUE;
   std::string localstorage_file;
   bool experimental_global_navigator = true;
   bool experimental_global_web_crypto = true;
-  bool experimental_import_meta_resolve = false;
+  bool experimental_import_meta_resolve = EXPERIMENTALS_DEFAULT_VALUE;
   std::string input_type;  // Value of --input-type
   bool entry_is_url = false;
   bool permission = false;
@@ -148,7 +152,7 @@ class EnvironmentOptions : public Options {
   bool allow_ffi = false;
   bool allow_worker_threads = false;
   bool experimental_repl_await = true;
-  bool experimental_vm_modules = false;
+  bool experimental_vm_modules = EXPERIMENTALS_DEFAULT_VALUE;
   bool async_context_frame = true;
   bool expose_internals = false;
   bool force_node_api_uncaught_exceptions_policy = false;
@@ -175,10 +179,10 @@ class EnvironmentOptions : public Options {
   uint64_t cpu_prof_interval = kDefaultCpuProfInterval;
   std::string cpu_prof_name;
   bool cpu_prof = false;
-  bool experimental_network_inspection = false;
-  bool experimental_worker_inspection = false;
-  bool experimental_storage_inspection = false;
-  bool experimental_inspector_network_resource = false;
+  bool experimental_network_inspection = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_worker_inspection = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_storage_inspection = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_inspector_network_resource = EXPERIMENTALS_DEFAULT_VALUE;
   std::string heap_prof_dir;
   std::string heap_prof_name;
   static const uint64_t kDefaultHeapProfInterval = 512 * 1024;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -112,9 +112,7 @@ class DebugOptions : public Options {
                     std::vector<std::string>* argv) override;
 };
 
-#ifdef NODE_ENABLE_EXPERIMENTALS
-#define EXPERIMENTALS_DEFAULT_VALUE true
-#else
+#ifndef EXPERIMENTALS_DEFAULT_VALUE
 #define EXPERIMENTALS_DEFAULT_VALUE false
 #endif
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -183,8 +183,7 @@ class EnvironmentOptions : public Options {
   bool experimental_network_inspection = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_worker_inspection = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_storage_inspection = EXPERIMENTALS_DEFAULT_VALUE;
-  bool experimental_inspector_network_resource =
-      EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_inspector_network_resource = EXPERIMENTALS_DEFAULT_VALUE;
   std::string heap_prof_dir;
   std::string heap_prof_name;
   static const uint64_t kDefaultHeapProfInterval = 512 * 1024;

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -112,6 +112,12 @@ class DebugOptions : public Options {
                     std::vector<std::string>* argv) override;
 };
 
+#ifdef NODE_ENABLE_EXPERIMENTALS
+#define EXPERIMENTALS_DEFAULT_VALUE true
+#else
+#define EXPERIMENTALS_DEFAULT_VALUE false
+#endif
+
 class EnvironmentOptions : public Options {
  public:
   bool abort_on_uncaught_exception = false;
@@ -122,19 +128,19 @@ class EnvironmentOptions : public Options {
   bool require_module = true;
   std::string dns_result_order;
   bool enable_source_maps = false;
-  bool experimental_addon_modules = false;
-  bool experimental_eventsource = false;
+  bool experimental_addon_modules = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_eventsource = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_fetch = true;
-  bool experimental_ffi = false;
+  bool experimental_ffi = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_websocket = true;
   bool experimental_sqlite = true;
-  bool experimental_stream_iter = false;
+  bool experimental_stream_iter = EXPERIMENTALS_DEFAULT_VALUE;
   bool webstorage = HAVE_SQLITE;
-  bool experimental_quic = false;
+  bool experimental_quic = EXPERIMENTALS_DEFAULT_VALUE;
   std::string localstorage_file;
   bool experimental_global_navigator = true;
   bool experimental_global_web_crypto = true;
-  bool experimental_import_meta_resolve = false;
+  bool experimental_import_meta_resolve = EXPERIMENTALS_DEFAULT_VALUE;
   std::string input_type;  // Value of --input-type
   bool entry_is_url = false;
   bool permission = false;
@@ -149,7 +155,7 @@ class EnvironmentOptions : public Options {
   bool allow_ffi = false;
   bool allow_worker_threads = false;
   bool experimental_repl_await = true;
-  bool experimental_vm_modules = false;
+  bool experimental_vm_modules = EXPERIMENTALS_DEFAULT_VALUE;
   bool async_context_frame = true;
   bool expose_internals = false;
   bool force_node_api_uncaught_exceptions_policy = false;
@@ -176,10 +182,11 @@ class EnvironmentOptions : public Options {
   uint64_t cpu_prof_interval = kDefaultCpuProfInterval;
   std::string cpu_prof_name;
   bool cpu_prof = false;
-  bool experimental_network_inspection = false;
-  bool experimental_worker_inspection = false;
-  bool experimental_storage_inspection = false;
-  bool experimental_inspector_network_resource = false;
+  bool experimental_network_inspection = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_worker_inspection = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_storage_inspection = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_inspector_network_resource =
+      EXPERIMENTALS_DEFAULT_VALUE;
   std::string heap_prof_dir;
   std::string heap_prof_name;
   static const uint64_t kDefaultHeapProfInterval = 512 * 1024;


### PR DESCRIPTION
This PR adds a new `--enable-all-experimentals` BUILD flag which can be used to turn ALL experimental features on by default.