### PR TITLE
inspector: fix dead 'For help' URL printed by --inspect

### DIFF
--- a/src/inspector_socket_server.cc
+++ b/src/inspector_socket_server.cc
@@ -248,7 +248,7 @@ void PrintDebuggerReadyMessage(
     }
   }
   fprintf(out, "For help, see: %s\n",
-          "https://nodejs.org/en/docs/inspector");
+          "https://nodejs.org/en/learn/getting-started/debugging");
   fflush(out);
 }
 


### PR DESCRIPTION
## Summary

When `node --inspect` starts, it prints:

```
For help, see: https://nodejs.org/en/docs/inspector
```

That URL 404s on nodejs.org — the `en/docs/inspector` page no longer exists. The closest user-facing debugging help page is `https://nodejs.org/en/learn/getting-started/debugging`, which walks through connecting DevTools / IDEs to the inspector. This patch points the `--inspect` help message there.

Refs: #62743

## Testing

Single-line string change in `src/inspector_socket_server.cc`. Verified:
- the replacement URL (`https://nodejs.org/en/learn/getting-started/debugging`) currently resolves to the *Debugging Node.js* guide;
- no other callers reference `nodejs.org/en/docs/inspector`.

## Notes

The alternative URL suggested in the issue (`https://nodejs.org/api/inspector.html`) is the API reference for the `inspector` module, not a user-facing help page for `--inspect`. Happy to switch if maintainers prefer that target.