### PR TITLE
lib: use js-only implementation of `isDataView()`

### DIFF
--- a/benchmark/util/type-check.js
+++ b/benchmark/util/type-check.js
@@ -23,6 +23,11 @@ const args = {
     'false-primitive': true,
     'false-object': int32Array,
   },
+  DataView: {
+    'true': dataView,
+    'false-primitive': true,
+    'false-object': uint8Array,
+  },
 };
 
 const bench = common.createBenchmark(main, {

--- a/lib/internal/util/types.js
+++ b/lib/internal/util/types.js
@@ -6,6 +6,10 @@ const {
   TypedArrayPrototypeGetSymbolToStringTag,
 } = primordials;
 
+function isDataView(value) {
+  return ArrayBufferIsView(value) && TypedArrayPrototypeGetSymbolToStringTag(value) === undefined;
+}
+
 function isTypedArray(value) {
   return TypedArrayPrototypeGetSymbolToStringTag(value) !== undefined;
 }
@@ -61,6 +65,7 @@ function isBigUint64Array(value) {
 module.exports = {
   ...internalBinding('types'),
   isArrayBufferView: ArrayBufferIsView,
+  isDataView,
   isTypedArray,
   isUint8Array,
   isUint8ClampedArray,

--- a/src/node_types.cc
+++ b/src/node_types.cc
@@ -19,7 +19,6 @@ namespace {
   V(AsyncFunction)                                                             \
   V(BigIntObject)                                                              \
   V(BooleanObject)                                                             \
-  V(DataView)                                                                  \
   V(Date)                                                                      \
   V(External)                                                                  \
   V(GeneratorFunction)                                                         \

--- a/test/parallel/test-util-types.js
+++ b/test/parallel/test-util-types.js
@@ -651,23 +651,6 @@ for (const [ value, _method ] of [
 }
 
 {
-  function testIsDataView(input) {
-    return types.isDataView(input);
-  }
-
-  eval('%PrepareFunctionForOptimization(testIsDataView)');
-  testIsDataView(new DataView(new ArrayBuffer()));
-  eval('%OptimizeFunctionOnNextCall(testIsDataView)');
-  assert.strictEqual(testIsDataView(new DataView(new ArrayBuffer())), true);
-  assert.strictEqual(testIsDataView(Math.random()), false);
-
-  if (common.isDebug) {
-    const { getV8FastApiCallCount } = internalBinding('debug');
-    assert.strictEqual(getV8FastApiCallCount('types.isDataView'), 2);
-  }
-}
-
-{
   function testIsSharedArrayBuffer(input) {
     return types.isSharedArrayBuffer(input);
   }


### PR DESCRIPTION
We already implement the TypedArray type check methods in the JS layer, as it's more performant to do it this way than to call into the embedder.

We can do the same with DataView – even though it potentially requires two JS calls, it's still more performant than using the V8 API, even when invoking the fast callback in a benchmarking scenario.

```
                                                                                          confidence improvement accuracy (*)    (**)   (***)
util/type-check.js n=1000000 argument='false-object' version='js' type='DataView'               ***     22.32 %       ±9.54% ±12.72% ±16.63%
util/type-check.js n=1000000 argument='false-primitive' version='js' type='DataView'            ***     64.16 %      ±11.84% ±15.79% ±20.64%
util/type-check.js n=1000000 argument='true' version='js' type='DataView'                       ***     26.70 %       ±8.24% ±10.99% ±14.34%
```