### PR TITLE
src: use context-free V8 message column getters

### DIFF
--- a/src/inspector_agent.cc
+++ b/src/inspector_agent.cc
@@ -677,7 +677,7 @@ class NodeInspectorClient : public V8InspectorClient {
         ToInspectorString(isolate, message->Get())->string(),
         ToInspectorString(isolate, message->GetScriptResourceName())->string(),
         message->GetLineNumber(context).FromMaybe(0),
-        message->GetStartColumn(context).FromMaybe(0),
+        message->GetStartColumn(),
         client_->createStackTrace(stack_trace),
         script_id);
   }

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -65,7 +65,7 @@ static std::string GetSourceMapErrorSource(Isolate* isolate,
   // the source texts.
   Local<Value> script_resource_name = message->GetScriptResourceName();
   int linenum = message->GetLineNumber(context).FromJust();
-  int columnum = message->GetStartColumn(context).FromJust();
+  int columnum = message->GetStartColumn();
 
   Local<Value> argv[] = {script_resource_name,
                          v8::Int32::New(isolate, linenum),
@@ -148,8 +148,8 @@ static std::string GetErrorSource(Isolate* isolate,
   int script_start = (linenum - origin.LineOffset()) == 1
                          ? origin.ColumnOffset()
                          : 0;
-  int start = message->GetStartColumn(context).FromMaybe(0);
-  int end = message->GetEndColumn(context).FromMaybe(0);
+  int start = message->GetStartColumn();
+  int end = message->GetEndColumn();
   if (start >= script_start) {
     CHECK_GE(end, start);
     start -= script_start;


### PR DESCRIPTION
The `Message::Get*Column(context)` getters return a `Maybe<int>`, but since v8/v8@9fe417cb7f5ccd915a26afd929d2f5e4e811466d, the context is no longer necessary and these methods just return `Just(Get*Column())`. We may as well cut out the overhead.

Refs: https://issues.chromium.org/issues/42210793