### PR TITLE
test: migrate console_assert message test to snapshot

### DIFF
--- a/test/fixtures/console/console_assert.js
+++ b/test/fixtures/console/console_assert.js
@@ -1,5 +1,5 @@
 'use strict';
 
-require('../common');
+require('../../common');
 
 console.assert(false, Symbol('hello'));

--- a/test/fixtures/console/console_assert.snapshot
+++ b/test/fixtures/console/console_assert.snapshot
@@ -1,0 +1,1 @@
+Assertion failed Symbol(hello)

--- a/test/message/console_assert.out
+++ b/test/message/console_assert.out
@@ -1,1 +1,0 @@
-Assertion failed* Symbol(hello)

--- a/test/parallel/test-node-output-console.mjs
+++ b/test/parallel/test-node-output-console.mjs
@@ -9,6 +9,7 @@ const skipForceColors =
 
 describe('console output', { concurrency: !process.env.TEST_PARALLEL }, () => {
   const tests = [
+    { name: 'console/console_assert.js' },
     { name: 'console/2100bytes.js' },
     { name: 'console/console_low_stack_space.js' },
     { name: 'console/console.js' },


### PR DESCRIPTION
## Summary

Migrates `test/message/console_assert` from the legacy Python-based test runner (`testcfg.py` + `.out` file) to the modern JS snapshot approach.

### Changes

- Add `test/fixtures/console/console_assert.js` — the fixture script
  (same logic as the old `test/message/console_assert.js`, with the
  `require` path adjusted for the new location)
- Add `test/fixtures/console/console_assert.snapshot` — expected output
- Add `console/console_assert.js` entry to `test-node-output-console.mjs`
- Remove `test/message/console_assert.js` and `test/message/console_assert.out`

### What the test verifies

`console.assert(false, Symbol('hello'))` should print
`Assertion failed Symbol(hello)` to stderr without throwing or exiting.
The snapshot captures this expected output.

Refs: #47707

## Test plan

- [ ] `node --test test/parallel/test-node-output-console.mjs` passes
- [ ] No other `test/message/` tests affected