### PR TITLE
tools: exclude @node-core/doc-kit from dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -52,6 +52,8 @@ updates:
       semver-major-days: 5
       semver-minor-days: 5
       semver-patch-days: 5
+      exclude:
+        - '@node-core/doc-kit'
     commit-message:
       prefix: tools
     open-pull-requests-limit: 10


### PR DESCRIPTION
`@node-core/doc-kit` is an internal package maintained within the nodejs organization, which is unlikely to be a direct source of supply-chain attack. The cooldown only slow down the propagation of new improvements from doc-kit to Node.js repo and causes [surprises](https://github.com/nodejs/node/pull/62512#issuecomment-4260356406).

The cooldown should be configured in the `doc-kit` repository instead. Currently there is a 3-day cooldown. Maybe we need to increase that to match the 5-day cooldown used in this repository.

This patch excludes `@node-core/doc-kit` from the cooldown.
Note that `@node-core/doc-kit` is the only dependency in `tools/doc`.
But to be future proof, I did't remove the cooldown directly.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

CC @nodejs/security-wg @nodejs/web-infra