### PR TITLE
test_runner: align MockTimers timeout API

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -69,12 +69,15 @@ const TIMERS_DEFAULT_INTERVAL = {
 };
 
 class Timeout {
+  #clear;
+
   constructor(opts) {
     this.id = opts.id;
     this.callback = opts.callback;
     this.runAt = opts.runAt;
     this.interval = opts.interval;
     this.args = opts.args;
+    this.#clear = opts.clear;
   }
 
   hasRef() {
@@ -91,6 +94,15 @@ class Timeout {
 
   refresh() {
     return this;
+  }
+
+  close() {
+    this.#clear(this);
+    return this;
+  }
+
+  [SymbolDispose]() {
+    this.#clear(this);
   }
 }
 
@@ -310,6 +322,7 @@ class MockTimers {
       runAt: this.#now + delay,
       interval: isInterval ? delay : undefined,
       args,
+      clear: this.#clearTimeout,
     };
 
     const timer = new Timeout(opts);

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -266,6 +266,32 @@ describe('Mock Timers Test Suite', () => {
         assert.deepStrictEqual(fn.mock.calls[0].arguments, args);
       });
 
+      it('should expose Timeout.prototype[Symbol.dispose]', (t) => {
+        t.mock.timers.enable({ apis: ['setTimeout'] });
+        const fn = t.mock.fn();
+        const timeout = globalThis.setTimeout(fn, 2000);
+
+        assert.strictEqual(typeof timeout[Symbol.dispose], 'function');
+
+        timeout[Symbol.dispose]();
+        t.mock.timers.tick(2000);
+
+        assert.strictEqual(fn.mock.callCount(), 0);
+      });
+
+      it('should expose Timeout.prototype.close()', (t) => {
+        t.mock.timers.enable({ apis: ['setTimeout'] });
+        const fn = t.mock.fn();
+        const timeout = globalThis.setTimeout(fn, 2000);
+
+        assert.strictEqual(typeof timeout.close, 'function');
+        assert.strictEqual(timeout.close(), timeout);
+
+        t.mock.timers.tick(2000);
+
+        assert.strictEqual(fn.mock.callCount(), 0);
+      });
+
       it('should keep setTimeout working if timers are disabled', (t, done) => {
         const now = Date.now();
         const timeout = 2;


### PR DESCRIPTION
## Summary

Align MockTimers timeout handles with the public Timeout API by exposing `close()` and `[Symbol.dispose]()` on fake `setTimeout()` results.

## Problem

When `test.mock.timers.enable()` is active, `setTimeout()` returns a mock timeout handle that does not implement `Timeout.close()` or `Timeout[Symbol.dispose]()`. That breaks disposal-based patterns such as `DisposableStack.use(timeout)`.

## Root cause

MockTimers used its own `Timeout` wrapper with only `ref()`, `unref()`, `refresh()`, and `hasRef()`, so the fake timeout handle diverged from the documented timeout API.

## Changes

- add `Timeout.close()` to the MockTimers timeout wrapper
- add `Timeout[Symbol.dispose]()` to the MockTimers timeout wrapper
- route both methods through the existing timer clear path
- add targeted coverage for both disposal entry points

## Validation

- reproduced the issue with `out/Release/node` before the change
- `python3 tools/test.py test/parallel/test-runner-mock-timers.js`
- verified the built `out/Release/node` now reports `dispose function`, `close function`, and allows `DisposableStack.use(timeout)`

Fixes: https://github.com/nodejs/node/issues/62815
