### PR TITLE
crypto: replace CHECK with NULL checks for EVP_CIPHER_CTX_new allocations

### DIFF
--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -48,7 +48,9 @@ WebCryptoCipherStatus AES_Cipher(Environment* env,
   CHECK_EQ(key_data.GetKeyType(), kKeyTypeSecret);
 
   auto ctx = CipherCtxPointer::New();
-  CHECK(ctx);
+  if (!ctx) {
+    return WebCryptoCipherStatus::FAILED;
+  }
 
   if (params.cipher.isWrapMode()) {
     ctx.setAllowWrap();

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -338,7 +338,11 @@ void CipherBase::CommonInit(const char* cipher_type,
   MarkPopErrorOnReturn mark_pop_error_on_return;
   CHECK(!ctx_);
   ctx_ = CipherCtxPointer::New();
-  CHECK(ctx_);
+  if (!ctx_) {
+    return ThrowCryptoError(env(),
+                            mark_pop_error_on_return.peekError(),
+                            "EVP_CIPHER_CTX_new");
+  }
 
   if (cipher.isWrapMode()) {
     ctx_.setAllowWrap();


### PR DESCRIPTION
Good day

This PR addresses issue #62774, which identifies missing NULL checks for OpenSSL allocation functions in the Node.js crypto module.

## Changes

### src/crypto/crypto_aes.cc
In the \`AES_Cipher\` function, replaced \`CHECK(ctx)\` with a proper NULL check:

\`\`\`cpp
auto ctx = CipherCtxPointer::New();
if (!ctx) {
  return WebCryptoCipherStatus::FAILED;
}
\`\`\`

### src/crypto/crypto_cipher.cc
In the \`CipherBase::CommonInit\` function, replaced \`CHECK(ctx_)\` with a proper error throw:

\`\`\`cpp
ctx_ = CipherCtxPointer::New();
if (!ctx_) {
  return ThrowCryptoError(env(),
                          mark_pop_error_on_return.peekError(),
                          \"EVP_CIPHER_CTX_new\");
}
\`\`\`

## Why These Changes

The \`CHECK()\` macro is an assertion that calls \`abort()\` on failure. This is not appropriate for recoverable allocation failures (such as out-of-memory conditions). The new code:

1. Checks for NULL after \`EVP_CIPHER_CTX_new()\` allocation
2. Returns a proper error status (\`WebCryptoCipherStatus::FAILED\` or \`ThrowCryptoError\`)
3. Follows the same pattern already used in \`AES_CTR_Cipher2\` in the same file

This makes the code consistent with the rest of the codebase and handles allocation failures gracefully instead of crashing.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof