### PR TITLE
http: increase keepAliveTimeout default to 65 seconds

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1998,9 +1998,13 @@ value only affects new connections to the server, not any existing connections.
 
 <!-- YAML
 added: v8.0.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62782
+    description: the default value for `http.Server.keepAliveTimeout` is changed from 5 to 65 seconds.
 -->
 
-* Type: {number} Timeout in milliseconds. **Default:** `5000` (5 seconds).
+* Type: {number} Timeout in milliseconds. **Default:** `65000` (65 seconds).
 
 The number of milliseconds of inactivity a server needs to wait for additional
 incoming data, after it has finished writing the last response, before a socket

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -499,7 +499,7 @@ function storeHTTPOptions(options) {
     validateInteger(keepAliveTimeout, 'keepAliveTimeout', 0);
     this.keepAliveTimeout = keepAliveTimeout;
   } else {
-    this.keepAliveTimeout = 5_000; // 5 seconds;
+    this.keepAliveTimeout = 65_000; // 65 seconds;
   }
 
   const keepAliveTimeoutBuffer = options.keepAliveTimeoutBuffer;

--- a/test/parallel/test-http-keep-alive-max-requests.js
+++ b/test/parallel/test-http-keep-alive-max-requests.js
@@ -10,11 +10,11 @@ const bodySent = 'This is my request';
 function assertResponse(headers, body, expectClosed) {
   if (expectClosed) {
     assert.match(headers, /Connection: close\r\n/m);
-    assert.strictEqual(headers.search(/Keep-Alive: timeout=5\r\n/m), -1);
+    assert.strictEqual(headers.search(/Keep-Alive: timeout=65\r\n/m), -1);
     assert.match(body, /Hello World!/m);
   } else {
     assert.match(headers, /Connection: keep-alive\r\n/m);
-    assert.match(headers, /Keep-Alive: timeout=5, max=3\r\n/m);
+    assert.match(headers, /Keep-Alive: timeout=65, max=3\r\n/m);
     assert.match(body, /Hello World!/m);
   }
 }

--- a/test/parallel/test-http-keep-alive-pipeline-max-requests.js
+++ b/test/parallel/test-http-keep-alive-pipeline-max-requests.js
@@ -10,11 +10,11 @@ const bodySent = 'This is my request';
 function assertResponse(headers, body, expectClosed) {
   if (expectClosed) {
     assert.match(headers, /Connection: close\r\n/m);
-    assert.strictEqual(headers.search(/Keep-Alive: timeout=5, max=3\r\n/m), -1);
+    assert.strictEqual(headers.search(/Keep-Alive: timeout=65, max=3\r\n/m), -1);
     assert.match(body, /Hello World!/m);
   } else {
     assert.match(headers, /Connection: keep-alive\r\n/m);
-    assert.match(headers, /Keep-Alive: timeout=5, max=3\r\n/m);
+    assert.match(headers, /Keep-Alive: timeout=65, max=3\r\n/m);
     assert.match(body, /Hello World!/m);
   }
 }
@@ -76,7 +76,7 @@ server.listen(0, common.mustCall((res) => {
 
       assert.match(responseParts[6], /HTTP\/1\.1 503 Service Unavailable/m);
       assert.match(responseParts[6], /Connection: close\r\n/m);
-      assert.strictEqual(responseParts[6].search(/Keep-Alive: timeout=5\r\n/m), -1);
+      assert.strictEqual(responseParts[6].search(/Keep-Alive: timeout=65\r\n/m), -1);
       assert.strictEqual(responseParts[7].search(/Hello World!/m), -1);
 
       socket.end();

--- a/test/parallel/test-http-server-keep-alive-defaults.js
+++ b/test/parallel/test-http-server-keep-alive-defaults.js
@@ -9,7 +9,7 @@ const bodySent = 'This is my request';
 
 function assertResponse(headers, body, expectClosed) {
   assert.match(headers, /Connection: keep-alive\r\n/m);
-  assert.match(headers, /Keep-Alive: timeout=5\r\n/m);
+  assert.match(headers, /Keep-Alive: timeout=65\r\n/m);
   assert.match(body, /Hello World!/m);
 }
 

--- a/test/parallel/test-http-server-keep-alive-max-requests-null.js
+++ b/test/parallel/test-http-server-keep-alive-max-requests-null.js
@@ -9,7 +9,7 @@ const bodySent = 'This is my request';
 
 function assertResponse(headers, body, expectClosed) {
   assert.match(headers, /Connection: keep-alive\r\n/m);
-  assert.match(headers, /Keep-Alive: timeout=5\r\n/m);
+  assert.match(headers, /Keep-Alive: timeout=65\r\n/m);
   assert.match(body, /Hello World!/m);
 }
 


### PR DESCRIPTION
This PR takes the code from #59203 (now stalled) and fixes it up to get the tests & linting passing so we can hopefully merge just in time for v26. Conclusion there I think it this is possibly semver-major, we're not 100% sure but better to release with a major bump initially at least.

See discussion there for context. I've kept @pras529 as a co-author on the commit.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
