### PR TITLE
src: add a native mode to monitorEventLoopDelay

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1705,11 +1705,19 @@ are not guaranteed to reflect any correct state of the event loop.
 
 <!-- YAML
 added: v11.10.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/XXXXX
+    description: Added the `native` option.
 -->
 
 * `options` {Object}
   * `resolution` {number} The sampling rate in milliseconds. Must be greater
-    than zero. **Default:** `10`.
+    than zero. Only used when `native` is `false`. **Default:** `10`.
+  * `native` {boolean} When `true`, uses libuv's `uv_check_t` handle and
+    `uv_metrics_idle_time()` to measure the busy time of each event loop
+    iteration directly, instead of relying on a sampling timer. **Default:**
+    `false`.
 * Returns: {IntervalHistogram}
 
 _This property is an extension by Node.js. It is not available in Web browsers._
@@ -1717,11 +1725,20 @@ _This property is an extension by Node.js. It is not available in Web browsers._
 Creates an `IntervalHistogram` object that samples and reports the event loop
 delay over time. The delays will be reported in nanoseconds.
 
-Using a timer to detect approximate event loop delay works because the
-execution of timers is tied specifically to the lifecycle of the libuv
-event loop. That is, a delay in the loop will cause a delay in the execution
-of the timer, and those delays are specifically what this API is intended to
-detect.
+Two measurement strategies are available:
+
+**Timer-based (default, `native: false`):** Uses a repeating timer that fires
+every `resolution` milliseconds. A delay in the loop causes a corresponding
+delay in timer execution, and that difference is recorded. This approach
+samples the event loop at a fixed rate and is suitable for coarse-grained
+monitoring.
+
+**Native (`native: true`):** Registers a libuv `uv_check_t` handle that fires
+after every I/O poll phase. Each firing computes the busy time for that
+iteration as the total elapsed time minus the time spent waiting in the I/O
+poll (obtained from `uv_metrics_idle_time()`). This provides a per-iteration
+measurement without any sampling interval overhead. The `resolution` option
+has no effect in this mode.
 
 ```mjs
 import { monitorEventLoopDelay } from 'node:perf_hooks';
@@ -1751,6 +1768,33 @@ console.log(h.mean);
 console.log(h.stddev);
 console.log(h.percentiles);
 console.log(h.percentile(50));
+console.log(h.percentile(99));
+```
+
+Using the native mode:
+
+```mjs
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+
+const h = monitorEventLoopDelay({ native: true });
+h.enable();
+// Do something.
+h.disable();
+console.log(h.min);
+console.log(h.max);
+console.log(h.mean);
+console.log(h.percentile(99));
+```
+
+```cjs
+const { monitorEventLoopDelay } = require('node:perf_hooks');
+const h = monitorEventLoopDelay({ native: true });
+h.enable();
+// Do something.
+h.disable();
+console.log(h.min);
+console.log(h.max);
+console.log(h.mean);
 console.log(h.percentile(99));
 ```
 

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1707,7 +1707,7 @@ are not guaranteed to reflect any correct state of the event loop.
 added: v11.10.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/XXXXX
+    pr-url: https://github.com/nodejs/node/pull/62934
     description: Added the `native` option.
 -->
 

--- a/lib/internal/perf/event_loop_delay.js
+++ b/lib/internal/perf/event_loop_delay.js
@@ -18,6 +18,7 @@ const {
 } = internalBinding('performance');
 
 const {
+  validateBoolean,
   validateInteger,
   validateObject,
 } = require('internal/validators');
