### PR TITLE
test: normalize known inspector crash as completion

### DIFF
--- a/test/common/debugger-probe.js
+++ b/test/common/debugger-probe.js
@@ -1,18 +1,54 @@
 'use strict';
 
+const assert = require('assert');
 const fixtures = require('./fixtures');
 const path = require('path');
+
+const probeTargetExitSignal = 'SIGSEGV';
+const probeTargetExitMessage =
+  `Target exited with signal ${probeTargetExitSignal} before target completion`;
 
 function debuggerFixturePath(name) {
   return path.relative(process.cwd(), fixtures.path('debugger', name));
 }
 
-function escapeRegex(string) {
-  return string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
+// Work around a pre-existing inspector issue: if the debuggee exits too quickly
+// the inspector can segfault while tearing down. For now normalize the
+// trailing segfault as completion until the upstream bug is fixed.
+// See https://github.com/nodejs/node/issues/62765
+// https://github.com/nodejs/node/issues/58245
+function assertProbeJson(output, expected) {
+  const normalized = JSON.parse(output);
+  const lastResult = normalized.results?.[normalized.results.length - 1];
+
+  if (lastResult?.event === 'error' &&
+    lastResult.error?.code === 'probe_target_exit' &&
+    lastResult.error?.signal === probeTargetExitSignal &&
+    lastResult.error?.message === probeTargetExitMessage) {
+    // Log to facilitate debugging if this normalization is occurring.
+    console.log('Normalizing trailing SIGSEGV in JSON probe output');
+    normalized.results[normalized.results.length - 1] = { event: 'completed' };
+  }
+
+  assert.deepStrictEqual(normalized, expected);
+}
+
+function assertProbeText(output, expected) {
+  const idx = output.indexOf(probeTargetExitMessage);
+  let normalized;
+  if (idx !== -1) {
+    // Log to facilitate debugging if this normalization is occurring.
+    console.log('Normalizing trailing SIGSEGV in text probe output');
+    normalized = output.slice(0, output.lastIndexOf('\n', idx)) + '\nCompleted';
+  } else {
+    normalized = output;
+  }
+  assert.strictEqual(normalized, expected);
 }
 
 module.exports = {
-  escapeRegex,
+  assertProbeJson,
+  assertProbeText,
   missScript: debuggerFixturePath('probe-miss.js'),
   probeScript: debuggerFixturePath('probe.js'),
   throwScript: debuggerFixturePath('probe-throw.js'),

--- a/test/common/debugger-probe.js
+++ b/test/common/debugger-probe.js
@@ -25,8 +25,7 @@ function assertProbeJson(output, expected) {
     lastResult.error?.signal === probeTargetExitSignal) {
     // Log to facilitate debugging if this normalization is occurring.
     console.log('Normalizing trailing SIGSEGV in JSON probe output');
-    normalized.results[normalized.results.length - 1] =
-      expected.results[expected.results.length - 1];
+    normalized.results.at(-1) = expected.results.at(-1);
   }
 
   assert.deepStrictEqual(normalized, expected);

--- a/test/common/debugger-probe.js
+++ b/test/common/debugger-probe.js
@@ -25,7 +25,7 @@ function assertProbeJson(output, expected) {
     lastResult.error?.signal === probeTargetExitSignal) {
     // Log to facilitate debugging if this normalization is occurring.
     console.log('Normalizing trailing SIGSEGV in JSON probe output');
-    normalized.results.at(-1) = expected.results.at(-1);
+    normalized.results[normalized.results.length - 1] = expected.results.at(-1);
   }
 
   assert.deepStrictEqual(normalized, expected);

--- a/test/common/debugger-probe.js
+++ b/test/common/debugger-probe.js
@@ -4,42 +4,43 @@ const assert = require('assert');
 const fixtures = require('./fixtures');
 const path = require('path');
 
-const probeTargetExitSignal = 'SIGSEGV';
-const probeTargetExitMessage =
-  `Target exited with signal ${probeTargetExitSignal} before target completion`;
-
 function debuggerFixturePath(name) {
   return path.relative(process.cwd(), fixtures.path('debugger', name));
 }
 
 // Work around a pre-existing inspector issue: if the debuggee exits too quickly
-// the inspector can segfault while tearing down. For now normalize the
-// trailing segfault as completion until the upstream bug is fixed.
+// the inspector can segfault while tearing down. For now normalize the segfault
+// back to the expected terminal event (e.g. "completed" or "miss")
+// until the upstream bug is fixed.
 // See https://github.com/nodejs/node/issues/62765
 // https://github.com/nodejs/node/issues/58245
+const probeTargetExitSignal = 'SIGSEGV';
+
 function assertProbeJson(output, expected) {
   const normalized = JSON.parse(output);
   const lastResult = normalized.results?.[normalized.results.length - 1];
 
   if (lastResult?.event === 'error' &&
     lastResult.error?.code === 'probe_target_exit' &&
-    lastResult.error?.signal === probeTargetExitSignal &&
-    lastResult.error?.message === probeTargetExitMessage) {
+    lastResult.error?.signal === probeTargetExitSignal) {
     // Log to facilitate debugging if this normalization is occurring.
     console.log('Normalizing trailing SIGSEGV in JSON probe output');
-    normalized.results[normalized.results.length - 1] = { event: 'completed' };
+    normalized.results[normalized.results.length - 1] =
+      expected.results[expected.results.length - 1];
   }
 
   assert.deepStrictEqual(normalized, expected);
 }
 
 function assertProbeText(output, expected) {
-  const idx = output.indexOf(probeTargetExitMessage);
+  const signalPrefix = `Target exited with signal ${probeTargetExitSignal}`;
+  const idx = output.indexOf(signalPrefix);
   let normalized;
   if (idx !== -1) {
     // Log to facilitate debugging if this normalization is occurring.
     console.log('Normalizing trailing SIGSEGV in text probe output');
-    normalized = output.slice(0, output.lastIndexOf('\n', idx)) + '\nCompleted';
+    const lineStart = output.lastIndexOf('\n', idx);
+    normalized = (lineStart === -1 ? '' : output.slice(0, lineStart)) + '\nCompleted';
   } else {
     normalized = output;
   }

--- a/test/parallel/test-debugger-probe-child-inspect-port-zero.js
+++ b/test/parallel/test-debugger-probe-child-inspect-port-zero.js
@@ -4,9 +4,8 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { probeScript } = require('../common/debugger-probe');
+const { assertProbeJson, probeScript } = require('../common/debugger-probe');
 
 spawnSyncAndAssert(process.execPath, [
   'inspect',
@@ -18,7 +17,7 @@ spawnSyncAndAssert(process.execPath, [
   probeScript,
 ], {
   stdout(output) {
-    assert.deepStrictEqual(JSON.parse(output), {
+    assertProbeJson(output, {
       v: 1,
       probes: [{
         expr: 'finalValue',

--- a/test/parallel/test-debugger-probe-global-option-order.js
+++ b/test/parallel/test-debugger-probe-global-option-order.js
@@ -4,9 +4,8 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { probeScript } = require('../common/debugger-probe');
+const { assertProbeJson, probeScript } = require('../common/debugger-probe');
 
 spawnSyncAndAssert(process.execPath, [
   'inspect',
@@ -16,7 +15,7 @@ spawnSyncAndAssert(process.execPath, [
   probeScript,
 ], {
   stdout(output) {
-    assert.deepStrictEqual(JSON.parse(output), {
+    assertProbeJson(output, {
       v: 1,
       probes: [{
         expr: 'finalValue',

--- a/test/parallel/test-debugger-probe-json-preview.js
+++ b/test/parallel/test-debugger-probe-json-preview.js
@@ -4,9 +4,11 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { probeTypesScript } = require('../common/debugger-probe');
+const {
+  assertProbeJson,
+  probeTypesScript,
+} = require('../common/debugger-probe');
 
 const location = `${probeTypesScript}:17`;
 
@@ -23,7 +25,7 @@ spawnSyncAndAssert(process.execPath, [
   probeTypesScript,
 ], {
   stdout(output) {
-    assert.deepStrictEqual(JSON.parse(output), {
+    assertProbeJson(output, {
       v: 1,
       probes: [
         { expr: 'objectValue', target: [probeTypesScript, 17] },

--- a/test/parallel/test-debugger-probe-json-special-values.js
+++ b/test/parallel/test-debugger-probe-json-special-values.js
@@ -4,9 +4,11 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { probeTypesScript } = require('../common/debugger-probe');
+const {
+  assertProbeJson,
+  probeTypesScript,
+} = require('../common/debugger-probe');
 
 const location = `${probeTypesScript}:17`;
 
@@ -38,7 +40,7 @@ spawnSyncAndAssert(process.execPath, [
   probeTypesScript,
 ], {
   stdout(output) {
-    assert.deepStrictEqual(JSON.parse(output), {
+    assertProbeJson(output, {
       v: 1,
       probes: [
         { expr: 'stringValue', target: [probeTypesScript, 17] },

--- a/test/parallel/test-debugger-probe-json.js
+++ b/test/parallel/test-debugger-probe-json.js
@@ -4,9 +4,8 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { probeScript } = require('../common/debugger-probe');
+const { assertProbeJson, probeScript } = require('../common/debugger-probe');
 
 spawnSyncAndAssert(process.execPath, [
   'inspect',
@@ -20,7 +19,7 @@ spawnSyncAndAssert(process.execPath, [
   probeScript,
 ], {
   stdout(output) {
-    assert.deepStrictEqual(JSON.parse(output), {
+    assertProbeJson(output, {
       v: 1,
       probes: [
         { expr: 'index', target: [probeScript, 8] },

--- a/test/parallel/test-debugger-probe-miss.js
+++ b/test/parallel/test-debugger-probe-miss.js
@@ -4,9 +4,8 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { missScript } = require('../common/debugger-probe');
+const { assertProbeJson, missScript } = require('../common/debugger-probe');
 
 spawnSyncAndAssert(process.execPath, [
   'inspect',
@@ -16,7 +15,7 @@ spawnSyncAndAssert(process.execPath, [
   missScript,
 ], {
   stdout(output) {
-    assert.deepStrictEqual(JSON.parse(output), {
+    assertProbeJson(output, {
       v: 1,
       probes: [{ expr: '42', target: [missScript, 99] }],
       results: [{

--- a/test/parallel/test-debugger-probe-text-special-values.js
+++ b/test/parallel/test-debugger-probe-text-special-values.js
@@ -4,9 +4,11 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { probeTypesScript } = require('../common/debugger-probe');
+const {
+  assertProbeText,
+  probeTypesScript,
+} = require('../common/debugger-probe');
 
 const location = `${probeTypesScript}:17`;
 
@@ -37,7 +39,7 @@ spawnSyncAndAssert(process.execPath, [
   probeTypesScript,
 ], {
   stdout(output) {
-    assert.strictEqual(output, [
+    assertProbeText(output, [
       `Hit 1 at ${location}`,
       '  stringValue = "hello"',
       `Hit 1 at ${location}`,

--- a/test/parallel/test-debugger-probe-text.js
+++ b/test/parallel/test-debugger-probe-text.js
@@ -4,9 +4,8 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndAssert } = require('../common/child_process');
-const { probeScript } = require('../common/debugger-probe');
+const { assertProbeText, probeScript } = require('../common/debugger-probe');
 
 spawnSyncAndAssert(process.execPath, [
   'inspect',
@@ -15,10 +14,10 @@ spawnSyncAndAssert(process.execPath, [
   probeScript,
 ], {
   stdout(output) {
-    assert.strictEqual(output,
-                       `Hit 1 at ${probeScript}:12\n` +
-                       '  finalValue = 81\n' +
-                       'Completed');
+    assertProbeText(output,
+                    `Hit 1 at ${probeScript}:12\n` +
+                    '  finalValue = 81\n' +
+                    'Completed');
   },
   trim: true,
 });

--- a/test/parallel/test-debugger-probe-timeout.js
+++ b/test/parallel/test-debugger-probe-timeout.js
@@ -4,9 +4,8 @@
 const common = require('../common');
 common.skipIfInspectorDisabled();
 
-const assert = require('assert');
 const { spawnSyncAndExit } = require('../common/child_process');
-const { timeoutScript } = require('../common/debugger-probe');
+const { assertProbeJson, timeoutScript } = require('../common/debugger-probe');
 
 spawnSyncAndExit(process.execPath, [
   'inspect',
@@ -19,7 +18,7 @@ spawnSyncAndExit(process.execPath, [
   signal: null,
   status: 1,
   stdout(output) {
-    assert.deepStrictEqual(JSON.parse(output), {
+    assertProbeJson(output, {
       v: 1,
       probes: [{ expr: '1', target: [timeoutScript, 99] }],
       results: [{


### PR DESCRIPTION
This works around a pre-existing inspector issue: if the debuggee exits too quickly the inspector can segfault while tearing down. For now normalize the trailing segfault as completion to keep the CI green until the upstream bug is fixed, since it only reproduces on some slow CI machines and is not what the probe tests care about.

Refs: https://github.com/nodejs/node/issues/62765
Refs: https://github.com/nodejs/node/issues/58245
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
