### PR TITLE
lib: fix `evenRound` sign for fractional values in (-1, 1)

### DIFF
--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -80,7 +80,7 @@ function evenRound(x) {
   // Convert -0 to +0.
   const i = integerPart(x) + 0;
   const reminder = MathAbs(x % 1);
-  const sign = MathSign(i);
+  const sign = MathSign(x);
   if (reminder === 0.5) {
     return i % 2 === 0 ? i : i + sign;
   }

--- a/test/parallel/test-internal-webidl-converttoint.js
+++ b/test/parallel/test-internal-webidl-converttoint.js
@@ -13,6 +13,13 @@ assert.strictEqual(evenRound(3.4), 3);
 assert.strictEqual(evenRound(4.6), 5);
 assert.strictEqual(evenRound(5), 5);
 assert.strictEqual(evenRound(6), 6);
+// Fractional values in (-1, 0) ∪ (0, 1) whose truncated integer part is 0.
+assert.strictEqual(evenRound(0.7), 1);
+assert.strictEqual(evenRound(-0.7), -1);
+assert.strictEqual(evenRound(0.3), 0);
+assert.strictEqual(evenRound(-0.3), 0);
+assert.strictEqual(convertToInt('x', -0.9999999, 64, { signed: true, clamp: true }), -1);
+assert.strictEqual(convertToInt('x', 0.9999999, 64, { clamp: true }), 1);
 
 // https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
 assert.strictEqual(convertToInt('x', 0, 64), 0);


### PR DESCRIPTION
`evenRound` derived the rounding direction from `MathSign(i)` where `i = integerPart(x)`. For any `x` whose truncated integer part is zero (e.g. `0.7`, `-0.7`), `sign` was `0`, so the non-halfway branch returned `i + sign === 0` instead of rounding away from zero.

This produced incorrect `[Clamp]` WebIDL integer conversions for fractional inputs in `(-1, 0) ∪ (0, 1)` that are not exactly `±0.5`

Observable e.g. via `new Blob([Uint8Array.of(1,2,3)]).slice(-0.9999999)` returning the whole blob instead of a 1-byte slice.

Use `MathSign(x)` so the rounding direction follows the sign of the original value.