### PR TITLE
http: make req.headers have a null prototype

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2863,6 +2863,9 @@ The request/response headers object.
 
 Key-value pairs of header names and values. Header names are lower-cased.
 
+The object has a null prototype and should not be accessed using the `in`
+operator.
+
 ```js
 // Prints something like:
 //
@@ -2899,6 +2902,9 @@ added:
 
 Similar to [`message.headers`][], but there is no join logic and the values are
 always arrays of strings, even for headers received just once.
+
+The object has a null prototype and should not be accessed using the `in`
+operator.
 
 ```js
 // Prints something like:
@@ -3086,6 +3092,9 @@ added: v0.3.0
 
 The request/response trailers object. Only populated at the `'end'` event.
 
+The object has a null prototype and should not be accessed using the `in`
+operator.
+
 ### `message.trailersDistinct`
 
 <!-- YAML
@@ -3099,6 +3108,9 @@ added:
 Similar to [`message.trailers`][], but there is no join logic and the values are
 always arrays of strings, even for headers received just once.
 Only populated at the `'end'` event.
+
+The object has a null prototype and should not be accessed using the `in`
+operator.
 
 ### `message.url`
 

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -4120,6 +4120,9 @@ The request/response headers object.
 
 Key-value pairs of header names and values. Header names are lower-cased.
 
