### PR TITLE
doc,test: mem protection must be observed in ffi

### DIFF
--- a/doc/api/ffi.md
+++ b/doc/api/ffi.md
@@ -533,6 +533,7 @@ native memory directly. The caller must guarantee that:
 * `length` stays within the allocated native region.
 * no native code frees or repurposes that memory while JavaScript still uses
   the `Buffer`.
+* Memory protection is observed.
 
 If these guarantees are not met, reading or writing the `Buffer` can corrupt
 memory or crash the process.

--- a/doc/api/ffi.md
+++ b/doc/api/ffi.md
@@ -533,7 +533,8 @@ native memory directly. The caller must guarantee that:
 * `length` stays within the allocated native region.
 * no native code frees or repurposes that memory while JavaScript still uses
   the `Buffer`.
-* Memory protection is observed.
+* Memory protection is observed. For example, read-only memory pages must not
+  be written to.
 
 If these guarantees are not met, reading or writing the `Buffer` can corrupt
 memory or crash the process.

--- a/test/ffi/ffi-test-common.js
+++ b/test/ffi/ffi-test-common.js
@@ -77,7 +77,6 @@ const fixtureSymbols = {
   array_set_i32: { parameters: ['pointer', 'u64', 'i32'], result: 'void' },
   array_get_f64: { parameters: ['pointer', 'u64'], result: 'f64' },
   array_set_f64: { parameters: ['pointer', 'u64', 'f64'], result: 'void' },
-  readonly_memory: { parameters: [], result: 'pointer' },
 };
 
 if (!common.isWindows) {

--- a/test/ffi/ffi-test-common.js
+++ b/test/ffi/ffi-test-common.js
@@ -77,6 +77,7 @@ const fixtureSymbols = {
   array_set_i32: { parameters: ['pointer', 'u64', 'i32'], result: 'void' },
   array_get_f64: { parameters: ['pointer', 'u64'], result: 'f64' },
   array_set_f64: { parameters: ['pointer', 'u64', 'f64'], result: 'void' },
+  readonly_memory: { parameters: [], result: 'pointer' },
 };
 
 function cString(value) {

--- a/test/ffi/ffi-test-common.js
+++ b/test/ffi/ffi-test-common.js
@@ -80,6 +80,10 @@ const fixtureSymbols = {
   readonly_memory: { parameters: [], result: 'pointer' },
 };
 
+if (!common.isWindows) {
+  fixtureSymbols.readonly_memory = { parameters: [], result: 'pointer' };
+}
+
 function cString(value) {
   return Buffer.from(`${value}\0`);
 }

--- a/test/ffi/fixture_library/ffi_test_library.c
+++ b/test/ffi/fixture_library/ffi_test_library.c
@@ -2,6 +2,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/mman.h>
 
 #ifdef _WIN32
 #define FFI_EXPORT __declspec(dllexport)
@@ -377,4 +378,11 @@ FFI_EXPORT void array_set_f64(double* arr, size_t index, double value) {
   }
 
   arr[index] = value;
+}
+
+FFI_EXPORT void * readonly_memory() {
+  // TODO(bengl) Add a Windows version of this.
+
+  void * p = mmap(0, 4096, PROT_READ, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+  return p;
 }

--- a/test/ffi/fixture_library/ffi_test_library.c
+++ b/test/ffi/fixture_library/ffi_test_library.c
@@ -2,11 +2,10 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/mman.h>
-
 #ifdef _WIN32
 #define FFI_EXPORT __declspec(dllexport)
 #else
+#include <sys/mman.h>
 #define FFI_EXPORT
 #endif
 
@@ -380,9 +379,11 @@ FFI_EXPORT void array_set_f64(double* arr, size_t index, double value) {
   arr[index] = value;
 }
 
-FFI_EXPORT void * readonly_memory() {
+#ifndef _WIN32
+FFI_EXPORT void* readonly_memory() {
   // TODO(bengl) Add a Windows version of this.
 
-  void * p = mmap(0, 4096, PROT_READ, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+  void* p = mmap(0, 4096, PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   return p;
 }
+#endif

--- a/test/ffi/test-ffi-readonly-write.js
+++ b/test/ffi/test-ffi-readonly-write.js
@@ -11,14 +11,15 @@ if (isWindows) {
   skip('This test currently relies on POSIX APIs');
 }
 
-test('writing to readonly memory via buffer results in SIGBUS', () => {
+test('writing to readonly memory via buffer fails', () => {
   const symbols = JSON.stringify(fixtureSymbols);
-  const { stdout, status, signal } = spawnSync(process.execPath, [
+  const libPath = JSON.stringify(libraryPath);
+  const { stdout, status } = spawnSync(process.execPath, [
     '--experimental-ffi',
     '-p',
     `
     const ffi = require('node:ffi');
-    const { functions } = ffi.dlopen('${libraryPath}', ${symbols})
+    const { functions } = ffi.dlopen(${libPath}, ${symbols})
     const p = functions.readonly_memory();
     const b = ffi.toBuffer(p, 4096, false);
     b[0] = 42;

--- a/test/ffi/test-ffi-readonly-write.js
+++ b/test/ffi/test-ffi-readonly-write.js
@@ -1,0 +1,30 @@
+// Flags: --experimental-ffi
+'use strict';
+const { skipIfFFIMissing, isWindows, skip } = require('../common');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { test } = require('node:test');
+const { fixtureSymbols, libraryPath } = require('./ffi-test-common');
+
+skipIfFFIMissing();
+if (isWindows) {
+  skip('This test currently relies on POSIX APIs');
+}
+
+test('writing to readonly memory via buffer results in SIGBUS', () => {
+  const symbols = JSON.stringify(fixtureSymbols);
+  const { stdout, status, signal } = spawnSync(process.execPath, [
+    '--experimental-ffi',
+    '-p',
+    `
+    const ffi = require('node:ffi');
+    const { functions } = ffi.dlopen('${libraryPath}', ${symbols})
+    const p = functions.readonly_memory();
+    const b = ffi.toBuffer(p, 4096, false);
+    b[0] = 42;
+    console.log('success');
+    `,
+  ]);
+  assert.notStrictEqual(status, 0);
+  assert.strictEqual(stdout.length, 0);
+});


### PR DESCRIPTION
When using ffi.toBuffer, memory protection on any memory pages exposed must be observed by the caller, otherwise crashes will occur.

Now documented, and tested.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
