### PR TITLE
src: preserve dotenv key insertion order

### DIFF
--- a/src/node_dotenv.cc
+++ b/src/node_dotenv.cc
@@ -89,19 +89,24 @@ Maybe<void> Dotenv::SetEnvironment(node::Environment* env) {
 MaybeLocal<Object> Dotenv::ToObject(Environment* env) const {
   EscapableHandleScope scope(env->isolate());
 
-  LocalVector<Name> names(env->isolate(), store_.size());
-  LocalVector<Value> values(env->isolate(), store_.size());
+  LocalVector<Name> names(env->isolate(), keys_order_.size());
+  LocalVector<Value> values(env->isolate(), keys_order_.size());
   auto context = env->context();
 
   Local<Value> tmp;
 
   int n = 0;
-  for (const auto& entry : store_) {
-    if (!ToV8Value(context, entry.first).ToLocal(&tmp)) {
+  for (const auto& key : keys_order_) {
+    auto entry = store_.find(key);
+    if (entry == store_.end()) {
+      continue;
+    }
+
+    if (!ToV8Value(context, entry->first).ToLocal(&tmp)) {
       return MaybeLocal<Object>();
     }
     names[n] = tmp.As<Name>();
-    if (!ToV8Value(context, entry.second).ToLocal(&tmp)) {
+    if (!ToV8Value(context, entry->second).ToLocal(&tmp)) {
       return MaybeLocal<Object>();
     }
     values[n++] = tmp;
@@ -137,6 +142,17 @@ std::string_view trim_spaces(std::string_view input) {
 
 void Dotenv::ParseContent(const std::string_view input) {
   std::string lines(input);
+
+  const auto set_entry = [this](std::string_view entry_key,
+                                std::string entry_value) {
+    auto [it, inserted] =
+        store_.insert_or_assign(std::string(entry_key),
+                                std::move(entry_value));
+
+    if (inserted) {
+      keys_order_.push_back(it->first);
+    }
+  };
 
   // Handle windows newlines "\r\n": remove "\r" and keep only "\n"
   lines.erase(std::remove(lines.begin(), lines.end(), '\r'), lines.end());
@@ -187,7 +203,7 @@ void Dotenv::ParseContent(const std::string_view input) {
 
     // If the value is not present (e.g. KEY=) set it to an empty string
     if (content.empty() || content.front() == '\n') {
-      store_.insert_or_assign(std::string(key), "");
+      set_entry(key, "");
       continue;
     }
 
@@ -212,7 +228,7 @@ void Dotenv::ParseContent(const std::string_view input) {
     if (content.empty()) {
       // In case the last line is a single key without value
       // Example: KEY= (without a newline at the EOF)
-      store_.insert_or_assign(std::string(key), "");
+      set_entry(key, "");
       break;
     }
 
@@ -232,7 +248,7 @@ void Dotenv::ParseContent(const std::string_view input) {
           pos += 1;
         }
 
-        store_.insert_or_assign(std::string(key), multi_line_value);
+        set_entry(key, std::move(multi_line_value));
         auto newline = content.find('\n', closing_quote + 1);
         if (newline != std::string_view::npos) {
           content.remove_prefix(newline + 1);
@@ -259,18 +275,18 @@ void Dotenv::ParseContent(const std::string_view input) {
         auto newline = content.find('\n');
         if (newline != std::string_view::npos) {
           value = content.substr(0, newline);
-          store_.insert_or_assign(std::string(key), value);
+          set_entry(key, std::string(value));
           content.remove_prefix(newline + 1);
         } else {
           // No newline - take rest of content
           value = content;
-          store_.insert_or_assign(std::string(key), value);
+          set_entry(key, std::string(value));
           break;
         }
       } else {
         // Found closing quote - take content between quotes
         value = content.substr(1, closing_quote - 1);
-        store_.insert_or_assign(std::string(key), value);
+        set_entry(key, std::string(value));
         auto newline = content.find('\n', closing_quote + 1);
         if (newline != std::string_view::npos) {
           // Use +1 to discard the '\n' itself => next line
@@ -296,7 +312,7 @@ void Dotenv::ParseContent(const std::string_view input) {
           value = value.substr(0, hash_character);
         }
         value = trim_spaces(value);
-        store_.insert_or_assign(std::string(key), std::string(value));
+        set_entry(key, std::string(value));
         content.remove_prefix(newline + 1);
       } else {
         // Last line without newline
@@ -305,7 +321,7 @@ void Dotenv::ParseContent(const std::string_view input) {
         if (hash_char != std::string_view::npos) {
           value = content.substr(0, hash_char);
         }
-        store_.insert_or_assign(std::string(key), trim_spaces(value));
+        set_entry(key, std::string(trim_spaces(value)));
         content = {};
       }
     }

--- a/src/node_dotenv.h
+++ b/src/node_dotenv.h
@@ -36,6 +36,7 @@ class Dotenv {
 
  private:
   std::map<std::string, std::string> store_;
+  std::vector<std::string> keys_order_;
 };
 
 }  // namespace node

--- a/test/parallel/test-util-parse-env.js
+++ b/test/parallel/test-util-parse-env.js
@@ -74,3 +74,27 @@ assert.throws(() => {
 }, {
   code: 'ERR_INVALID_ARG_TYPE',
 });
+
+// Test parse envs keep the order of keys as they appear in the input string
+{
+  const input = `
+PASSWORD="s1mpl3"
+DB_PASS=$PASSWORD
+  `.trim();
+
+  const parsed = util.parseEnv(input);
+  const keys = Object.keys(parsed);
+
+  assert.deepStrictEqual(keys, ['PASSWORD', 'DB_PASS']);
+}
+
+// Test that when a key appears multiple times, the last value is used,
+// but the order of keys is determined by the first occurrence
+{
+  const input = 'A=1\nB=2\nA=3';
+  const parsed = util.parseEnv(input);
+  const keys = Object.keys(parsed);
+
+  assert.deepStrictEqual(keys, ['A', 'B']);
+  assert.deepStrictEqual(parsed, { A: '3', B: '2', __proto__: null });
+}


### PR DESCRIPTION
Keep parseEnv output keys in the same order they first appear in the input

Fixes: https://github.com/nodejs/node/issues/62736

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
