### PR TITLE
test: skip test-snapshot-reproducible on all platforms

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -19,6 +19,9 @@ test-fs-read-stream-concurrent-reads: PASS, FLAKY
 # https://github.com/nodejs/build/issues/3043
 test-snapshot-incompatible: SKIP
 
+# https://github.com/nodejs/node/issues/53579
+test-snapshot-reproducible: PASS, FLAKY
+
 [$system==win32]
 # https://github.com/nodejs/node/issues/59090
 test-inspector-network-fetch: PASS, FLAKY

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -20,7 +20,7 @@ test-fs-read-stream-concurrent-reads: PASS, FLAKY
 test-snapshot-incompatible: SKIP
 
 # https://github.com/nodejs/node/issues/53579
-test-snapshot-reproducible: PASS, FLAKY
+test-snapshot-reproducible: SKIP
 
 [$system==win32]
 # https://github.com/nodejs/node/issues/59090


### PR DESCRIPTION
https://github.com/nodejs/node/issues/53579

> @joyeecheung: I also ran into it in another unrelated PR, I think I might have some leads in how to fix it. For now I think we can just temporarily skip the test - the test is mostly FYI, we are not super serious about reproducibility of our builds, it's mostly a nice to have.

> @joyeecheung: Yeah it's likely a V8 bug that's in my backlog or the way we configure V8 makes it somewhat prone to moving bits in paddings