### PR TITLE
quic: disable building ngtcp2 examples

### DIFF
--- a/node.gypi
+++ b/node.gypi
@@ -469,9 +469,10 @@
             './deps/ngtcp2/ngtcp2.gyp:ngtcp2',
             './deps/ngtcp2/ngtcp2.gyp:nghttp3',
 
-            # For tests
-            './deps/ngtcp2/ngtcp2.gyp:ngtcp2_test_server',
-            './deps/ngtcp2/ngtcp2.gyp:ngtcp2_test_client',
+            # Example implementations used in test suite
+            # TODO(@nodejs/quic): re-enable once builds support c++-23 headers
+            #'./deps/ngtcp2/ngtcp2.gyp:ngtcp2_test_server',
+            #'./deps/ngtcp2/ngtcp2.gyp:ngtcp2_test_client',
           ],
         }],
       ],

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -22,6 +22,10 @@ test-snapshot-incompatible: SKIP
 # https://github.com/nodejs/node/issues/53579
 test-snapshot-reproducible: SKIP
 
+# ngtcp2's example implementations cannot be built without c++-23 headers.
+test-quic-test-client: SKIP
+test-quic-test-server: SKIP
+
 [$system==win32]
 # https://github.com/nodejs/node/issues/59090
 test-inspector-network-fetch: PASS, FLAKY


### PR DESCRIPTION
The ngtcp2 client and server examples are built with the intention of using them as reference implementations for future quic tests. However, as of ngtcp2 1.22.0, these examples are using c++-23 libraries, which doesn't match the current Node.js build requirements.

These reference implementations aren't used in any actual quic tests yet, so the path of least resistance is to disable these for now.

Refs: #59946
Refs: https://github.com/nodejs/node/pull/62595#issuecomment-4215124342