### PR TITLE
crypto: fix unsigned conversion of 4-byte RSA publicExponent

### DIFF
--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -696,7 +696,7 @@ function bigIntArrayToUnsignedInt(input) {
     result |= input[n] << 8 * n_reversed;
   }
 
-  return result;
+  return result >>> 0;
 }
 
 function bigIntArrayToUnsignedBigInt(input) {

--- a/test/parallel/test-webcrypto-util.js
+++ b/test/parallel/test-webcrypto-util.js
@@ -8,8 +8,27 @@ if (!common.hasCrypto)
 const assert = require('assert');
 
 const {
+  bigIntArrayToUnsignedInt,
   normalizeAlgorithm,
 } = require('internal/crypto/util');
+
+// bigIntArrayToUnsignedInt must return an unsigned 32-bit value even when
+// the most significant byte has its top bit set. Otherwise the signed `<<`
+// operator yields a negative Int32 for inputs like [0x80, 0x00, 0x00, 0x01].
+{
+  assert.strictEqual(
+    bigIntArrayToUnsignedInt(new Uint8Array([0x80, 0x00, 0x00, 0x01])),
+    0x80000001);
+  assert.strictEqual(
+    bigIntArrayToUnsignedInt(new Uint8Array([0xff, 0xff, 0xff, 0xff])),
+    0xffffffff);
+  assert.strictEqual(
+    bigIntArrayToUnsignedInt(new Uint8Array([1, 0, 1])),
+    65537);
+  assert.strictEqual(
+    bigIntArrayToUnsignedInt(new Uint8Array([1, 0, 0, 0, 0])),
+    undefined);
+}
 
 {
   // Check that normalizeAlgorithm does not mutate object inputs.


### PR DESCRIPTION
`bigIntArrayToUnsignedInt` used the signed `<<` operator, so when the most significant byte of a 4-byte input had its top bit set (e.g. `[0x80, 0x00, 0x00, 0x01]`) the result was a negative Int32 instead of the intended unsigned 32-bit value. This caused any RSA `publicExponent` exactly 4 bytes long with the top bit set to be parsed incorrectly. Coerce the final value with `>>> 0` and add a unit test.