### PR TITLE
stream: fix ERR_INVALID_STATE when cancelling Readable.toWeb()

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -507,6 +507,7 @@ function newReadableStreamFromStreamReadable(streamReadable, options = kEmptyObj
   let wasCanceled = false;
 
   function onData(chunk) {
+    if (wasCanceled) return;
     // Copy the Buffer to detach it from the pool.
     if (Buffer.isBuffer(chunk) && !objectMode)
       chunk = new Uint8Array(chunk);

--- a/test/parallel/test-stream-readable-to-web-termination.js
+++ b/test/parallel/test-stream-readable-to-web-termination.js
@@ -10,3 +10,25 @@ const { Readable } = require('stream');
   const reader = Readable.toWeb(r).getReader();
   reader.read();
 }
+
+// Cancelling a web ReadableStream while the underlying Readable is actively
+// producing data should not throw ERR_INVALID_STATE. The onData handler in
+// newReadableStreamFromStreamReadable must check wasCanceled before calling
+// controller.enqueue(). See: https://github.com/nodejs/node/issues/54205
+{
+  const readable = new Readable({
+    read() {
+      this.push(Buffer.alloc(1024));
+    },
+  });
+
+  const webStream = Readable.toWeb(readable);
+  const reader = webStream.getReader();
+
+  (async () => {
+    await reader.read();
+    await reader.read();
+    reader.releaseLock();
+    await webStream.cancel();
+  })();
+}


### PR DESCRIPTION
When a web ReadableStream returned by Readable.toWeb() is cancelled while the underlying Readable is actively producing data, a pending onData callback can still fire after the controller has been closed and attempt to enqueue a chunk, throwing ERR_INVALID_STATE.

Check wasCanceled in the onData handler and return early to avoid calling controller.enqueue() on a closed controller.

Refs: https://github.com/nodejs/node/issues/54205

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
