### PR TITLE
sea: add allowDynamicImportFromFileSystem config option

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -111,6 +111,7 @@ The configuration currently reads the following top-level fields:
 {
   "main": "/path/to/bundled/script.js",
   "mainFormat": "commonjs", // Default: "commonjs", options: "commonjs", "module"
+  "allowDynamicImportFromFileSystem": false, // Default: false
   "executable": "/path/to/node/binary", // Optional, if not specified, uses the current Node.js binary
   "output": "/path/to/write/the/generated/executable",
   "disableExperimentalSEAWarning": true, // Default: false
@@ -451,9 +452,12 @@ injected main script with the following properties:
 
 <!-- TODO(joyeecheung): support and document module.registerHooks -->
 
-When using `"mainFormat": "module"`, `import()` can be used to dynamically
-load built-in modules. Attempting to use `import()` to load modules from
-the file system will throw an error.
+By default, `import()` in the injected main script can only load built-in
+modules. When `allowDynamicImportFromFileSystem` is set to `true` in the SEA
+configuration, `import()` can also load modules from the file system. This
+works for both `"mainFormat": "commonjs"` and `"mainFormat": "module"`
+entry points. Relative specifiers are resolved relative to the directory of the
+executable.
 
 ### Using native addons in the injected main script
 

--- a/lib/internal/modules/esm/utils.js
+++ b/lib/internal/modules/esm/utils.js
@@ -48,6 +48,7 @@ const {
 } = require('internal/modules/helpers');
 
 let defaultConditions;
+let seaBinding;
 /**
  * Returns the default conditions for ES module loading.
  * @returns {object}
@@ -66,6 +67,10 @@ let defaultConditionsSet;
 function getDefaultConditionsSet() {
   assert(defaultConditionsSet !== undefined);
   return defaultConditionsSet;
+}
+
+function getSeaBinding() {
+  return seaBinding ??= internalBinding('sea');
 }
 
 /**
@@ -238,15 +243,25 @@ function getBuiltinModuleWrapForEmbedder(specifier) {
 }
 
 /**
- * Get the built-in module dynamically for embedder ESM.
+ * Handle dynamic import for embedder entry points.
+ * SEA can opt into the default loader via explicit configuration; other embedder
+ * entry points continue to be limited to built-in modules.
  * @param {string} specifier - The module specifier string.
  * @param {number} phase - The module import phase. Ignored for now.
  * @param {Record<string, string>} attributes - The import attributes object. Ignored for now.
  * @param {string|null|undefined} referrerName - name of the referrer.
- * @returns {import('internal/modules/esm/loader.js').ModuleExports} - The imported module object.
+ * @returns {Promise<import('internal/modules/esm/loader.js').ModuleExports>} - The imported module object.
  */
 function importModuleDynamicallyForEmbedder(specifier, phase, attributes, referrerName) {
-  // Ignore phase and attributes for embedder ESM for now, because this only supports loading builtins.
+  const { isSeaDynamicImportFromFileSystemEnabled } = getSeaBinding();
+  if (isSeaDynamicImportFromFileSystemEnabled()) {
+    return defaultImportModuleDynamicallyForScript(
+      specifier,
+      phase,
+      attributes,
+      referrerName,
+    );
+  }
   return getBuiltinModuleWrapForEmbedder(specifier).getNamespace();
 }
 

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -283,6 +283,18 @@ void IsExperimentalSeaWarningNeeded(const FunctionCallbackInfo<Value>& args) {
       sea_resource.flags & SeaFlags::kDisableExperimentalSeaWarning));
 }
 
