### PR TITLE
lib: harden kKeyOps lookup with null prototype

### DIFF
--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -764,6 +764,7 @@ function getDigestSizeInBytes(name) {
 }
 
 const kKeyOps = {
+  __proto__: null,
   sign: 1,
   verify: 2,
   encrypt: 3,

--- a/test/parallel/test-webcrypto-util.js
+++ b/test/parallel/test-webcrypto-util.js
@@ -9,6 +9,7 @@ const assert = require('assert');
 
 const {
   normalizeAlgorithm,
+  validateKeyOps,
 } = require('internal/crypto/util');
 
 {
@@ -48,4 +49,13 @@ const {
   const normalized = normalizeAlgorithm(algorithm, 'sign');
   assert.strictEqual(normalized.name, 'ECDSA');
   assert.strictEqual(nameReadCount, 1);
+}
+
+{
+  for (const ops of [
+    ['sign', 'toString', 'constructor'],
+    ['sign', '__proto__', 'constructor'],
+  ]) {
+    validateKeyOps(ops);
+  }
 }


### PR DESCRIPTION
`validateKeyOps(['sign', 'toString', 'constructor'])` was throwing DataError before when it should instead ignore unrecognized values.