### PR TITLE
src: fix dead inspector help URL

### DIFF
--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -248,7 +248,7 @@ void PrintDebuggerReadyMessage(
     }
   }
   fprintf(out, "For help, see: %s\n",
-          "https://nodejs.org/en/docs/inspector");
+          "https://nodejs.org/api/inspector.html");
   fflush(out);
 }
 


### PR DESCRIPTION
## Summary

When running `node --inspect`, Node.js prints:

```
For help, see: https://nodejs.org/en/docs/inspector
```

This URL returns 404. Update it to the current location of the
inspector API documentation.

## Changes

- `src/inspector_socket_server.cc`: replace `https://nodejs.org/en/docs/inspector`
  with `https://nodejs.org/api/inspector.html`

Fixes: #62743

## Test plan

- [ ] Run `node --inspect -e ""` and verify the printed URL is reachable