### PR TITLE
doc: clarify dns.lookup() callback signature when all is true

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -277,9 +277,15 @@ changes:
 * `callback` {Function}
   * `err` {Error}
   * `address` {string} A string representation of an IPv4 or IPv6 address.
+    Not provided when `options.all` is `true`.
   * `family` {integer} `4` or `6`, denoting the family of `address`, or `0` if
     the address is not an IPv4 or IPv6 address. `0` is a likely indicator of a
     bug in the name resolution service used by the operating system.
+    Not provided when `options.all` is `true`.
+  * `addresses` {Object\[]} An array of address objects when `options.all` is
+    `true`. Each object has the following properties:
+    * `address` {string} A string representation of an IPv4 or IPv6 address.
+    * `family` {integer} `4` or `6`, denoting the family of `address`.
 
 Resolves a host name (e.g. `'nodejs.org'`) into the first found A (IPv4) or
 AAAA (IPv6) record. All `option` properties are optional. If `options` is an


### PR DESCRIPTION
## Summary

The `callback` parameter block for `dns.lookup()` only documented the default signature `(err, address, family)`. When `options.all` is set to `true`, the callback signature changes to `(err, addresses)`, but the `addresses` argument was absent from the structured parameter documentation.
it was only mentioned in prose below.

### Changes

- Add `addresses` {Object[]} to the `callback` parameter block, describing
  the array of `{ address, family }` objects returned when `options.all`
  is `true`
- Add "Not provided when `options.all` is `true`" notes to `address` and
  `family` parameters to make the two code paths explicit

Fixes: #57355

## Test plan

- [ ] Documentation change only — no runtime behavior affected
- [ ] `make lint-md` passes