### PR TITLE
stream: reject duplicate nested transferables

### DIFF
--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -415,10 +415,15 @@ class SerializerDelegate : public ValueSerializer::Delegate {
       if (!host_objects_[i]->NestedTransferables().To(&nested_transferables))
         return Nothing<bool>();
       for (auto& nested_transferable : nested_transferables) {
-        if (std::ranges::find(host_objects_, nested_transferable) ==
+        if (std::ranges::find(host_objects_, nested_transferable) !=
             host_objects_.end()) {
-          AddHostObject(nested_transferable);
+          ThrowDataCloneException(
+              context_,
+              FIXED_ONE_BYTE_STRING(env_->isolate(),
+                                    "The transfer list is invalid."));
+          return Nothing<bool>();
         }
+        AddHostObject(nested_transferable);
       }
     }
     return Just(true);

--- a/test/parallel/test-whatwg-webstreams-transform-stream-members.js
+++ b/test/parallel/test-whatwg-webstreams-transform-stream-members.js
@@ -1,0 +1,19 @@
+'use strict';
+
+require('../common');
+const assert = require('node:assert');
+
+const combinations = [
+  ((t) => [t, t.readable])(new TransformStream()),
+  ((t) => [t.readable, t])(new TransformStream()),
+  ((t) => [t, t.writable])(new TransformStream()),
+  ((t) => [t.writable, t])(new TransformStream()),
+];
+
+for (const combination of combinations) {
+  assert.throws(() => structuredClone(combination, { transfer: combination }), {
+    constructor: DOMException,
+    name: 'DataCloneError',
+    code: 25,
+  });
+}

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -41,14 +41,6 @@
   "transferable/transfer-with-messageport.window.js": {
     "skip": "Browser-specific test"
   },
-  "transferable/transform-stream-members.any.js": {
-    "fail": {
-      "expected": [
-        "Transferring [object TransformStream],[object ReadableStream] should fail",
-        "Transferring [object TransformStream],[object WritableStream] should fail"
-      ]
-    }
-  },
   "transform-streams/invalid-realm.tentative.window.js": {
     "skip": "Browser-specific test"
   }


### PR DESCRIPTION
This fixes `structuredClone()` transfer-list validation for nested transfer conflicts.

```js
// This should fail, matching browser and other JavaScript runtime behavior.
const t = new TransformStream();
structuredClone([t, t.readable],{ transfer: [t, t.readable] });
```

We already reject direct duplicate transfer entries, but validation could depend on 
transfer-list order when transferring a `TransformStream` together with one of its members.

This could be handled in two ways:

1. reject it when nested transferables create duplicates
2. let serialization fail later with a lock error

Nested transferables are currently expanded during validation, so this patch uses option 1.
Option 2 would require broader changes to the current transfer design than this fix warrants.