+void IsSeaDynamicImportFromFileSystemEnabled(
+    const FunctionCallbackInfo<Value>& args) {
+  if (!IsSingleExecutable()) {
+    args.GetReturnValue().Set(false);
+    return;
+  }
+
+  SeaResource sea_resource = FindSingleExecutableResource();
+  args.GetReturnValue().Set(static_cast<bool>(
+      sea_resource.flags & SeaFlags::kAllowDynamicImportFromFileSystem));
+}
+
 std::tuple<int, char**> FixupArgsForSEA(int argc, char** argv) {
   // Repeats argv[0] at position 1 on argv as a replacement for the missing
   // entry point file path.
@@ -443,6 +455,18 @@ std::optional<SeaConfig> ParseSingleExecutableConfig(
       }
       if (use_code_cache_value) {
         result.flags |= SeaFlags::kUseCodeCache;
+      }
+    } else if (key == "allowDynamicImportFromFileSystem") {
+      bool allow_dynamic_import_from_file_system;
+      if (field.value().get_bool().get(allow_dynamic_import_from_file_system)) {
+        FPrintF(stderr,
+                "\"allowDynamicImportFromFileSystem\" field of %s is not a "
+                "Boolean\n",
+                config_path);
+        return std::nullopt;
+      }
+      if (allow_dynamic_import_from_file_system) {
+        result.flags |= SeaFlags::kAllowDynamicImportFromFileSystem;
       }
     } else if (key == "assets") {
       simdjson::ondemand::object assets_object;
@@ -918,6 +942,10 @@ void Initialize(Local<Object> target,
             target,
             "isExperimentalSeaWarningNeeded",
             IsExperimentalSeaWarningNeeded);
+  SetMethod(context,
+            target,
+            "isSeaDynamicImportFromFileSystemEnabled",
+            IsSeaDynamicImportFromFileSystemEnabled);
   SetMethod(context, target, "getAsset", GetAsset);
   SetMethod(context, target, "getAssetKeys", GetAssetKeys);
 }
@@ -925,6 +953,7 @@ void Initialize(Local<Object> target,
 void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(IsSea);
   registry->Register(IsExperimentalSeaWarningNeeded);
+  registry->Register(IsSeaDynamicImportFromFileSystemEnabled);
   registry->Register(GetAsset);
   registry->Register(GetAssetKeys);
 }

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -30,6 +30,7 @@ enum class SeaFlags : uint32_t {
   kUseCodeCache = 1 << 2,
   kIncludeAssets = 1 << 3,
   kIncludeExecArgv = 1 << 4,
+  kAllowDynamicImportFromFileSystem = 1 << 5,
 };
 
 enum class SeaExecArgvExtension : uint8_t {

--- a/test/fixtures/sea/dynamic-import-cjs/sea-config-opt-in-code-cache.json
+++ b/test/fixtures/sea/dynamic-import-cjs/sea-config-opt-in-code-cache.json
@@ -1,0 +1,7 @@
+{
+  "main": "sea.js",
+  "output": "sea",
+  "allowDynamicImportFromFileSystem": true,
+  "useCodeCache": true,
+  "disableExperimentalSEAWarning": true
+}

--- a/test/fixtures/sea/dynamic-import-cjs/sea-config-opt-in.json
+++ b/test/fixtures/sea/dynamic-import-cjs/sea-config-opt-in.json
@@ -1,0 +1,6 @@
+{
+  "main": "sea.js",
+  "output": "sea",
+  "allowDynamicImportFromFileSystem": true,
+  "disableExperimentalSEAWarning": true
+}

--- a/test/fixtures/sea/dynamic-import-cjs/sea-config.json
+++ b/test/fixtures/sea/dynamic-import-cjs/sea-config.json
@@ -1,0 +1,5 @@
+{
+  "main": "sea.js",
+  "output": "sea",
+  "disableExperimentalSEAWarning": true
+}

--- a/test/fixtures/sea/dynamic-import-cjs/sea.js
+++ b/test/fixtures/sea/dynamic-import-cjs/sea.js
@@ -1,0 +1,15 @@
+const { pathToFileURL } = require('node:url');
+const { dirname, join } = require('node:path');
+
+const userURL = pathToFileURL(
+  join(dirname(process.execPath), 'user.mjs'),
+).href;
+
+import(userURL)
+  .then(({ message }) => {
+    console.log(message);
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/test/fixtures/sea/dynamic-import-cjs/user.mjs
+++ b/test/fixtures/sea/dynamic-import-cjs/user.mjs
@@ -1,0 +1,3 @@
+await Promise.resolve();
+
+export const message = 'CJS SEA dynamic import executed successfully';

--- a/test/fixtures/sea/dynamic-import-esm/sea-config-opt-in.json
+++ b/test/fixtures/sea/dynamic-import-esm/sea-config-opt-in.json
@@ -1,0 +1,7 @@
+{
+  "main": "sea.mjs",
+  "output": "sea",
+  "mainFormat": "module",
+  "allowDynamicImportFromFileSystem": true,
+  "disableExperimentalSEAWarning": true
+}

--- a/test/fixtures/sea/dynamic-import-esm/sea-config.json
+++ b/test/fixtures/sea/dynamic-import-esm/sea-config.json
@@ -1,0 +1,6 @@
+{
+  "main": "sea.mjs",
+  "output": "sea",
+  "mainFormat": "module",
+  "disableExperimentalSEAWarning": true
+}

--- a/test/fixtures/sea/dynamic-import-esm/sea.mjs
+++ b/test/fixtures/sea/dynamic-import-esm/sea.mjs
@@ -1,0 +1,2 @@
+const { message } = await import('./user.mjs');
+console.log(message);

--- a/test/fixtures/sea/dynamic-import-esm/user.mjs
+++ b/test/fixtures/sea/dynamic-import-esm/user.mjs
@@ -1,0 +1,3 @@
+await Promise.resolve();
+
+export const message = 'ESM SEA dynamic import executed successfully';

--- a/test/sea/test-build-sea-invalid-boolean-fields.js
+++ b/test/sea/test-build-sea-invalid-boolean-fields.js
@@ -72,3 +72,24 @@ skipIfBuildSEAIsNotSupported();
       stderr: /"useCodeCache" field of .*invalid-useCodeCache\.json is not a Boolean/,
     });
 }
