### PR TITLE
doc: improve fs.StatFs documentation

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7938,6 +7938,16 @@ added:
 
 Free blocks available to unprivileged users.
 
+Example using `bsize` and `bavail` to calculate available space in bytes:
+
+```js
+import { statfs } from "fs/promises";
+
+const stats = await statfs("/tmp");
+const availableBytes = stats.bsize * stats.bavail;
+console.log(`Available space: ${availableBytes} bytes`);
+```
+
 #### `statfs.bfree`
 
 <!-- YAML
@@ -7949,6 +7959,16 @@ added:
 * Type: {number|bigint}
 
 Free blocks in file system.
+
+Example using `bsize` and `bfree` to calculate total free space in bytes:
+
+```js
+import { statfs } from "fs/promises";
+
+const stats = await statfs("/tmp");
+const freeBytes = stats.bsize * stats.bfree;
+console.log(`Free space: ${freeBytes} bytes`);
+```
 
 #### `statfs.blocks`
 
@@ -7962,6 +7982,16 @@ added:
 
 Total data blocks in file system.
 
+Example using `bsize` and `blocks` to calculate total file system size in bytes:
+
+```js
+import { statfs } from "fs/promises";
+
+const stats = await statfs("/tmp");
+const totalBytes = stats.bsize * stats.blocks;
+console.log(`Total size: ${totalBytes} bytes`);
+```
+
 #### `statfs.bsize`
 
 <!-- YAML
@@ -7972,7 +8002,7 @@ added:
 
 * Type: {number|bigint}
 
-Optimal transfer block size.
+Optimal transfer block size, in **bytes**.
 
 #### `statfs.frsize`
 
@@ -8006,7 +8036,7 @@ added:
 
 * Type: {number|bigint}
 
-Total file nodes in file system.
+Total file nodes (inodes) in file system.
 
 #### `statfs.type`
 
@@ -8018,7 +8048,10 @@ added:
 
 * Type: {number|bigint}
 
-Type of file system.
+File system type identifier. The value corresponds to the `f_type` field
+from the underlying `statfs` system call (e.g., `0x1021994` for `ext2`,
+`0x4d44` for `vfat`). Platform-specific constants like `FStype.EXT2`
+may be used for comparison when available.
 
 ### Class: `fs.Utf8Stream`
 


### PR DESCRIPTION
Good day

## Summary

This PR improves the documentation for `fs.StatFs` class based on issue #50749.

### Changes made:

1. **Clarified `bsize` unit**: Explicitly states that block size is in bytes (not bits)
2. **Added examples for calculating space**:
   - `bavail`: Example showing how to calculate available space in bytes
   - `bfree`: Example showing how to calculate free space in bytes
   - `blocks`: Example showing how to calculate total file system size in bytes
3. **Improved `files` description**: Clarified that it refers to inodes
4. **Enhanced `type` documentation**: Added explanation of what the type identifier represents and examples of common file system type values

### Example additions:

```js
import { statfs } from "fs/promises";

const stats = await statfs("/tmp");
const availableBytes = stats.bsize * stats.bavail;
console.log(`Available space: ${availableBytes} bytes`);
```

These changes help developers understand how to use the `StatFs` properties correctly, especially for calculating disk space.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof