### PR TITLE
src: workaround AIX libc++ std::filesystem bug

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1833,7 +1833,15 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
   } else if (error == std::errc::not_a_directory) {
     std::string message = "Not a directory: " + file_path_str;
     return env->ThrowErrnoException(ENOTDIR, "rm", message.c_str(), path_c_str);
+#ifdef _AIX
+  } else if (error == std::errc::permission_denied ||
+             error == std::errc::file_exists) {
+    // Workaround for clang libc++ bug on AIX: std::filesystem::remove_all()
+    // incorrectly returns EEXIST (17) instead of EACCES (13) for permission
+    // errors when trying to remove directories without proper permissions.
+#else
   } else if (error == std::errc::permission_denied) {
+#endif
     std::string message = "Permission denied: " + file_path_str;
     return env->ThrowErrnoException(
         permission_denied_error, "rm", message.c_str(), path_c_str);


### PR DESCRIPTION
On AIX libc++ is returning `EEXIST` instead of `EACCES` when using `std::filesystem::remove_all()` without appropriate permissions to recursively remove the directory.

Refs: https://github.com/nodejs/build/pull/4286#issuecomment-4262870150
Refs: https://github.com/nodejs/node/issues/62790

---

When built on AIX with clang, we consistently hit this test failure in `parallel/test-fs-rm`:
```
bash-5.3$ ./tools/test.py --temp-dir /home/iojs/build/ parallel/test-fs-rm
=== release test-fs-rm ===
Path: parallel/test-fs-rm
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
hint:
hint: Disable this message with "git config set advice.defaultBranchName false"
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
hint:
hint: Disable this message with "git config set advice.defaultBranchName false"
hint: Using 'master' as the name for the initial branch. This default branch name
hint: is subject to change. To configure the initial branch name to use in all
hint: of your new repositories, which will suppress this warning, call:
hint:
hint:   git config --global init.defaultBranch <name>
hint:
hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
hint: 'development'. The just-created branch can be renamed via this command:
hint:
hint:   git branch -m <name>
hint:
hint: Disable this message with "git config set advice.defaultBranchName false"
/home/iojs/build/workspace/node-test-commit-aix-abmusse/nodes/test-ibm-aix72-ppc64_be-2/test/parallel/test-fs-rm.js:563
            throw err;
            ^

AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
+ actual - expected

  Comparison {
+   code: '',
-   code: 'EACCES',
    name: 'Error'
  }

    at Object.<anonymous> (/home/iojs/build/workspace/node-test-commit-aix-abmusse/nodes/test-ibm-aix72-ppc64_be-2/test/parallel/test-fs-rm.js:553:18)
    at Module._compile (node:internal/modules/cjs/loader:1829:14)
    at Object..js (node:internal/modules/cjs/loader:1969:10)
    at Module.load (node:internal/modules/cjs/loader:1552:32)
    at Module._load (node:internal/modules/cjs/loader:1354:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  generatedMessage: true,
  code: 'ERR_ASSERTION',
  actual: Error: , Unknown error: File exists '/home/iojs/build/.tmp.0/rm-11/fs-LcfMea'
      at Object.rmSync (node:fs:1206:18)
      at assert.throws.code.code (/home/iojs/build/workspace/node-test-commit-aix-abmusse/nodes/test-ibm-aix72-ppc64_be-2/test/parallel/test-fs-rm.js:554:16)
      at getActual (node:assert:580:5)
      at assert.throws (node:assert:728:24)
      at Object.<anonymous> (/home/iojs/build/workspace/node-test-commit-aix-abmusse/nodes/test-ibm-aix72-ppc64_be-2/test/parallel/test-fs-rm.js:553:18)
      at Module._compile (node:internal/modules/cjs/loader:1829:14)
      at Object..js (node:internal/modules/cjs/loader:1969:10)
      at Module.load (node:internal/modules/cjs/loader:1552:32)
      at Module._load (node:internal/modules/cjs/loader:1354:12)
      at wrapModuleLoad (node:internal/modules/cjs/loader:255:19) {
    errno: -4094,
    code: '',
    path: '/home/iojs/build/.tmp.0/rm-11/fs-LcfMea',
    syscall: 'rm'
  },
  expected: { code: 'EACCES', name: 'Error' },
  operator: 'throws',
  diff: 'simple'
}

Node.js v26.0.0-pre
Command: out/Release/node --expose-internals /home/iojs/build/workspace/node-test-commit-aix-abmusse/nodes/test-ibm-aix72-ppc64_be-2/test/parallel/test-fs-rm.js


[00:11|% 100|+   0|-   1]: Done

Failed tests:
out/Release/node --expose-internals /home/iojs/build/workspace/node-test-commit-aix-abmusse/nodes/test-ibm-aix72-ppc64_be-2/test/parallel/test-fs-rm.js
bash-5.3$
```

@abmusse has done investigation that indicates this might be a libc++ on AIX bug (or at least difference). We'll try and pursue that as a longer term solution, but to unblock switching the AIX builds to clang this PR works around the difference.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
