### PR TITLE
assert: avoid expensive diff for large values

### DIFF
--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -42,6 +42,8 @@ const kReadableOperator = {
 
 const kMaxShortStringLength = 12;
 const kMaxLongStringLength = 512;
+const kMaxDiffLineCount = 1000;
+const kMaxDiffLinesToShow = 50;
 
 const kMethodsWithCustomMessageDiff = new SafeSet()
   .add('deepStrictEqual')
@@ -182,6 +184,13 @@ function isSimpleDiff(actual, inspectedActual, expected, inspectedExpected) {
   return typeof actual !== 'object' || actual === null || typeof expected !== 'object' || expected === null;
 }
 
+function getTruncatedDiffValue(lines) {
+  if (lines.length > kMaxDiffLinesToShow) {
+    return `${ArrayPrototypeJoin(ArrayPrototypeSlice(lines, 0, kMaxDiffLinesToShow), '\n')}\n...`;
+  }
+  return ArrayPrototypeJoin(lines, '\n');
+}
+
 function createErrDiff(actual, expected, operator, customMessage, diffType = 'simple') {
   operator = checkOperator(actual, expected, operator);
 
@@ -213,6 +222,13 @@ function createErrDiff(actual, expected, operator, customMessage, diffType = 'si
       message = ArrayPrototypeJoin(inspectedSplitActual, '\n');
     }
     header = '';
+  } else if (
+    diffType !== 'full' &&
+    inspectedSplitActual.length + inspectedSplitExpected.length > kMaxDiffLineCount
+  ) {
+    message = `\n${colors.green}+${colors.white} ${getTruncatedDiffValue(inspectedSplitActual)}\n` +
+              `${colors.red}-${colors.white} ${getTruncatedDiffValue(inspectedSplitExpected)}`;
+    skipped = true;
   } else {
     const checkCommaDisparity = actual != null && typeof actual === 'object';
     const diff = myersDiff(inspectedSplitActual, inspectedSplitExpected, checkCommaDisparity);

--- a/lib/internal/assert/assertion_error.js
+++ b/lib/internal/assert/assertion_error.js
@@ -191,6 +191,12 @@ function getTruncatedDiffValue(lines) {
   return ArrayPrototypeJoin(lines, '\n');
 }
 
+function hasLargeRootMismatch(inspectedActual, inspectedExpected, diffType) {
+  return diffType !== 'full' &&
+         inspectedActual.length + inspectedExpected.length > kMaxDiffLineCount &&
+         inspectedActual[0] !== inspectedExpected[0];
+}
+
 function createErrDiff(actual, expected, operator, customMessage, diffType = 'simple') {
   operator = checkOperator(actual, expected, operator);
 
@@ -222,13 +228,16 @@ function createErrDiff(actual, expected, operator, customMessage, diffType = 'si
       message = ArrayPrototypeJoin(inspectedSplitActual, '\n');
     }
     header = '';
-  } else if (
-    diffType !== 'full' &&
-    inspectedSplitActual.length + inspectedSplitExpected.length > kMaxDiffLineCount
-  ) {
-    message = `\n${colors.green}+${colors.white} ${getTruncatedDiffValue(inspectedSplitActual)}\n` +
+  } else if (hasLargeRootMismatch(inspectedSplitActual, inspectedSplitExpected, diffType)) {
+    const actualPrefix = operator === 'partialDeepStrictEqual' ?
+      `${colors.gray}${colors.hasColors ? ' ' : '+'}` :
+      `${colors.green}+${colors.white}`;
+    message = `\n${actualPrefix} ${getTruncatedDiffValue(inspectedSplitActual)}\n` +
               `${colors.red}-${colors.white} ${getTruncatedDiffValue(inspectedSplitExpected)}`;
     skipped = true;
+    if (operator === 'partialDeepStrictEqual') {
+      header = `${colors.gray}${colors.hasColors ? '' : '+ '}actual${colors.white} ${colors.red}- expected${colors.white}`;
+    }
   } else {
     const checkCommaDisparity = actual != null && typeof actual === 'object';
     const diff = myersDiff(inspectedSplitActual, inspectedSplitExpected, checkCommaDisparity);

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -1180,6 +1180,19 @@ test('Strict equal with identical objects that are not identical ' +
   );
 });
 
+test('Strict equal skips line diff for very large objects', () => {
+  const buffer = Buffer.alloc(1_000);
+
+  assert.throws(
+    () => assert.strictEqual(buffer, [buffer]),
+    {
+      code: 'ERR_ASSERTION',
+      name: 'AssertionError',
+      message: /Skipped lines[\s\S]*Buffer\(1000\)/
+    }
+  );
+});
+
 test('Basic valueOf check', () => {
   const a = new String(1);
   a.valueOf = undefined;

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -1193,6 +1193,21 @@ test('Strict equal skips line diff for very large objects', () => {
   );
 });
 
+test('Deep strict equal preserves line diff for large values with the same root', () => {
+  const actual = new Array(1_000).fill(0);
+  const expected = new Array(1_000).fill(0);
+  expected[10] = 1;
+
+  assert.throws(
+    () => assert.deepStrictEqual(actual, expected),
+    {
+      code: 'ERR_ASSERTION',
+      name: 'AssertionError',
+      message: /- {3}1/
+    }
+  );
+});
+
 test('Basic valueOf check', () => {
   const a = new String(1);
   a.valueOf = undefined;


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

  This limits the input size used for simple assertion diffs.

  When an assertion fails for large inspected values, such as
  `assert.strictEqual(Buffer.alloc(n), [buffer])`, `AssertionError` currently
  runs the full line-based Myers diff over the inspected output. For large
  Buffers this can make the failure path much slower than linear even though the
  values are trivially different.

  This change keeps the existing rich diff behavior for smaller values, but skips
  the Myers diff for very large inspected outputs in the default `simple` diff
  mode. In that case, the error message includes a truncated representation of
  both sides and marks skipped lines instead.

  `diff: 'full'` remains available for callers that explicitly request the full
  diff.

  Refs: https://github.com/nodejs/node/issues/62792

  ## Test

  - Added coverage in `test/parallel/test-assert-deep.js`
  - Not run locally: this machine has Apple clang 16.0.0 / Command Line Tools
    16.0, while this tree requires a newer macOS toolchain. Local build fails in
    V8 because `std::atomic_ref` is unavailable.
