### PR TITLE
test_runner: add [Symbol.dispose] to mock Timeout class

### DIFF
--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -92,6 +92,10 @@ class Timeout {
   refresh() {
     return this;
   }
+
+  [SymbolDispose]() {
+    globalThis.clearTimeout(this);
+  }
 }
 
 class MockTimers {


### PR DESCRIPTION
## Summary

Fixes #62815

The `Timeout` object returned by `MockTimers` was missing `[Symbol.dispose]`, which means code using the `using` keyword with `setTimeout` would throw when mock timers are active.

## Fix

Added `[Symbol.dispose]()` to the `Timeout` class in `mock_timers.js`. It calls `globalThis.clearTimeout(this)`, which — when mocks are active — routes to the mock's own `#clearTimeout`, matching real `Timeout` behavior.

## Test

```js
// Should not throw
const t = mock.timers.enable({ apis: ['setTimeout'] });
{
  using timer = setTimeout(() => {}, 1000);
} // [Symbol.dispose] called here
```