+
+// Test: Invalid "allowDynamicImportFromFileSystem" type (should be Boolean)
+{
+  tmpdir.refresh();
+  const config = tmpdir.resolve('invalid-allowDynamicImportFromFileSystem.json');
+  writeFileSync(config, `
+{
+  "main": "bundle.js",
+  "output": "sea",
+  "allowDynamicImportFromFileSystem": "true"
+}
+  `, 'utf8');
+  spawnSyncAndAssert(
+    process.execPath,
+    ['--build-sea', config], {
+      cwd: tmpdir.path,
+    }, {
+      status: 1,
+      stderr: /"allowDynamicImportFromFileSystem" field of .*invalid-allowDynamicImportFromFileSystem\.json is not a Boolean/,
+    });
+}

--- a/test/sea/test-single-executable-application-dynamic-import-cjs-code-cache.js
+++ b/test/sea/test-single-executable-application-dynamic-import-cjs-code-cache.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('../common');
+
+// This tests that a CommonJS SEA entry point can dynamically import a user
+// module from the file system when explicitly enabled, even with code cache.
+
+const {
+  buildSEA,
+  skipIfBuildSEAIsNotSupported,
+} = require('../common/sea');
+
+skipIfBuildSEAIsNotSupported();
+
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+
+tmpdir.refresh();
+
+const outputFile = buildSEA(fixtures.path('sea', 'dynamic-import-cjs'), {
+  configPath: 'sea-config-opt-in-code-cache.json',
+});
+
+spawnSyncAndExitWithoutError(
+  outputFile,
+  {
+    env: {
+      NODE_DEBUG_NATIVE: 'SEA',
+      ...process.env,
+    },
+  },
+  {
+    stdout: /CJS SEA dynamic import executed successfully/,
+  });

--- a/test/sea/test-single-executable-application-dynamic-import-cjs-default.js
+++ b/test/sea/test-single-executable-application-dynamic-import-cjs-default.js
@@ -1,0 +1,34 @@
+'use strict';
+
+require('../common');
+
+// This tests that a CommonJS SEA entry point cannot dynamically import a user
+// module from the file system without explicit configuration.
+
+const {
+  buildSEA,
+  skipIfBuildSEAIsNotSupported,
+} = require('../common/sea');
+
+skipIfBuildSEAIsNotSupported();
+
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndAssert } = require('../common/child_process');
+
+tmpdir.refresh();
+
+const outputFile = buildSEA(fixtures.path('sea', 'dynamic-import-cjs'));
+
+spawnSyncAndAssert(
+  outputFile,
+  {
+    env: {
+      NODE_DEBUG_NATIVE: 'SEA',
+      ...process.env,
+    },
+  },
+  {
+    status: 1,
+    stderr: /ERR_UNKNOWN_BUILTIN_MODULE/,
+  });

