### PR TITLE
crypto: strengthen argument CHECKs in TurboSHAKE

### DIFF
--- a/src/crypto/crypto_turboshake.cc
+++ b/src/crypto/crypto_turboshake.cc
@@ -449,10 +449,10 @@ Maybe<void> TurboShakeTraits::AdditionalConfig(
 
   // args[offset + 1] = domain separation byte (uint32)
   CHECK(args[offset + 1]->IsUint32());
-  params->domain_separation =
-      static_cast<uint8_t>(args[offset + 1].As<Uint32>()->Value());
-  CHECK_GE(params->domain_separation, 0x01);
-  CHECK_LE(params->domain_separation, 0x7F);
+  uint32_t domain_separation_u32 = args[offset + 1].As<Uint32>()->Value();
+  CHECK_GE(domain_separation_u32, 0x01);
+  CHECK_LE(domain_separation_u32, 0x7F);
+  params->domain_separation = static_cast<uint8_t>(domain_separation_u32);
 
   // args[offset + 2] = output length in bytes (uint32)
   CHECK(args[offset + 2]->IsUint32());


### PR DESCRIPTION
Instead of first discarding the top 24 bits of the argument and then checking that the low 8 bits are within the expected range, first check that the original 32-bit integer is within the expected range and then discard the top 24 bits.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
