### PR TITLE
build: track PDL files as inputs in inspector GN build

### DIFF
--- a/src/inspector/unofficial.gni
+++ b/src/inspector/unofficial.gni
@@ -29,7 +29,7 @@ template("inspector_gn_build") {
     deps = [ ":node_protocol_json" ]
 
     outputs = gypi_values.node_inspector_generated_sources
-    inputs = gypi_values.node_protocol_files + [
+    inputs = gypi_values.node_protocol_files + gypi_values.node_pdl_files + [
       "node_protocol_config.json",
       "$node_gen_dir/src/node_protocol.json",
     ]


### PR DESCRIPTION
The `node_protocol_generated_sources` action was missing `gypi_values.node_pdl_files` from its inputs, causing Ninja to skip regeneration when PDL domain files changed.

Refs https://github.com/electron/electron/pull/51239