### PR TITLE
tools: silence cpplint refs warning for v8 fast api options

### DIFF
--- a/tools/cpplint.py
+++ b/tools/cpplint.py
@@ -6036,6 +6036,11 @@ _RE_PATTERN_CONST_REF_PARAM = (
 )
 # Stream types.
 _RE_PATTERN_REF_STREAM_PARAM = r"(?:.*stream\s*&\s*" + _RE_PATTERN_IDENT + r")"
+# V8 Fast API types whose signatures are dictated by V8 and require a
+# non-const reference parameter; Node.js cannot change these.
+_RE_PATTERN_REF_V8_FAST_API_PARAM = (
+    r"(?:.*\b(?:v8::)?FastApiCallbackOptions\s*&\s*" + _RE_PATTERN_IDENT + r")"
+)
 
 
 def CheckLanguage(
@@ -6585,8 +6590,10 @@ def CheckForNonConstReference(filename, clean_lines, linenum, nesting_state, err
 
     decls = re.sub(r"{[^}]*}", " ", line)  # exclude function body
     for parameter in re.findall(_RE_PATTERN_REF_PARAM, decls):
-        if not re.match(_RE_PATTERN_CONST_REF_PARAM, parameter) and not re.match(
-            _RE_PATTERN_REF_STREAM_PARAM, parameter
+        if (
+            not re.match(_RE_PATTERN_CONST_REF_PARAM, parameter)
+            and not re.match(_RE_PATTERN_REF_STREAM_PARAM, parameter)
+            and not re.match(_RE_PATTERN_REF_V8_FAST_API_PARAM, parameter)
         ):
             error(
                 filename,

--- a/tools/test_cpplint_fast_api.py
+++ b/tools/test_cpplint_fast_api.py
@@ -1,0 +1,72 @@
+"""Regression tests for cpplint runtime/references and V8 Fast API.
+
+Refs: https://github.com/nodejs/node/issues/45761
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import cpplint  # noqa: E402
+
+
+def _lint(source):
+    errors = []
+
+    def collect(filename, linenum, category, confidence, message):
+        errors.append((linenum, category, message))
+
+    cpplint.ProcessFileData("test.cc", "cc", source.splitlines(), collect)
+    return [e for e in errors if e[1] == "runtime/references"]
+
+
+class FastApiCallbackOptionsRefTest(unittest.TestCase):
+    def test_unqualified_fast_api_callback_options_not_flagged(self):
+        # Mirrors src/node_buffer.cc usage after `using v8::FastApiCallbackOptions;`.
+        src = (
+            "namespace node {\n"
+            "void FastFn(Local<Value> recv,\n"
+            "            FastApiCallbackOptions& options) {\n"
+            "}\n"
+            "}  // namespace node\n"
+        )
+        self.assertEqual(_lint(src), [])
+
+    def test_qualified_fast_api_callback_options_not_flagged(self):
+        src = (
+            "namespace node {\n"
+            "void FastFn(Local<Value> recv,\n"
+            "            v8::FastApiCallbackOptions& options) {\n"
+            "}\n"
+            "}  // namespace node\n"
+        )
+        self.assertEqual(_lint(src), [])
+
+    def test_plain_non_const_reference_still_flagged(self):
+        src = (
+            "namespace node {\n"
+            "void Bad(int& value) {\n"
+            "}\n"
+            "}  // namespace node\n"
+        )
+        errors = _lint(src)
+        self.assertEqual(len(errors), 1, errors)
+        self.assertIn("int& value", errors[0][2])
+
+    def test_unrelated_type_with_similar_name_still_flagged(self):
+        # Guard against an over-broad regex that would also accept e.g.
+        # FastApiCallbackOptionsExtra&.
+        src = (
+            "namespace node {\n"
+            "void Bad(FastApiCallbackOptionsExtra& opts) {\n"
+            "}\n"
+            "}  // namespace node\n"
+        )
+        errors = _lint(src)
+        self.assertEqual(len(errors), 1, errors)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Allowlist `FastApiCallbackOptions&` (with or without the `v8::` prefix)
in cpplint's `CheckForNonConstReference` so that V8 Fast API callbacks
no longer trigger spurious `runtime/references` warnings.

## Why

cpplint's `runtime/references` rule requires non-const references to be
replaced with pointers or `const` references. V8 Fast API callbacks
declare a non-const `v8::FastApiCallbackOptions&` parameter, and the
signature is dictated by V8 — Node.js cannot change it. Running
cpplint against a minimal callback reproduces the false positive:

```cpp
void FastFn(v8::Local<v8::Value> recv,
            v8::FastApiCallbackOptions& options) {}
```

```
repro.cc:2:  Is this a non-const reference? If so, make const or use a
pointer: v8::FastApiCallbackOptions& options  [runtime/references] [2]
```

Several real users in `src/` (e.g. `node_buffer.cc`) already carry
`// NOLINT(runtime/references)` to silence the warning; others bring
the type into scope with `using v8::FastApiCallbackOptions;` and use
the unqualified spelling.

## Fix

Add `_RE_PATTERN_REF_V8_FAST_API_PARAM` matching both
`FastApiCallbackOptions&` and `v8::FastApiCallbackOptions&` and skip
the `runtime/references` error for parameters that match it. Genuine
non-const references (e.g. `int& value`, `SomeType& thing`) and
similarly-named-but-distinct types (e.g. `FastApiCallbackOptionsExtra&`)
continue to be flagged.

A `unittest`-based regression test is added at
`tools/test_cpplint_fast_api.py` and locks in both the allowlist and
the negative cases.

## Relationship to #62585

PR #62585 takes a similar approach but matches only the fully
qualified `v8::FastApiCallbackOptions&`. Most existing call sites in
`src/` (`node_buffer.cc`, `node_url.cc`, `node_debug.cc`,
`crypto/crypto_timing.cc`, `node_wasi.cc`) write the parameter as the
unqualified `FastApiCallbackOptions&` after a `using` declaration, so
those sites would still warn. This PR extends the pattern to cover the
unqualified form and adds tests; happy to defer or rebase if #62585
lands first.

## Validation

- `py tools/cpplint.py --filter=-,+runtime/references` against
  `src/node_buffer.cc`, `src/node_url.cc`, `src/node_debug.cc`,
  `src/crypto/crypto_timing.cc`, `src/node_wasi.cc`, `src/node_zlib.cc`
  — zero warnings before and after, with no regressions.
- `py -m unittest tools.test_cpplint_fast_api` — 4/4 tests pass with
  the fix; 2/4 fail without it (verified by stashing the cpplint
  change), confirming the test exercises the bug.
- No Node binary build was required; this is a tooling-only change.

Fixes: https://github.com/nodejs/node/issues/45761