--- a/test/sea/test-single-executable-application-dynamic-import-cjs.js
+++ b/test/sea/test-single-executable-application-dynamic-import-cjs.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('../common');
+
+// This tests that a CommonJS SEA entry point can use dynamic import() to
+// load a user module from the file system.
+
+const {
+  buildSEA,
+  skipIfBuildSEAIsNotSupported,
+} = require('../common/sea');
+
+skipIfBuildSEAIsNotSupported();
+
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+
+tmpdir.refresh();
+
+const outputFile = buildSEA(fixtures.path('sea', 'dynamic-import-cjs'), {
+  configPath: 'sea-config-opt-in.json',
+});
+
+spawnSyncAndExitWithoutError(
+  outputFile,
+  {
+    env: {
+      NODE_DEBUG_NATIVE: 'SEA',
+      ...process.env,
+    },
+  },
+  {
+    stdout: /CJS SEA dynamic import executed successfully/,
+  });

--- a/test/sea/test-single-executable-application-dynamic-import-esm-default.js
+++ b/test/sea/test-single-executable-application-dynamic-import-esm-default.js
@@ -1,0 +1,34 @@
+'use strict';
+
+require('../common');
+
+// This tests that an ESM SEA entry point cannot dynamically import a user
+// module from the file system without explicit configuration.
+
+const {
+  buildSEA,
+  skipIfBuildSEAIsNotSupported,
+} = require('../common/sea');
+
+skipIfBuildSEAIsNotSupported();
+
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndAssert } = require('../common/child_process');
+
+tmpdir.refresh();
+
+const outputFile = buildSEA(fixtures.path('sea', 'dynamic-import-esm'));
+
+spawnSyncAndAssert(
+  outputFile,
+  {
+    env: {
+      NODE_DEBUG_NATIVE: 'SEA',
+      ...process.env,
+    },
+  },
+  {
+    status: 1,
+    stderr: /ERR_UNKNOWN_BUILTIN_MODULE/,
+  });

--- a/test/sea/test-single-executable-application-dynamic-import-esm.js
+++ b/test/sea/test-single-executable-application-dynamic-import-esm.js
@@ -1,0 +1,35 @@
+'use strict';
+
+require('../common');
+
+// This tests that an ESM SEA entry point can use dynamic import() with a
+// relative specifier resolved from the executable location.
+
+const {
+  buildSEA,
+  skipIfBuildSEAIsNotSupported,
+} = require('../common/sea');
+
+skipIfBuildSEAIsNotSupported();
+
+const tmpdir = require('../common/tmpdir');
+const fixtures = require('../common/fixtures');
+const { spawnSyncAndExitWithoutError } = require('../common/child_process');
+
+tmpdir.refresh();
+
+const outputFile = buildSEA(fixtures.path('sea', 'dynamic-import-esm'), {
+  configPath: 'sea-config-opt-in.json',
+});
+
+spawnSyncAndExitWithoutError(
+  outputFile,
+  {
+    env: {
+      NODE_DEBUG_NATIVE: 'SEA',
+      ...process.env,
+    },
+  },
+  {
+    stdout: /ESM SEA dynamic import executed successfully/,
+  });


### PR DESCRIPTION
Adds an explicit `allowDynamicImportFromFileSystem` config option for SEA. When set to `true`, `import()` from the injected main script can load modules from the file system. Default remains sealed (built-ins only), matching the current behavior.
                                                                                                                   
This enables the common SEA pattern where a small bootstrap hands off to a user entrypoint on disk via dynamic import.                                                                                                                                                                    
Refs: https://github.com/nodejs/node/issues/62726
 
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
