### PR TITLE
src: simplify `TCPWrap::Connect` signature

### DIFF
--- a/src/tcp_wrap.cc
+++ b/src/tcp_wrap.cc
@@ -373,10 +373,11 @@ void TCPWrap::Open(const FunctionCallbackInfo<Value>& args) {
 }
 
 template <typename T>
-void TCPWrap::Bind(
-    const FunctionCallbackInfo<Value>& args,
-    int family,
-    std::function<int(const char* ip_address, int port, T* addr)> uv_ip_addr) {
+void TCPWrap::Bind(const FunctionCallbackInfo<Value>& args,
+                   int family,
+                   int (*uv_ip_addr)(const char* ip_address,
+                                     int port,
+                                     T* addr)) {
   TCPWrap* wrap;
   ASSIGN_OR_RETURN_UNWRAP(
       &wrap, args.This(), args.GetReturnValue().Set(UV_EBADF));
@@ -430,29 +431,18 @@ void TCPWrap::Listen(const FunctionCallbackInfo<Value>& args) {
 }
 
 void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args) {
-  CHECK(args[2]->IsUint32());
-  // explicit cast to fit to libuv's type expectation
-  int port = static_cast<int>(args[2].As<Uint32>()->Value());
-  Connect<sockaddr_in>(args, [port](const char* ip_address, sockaddr_in* addr) {
-    return uv_ip4_addr(ip_address, port, addr);
-  });
+  Connect<sockaddr_in>(args, uv_ip4_addr);
 }
 
 void TCPWrap::Connect6(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  CHECK(args[2]->IsUint32());
-  int port;
-  if (!args[2]->Int32Value(env->context()).To(&port)) return;
-  Connect<sockaddr_in6>(args,
-                        [port](const char* ip_address, sockaddr_in6* addr) {
-                          return uv_ip6_addr(ip_address, port, addr);
-                        });
+  Connect<sockaddr_in6>(args, uv_ip6_addr);
 }
 
 template <typename T>
-void TCPWrap::Connect(
-    const FunctionCallbackInfo<Value>& args,
-    std::function<int(const char* ip_address, T* addr)> uv_ip_addr) {
+void TCPWrap::Connect(const FunctionCallbackInfo<Value>& args,
+                      int (*uv_ip_addr)(const char* ip_address,
+                                        int port,
+                                        T* addr)) {
   Environment* env = Environment::GetCurrent(args);
 
   TCPWrap* wrap;
@@ -462,6 +452,9 @@ void TCPWrap::Connect(
   CHECK(args[0]->IsObject());
   CHECK(args[1]->IsString());
 
+  int port;
+  if (!args[2]->Int32Value(env->context()).To(&port)) return;
+
   Local<Object> req_wrap_obj = args[0].As<Object>();
   node::Utf8Value ip_address(env->isolate(), args[1]);
 
@@ -469,7 +462,7 @@ void TCPWrap::Connect(
       env, permission::PermissionScope::kNet, ip_address.ToStringView(), args);
 
   T addr;
-  int err = uv_ip_addr(*ip_address, &addr);
+  int err = uv_ip_addr(*ip_address, port, &addr);
 
   if (err == 0) {
     AsyncHooks::DefaultTriggerAsyncIdScope trigger_scope(wrap);

--- a/src/tcp_wrap.h
+++ b/src/tcp_wrap.h
@@ -83,13 +83,16 @@ class TCPWrap : public ConnectionWrap<TCPWrap, uv_tcp_t> {
   static void Connect6(const v8::FunctionCallbackInfo<v8::Value>& args);
   template <typename T>
   static void Connect(const v8::FunctionCallbackInfo<v8::Value>& args,
-      std::function<int(const char* ip_address, T* addr)> uv_ip_addr);
+                      int (*uv_ip_addr)(const char* ip_address,
+                                        int port,
+                                        T* addr));
   static void Open(const v8::FunctionCallbackInfo<v8::Value>& args);
   template <typename T>
-  static void Bind(
-      const v8::FunctionCallbackInfo<v8::Value>& args,
-      int family,
-      std::function<int(const char* ip_address, int port, T* addr)> uv_ip_addr);
+  static void Bind(const v8::FunctionCallbackInfo<v8::Value>& args,
+                   int family,
+                   int (*uv_ip_addr)(const char* ip_address,
+                                     int port,
+                                     T* addr));
   static void Reset(const v8::FunctionCallbackInfo<v8::Value>& args);
   int Reset(v8::Local<v8::Value> close_callback = v8::Local<v8::Value>());
 


### PR DESCRIPTION
Just a little piece of cleanup -- this aligns `TCPWrap::Connect` with its sibling `TCPWrap::Bind`, deduplicates code and removes an unnecessary heap allocation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
