### PR TITLE
meta: add automation policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,7 @@ works.
 * [Code of Conduct](#code-of-conduct)
 * [Issues](#issues)
 * [Pull Requests](#pull-requests)
+* [Automation and bots](#automation-and-bots)
 * [Developer's Certificate of Origin 1.1](#developers-certificate-of-origin-11)
 
 ## [Code of Conduct](./doc/contributing/code-of-conduct.md)
@@ -46,6 +47,18 @@ dependencies, and tools contained in the `nodejs/node` repository.
 * [The Process of Making Changes](./doc/contributing/pull-requests.md#the-process-of-making-changes)
 * [Reviewing Pull Requests](./doc/contributing/pull-requests.md#reviewing-pull-requests)
 * [Notes](./doc/contributing/pull-requests.md#notes)
+
+## Automation and bots
+
+An automation tool or bot that is not managed by the Node.js project
+must seek explicit authorization by opening an issue with their owner
+in [nodejs/admin](https://github.com/nodejs/admin) before interacting
+with the project.
+
+Interactions (including Issues, Comments, Pull Requests and Reviews) made
+by an automation that was not authorized by Node.js collaborators are
+subject to immediate moderation enforcement on the automation and owner
+without notice.
 
 ## Developer's Certificate of Origin 1.1
 


### PR DESCRIPTION
Add an automation policy indicating that non-Node.js managed automation must seek approval or subject to immediate moderation.

Collaborators may use automation tools under their own names -- subject to CoC.