### PR TITLE
deps: cherry-pick libuv/libuv@439a54b

### DIFF
--- a/deps/uv/src/unix/fs.c
+++ b/deps/uv/src/unix/fs.c
@@ -1322,10 +1322,7 @@ static ssize_t uv__fs_copyfile(uv_fs_t* req) {
   times[1] = src_statsbuf.st_mtim;
 #endif
 
-  if (futimens(dstfd, times) == -1) {
-    err = UV__ERR(errno);
-    goto out;
-  }
+  (void) futimens(dstfd, times);
 
   /*
    * Change the ownership and permissions of the destination file to match the


### PR DESCRIPTION
Cherry-pick libuv/libuv@439a54b to fix `uv_fs_copyfile()` failing with `EPERM` on CIFS/SMB mounts. Timestamp preservation is now best-effort, matching the existing treatment of `fchown()` in the same function. I'm also the author of the libuv fix.

This is a regression introduced by the libuv 1.49.0 update (Node.js 22.12.0 via #55114), which added timestamp preservation to `uv_fs_copyfile()`. Since then, `fs.copyFile()` / `fs.copyFileSync()` have failed with `EPERM` on CIFS/SMB mounts on Linux.

The buggy block is the same on `v22.x-staging` and `v24.x-staging` (both on libuv 1.51.0), so `lts-watch-v22.x` and `lts-watch-v24.x` are good candidates once this matures.

Fixes: https://github.com/nodejs/node/issues/56248
Refs: https://github.com/libuv/libuv/pull/5053
Refs: https://github.com/libuv/libuv/pull/4396