### PR TITLE
src: simplify and fix FFI ArrayBuffer accesses

### DIFF
--- a/src/ffi/data.cc
+++ b/src/ffi/data.cc
@@ -25,6 +25,7 @@ using v8::MaybeLocal;
 using v8::NewStringType;
 using v8::Number;
 using v8::Object;
+using v8::SharedArrayBuffer;
 using v8::String;
 using v8::Value;
 

--- a/src/ffi/data.cc
+++ b/src/ffi/data.cc
@@ -675,26 +675,17 @@ void ExportBytes(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  const uint8_t* source_data = nullptr;
-  size_t source_len = 0;
+  // This needs to be kept alive until the data
+  // is actually copied.
+  ArrayBufferViewContents<uint8_t> view;
 
-  if (args[0]->IsArrayBuffer()) {
-    Local<ArrayBuffer> array_buffer = args[0].As<ArrayBuffer>();
-    std::shared_ptr<BackingStore> store = array_buffer->GetBackingStore();
-    if (!store) {
-      THROW_ERR_INVALID_ARG_VALUE(env, "Invalid ArrayBuffer backing store");
-      return;
-    }
-    source_data = static_cast<const uint8_t*>(store->Data());
-    source_len = array_buffer->ByteLength();
-  } else if (args[0]->IsArrayBufferView()) {
-    ArrayBufferViewContents<uint8_t> view(args[0]);
+  if (args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer() ||
+      args[0]->IsArrayBufferView()) {
+    view.ReadValue(args[0]);
     if (view.WasDetached()) {
       THROW_ERR_INVALID_ARG_VALUE(env, "Invalid ArrayBufferView backing store");
       return;
     }
-    source_data = view.data();
-    source_len = view.length();
   } else {
     THROW_ERR_INVALID_ARG_TYPE(
         env,
@@ -713,12 +704,12 @@ void ExportBytes(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  if (len < source_len) {
+  if (len < view.length()) {
     THROW_ERR_OUT_OF_RANGE(env, "The length must be >= source byte length");
     return;
   }
 
-  if (ptr == 0 && source_len > 0) {
+  if (ptr == 0 && view.length() > 0) {
     THROW_ERR_FFI_INVALID_POINTER(env,
                                   "Cannot create a buffer from a null pointer");
     return;
@@ -733,9 +724,7 @@ void ExportBytes(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  if (source_len > 0) {
-    std::memcpy(reinterpret_cast<void*>(ptr), source_data, source_len);
-  }
+  std::memcpy(reinterpret_cast<void*>(ptr), view.data(), view.length());
 }
 
 void GetRawPointer(const FunctionCallbackInfo<Value>& args) {
@@ -752,28 +741,34 @@ void GetRawPointer(const FunctionCallbackInfo<Value>& args) {
   }
 
   uintptr_t ptr = 0;
+  size_t offset = 0;
+  std::shared_ptr<BackingStore> store;
 
   if (args[0]->IsArrayBuffer()) {
-    Local<ArrayBuffer> array_buffer = args[0].As<ArrayBuffer>();
-    std::shared_ptr<BackingStore> store = array_buffer->GetBackingStore();
-    if (!store) {
-      THROW_ERR_INVALID_ARG_VALUE(env, "Invalid ArrayBuffer backing store");
-      return;
-    }
-    ptr = reinterpret_cast<uintptr_t>(store->Data());
+    store = args[0].As<ArrayBuffer>()->GetBackingStore();
+  } else if (args[0]->IsSharedArrayBuffer()) {
+    store = args[0].As<SharedArrayBuffer>()->GetBackingStore();
   } else if (args[0]->IsArrayBufferView()) {
-    ArrayBufferViewContents<uint8_t> view(args[0]);
-    if (view.WasDetached()) {
-      THROW_ERR_INVALID_ARG_VALUE(env, "Invalid ArrayBufferView backing store");
-      return;
-    }
-    ptr = reinterpret_cast<uintptr_t>(view.data());
+    // Access the store here to ensure that it exists. Small typed arrays
+    // may not have a store until this point and can instead be stored
+    // entirely in-heap.
+    store = args[0].As<ArrayBufferView>()->Buffer()->GetBackingStore();
+    offset = args[0].As<ArrayBufferView>()->ByteOffset();
   } else {
-    THROW_ERR_INVALID_ARG_TYPE(
-        env,
-        "The first argument must be a Buffer, ArrayBuffer, or ArrayBufferView");
+    THROW_ERR_INVALID_ARG_TYPE(env,
+                               "The first argument must be a Buffer, "
+                               "ArrayBuffer, or ArrayBufferView");
     return;
   }
+
+  // WARNING: There is no inherent guarantee that the pointer returned
+  // from this function will be valid beyond the lifetime of the BackingStore
+  // instance!
+  if (!store) {
+    THROW_ERR_INVALID_ARG_VALUE(env, "Invalid ArrayBuffer backing store");
+    return;
+  }
+  ptr = reinterpret_cast<uintptr_t>(store->Data()) + offset;
 
   args.GetReturnValue().Set(
       BigInt::NewFromUnsigned(isolate, static_cast<uint64_t>(ptr)));


### PR DESCRIPTION
`ArrayBufferViewContents` supports `ArrayBuffer`s, so we do not need to provide special treatment for those.

Also, small typed arrays may not have backing stores until their corresponding `ArrayBuffer`s are accessed, so do that in order to avoid accidentally accessing arbitrary stack memory.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
