### PR TITLE
http: fix leaked error listener on sync HTTP req create + destroy

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -957,7 +957,8 @@ changes:
 
 Destroy the request. Optionally emit an `'error'` event,
 and emit a `'close'` event. Calling this will cause remaining data
-in the response to be dropped and the socket to be destroyed.
+in the response to be dropped, and the socket to be destroyed if used,
+or returned to the corresponding Agent pool otherwise if possible.
 
 See [`writable.destroy()`][] for further details.
 

--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -999,6 +999,7 @@ function onSocketNT(req, socket, err) {
     if (socket) {
       if (!err && req.agent && !socket.destroyed) {
         socket.emit('free');
+        socket.removeListener('error', socketErrorListener);
       } else {
         finished(socket.destroy(err || req[kError]), (er) => {
           if (er?.code === 'ERR_STREAM_PREMATURE_CLOSE') {

--- a/test/parallel/test-http-client-request-listeners-leak.js
+++ b/test/parallel/test-http-client-request-listeners-leak.js
@@ -1,0 +1,38 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const { defaultMaxListeners } = require('events');
+
+// Immediately destroying an HTTP request must not leak listeners on the
+// freed socket. When sockets are reused via a keep-alive agent leaked
+// listeners would accumulate to trigger a MaxListenersExceededWarning.
+
+// Check we don't get a MaxListenersExceededWarning:
+process.on('warning', common.mustNotCall('Unexpected warning emitted'));
+
+const server = http.createServer(common.mustNotCall());
+
+server.listen(0, common.mustCall(() => {
+  const agent = new http.Agent({ keepAlive: true });
+  const port = server.address().port;
+
+  function executeHttpGet() {
+    return new Promise((resolve) => {
+      const req = http.get({ host: '127.0.0.1', port, agent });
+      req.on('error', resolve);
+      req.on('close', resolve);
+      req.on('response', common.mustNotCall());
+      req.destroy();
+    });
+  }
+
+  async function main() {
+    for (let i = 0; i < defaultMaxListeners + 1; i++) {
+      await executeHttpGet();
+    }
+    server.close();
+    agent.destroy();
+  }
+
+  main();
+}));

--- a/test/parallel/test-http-client-request-listeners-leak.js
+++ b/test/parallel/test-http-client-request-listeners-leak.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const assert = require('assert');
 const http = require('http');
 const { defaultMaxListeners } = require('events');
 
@@ -16,6 +17,14 @@ server.listen(0, common.mustCall(() => {
   const agent = new http.Agent({ keepAlive: true });
   const port = server.address().port;
 
+  // Count actual socket creations to confirm reuse:
+  let createSocketCount = 0;
+  const origCreateSocket = agent.createSocket.bind(agent);
+  agent.createSocket = function(...args) {
+    createSocketCount++;
+    return origCreateSocket(...args);
+  };
+
   function executeHttpGet() {
     return new Promise((resolve) => {
       const req = http.get({ host: '127.0.0.1', port, agent });
@@ -30,9 +39,12 @@ server.listen(0, common.mustCall(() => {
     for (let i = 0; i < defaultMaxListeners + 1; i++) {
       await executeHttpGet();
     }
+
+    assert.strictEqual(createSocketCount, 1);
+
     server.close();
     agent.destroy();
   }
 
-  main();
+  main().then(common.mustCall());
 }));


### PR DESCRIPTION
If you create a request and them immediately destroy it, a socket is created and then freed back to its agent (if there is one) next tick in `onSocketNT`, when we discover that the request is already gone before the socket is hooked up.

In that past that was fine, but in #61770 error handler setup was made synchronous, rather than waiting for next tick, to handle sync errors during request creation. Error handlers are cleaned up correctly if sockets are normally reused with agents, but not in the specific reuse-at-first-tick flow, because until now it wasn't required.

This change adds cleanup for that specific case. This doesn't leave any gap in error handler coverage - on `'free'` the agent either synchronously adds its own error handler [here](https://github.com/nodejs/node/blob/a6e83689258efaef28ee4ff1a4a71d1c78a75f22/lib/_http_agent.js#L199) or it assigns the socket to a request (going back to step one: setting up a new request error handler synchronously then initializing in `onSocketNT`) and we drop the leftover error handler immediately after that returns.

This PR also updates the docs to clarify when req.destroy() destroys the underlying socket: after onSocketNT, at which point we've hooked up the socket and may have started reading & writing for real. This matches existing behaviour going back many years, there's no recent change here and I think the behaviour is sane & expected, just making it explicit.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