@@ -74,21 +75,23 @@ class ELDHistogram extends Histogram {
 
 /**
  * @param {{
- *   resolution : number
+ *   resolution? : number,
+ *   native? : boolean
  * }} [options]
  * @returns {ELDHistogram}
  */
 function monitorEventLoopDelay(options = kEmptyObject) {
   validateObject(options, 'options');
 
-  const { resolution = 10 } = options;
+  const { resolution = 10, native = false } = options;
   validateInteger(resolution, 'options.resolution', 1);
+  validateBoolean(native, 'options.native');
 
   return ReflectConstruct(
     function() {
       markTransferMode(this, true, false);
       this[kEnabled] = false;
-      this[kHandle] = createELDHistogram(resolution);
+      this[kHandle] = createELDHistogram(resolution, native);
       this[kMap] = new SafeMap();
     }, [], ELDHistogram);
 }

--- a/src/async_wrap.h
+++ b/src/async_wrap.h
@@ -36,6 +36,7 @@ namespace node {
   V(DIRHANDLE)                                                                 \
   V(DNSCHANNEL)                                                                \
   V(ELDHISTOGRAM)                                                              \
+  V(ELDNATIVEHISTOGRAM)                                                        \
   V(FILEHANDLE)                                                                \
   V(FILEHANDLECLOSEREQ)                                                        \
   V(BLOBREADER)                                                                \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -424,6 +424,7 @@
   V(http2stream_constructor_template, v8::ObjectTemplate)                      \
   V(http2ping_constructor_template, v8::ObjectTemplate)                        \
   V(i18n_converter_template, v8::ObjectTemplate)                               \
+  V(eld_native_histogram_constructor_template, v8::FunctionTemplate)           \
   V(intervalhistogram_constructor_template, v8::FunctionTemplate)              \
   V(iter_template, v8::DictionaryTemplate)                                     \
   V(js_transferable_constructor_template, v8::FunctionTemplate)                \

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -646,11 +646,10 @@ void ELDNativeHistogram::RegisterExternalReferences(
 }
 
 ELDNativeHistogram::ELDNativeHistogram(Environment* env, Local<Object> wrap)
-    : HandleWrap(
-          env,
-          wrap,
-          reinterpret_cast<uv_handle_t*>(&check_),
-          AsyncWrap::PROVIDER_ELDNATIVEHISTOGRAM),
+    : HandleWrap(env,
+                 wrap,
+                 reinterpret_cast<uv_handle_t*>(&check_),
+                 AsyncWrap::PROVIDER_ELDNATIVEHISTOGRAM),
       HistogramImpl() {
   MakeWeak();
   wrap->SetAlignedPointerInInternalField(
@@ -660,8 +659,7 @@ ELDNativeHistogram::ELDNativeHistogram(Environment* env, Local<Object> wrap)
   uv_check_init(env->event_loop(), &check_);
 }
 
-BaseObjectPtr<ELDNativeHistogram> ELDNativeHistogram::Create(
-    Environment* env) {
+BaseObjectPtr<ELDNativeHistogram> ELDNativeHistogram::Create(Environment* env) {
   Local<Object> obj;
   if (!GetConstructorTemplate(env)
            ->InstanceTemplate()
@@ -684,8 +682,7 @@ void ELDNativeHistogram::CheckCB(uv_check_t* handle) {
     uint64_t idle = idle_now - histogram->prev_idle_time_;
     if (idle > total) idle = total;
     int64_t busy = static_cast<int64_t>(total - idle);
-    if (busy > 0)
-      histogram->histogram()->Record(busy);
+    if (busy > 0) histogram->histogram()->Record(busy);
   }
 
   histogram->prev_hrtime_ = now;
@@ -738,8 +735,8 @@ void ELDNativeHistogram::FastStop(Local<Value> receiver) {
   histogram->OnStop();
 }
 
-std::unique_ptr<worker::TransferData>
-ELDNativeHistogram::CloneForMessaging() const {
+std::unique_ptr<worker::TransferData> ELDNativeHistogram::CloneForMessaging()
+    const {
   return std::make_unique<HistogramBase::HistogramTransferData>(histogram());
 }
 

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -612,4 +612,135 @@ IntervalHistogram::CloneForMessaging() const {
   return std::make_unique<HistogramBase::HistogramTransferData>(histogram());
 }
 
+CFunction ELDNativeHistogram::fast_start_(
+    CFunction::Make(&ELDNativeHistogram::FastStart));
+CFunction ELDNativeHistogram::fast_stop_(
+    CFunction::Make(&ELDNativeHistogram::FastStop));
+
+Local<FunctionTemplate> ELDNativeHistogram::GetConstructorTemplate(
+    Environment* env) {
+  Local<FunctionTemplate> tmpl =
+      env->eld_native_histogram_constructor_template();
+  if (tmpl.IsEmpty()) {
+    Isolate* isolate = env->isolate();
+    tmpl = NewFunctionTemplate(isolate, nullptr);
+    tmpl->Inherit(HandleWrap::GetConstructorTemplate(env));
+    tmpl->SetClassName(FIXED_ONE_BYTE_STRING(isolate, "Histogram"));
+    auto instance = tmpl->InstanceTemplate();
+    instance->SetInternalFieldCount(ELDNativeHistogram::kInternalFieldCount);
+    HistogramImpl::AddMethods(isolate, tmpl);
+    SetFastMethod(isolate, instance, "start", Start, &fast_start_);
+    SetFastMethod(isolate, instance, "stop", Stop, &fast_stop_);
+    env->set_eld_native_histogram_constructor_template(tmpl);
+  }
+  return tmpl;
+}
+
+void ELDNativeHistogram::RegisterExternalReferences(
+    ExternalReferenceRegistry* registry) {
+  registry->Register(Start);
+  registry->Register(Stop);
+  registry->Register(fast_start_);
+  registry->Register(fast_stop_);
+  HistogramImpl::RegisterExternalReferences(registry);
+}
+
+ELDNativeHistogram::ELDNativeHistogram(Environment* env, Local<Object> wrap)
+    : HandleWrap(
+          env,
+          wrap,
+          reinterpret_cast<uv_handle_t*>(&check_),
+          AsyncWrap::PROVIDER_ELDNATIVEHISTOGRAM),
+      HistogramImpl() {
+  MakeWeak();
+  wrap->SetAlignedPointerInInternalField(
+      HistogramImpl::InternalFields::kImplField,
+      static_cast<HistogramImpl*>(this),
+      EmbedderDataTag::kDefault);
+  uv_check_init(env->event_loop(), &check_);
+}
+
+BaseObjectPtr<ELDNativeHistogram> ELDNativeHistogram::Create(
+    Environment* env) {
+  Local<Object> obj;
+  if (!GetConstructorTemplate(env)
+           ->InstanceTemplate()
+           ->NewInstance(env->context())
+           .ToLocal(&obj)) {
+    return nullptr;
+  }
+  return MakeBaseObject<ELDNativeHistogram>(env, obj);
+}
+
+void ELDNativeHistogram::CheckCB(uv_check_t* handle) {
+  ELDNativeHistogram* histogram =
+      ContainerOf(&ELDNativeHistogram::check_, handle);
+
+  uint64_t now = uv_hrtime();
+  uint64_t idle_now = uv_metrics_idle_time(histogram->env()->event_loop());
+
+  if (histogram->prev_hrtime_ > 0) {
+    uint64_t total = now - histogram->prev_hrtime_;
+    uint64_t idle = idle_now - histogram->prev_idle_time_;
+    if (idle > total) idle = total;
+    int64_t busy = static_cast<int64_t>(total - idle);
+    if (busy > 0)
+      histogram->histogram()->Record(busy);
+  }
+
+  histogram->prev_hrtime_ = now;
+  histogram->prev_idle_time_ = idle_now;
+}
+
+void ELDNativeHistogram::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("histogram", histogram());
+}
+
+void ELDNativeHistogram::OnStart(bool reset) {
+  if (enabled_ || IsHandleClosing()) return;
+  enabled_ = true;
+  if (reset) histogram()->Reset();
+  prev_hrtime_ = 0;
+  prev_idle_time_ = 0;
+  uv_check_start(&check_, CheckCB);
+  uv_unref(reinterpret_cast<uv_handle_t*>(&check_));
+}
+
+void ELDNativeHistogram::OnStop() {
+  if (!enabled_ || IsHandleClosing()) return;
+  enabled_ = false;
+  uv_check_stop(&check_);
+}
+
+void ELDNativeHistogram::Start(const FunctionCallbackInfo<Value>& args) {
+  ELDNativeHistogram* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
+  histogram->OnStart(args[0]->IsTrue());
+}
+
+void ELDNativeHistogram::FastStart(Local<Value> receiver, bool reset) {
+  TRACK_V8_FAST_API_CALL("histogram.start");
+  ELDNativeHistogram* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
+  histogram->OnStart(reset);
+}
+
+void ELDNativeHistogram::Stop(const FunctionCallbackInfo<Value>& args) {
+  ELDNativeHistogram* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
+  histogram->OnStop();
+}
+
+void ELDNativeHistogram::FastStop(Local<Value> receiver) {
+  TRACK_V8_FAST_API_CALL("histogram.stop");
+  ELDNativeHistogram* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
+  histogram->OnStop();
+}
+
+std::unique_ptr<worker::TransferData>
+ELDNativeHistogram::CloneForMessaging() const {
+  return std::make_unique<HistogramBase::HistogramTransferData>(histogram());
+}
+
 }  // namespace node

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -266,6 +266,51 @@ class IntervalHistogram final : public HandleWrap, public HistogramImpl {
   static v8::CFunction fast_stop_;
 };
 
+class ELDNativeHistogram final : public HandleWrap, public HistogramImpl {
+ public:
+  enum InternalFields {
+    kInternalFieldCount = std::max<uint32_t>(
+        HandleWrap::kInternalFieldCount, HistogramImpl::kInternalFieldCount),
+  };
+
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
+
+  static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
+      Environment* env);
+
+  static BaseObjectPtr<ELDNativeHistogram> Create(Environment* env);
+
+  ELDNativeHistogram(Environment* env, v8::Local<v8::Object> wrap);
+
+  static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static void FastStart(v8::Local<v8::Value> receiver, bool reset);
+  static void FastStop(v8::Local<v8::Value> receiver);
+
+  BaseObject::TransferMode GetTransferMode() const override {
+    return TransferMode::kCloneable;
+  }
+  std::unique_ptr<worker::TransferData> CloneForMessaging() const override;
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_MEMORY_INFO_NAME(ELDNativeHistogram)
+  SET_SELF_SIZE(ELDNativeHistogram)
+
+ private:
+  static void CheckCB(uv_check_t* handle);
+  void OnStart(bool reset);
+  void OnStop();
+
+  bool enabled_ = false;
+  uint64_t prev_hrtime_ = 0;
+  uint64_t prev_idle_time_ = 0;
+  uv_check_t check_;
+
+  static v8::CFunction fast_start_;
+  static v8::CFunction fast_stop_;
+};
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -282,6 +282,15 @@ void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   int64_t interval = args[0].As<Integer>()->Value();
   CHECK_GT(interval, 0);
+
+  if (args[1]->IsTrue()) {
+    BaseObjectPtr<ELDNativeHistogram> histogram =
+        ELDNativeHistogram::Create(env);
+    if (histogram)
+      args.GetReturnValue().Set(histogram->object());
+    return;
+  }
+
   BaseObjectPtr<IntervalHistogram> histogram =
       IntervalHistogram::Create(env, interval, [](Histogram& histogram) {
         uint64_t delta = histogram.RecordDelta();
@@ -413,6 +422,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(fast_performance_now);
   HistogramBase::RegisterExternalReferences(registry);
   IntervalHistogram::RegisterExternalReferences(registry);
+  ELDNativeHistogram::RegisterExternalReferences(registry);
 }
 }  // namespace performance
 }  // namespace node

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -286,8 +286,7 @@ void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {
   if (args[1]->IsTrue()) {
     BaseObjectPtr<ELDNativeHistogram> histogram =
         ELDNativeHistogram::Create(env);
-    if (histogram)
-      args.GetReturnValue().Set(histogram->object());
+    if (histogram) args.GetReturnValue().Set(histogram->object());
     return;
   }
 

--- a/test/sequential/test-performance-eventloopdelay-native.js
+++ b/test/sequential/test-performance-eventloopdelay-native.js
@@ -1,0 +1,97 @@
+// Flags: --expose-gc --expose-internals
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const {
+  monitorEventLoopDelay,
+} = require('perf_hooks');
+const { sleep } = require('internal/util');
+
+// Validate the native option type.
+{
+  [null, 'a', 1, 0, {}, []].forEach((i) => {
+    assert.throws(
+      () => monitorEventLoopDelay({ native: i }),
+      {
+        name: 'TypeError',
+        code: 'ERR_INVALID_ARG_TYPE',
+      }
+    );
+  });
+}
+
+// When native: true, resolution validation still runs.
+{
+  [-1, 0].forEach((i) => {
+    assert.throws(
+      () => monitorEventLoopDelay({ native: true, resolution: i }),
+      {
+        name: 'RangeError',
+        code: 'ERR_OUT_OF_RANGE',
+      }
+    );
+  });
+}
+
+// Basic enable/disable API works the same as the timer-based histogram.
+{
+  const histogram = monitorEventLoopDelay({ native: true });
+  assert(histogram);
+  assert(histogram.enable());
+  assert(!histogram.enable());
+  histogram.reset();
+  assert(histogram.disable());
+  assert(!histogram.disable());
+}
+
+// The native histogram records busy time per event loop iteration.
+//
+// The uv_check_t fires after each I/O poll phase. Each firing computes:
+//   busy = (now - prev_check_time) - (idle_now - prev_idle_time)
+// where idle is time spent blocked in the I/O poll. Blocking synchronously
+// in a timer callback shows up as busy time in the subsequent check.
+//
+// Trace across iterations:
+//   Iter 1 timers: tick(1) → sleep(50ms) → schedule tick for iter 2
+//   Iter 1 check:  CheckCB fires → prev_hrtime_ was 0, so just initializes state
+//   Iter 2 timers: tick(2) → sleep(50ms) → schedule tick for iter 3
+//   Iter 2 check:  CheckCB fires → records ~50ms of busy time (count becomes 1)
+//   Iter 3 timers: tick(3) → disable() + assertions (count >= 1)
+{
+  const histogram = monitorEventLoopDelay({ native: true });
+  histogram.enable();
+
+  let ticks = 0;
+  function tick() {
+    if (++ticks < 3) {
+      sleep(50);
+      setTimeout(tick, 0);
+    } else {
+      histogram.disable();
+      assert(histogram.count > 0,
+             `Expected samples to be recorded, got count=${histogram.count}`);
+      assert(histogram.min > 0);
+      assert(histogram.max > 0);
+      assert(histogram.max >= histogram.min);
+      assert(histogram.mean > 0);
+      assert(histogram.percentiles.size > 0);
+      for (let n = 1; n < 100; n += 0.1) {
+        assert(histogram.percentile(n) >= 0);
+      }
+
+      histogram.reset();
+      assert.strictEqual(histogram.min, 9223372036854776000);
+      assert.strictEqual(histogram.max, 0);
+      assert(Number.isNaN(histogram.stddev));
+      assert(Number.isNaN(histogram.mean));
+      assert.strictEqual(histogram.percentiles.size, 1);
+    }
+  }
+
+  setTimeout(common.mustCall(tick), 0);
+}
+
+// Make sure that the histogram instances can be garbage-collected without
+// and not just implicitly destroyed when the Environment is torn down.
+process.on('exit', global.gc);


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Add a native mode to `monitorEventLoopDelay`. The JavaScript implementation is inaccurate and has a completely invalid count. When using the native mode, the resolution is ignored since by hooking into libuv a timer is not needed.