### PR TITLE
test: wait for ok before initial break after restart

### DIFF
--- a/test/parallel/test-debugger-run-after-quit-restart.js
+++ b/test/parallel/test-debugger-run-after-quit-restart.js
@@ -42,6 +42,7 @@ const path = require('path');
       assert.match(cli.output, /Use `run` to start the app again/);
     })
     .then(() => cli.command('run'))
+    .then(() => cli.waitFor(/ ok\n/))
     .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {
@@ -58,9 +59,9 @@ const path = require('path');
       );
     })
     .then(() => cli.command('restart'))
-    .then(() => cli.waitFor(/Debugger attached\./))
-    .then(() => cli.waitForPrompt())
+    .then(() => cli.waitFor(/ ok\n/))
     .then(() => cli.waitForInitialBreak())
+    .then(() => cli.waitForPrompt())
     .then(() => {
       assert.deepStrictEqual(
         cli.breakInfo,
@@ -74,6 +75,7 @@ const path = require('path');
       assert.match(cli.output, /Use `run` to start the app again/);
     })
     .then(() => cli.command('run'))
+    .then(() => cli.waitFor(/ ok\n/))
     .then(() => cli.waitForInitialBreak())
     .then(() => cli.waitForPrompt())
     .then(() => {


### PR DESCRIPTION
Follow-up to: https://github.com/nodejs/node/pull/62471

Waiting for `Debugger attached.` before `waitForInitialBreak()` reduced one race, but it still was not a strong enough sync point. During reconnect, `debug>` can be re-displayed before the CLI finishes `run()/restart()`, and the output can still look like:

```text
Debugger attached.
debug>
ok
debug>
```

This change waits for `ok` before `waitForInitialBreak()`, so the test only starts waiting for the initial break after the CLI has completed reconnecting.

## CI logs
- https://github.com/nodejs/node/actions/runs/24588065778
- https://github.com/nodejs/node/actions/runs/24600780762

## Testing
```
UNUSUAL="$HOME/dir with \$unusual\"chars?'åß∂ƒ©∆¬…\`"
mkdir -p "$UNUSUAL"
ln -sfn "$PWD" "$UNUSUAL/node"
cd "$UNUSUAL/node"
```

- `./tools/test.py -p actions -j1 --repeat 50 parallel/test-debugger-run-after-quit-restart`

Refs: https://github.com/nodejs/node/issues/61762