### PR TITLE
repl: fix dedup comparing normalized line against raw history

### DIFF
--- a/lib/internal/repl/history.js
+++ b/lib/internal/repl/history.js
@@ -142,7 +142,7 @@ class ReplHistory {
     if (this[kHistory].length === 0 || this[kHistory][0] !== normalizedLine) {
       if (this[kRemoveHistoryDuplicates]) {
         // Remove older history line if identical to new one
-        const dupIndex = ArrayPrototypeIndexOf(this[kHistory], line);
+        const dupIndex = ArrayPrototypeIndexOf(this[kHistory], normalizedLine);
         if (dupIndex !== -1) ArrayPrototypeSplice(this[kHistory], dupIndex, 1);
       }
 

--- a/test/parallel/test-repl-history-dedup-multiline.js
+++ b/test/parallel/test-repl-history-dedup-multiline.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const common = require('../common');
+
+if (process.env.TERM === 'dumb') {
+  common.skip('skipping - dumb terminal');
+}
+
+const assert = require('assert');
+const readline = require('readline');
+const { EventEmitter } = require('events');
+
+class FakeInput extends EventEmitter {
+  resume() {}
+  pause() {}
+  write() {}
+  end() {}
+}
+FakeInput.prototype.readable = true;
+
+{
+  const fi = new FakeInput();
+  const rli = new readline.Interface({
+    input: fi,
+    output: fi,
+    terminal: true,
+    removeHistoryDuplicates: true,
+  });
+
+  function submitLine(line) {
+    rli.line = line;
+    fi.emit('keypress', '', { name: 'enter' });
+  }
+
+  submitLine('line1\nline2');
+  submitLine('other');
+  submitLine('line1\nline2');
+
+  assert.strictEqual(rli.history.length, 2);
+  assert.strictEqual(rli.history[0], 'line2\rline1');
+  assert.strictEqual(rli.history[1], 'other');
+
+  rli.close();
+}


### PR DESCRIPTION
This ensures consistency in how the REPL history handles duplicate entries.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
