### PR TITLE
crypto: reject inherited key type names

### DIFF
--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -3,7 +3,6 @@
 const {
   FunctionPrototypeCall,
   ObjectDefineProperty,
-  ObjectPrototypeHasOwnProperty,
   SafeArrayIterator,
 } = primordials;
 
@@ -182,6 +181,7 @@ function parseKeyEncoding(keyType, options = kEmptyObject) {
 }
 
 const nidOnlyKeyPairs = {
+  __proto__: null,
   'ed25519': EVP_PKEY_ED25519,
   'ed448': EVP_PKEY_ED448,
   'x25519': EVP_PKEY_X25519,
@@ -357,7 +357,7 @@ function createJob(mode, type, options) {
         ...encoding);
     }
     default: {
-      if (!ObjectPrototypeHasOwnProperty(nidOnlyKeyPairs, type)) {
+      if (nidOnlyKeyPairs[type] === undefined) {
         throw new ERR_INVALID_ARG_VALUE('type', type, 'must be a supported key type');
       }
       return new NidKeyPairGenJob(mode, nidOnlyKeyPairs[type], ...encoding);

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -3,6 +3,7 @@
 const {
   FunctionPrototypeCall,
   ObjectDefineProperty,
+  ObjectPrototypeHasOwnProperty,
   SafeArrayIterator,
 } = primordials;
 
@@ -356,7 +357,7 @@ function createJob(mode, type, options) {
         ...encoding);
     }
     default: {
-      if (nidOnlyKeyPairs[type] === undefined) {
+      if (!ObjectPrototypeHasOwnProperty(nidOnlyKeyPairs, type)) {
         throw new ERR_INVALID_ARG_VALUE('type', type, 'must be a supported key type');
       }
       return new NidKeyPairGenJob(mode, nidOnlyKeyPairs[type], ...encoding);

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -181,7 +181,7 @@ function parseKeyEncoding(keyType, options = kEmptyObject) {
 }
 
 const nidOnlyKeyPairs = {
-  __proto__: null,
+  '__proto__': null,
   'ed25519': EVP_PKEY_ED25519,
   'ed448': EVP_PKEY_ED448,
   'x25519': EVP_PKEY_X25519,

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -55,6 +55,20 @@ const { hasOpenSSL3 } = require('../common/crypto');
     code: 'ERR_INVALID_ARG_VALUE',
     message: "The argument 'type' must be a supported key type. Received 'rsa2'"
   });
+
+  for (const type of ['toString', 'constructor']) {
+    assert.throws(() => generateKeyPairSync(type, {}), {
+      name: 'TypeError',
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: `The argument 'type' must be a supported key type. Received '${type}'`
+    });
+
+    assert.throws(() => generateKeyPair(type, {}, common.mustNotCall()), {
+      name: 'TypeError',
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: `The argument 'type' must be a supported key type. Received '${type}'`
+    });
+  }
 }
 
 {


### PR DESCRIPTION
Use an own-property check when dispatching generateKeyPair's NID-only algorithm table

Fixes: https://github.com/nodejs/node/issues/62874

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
