### PR TITLE
process: handle rejections only when needed

### DIFF
--- a/lib/internal/process/task_queues.js
+++ b/lib/internal/process/task_queues.js
@@ -102,7 +102,8 @@ function processTicksAndRejections() {
       AsyncContextFrame.set(priorContextFrame);
     }
     runMicrotasks();
-  } while (!queue.isEmpty() || processPromiseRejections());
+  } while (!queue.isEmpty() ||
+           (hasRejectionToWarn() && processPromiseRejections()));
   setHasTickScheduled(false);
   setHasRejectionToWarn(false);
 }


### PR DESCRIPTION
After:

```
./node benchmark/timers/timers-timeout-nexttick.js
timers/timers-timeout-nexttick.js n=50000: 2,807,740.108387753
timers/timers-timeout-nexttick.js n=5000000: 9,041,959.898481071
```

Before:

```
./node benchmark/timers/timers-timeout-nexttick.js
timers/timers-timeout-nexttick.js n=50000: 2,127,372.8770254664
timers/timers-timeout-nexttick.js n=5000000: 6,926,259.012697572
```

* Skips noop `processPromiseRejections()` calls in `processTicksAndRejections()` when there is no pending rejection work

---

We already do a check before entering the loop through `runNextTicks()`:

https://github.com/nodejs/node/blob/926162a2eafa2cf53dac3028c9d6faa07f5081f2/lib/internal/process/task_queues.js#L62-L70

But once we are already inside `processTicksAndRejections()` because of tick work, the internal do..while loop still calls `processPromiseRejections()` on every iteration (where we have a Map instantiation, method calls, etc.) without checking if we should even call it:

https://github.com/nodejs/node/blob/926162a2eafa2cf53dac3028c9d6faa07f5081f2/lib/internal/process/task_queues.js#L105

https://github.com/nodejs/node/blob/012bf70908fafcbdf8d5c819e346c32b80f7aea4/lib/internal/process/promises.js#L377-L424

Now the name `hasRejectionToWarn` is inaccurate because we use it for any type of unhandled rejection:

https://github.com/nodejs/node/blob/012bf70908fafcbdf8d5c819e346c32b80f7aea4/lib/internal/process/promises.js#L193-L206

So skipping covers all types of rejections