### PR TITLE
ffi: fix FLOAT_32 and FLOAT_64 type constants

### DIFF
--- a/src/ffi/types.cc
+++ b/src/ffi/types.cc
@@ -246,9 +246,11 @@ v8::Maybe<ffi_type*> ToFFIType(Environment* env, std::string_view type_str) {
     return Just(&ffi_type_sint64);
   } else if (type_str == "u64" || type_str == "uint64") {
     return Just(&ffi_type_uint64);
-  } else if (type_str == "f32" || type_str == "float") {
+  } else if (type_str == "f32" || type_str == "float" ||
+             type_str == "float32") {
     return Just(&ffi_type_float);
-  } else if (type_str == "f64" || type_str == "double") {
+  } else if (type_str == "f64" || type_str == "double" ||
+             type_str == "float64") {
     return Just(&ffi_type_double);
   } else if (type_str == "buffer" || type_str == "arraybuffer" ||
              type_str == "string" || type_str == "str" ||


### PR DESCRIPTION
Test code
```bash
$ cat test.js
const ffi = require('node:ffi');

const { functions } = ffi.dlopen('libm.so.6', {
  sinf: { parameters: [ffi.types.FLOAT_32], result: ffi.types.FLOAT_32 },
});

console.log(functions.sinf(1.0));
```

Before
```bash
$ ./node --experimental-ffi test.js
node:ffi:75
    throw error;
    ^

TypeError: Unsupported FFI type: float32
    at Object.dlopen (node:ffi:71:91)
    at Object.<anonymous> (/home/moku/Developments/watilde/node/test.js:3:27)
    at Module._compile (node:internal/modules/cjs/loader:1829:14)
    at Object..js (node:internal/modules/cjs/loader:1969:10)
    at Module.load (node:internal/modules/cjs/loader:1552:32)
    at Module._load (node:internal/modules/cjs/loader:1354:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  code: 'ERR_INVALID_ARG_VALUE'
}

Node.js v26.0.0-pre
```

After
```bash
$ ./node --experimental-ffi test.js
0.8414709568023682
(node:721215) ExperimentalWarning: FFI is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
