### PR TITLE
deps: V8: cherry-pick d7b5bc223b8d

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.17',
+    'v8_embedder_string': '-node.19',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/builtins/riscv/builtins-riscv.cc
+++ b/deps/v8/src/builtins/riscv/builtins-riscv.cc
@@ -3188,7 +3188,10 @@ static void SaveVectorRegisters(MacroAssembler* masm,
   // Check if the machine has simd128 support. Otherwise, the
   // vector registers might not exist and accessing them would SIGILL.
   Label done;
+
+  ASM_CODE_COMMENT(masm);
   __ li(kScratchReg, ExternalReference::supports_wasm_simd_128_address());
+  __ Lb(kScratchReg, MemOperand(kScratchReg, 0));
   // If != 0, then simd is available.
   __ Branch(&done, eq, kScratchReg, Operand(zero_reg), Label::Distance::kNear);
 
@@ -3210,7 +3213,9 @@ static void RestoreVectorRegisters(MacroAssembler* masm,
   // Check if the machine has simd128 support. Otherwise, the
   // vector registers might not exist and accessing them would SIGILL.
   Label done;
+  ASM_CODE_COMMENT(masm);
   __ li(kScratchReg, ExternalReference::supports_wasm_simd_128_address());
+  __ Lb(kScratchReg, MemOperand(kScratchReg, 0));
   // If != 0, then simd is available.
   __ Branch(&done, eq, kScratchReg, Operand(zero_reg), Label::Distance::kNear);
 


### PR DESCRIPTION
[deps: V8: cherry-pick d7b5bc223b8d](https://github.com/nodejs/node/pull/62880/changes/112d0e34e6364e0c369502ce06b1221f07af95a9)
Original commit message:

    [riscv] Fix incorrect check supports_wasm_simd_128

    Change-Id: I3ee389a3036fddc6807cef18abea553d3861ad07
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7087478
    Commit-Queue: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
    Reviewed-by: Florian Loitsch <floitsch@rivosinc.com>
    Reviewed-by: Kasper Lund <kasperl@rivosinc.com>
    Auto-Submit: Yahan Lu (LuYahan) <yahan@iscas.ac.cn>
    Cr-Commit-Position: refs/heads/main@{#103365}

Refs: https://github.com/v8/v8/commit/d7b5bc223b8d3b1944d4ab61402ef0285d689c38