+The object has a null prototype and should not be accessed using the `in`
+operator.
+
 ```js
 // Prints something like:
 //
@@ -4278,6 +4281,9 @@ added: v8.4.0
 * Type: {Object}
 
 The request/response trailers object. Only populated at the `'end'` event.
+
+The object has a null prototype and should not be accessed using the `in`
+operator.
 
 #### `request.url`
 

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -112,7 +112,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'headers', {
   __proto__: null,
   get: function() {
     if (!this[kHeaders]) {
-      this[kHeaders] = {};
+      this[kHeaders] = { __proto__: null };
 
       const src = this.rawHeaders;
       const dst = this[kHeaders];
@@ -152,7 +152,7 @@ ObjectDefineProperty(IncomingMessage.prototype, 'trailers', {
   __proto__: null,
   get: function() {
     if (!this[kTrailers]) {
-      this[kTrailers] = {};
+      this[kTrailers] = { __proto__: null };
 
       const src = this.rawTrailers;
       const dst = this[kTrailers];

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -319,7 +319,7 @@ class Http2ServerRequest extends Readable {
     // initialization using Object.create(null) in HTTP/2 is intentional.
     this[kHeaders] = headers;
     this[kRawHeaders] = rawHeaders;
-    this[kTrailers] = {};
+    this[kTrailers] = { __proto__: null };
     this[kRawTrailers] = [];
     this[kStream] = stream;
     this[kAborted] = false;

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -29,10 +29,9 @@ const server = http.createServer(common.mustCall((req, res) => {
   assert.strictEqual(req.method, 'GET');
   assert.strictEqual(req.url, '/blah');
   assert.deepStrictEqual(req.headers, { __proto__: null,
-    host: 'example.org:443',
-    origin: 'http://example.org',
-    cookie: ''
-  });
+                                        host: 'example.org:443',
+                                        origin: 'http://example.org',
+                                        cookie: '' });
 }));
 
 

--- a/test/parallel/test-http-blank-header.js
+++ b/test/parallel/test-http-blank-header.js
@@ -28,7 +28,7 @@ const net = require('net');
 const server = http.createServer(common.mustCall((req, res) => {
   assert.strictEqual(req.method, 'GET');
   assert.strictEqual(req.url, '/blah');
-  assert.deepStrictEqual(req.headers, {
+  assert.deepStrictEqual(req.headers, { __proto__: null,
     host: 'example.org:443',
     origin: 'http://example.org',
     cookie: ''

--- a/test/parallel/test-http-client-headers-array.js
+++ b/test/parallel/test-http-client-headers-array.js
@@ -7,12 +7,11 @@ const http = require('http');
 
 function execute(options) {
   http.createServer(common.mustCall(function(req, res) {
-    const expectHeaders = { __proto__: null,
-      'x-foo': 'boom',
-      'cookie': 'a=1; b=2; c=3',
-      'connection': 'keep-alive',
-      'host': 'example.com',
-    };
+    const expectHeaders = { '__proto__': null,
+                            'x-foo': 'boom',
+                            'cookie': 'a=1; b=2; c=3',
+                            'connection': 'keep-alive',
+                            'host': 'example.com' };
 
     // no Host header when you set headers an array
     if (!Array.isArray(options.headers)) {

--- a/test/parallel/test-http-client-headers-array.js
+++ b/test/parallel/test-http-client-headers-array.js
@@ -7,7 +7,7 @@ const http = require('http');
 
 function execute(options) {
   http.createServer(common.mustCall(function(req, res) {
-    const expectHeaders = {
+    const expectHeaders = { __proto__: null,
       'x-foo': 'boom',
       'cookie': 'a=1; b=2; c=3',
       'connection': 'keep-alive',

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -4,20 +4,17 @@ const assert = require('assert');
 const http = require('http');
 const Countdown = require('../common/countdown');
 
-const expectedHeadersMultipleWrites = { __proto__: null,
-  'connection': 'keep-alive',
-  'transfer-encoding': 'chunked',
-};
+const expectedHeadersMultipleWrites = { '__proto__': null,
+                                        'connection': 'keep-alive',
+                                        'transfer-encoding': 'chunked' };
 
-const expectedHeadersEndWithData = { __proto__: null,
-  'connection': 'keep-alive',
-  'content-length': String('hello world'.length),
-};
+const expectedHeadersEndWithData = { '__proto__': null,
+                                     'connection': 'keep-alive',
+                                     'content-length': String('hello world'.length) };
 
-const expectedHeadersEndNoData = { __proto__: null,
-  'connection': 'keep-alive',
-  'content-length': '0',
-};
+const expectedHeadersEndNoData = { '__proto__': null,
+                                   'connection': 'keep-alive',
+                                   'content-length': '0' };
 
 
 const countdown = new Countdown(3, () => server.close());
@@ -62,7 +59,9 @@ server.listen(0, common.mustCall(function() {
   req.write('hello ');
   req.end('world');
   req.on('response', common.mustCall((res) => {
-    assert.deepStrictEqual(res.headers, { __proto__: null, ...expectedHeadersMultipleWrites, 'keep-alive': 'timeout=1' });
+    assert.deepStrictEqual(res.headers, {
+      '__proto__': null, ...expectedHeadersMultipleWrites, 'keep-alive': 'timeout=1',
+    });
     res.resume();
   }));
 
@@ -74,7 +73,9 @@ server.listen(0, common.mustCall(function() {
   req.removeHeader('Date');
   req.end('hello world');
   req.on('response', common.mustCall((res) => {
-    assert.deepStrictEqual(res.headers, { __proto__: null, ...expectedHeadersEndWithData, 'keep-alive': 'timeout=1' });
+    assert.deepStrictEqual(res.headers, {
+      '__proto__': null, ...expectedHeadersEndWithData, 'keep-alive': 'timeout=1',
+    });
     res.resume();
   }));
 
@@ -86,7 +87,7 @@ server.listen(0, common.mustCall(function() {
   req.removeHeader('Date');
   req.end();
   req.on('response', common.mustCall((res) => {
-    assert.deepStrictEqual(res.headers, { __proto__: null, ...expectedHeadersEndNoData, 'keep-alive': 'timeout=1' });
+    assert.deepStrictEqual(res.headers, { '__proto__': null, ...expectedHeadersEndNoData, 'keep-alive': 'timeout=1' });
     res.resume();
   }));
 

--- a/test/parallel/test-http-content-length.js
+++ b/test/parallel/test-http-content-length.js
@@ -4,17 +4,17 @@ const assert = require('assert');
 const http = require('http');
 const Countdown = require('../common/countdown');
 
-const expectedHeadersMultipleWrites = {
+const expectedHeadersMultipleWrites = { __proto__: null,
   'connection': 'keep-alive',
   'transfer-encoding': 'chunked',
 };
 
-const expectedHeadersEndWithData = {
+const expectedHeadersEndWithData = { __proto__: null,
   'connection': 'keep-alive',
   'content-length': String('hello world'.length),
 };
 
-const expectedHeadersEndNoData = {
+const expectedHeadersEndNoData = { __proto__: null,
   'connection': 'keep-alive',
   'content-length': '0',
 };
@@ -62,7 +62,7 @@ server.listen(0, common.mustCall(function() {
   req.write('hello ');
   req.end('world');
   req.on('response', common.mustCall((res) => {
-    assert.deepStrictEqual(res.headers, { ...expectedHeadersMultipleWrites, 'keep-alive': 'timeout=1' });
+    assert.deepStrictEqual(res.headers, { __proto__: null, ...expectedHeadersMultipleWrites, 'keep-alive': 'timeout=1' });
     res.resume();
   }));
 
@@ -74,7 +74,7 @@ server.listen(0, common.mustCall(function() {
   req.removeHeader('Date');
   req.end('hello world');
   req.on('response', common.mustCall((res) => {
-    assert.deepStrictEqual(res.headers, { ...expectedHeadersEndWithData, 'keep-alive': 'timeout=1' });
+    assert.deepStrictEqual(res.headers, { __proto__: null, ...expectedHeadersEndWithData, 'keep-alive': 'timeout=1' });
     res.resume();
   }));
 
@@ -86,7 +86,7 @@ server.listen(0, common.mustCall(function() {
   req.removeHeader('Date');
   req.end();
   req.on('response', common.mustCall((res) => {
-    assert.deepStrictEqual(res.headers, { ...expectedHeadersEndNoData, 'keep-alive': 'timeout=1' });
+    assert.deepStrictEqual(res.headers, { __proto__: null, ...expectedHeadersEndNoData, 'keep-alive': 'timeout=1' });
     res.resume();
   }));
 

--- a/test/parallel/test-http-multiple-headers.js
+++ b/test/parallel/test-http-multiple-headers.js
@@ -19,7 +19,7 @@ const server = createServer(
       'Host', host,
       'Transfer-Encoding', 'chunked',
     ]);
-    assert.deepStrictEqual(req.headers, {
+    assert.deepStrictEqual(req.headers, { __proto__: null,
       'connection': 'close',
       'x-req-a': 'eee, fff, ggg, hhh',
       'x-req-b': 'iii; jjj; kkk; lll',
@@ -41,7 +41,7 @@ const server = createServer(
         'X-req-Y', 'zzz; www',
       ]);
       assert.deepStrictEqual(
-        req.trailers, { 'x-req-x': 'xxx, yyy', 'x-req-y': 'zzz; www' }
+        req.trailers, { __proto__: null, 'x-req-x': 'xxx, yyy', 'x-req-y': 'zzz; www' }
       );
       assert.deepStrictEqual(
         req.trailersDistinct,
@@ -124,7 +124,7 @@ server.listen(0, common.mustCall(() => {
       'x-res-d', 'JJJ; KKK; LLL',
       'Transfer-Encoding', 'chunked',
     ]);
-    assert.deepStrictEqual(res.headers, {
+    assert.deepStrictEqual(res.headers, { __proto__: null,
       'x-res-a': 'AAA, BBB, CCC',
       'x-res-b': 'DDD; EEE; FFF; GGG',
       'connection': 'close',
@@ -149,7 +149,7 @@ server.listen(0, common.mustCall(() => {
       ]);
       assert.deepStrictEqual(
         res.trailers,
-        { 'x-res-x': 'XXX, YYY', 'x-res-y': 'ZZZ; WWW' }
+        { __proto__: null, 'x-res-x': 'XXX, YYY', 'x-res-y': 'ZZZ; WWW' }
       );
       assert.deepStrictEqual(
         res.trailersDistinct,

--- a/test/parallel/test-http-multiple-headers.js
+++ b/test/parallel/test-http-multiple-headers.js
@@ -19,13 +19,12 @@ const server = createServer(
       'Host', host,
       'Transfer-Encoding', 'chunked',
     ]);
-    assert.deepStrictEqual(req.headers, { __proto__: null,
-      'connection': 'close',
-      'x-req-a': 'eee, fff, ggg, hhh',
-      'x-req-b': 'iii; jjj; kkk; lll',
-      host,
-      'transfer-encoding': 'chunked'
-    });
+    assert.deepStrictEqual(req.headers, { '__proto__': null,
+                                          'connection': 'close',
+                                          'x-req-a': 'eee, fff, ggg, hhh',
+                                          'x-req-b': 'iii; jjj; kkk; lll',
+                                          host,
+                                          'transfer-encoding': 'chunked' });
     assert.deepStrictEqual(req.headersDistinct, Object.assign({ __proto__: null }, {
       'connection': ['close'],
       'x-req-a': ['eee', 'fff', 'ggg', 'hhh'],
@@ -41,7 +40,7 @@ const server = createServer(
         'X-req-Y', 'zzz; www',
       ]);
       assert.deepStrictEqual(
-        req.trailers, { __proto__: null, 'x-req-x': 'xxx, yyy', 'x-req-y': 'zzz; www' }
+        req.trailers, { '__proto__': null, 'x-req-x': 'xxx, yyy', 'x-req-y': 'zzz; www' }
       );
       assert.deepStrictEqual(
         req.trailersDistinct,
@@ -124,14 +123,13 @@ server.listen(0, common.mustCall(() => {
       'x-res-d', 'JJJ; KKK; LLL',
       'Transfer-Encoding', 'chunked',
     ]);
-    assert.deepStrictEqual(res.headers, { __proto__: null,
-      'x-res-a': 'AAA, BBB, CCC',
-      'x-res-b': 'DDD; EEE; FFF; GGG',
-      'connection': 'close',
-      'x-res-c': 'HHH, III',
-      'x-res-d': 'JJJ; KKK; LLL',
-      'transfer-encoding': 'chunked'
-    });
+    assert.deepStrictEqual(res.headers, { '__proto__': null,
+                                          'x-res-a': 'AAA, BBB, CCC',
+                                          'x-res-b': 'DDD; EEE; FFF; GGG',
+                                          'connection': 'close',
+                                          'x-res-c': 'HHH, III',
+                                          'x-res-d': 'JJJ; KKK; LLL',
+                                          'transfer-encoding': 'chunked' });
     assert.deepStrictEqual(res.headersDistinct, Object.assign({ __proto__: null }, {
       'x-res-a': [ 'AAA', 'BBB', 'CCC' ],
       'x-res-b': [ 'DDD; EEE; FFF; GGG' ],
@@ -149,7 +147,7 @@ server.listen(0, common.mustCall(() => {
       ]);
       assert.deepStrictEqual(
         res.trailers,
-        { __proto__: null, 'x-res-x': 'XXX, YYY', 'x-res-y': 'ZZZ; WWW' }
+        { '__proto__': null, 'x-res-x': 'XXX, YYY', 'x-res-y': 'ZZZ; WWW' }
       );
       assert.deepStrictEqual(
         res.trailersDistinct,

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -36,7 +36,7 @@ http.createServer(common.mustCall(function(req, res) {
     'Connection',
     'keep-alive',
   ];
-  const expectHeaders = {
+  const expectHeaders = { __proto__: null,
     'host': `localhost:${this.address().port}`,
     'transfer-encoding': 'CHUNKED',
     'x-bar': 'yoyoyo',
@@ -52,7 +52,7 @@ http.createServer(common.mustCall(function(req, res) {
     'X-baR',
     'OyOyOyO',
   ];
-  const expectTrailers = { 'x-bar': 'yOyOyOy, OyOyOyO, yOyOyOy, OyOyOyO' };
+  const expectTrailers = { __proto__: null, 'x-bar': 'yOyOyOy, OyOyOyO, yOyOyOy, OyOyOyO' };
 
   this.close();
 
@@ -98,7 +98,7 @@ http.createServer(common.mustCall(function(req, res) {
       'Transfer-Encoding',
       'chunked',
     ];
-    const expectHeaders = {
+    const expectHeaders = { __proto__: null,
       'keep-alive': 'timeout=1',
       'trailer': 'x-foo',
       'date': null,
@@ -120,7 +120,7 @@ http.createServer(common.mustCall(function(req, res) {
         'X-foO',
         'OxOxOxO',
       ];
-      const expectTrailers = { 'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO' };
+      const expectTrailers = { __proto__: null, 'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO' };
 
       assert.deepStrictEqual(res.rawTrailers, expectRawTrailers);
       assert.deepStrictEqual(res.trailers, expectTrailers);

--- a/test/parallel/test-http-raw-headers.js
+++ b/test/parallel/test-http-raw-headers.js
@@ -36,12 +36,11 @@ http.createServer(common.mustCall(function(req, res) {
     'Connection',
     'keep-alive',
   ];
-  const expectHeaders = { __proto__: null,
-    'host': `localhost:${this.address().port}`,
-    'transfer-encoding': 'CHUNKED',
-    'x-bar': 'yoyoyo',
-    'connection': 'keep-alive'
-  };
+  const expectHeaders = { '__proto__': null,
+                          'host': `localhost:${this.address().port}`,
+                          'transfer-encoding': 'CHUNKED',
+                          'x-bar': 'yoyoyo',
+                          'connection': 'keep-alive' };
   const expectRawTrailers = [
     'x-bAr',
     'yOyOyOy',
@@ -52,7 +51,7 @@ http.createServer(common.mustCall(function(req, res) {
     'X-baR',
     'OyOyOyO',
   ];
-  const expectTrailers = { __proto__: null, 'x-bar': 'yOyOyOy, OyOyOyO, yOyOyOy, OyOyOyO' };
+  const expectTrailers = { '__proto__': null, 'x-bar': 'yOyOyOy, OyOyOyO, yOyOyOy, OyOyOyO' };
 
   this.close();
 
@@ -98,13 +97,12 @@ http.createServer(common.mustCall(function(req, res) {
       'Transfer-Encoding',
       'chunked',
     ];
-    const expectHeaders = { __proto__: null,
-      'keep-alive': 'timeout=1',
-      'trailer': 'x-foo',
-      'date': null,
-      'connection': 'keep-alive',
-      'transfer-encoding': 'chunked'
-    };
+    const expectHeaders = { '__proto__': null,
+                            'keep-alive': 'timeout=1',
+                            'trailer': 'x-foo',
+                            'date': null,
+                            'connection': 'keep-alive',
+                            'transfer-encoding': 'chunked' };
     res.rawHeaders[5] = null;
     res.headers.date = null;
     assert.deepStrictEqual(res.rawHeaders, expectRawHeaders);
@@ -120,7 +118,7 @@ http.createServer(common.mustCall(function(req, res) {
         'X-foO',
         'OxOxOxO',
       ];
-      const expectTrailers = { __proto__: null, 'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO' };
+      const expectTrailers = { '__proto__': null, 'x-foo': 'xOxOxOx, OxOxOxO, xOxOxOx, OxOxOxO' };
 
       assert.deepStrictEqual(res.rawTrailers, expectRawTrailers);
       assert.deepStrictEqual(res.trailers, expectTrailers);

--- a/test/parallel/test-http-remove-header-stays-removed.js
+++ b/test/parallel/test-http-remove-header-stays-removed.js
@@ -50,7 +50,7 @@ const server = http.createServer(common.mustCall(function(request, response) {
 server.listen(0, common.mustCall(function() {
   http.get({ port: this.address().port }, common.mustCall((res) => {
     assert.strictEqual(res.statusCode, 200);
-    assert.deepStrictEqual(res.headers, { date: 'coffee o clock' });
+    assert.deepStrictEqual(res.headers, { __proto__: null, date: 'coffee o clock' });
 
     let response = '';
     res.setEncoding('ascii');

--- a/test/parallel/test-http-server-headers-null-proto.js
+++ b/test/parallel/test-http-server-headers-null-proto.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+// Test 1: req.headers has a null prototype
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    assert.strictEqual(Object.getPrototypeOf(req.headers), null);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+
+    const client = net.connect(port, common.mustCall(() => {
+      client.write(
+        'GET / HTTP/1.1\r\n' +
+        'Host: localhost\r\n' +
+        'Connection: close\r\n' +
+        '\r\n',
+      );
+    }));
+
+    client.on('end', common.mustCall(() => {
+      server.close();
+    }));
+
+    client.resume();
+  }));
+}
+
+// Test 2: req.trailers has a null prototype
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.setHeader('Transfer-Encoding', 'chunked');
+    res.write('Hello');
+    res.addTrailers({
+      'X-Trailer': 'test',
+    });
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+
+    const client = net.connect(port, common.mustCall(() => {
+      client.write(
+        'GET / HTTP/1.1\r\n' +
+        'Host: localhost\r\n' +
+        'TE: trailers\r\n' +
+        'Connection: close\r\n' +
+        '\r\n',
+      );
+    }));
+
+    client.on('data', () => {});
+
+    client.on('end', common.mustCall(() => {
+      server.close();
+    }));
+  }));
+}
+
+// Test 3: req.headers with __proto__ header (should not pollute prototype)
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    assert.strictEqual(Object.getPrototypeOf(req.headers), null);
+    // The __proto__ header should be stored as a regular property
+    assert.strictEqual(req.headers['__proto__'], 'test');
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const port = server.address().port;
+
+    const client = net.connect(port, common.mustCall(() => {
+      client.write(
+        'GET / HTTP/1.1\r\n' +
+        'Host: localhost\r\n' +
+        '__proto__: test\r\n' +
+        'Connection: close\r\n' +
+        '\r\n',
+      );
+    }));
+
+    client.on('end', common.mustCall(() => {
+      server.close();
+    }));
+
+    client.resume();
+  }));
+}

--- a/test/parallel/test-http-server-headers-null-proto.js
+++ b/test/parallel/test-http-server-headers-null-proto.js
@@ -35,7 +35,12 @@ const net = require('net');
 // Test 2: req.trailers has a null prototype
 {
   const server = http.createServer(common.mustCall((req, res) => {
+    req.on('end', common.mustCall(() => {
+      assert.strictEqual(Object.getPrototypeOf(req.trailers), null);
+      assert.strictEqual(req.trailers['x-client-trailer'], 'bar');
+    }));
     res.setHeader('Transfer-Encoding', 'chunked');
+    res.setHeader('Trailer', 'X-Trailer');
     res.write('Hello');
     res.addTrailers({
       'X-Trailer': 'test',
@@ -50,8 +55,12 @@ const net = require('net');
       client.write(
         'GET / HTTP/1.1\r\n' +
         'Host: localhost\r\n' +
-        'TE: trailers\r\n' +
+        'Transfer-Encoding: chunked\r\n' +
+        'Trailer: X-Client-Trailer\r\n' +
         'Connection: close\r\n' +
+        '\r\n' +
+        '0\r\n' +
+        'X-Client-Trailer: bar\r\n' +
         '\r\n',
       );
     }));

--- a/test/parallel/test-http-server-headers-null-proto.js
+++ b/test/parallel/test-http-server-headers-null-proto.js
@@ -69,7 +69,9 @@ const net = require('net');
   const server = http.createServer(common.mustCall((req, res) => {
     assert.strictEqual(Object.getPrototypeOf(req.headers), null);
     // The __proto__ header should be stored as a regular property
-    assert.strictEqual(req.headers['__proto__'], 'test');
+    assert.strictEqual(
+      Object.getOwnPropertyDescriptor(req.headers, '__proto__').value, 'test',
+    );
     res.end();
   }));
 

--- a/test/parallel/test-http-upgrade-agent.js
+++ b/test/parallel/test-http-upgrade-agent.js
@@ -76,7 +76,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
       assert.strictEqual(recvData.toString(), 'nurtzo');
     }));
 
-    const expectedHeaders = { 'hello': 'world',
+    const expectedHeaders = { __proto__: null, 'hello': 'world',
                               'connection': 'upgrade',
                               'upgrade': 'websocket' };
     assert.deepStrictEqual(expectedHeaders, res.headers);

--- a/test/parallel/test-http-upgrade-agent.js
+++ b/test/parallel/test-http-upgrade-agent.js
@@ -76,7 +76,7 @@ server.listen(0, '127.0.0.1', common.mustCall(function() {
       assert.strictEqual(recvData.toString(), 'nurtzo');
     }));
 
-    const expectedHeaders = { __proto__: null, 'hello': 'world',
+    const expectedHeaders = { '__proto__': null, 'hello': 'world',
                               'connection': 'upgrade',
                               'upgrade': 'websocket' };
     assert.deepStrictEqual(expectedHeaders, res.headers);

--- a/test/parallel/test-http-upgrade-client.js
+++ b/test/parallel/test-http-upgrade-client.js
@@ -85,7 +85,8 @@ server.listen(0, common.mustCall(function() {
       const expectedHeaders = {
         hello: 'world',
         connection: 'upgrade',
-        upgrade: 'websocket'
+        upgrade: 'websocket',
+        __proto__: null
       };
       assert.deepStrictEqual(res.headers, expectedHeaders);
       socket.end();

--- a/test/parallel/test-http-upgrade-server-with-body-and-extras.mjs
+++ b/test/parallel/test-http-upgrade-server-with-body-and-extras.mjs
@@ -24,7 +24,7 @@ server.on('upgrade', common.mustCall(function(req, socket, upgradeHead) {
   req.on('end', common.mustCall(() => {
     assert.strictEqual(reqBodyLength, EXPECTED_BODY_LENGTH);
 
-    assert.deepStrictEqual(req.trailers, { __proto__: null, 'extra-data': 'abc' });
+    assert.deepStrictEqual(req.trailers, { '__proto__': null, 'extra-data': 'abc' });
 
     // Defer upgrade stream read slightly to make sure it doesn't start
     // streaming along with the request body, until we actually read it:

--- a/test/parallel/test-http-upgrade-server-with-body-and-extras.mjs
+++ b/test/parallel/test-http-upgrade-server-with-body-and-extras.mjs
@@ -24,7 +24,7 @@ server.on('upgrade', common.mustCall(function(req, socket, upgradeHead) {
   req.on('end', common.mustCall(() => {
     assert.strictEqual(reqBodyLength, EXPECTED_BODY_LENGTH);
 
-    assert.deepStrictEqual(req.trailers, { 'extra-data': 'abc' });
+    assert.deepStrictEqual(req.trailers, { __proto__: null, 'extra-data': 'abc' });
 
     // Defer upgrade stream read slightly to make sure it doesn't start
     // streaming along with the request body, until we actually read it:

--- a/test/parallel/test-http2-compat-serverrequest-trailers.js
+++ b/test/parallel/test-http2-compat-serverrequest-trailers.js
@@ -22,6 +22,7 @@ server.listen(0, common.mustCall(function() {
     request.on('data', common.mustCallAtLeast((chunk) => data += chunk));
     request.on('end', common.mustCall(() => {
       const trailers = request.trailers;
+      assert.strictEqual(Object.getPrototypeOf(trailers), null);
       for (const [name, value] of Object.entries(expectedTrailers)) {
         assert.strictEqual(trailers[name], value);
       }


### PR DESCRIPTION
Make req.headers and req.trailers in http.createServer() have a null prototype, matching the existing behavior of headersDistinct and trailersDistinct. Also applies the same fix to HTTP/2 compatibility mode for req.trailers.