### PR TITLE
src: add event loop based metrics into node

### DIFF
--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1709,8 +1709,11 @@ added: v11.10.0
 -->
 
 * `options` {Object}
-  * `resolution` {number} The sampling rate in milliseconds. Must be greater
-    than zero. **Default:** `10`.
+  * `samplePerIteration` {boolean} When `true`, samples are taken once per
+    event loop iteration. **Default:** `false`.
+  * `resolution` {number} The sampling rate in milliseconds for interval-based
+    sampling. Must be greater than zero. This option is ignored when
+    `samplePerIteration` is `true`. **Default:** `10`.
 * Returns: {IntervalHistogram}
 
 _This property is an extension by Node.js. It is not available in Web browsers._
@@ -1718,11 +1721,11 @@ _This property is an extension by Node.js. It is not available in Web browsers._
 Creates an `IntervalHistogram` object that samples and reports the event loop
 delay over time. The delays will be reported in nanoseconds.
 
-Using a timer to detect approximate event loop delay works because the
-execution of timers is tied specifically to the lifecycle of the libuv
-event loop. That is, a delay in the loop will cause a delay in the execution
-of the timer, and those delays are specifically what this API is intended to
-detect.
+By default, the histogram is updated by a timer using the configured
+`resolution`. When `samplePerIteration` is `true`, samples are taken once per
+event loop iteration using `uv_prepare_t` and `uv_check_t` hooks. In that mode,
+the histogram does not keep the loop alive or force additional iterations when
+the application is idle.
 
 ```mjs
 import { monitorEventLoopDelay } from 'node:perf_hooks';
@@ -2001,7 +2004,7 @@ The standard deviation of the recorded event loop delays.
 
 ## Class: `IntervalHistogram extends Histogram`
 
-A `Histogram` that is periodically updated on a given interval.
+A `Histogram` that records event loop delay.
 
 ### `histogram.disable()`
 
@@ -2011,7 +2014,7 @@ added: v11.10.0
 
 * Returns: {boolean}
 
-Disables the update interval timer. Returns `true` if the timer was
+Disables event loop delay sampling. Returns `true` if sampling was
 stopped, `false` if it was already stopped.
 
 ### `histogram.enable()`
@@ -2022,7 +2025,7 @@ added: v11.10.0
 
 * Returns: {boolean}
 
-Enables the update interval timer. Returns `true` if the timer was
+Enables event loop delay sampling. Returns `true` if sampling was
 started, `false` if it was already started.
 
 ### `histogram[Symbol.dispose]()`
@@ -2031,7 +2034,7 @@ started, `false` if it was already started.
 added: v24.2.0
 -->
 
-Disables the update interval timer when the histogram is disposed.
+Disables event loop delay sampling when the histogram is disposed.
 
 ```js
 const { monitorEventLoopDelay } = require('node:perf_hooks');

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1718,7 +1718,7 @@ changes:
   * `resolution` {number} The sampling rate in milliseconds for interval-based
     sampling. Must be greater than zero. This option is ignored when
     `samplePerIteration` is `true`. **Default:** `10`.
-* Returns: {IntervalHistogram|ELDHistogram}
+* Returns: {ELDHistogram}
 
 _This property is an extension by Node.js. It is not available in Web browsers._
 
@@ -2008,9 +2008,10 @@ added: v11.10.0
 
 The standard deviation of the recorded event loop delays.
 
-## Class: `IntervalHistogram extends Histogram`
+## Class: `ELDHistogram extends Histogram`
 
-A `Histogram` that records event loop delay using interval-based sampling.
+A `Histogram` that records event loop delay, returned by
+[`perf_hooks.monitorEventLoopDelay()`][].
 
 ### `histogram.disable()`
 
@@ -2051,17 +2052,11 @@ const { monitorEventLoopDelay } = require('node:perf_hooks');
 }
 ```
 
-### Cloning event loop delay histograms
+### Cloning an `ELDHistogram`
 
-{IntervalHistogram} and {ELDHistogram} instances can be cloned via
-{MessagePort}. On the receiving end, the histogram is cloned as a plain
-{Histogram} object that does not implement the `enable()` and `disable()`
-methods.
-
-## Class: `ELDHistogram extends Histogram`
-
-A `Histogram` that records event loop delay once per event loop iteration. It
-provides the same API as {IntervalHistogram}.
+{ELDHistogram} instances can be cloned via {MessagePort}. On the receiving end,
+the histogram is cloned as a plain {Histogram} object that does not implement
+the `enable()` and `disable()` methods.
 
 ## Class: `RecordableHistogram extends Histogram`
 
@@ -2369,6 +2364,7 @@ dns.promises.resolve('localhost');
 [`'exit'`]: process.md#event-exit
 [`child_process.spawnSync()`]: child_process.md#child_processspawnsynccommand-args-options
 [`perf_hooks.eventLoopUtilization()`]: #perf_hookseventlooputilizationutilization1-utilization2
+[`perf_hooks.monitorEventLoopDelay()`]: #perf_hooksmonitoreventloopdelayoptions
 [`perf_hooks.timerify()`]: #perf_hookstimerifyfn-options
 [`process.hrtime()`]: process.md#processhrtimetime
 [`timeOrigin`]: https://w3c.github.io/hr-time/#dom-performance-timeorigin

--- a/doc/api/perf_hooks.md
+++ b/doc/api/perf_hooks.md
@@ -1706,6 +1706,10 @@ are not guaranteed to reflect any correct state of the event loop.
 
 <!-- YAML
 added: v11.10.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/62935
+    description: Added the `samplePerIteration` option.
 -->
 
 * `options` {Object}
@@ -1714,18 +1718,20 @@ added: v11.10.0
   * `resolution` {number} The sampling rate in milliseconds for interval-based
     sampling. Must be greater than zero. This option is ignored when
     `samplePerIteration` is `true`. **Default:** `10`.
-* Returns: {IntervalHistogram}
+* Returns: {IntervalHistogram|ELDHistogram}
 
 _This property is an extension by Node.js. It is not available in Web browsers._
 
-Creates an `IntervalHistogram` object that samples and reports the event loop
-delay over time. The delays will be reported in nanoseconds.
+Creates a histogram object that samples and reports the event loop delay over
+time. The delays will be reported in nanoseconds.
 
 By default, the histogram is updated by a timer using the configured
 `resolution`. When `samplePerIteration` is `true`, samples are taken once per
 event loop iteration using `uv_prepare_t` and `uv_check_t` hooks. In that mode,
 the histogram does not keep the loop alive or force additional iterations when
 the application is idle.
+The two sampling modes produce significantly different results and should not
+be compared directly.
 
 ```mjs
 import { monitorEventLoopDelay } from 'node:perf_hooks';
@@ -2004,7 +2010,7 @@ The standard deviation of the recorded event loop delays.
 
 ## Class: `IntervalHistogram extends Histogram`
 
-A `Histogram` that records event loop delay.
+A `Histogram` that records event loop delay using interval-based sampling.
 
 ### `histogram.disable()`
 
@@ -2045,11 +2051,17 @@ const { monitorEventLoopDelay } = require('node:perf_hooks');
 }
 ```
 
-### Cloning an `IntervalHistogram`
+### Cloning event loop delay histograms
 
-{IntervalHistogram} instances can be cloned via {MessagePort}. On the receiving
-end, the histogram is cloned as a plain {Histogram} object that does not
-implement the `enable()` and `disable()` methods.
+{IntervalHistogram} and {ELDHistogram} instances can be cloned via
+{MessagePort}. On the receiving end, the histogram is cloned as a plain
+{Histogram} object that does not implement the `enable()` and `disable()`
+methods.
+
+## Class: `ELDHistogram extends Histogram`
+
+A `Histogram` that records event loop delay once per event loop iteration. It
+provides the same API as {IntervalHistogram}.
 
 ## Class: `RecordableHistogram extends Histogram`
 

--- a/lib/internal/perf/event_loop_delay.js
+++ b/lib/internal/perf/event_loop_delay.js
@@ -18,6 +18,7 @@ const {
 } = internalBinding('performance');
 
 const {
+  validateBoolean,
   validateInteger,
   validateObject,
 } = require('internal/validators');
@@ -74,6 +75,7 @@ class ELDHistogram extends Histogram {
 
 /**
  * @param {{
+ *   samplePerIteration : boolean,
  *   resolution : number
  * }} [options]
  * @returns {ELDHistogram}
@@ -81,14 +83,15 @@ class ELDHistogram extends Histogram {
 function monitorEventLoopDelay(options = kEmptyObject) {
   validateObject(options, 'options');
 
-  const { resolution = 10 } = options;
+  const { samplePerIteration = false, resolution = 10 } = options;
+  validateBoolean(samplePerIteration, 'options.samplePerIteration');
   validateInteger(resolution, 'options.resolution', 1);
 
   return ReflectConstruct(
     function() {
       markTransferMode(this, true, false);
       this[kEnabled] = false;
-      this[kHandle] = createELDHistogram(resolution);
+      this[kHandle] = createELDHistogram(resolution, samplePerIteration);
       this[kMap] = new SafeMap();
     }, [], ELDHistogram);
 }

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -434,6 +434,7 @@
   V(http2ping_constructor_template, v8::ObjectTemplate)                        \
   V(i18n_converter_template, v8::ObjectTemplate)                               \
   V(intervalhistogram_constructor_template, v8::FunctionTemplate)              \
+  V(eldhistogram_constructor_template, v8::FunctionTemplate)                   \
   V(iter_template, v8::DictionaryTemplate)                                     \
   V(js_transferable_constructor_template, v8::FunctionTemplate)                \
   V(libuv_stream_wrap_ctor_template, v8::FunctionTemplate)                     \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -434,7 +434,7 @@
   V(http2ping_constructor_template, v8::ObjectTemplate)                        \
   V(i18n_converter_template, v8::ObjectTemplate)                               \
   V(intervalhistogram_constructor_template, v8::FunctionTemplate)              \
-  V(iterationhistogram_constructor_template, v8::FunctionTemplate)                   \
+  V(iterationhistogram_constructor_template, v8::FunctionTemplate)             \
   V(iter_template, v8::DictionaryTemplate)                                     \
   V(js_transferable_constructor_template, v8::FunctionTemplate)                \
   V(libuv_stream_wrap_ctor_template, v8::FunctionTemplate)                     \

--- a/src/env_properties.h
+++ b/src/env_properties.h
@@ -434,7 +434,7 @@
   V(http2ping_constructor_template, v8::ObjectTemplate)                        \
   V(i18n_converter_template, v8::ObjectTemplate)                               \
   V(intervalhistogram_constructor_template, v8::FunctionTemplate)              \
-  V(eldhistogram_constructor_template, v8::FunctionTemplate)                   \
+  V(iterationhistogram_constructor_template, v8::FunctionTemplate)                   \
   V(iter_template, v8::DictionaryTemplate)                                     \
   V(js_transferable_constructor_template, v8::FunctionTemplate)                \
   V(libuv_stream_wrap_ctor_template, v8::FunctionTemplate)                     \

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -68,6 +68,10 @@ CFunction IntervalHistogram::fast_start_(
     CFunction::Make(&IntervalHistogram::FastStart));
 CFunction IntervalHistogram::fast_stop_(
     CFunction::Make(&IntervalHistogram::FastStop));
+CFunction ELDHistogram::fast_start_(
+    CFunction::Make(&ELDHistogram::FastStart));
+CFunction ELDHistogram::fast_stop_(
+    CFunction::Make(&ELDHistogram::FastStop));
 
 void HistogramImpl::AddMethods(Isolate* isolate, Local<FunctionTemplate> tmpl) {
   // TODO(@jasnell): The bigint API variations do not yet support fast
@@ -444,6 +448,173 @@ void IntervalHistogram::FastStop(Local<Value> receiver) {
   histogram->OnStop();
 }
 
+Local<FunctionTemplate> ELDHistogram::GetConstructorTemplate(
+    Environment* env) {
+  Local<FunctionTemplate> tmpl = env->eldhistogram_constructor_template();
+  if (tmpl.IsEmpty()) {
+    Isolate* isolate = env->isolate();
+    tmpl = NewFunctionTemplate(isolate, nullptr);
+    tmpl->Inherit(HandleWrap::GetConstructorTemplate(env));
+    tmpl->SetClassName(FIXED_ONE_BYTE_STRING(isolate, "Histogram"));
+    auto instance = tmpl->InstanceTemplate();
+    instance->SetInternalFieldCount(ELDHistogram::kInternalFieldCount);
+    HistogramImpl::AddMethods(isolate, tmpl);
+    SetFastMethod(isolate, instance, "start", Start, &fast_start_);
+    SetFastMethod(isolate, instance, "stop", Stop, &fast_stop_);
+    env->set_eldhistogram_constructor_template(tmpl);
+  }
+  return tmpl;
+}
+
+void ELDHistogram::RegisterExternalReferences(
+    ExternalReferenceRegistry* registry) {
+  registry->Register(Start);
+  registry->Register(Stop);
+  registry->Register(fast_start_);
+  registry->Register(fast_stop_);
+  HistogramImpl::RegisterExternalReferences(registry);
+}
+
+ELDHistogram::ELDHistogram(
+    Environment* env,
+    Local<Object> wrap,
+    AsyncWrap::ProviderType type,
+    const Histogram::Options& options)
+    : HandleWrap(
+          env,
+          wrap,
+          reinterpret_cast<uv_handle_t*>(&check_handle_),
+          type),
+      HistogramImpl(options) {
+  MakeWeak();
+  wrap->SetAlignedPointerInInternalField(
+      HistogramImpl::InternalFields::kImplField,
+      static_cast<HistogramImpl*>(this),
+      EmbedderDataTag::kDefault);
+  uv_check_init(env->event_loop(), &check_handle_);
+  uv_prepare_init(env->event_loop(), &prepare_handle_);
+  uv_unref(reinterpret_cast<uv_handle_t*>(&check_handle_));
+  uv_unref(reinterpret_cast<uv_handle_t*>(&prepare_handle_));
+  prepare_handle_.data = this;
+}
+
+BaseObjectPtr<ELDHistogram> ELDHistogram::Create(
+    Environment* env,
+    const Histogram::Options& options) {
+  Local<Object> obj;
+  if (!GetConstructorTemplate(env)
+          ->InstanceTemplate()
+          ->NewInstance(env->context()).ToLocal(&obj)) {
+    return nullptr;
+  }
+
+  return MakeBaseObject<ELDHistogram>(
+      env,
+      obj,
+      AsyncWrap::PROVIDER_ELDHISTOGRAM,
+      options);
+}
+
+void ELDHistogram::PrepareCB(uv_prepare_t* handle) {
+  ELDHistogram* self = static_cast<ELDHistogram*>(handle->data);
+  if (!self->enabled_) return;
+  self->prepare_time_ = uv_hrtime();
+  self->timeout_ = uv_backend_timeout(handle->loop);
+}
+
+void ELDHistogram::CheckCB(uv_check_t* handle) {
+  ELDHistogram* self =
+      ContainerOf(&ELDHistogram::check_handle_, handle);
+  if (!self->enabled_) return;
+
+  uint64_t check_time = uv_hrtime();
+  uint64_t poll_time = check_time - self->prepare_time_;
+  uint64_t latency = self->prepare_time_ - self->check_time_;
+
+  if (self->timeout_ >= 0) {
+    uint64_t timeout_ns = static_cast<uint64_t>(self->timeout_) * 1000 * 1000;
+    if (poll_time > timeout_ns) {
+      latency += poll_time - timeout_ns;
+    }
+  }
+
+  self->histogram()->Record(latency == 0 ? 1 : latency);
+  self->check_time_ = check_time;
+}
+
+void ELDHistogram::MemoryInfo(MemoryTracker* tracker) const {
+  tracker->TrackField("histogram", histogram());
+}
+
+void ELDHistogram::OnStart(StartFlags flags) {
+  if (enabled_ || IsHandleClosing()) return;
+  enabled_ = true;
+  if (flags == StartFlags::RESET)
+    histogram()->Reset();
+  check_time_ = uv_hrtime();
+  prepare_time_ = check_time_;
+  timeout_ = 0;
+  uv_check_start(&check_handle_, CheckCB);
+  uv_prepare_start(&prepare_handle_, PrepareCB);
+  uv_unref(reinterpret_cast<uv_handle_t*>(&check_handle_));
+  uv_unref(reinterpret_cast<uv_handle_t*>(&prepare_handle_));
+}
+
+void ELDHistogram::OnStop() {
+  if (!enabled_ || IsHandleClosing()) return;
+  enabled_ = false;
+  uv_check_stop(&check_handle_);
+  uv_prepare_stop(&prepare_handle_);
+}
+
+void ELDHistogram::PrepareCloseCB(uv_handle_t* handle) {
+  ELDHistogram* self = static_cast<ELDHistogram*>(handle->data);
+  uv_close(reinterpret_cast<uv_handle_t*>(&self->check_handle_),
+           HandleWrap::OnClose);
+}
+
+void ELDHistogram::Close(Local<Value> close_callback) {
+  if (IsHandleClosing()) return;
+  OnStop();
+  state_ = kClosing;
+
+  if (!close_callback.IsEmpty() && close_callback->IsFunction() &&
+      !persistent().IsEmpty()) {
+    object()->Set(env()->context(),
+                  env()->handle_onclose_symbol(),
+                  close_callback).Check();
+  }
+
+  uv_close(reinterpret_cast<uv_handle_t*>(&prepare_handle_),
+           PrepareCloseCB);
+}
+
+void ELDHistogram::Start(const FunctionCallbackInfo<Value>& args) {
+  ELDHistogram* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
+  histogram->OnStart(args[0]->IsTrue() ? StartFlags::RESET : StartFlags::NONE);
+}
+
+void ELDHistogram::FastStart(Local<Value> receiver, bool reset) {
+  TRACK_V8_FAST_API_CALL("histogram.start");
+  ELDHistogram* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
+  histogram->OnStart(reset ? StartFlags::RESET : StartFlags::NONE);
+}
+
+void ELDHistogram::Stop(const FunctionCallbackInfo<Value>& args) {
+  ELDHistogram* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
+  histogram->OnStop();
+}
+
+void ELDHistogram::FastStop(Local<Value> receiver) {
+  TRACK_V8_FAST_API_CALL("histogram.stop");
+  ELDHistogram* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
+  histogram->OnStop();
+}
+
 void HistogramImpl::GetCount(const FunctionCallbackInfo<Value>& args) {
   HistogramImpl* histogram = HistogramImpl::FromJSObject(args.This());
   double value = static_cast<double>((*histogram)->Count());
@@ -605,6 +776,11 @@ HistogramImpl* HistogramImpl::FromJSObject(Local<Value> value) {
   DCHECK_GE(obj->InternalFieldCount(), HistogramImpl::kInternalFieldCount);
   return static_cast<HistogramImpl*>(obj->GetAlignedPointerFromInternalField(
       HistogramImpl::kImplField, EmbedderDataTag::kDefault));
+}
+
+std::unique_ptr<worker::TransferData>
+ELDHistogram::CloneForMessaging() const {
+  return std::make_unique<HistogramBase::HistogramTransferData>(histogram());
 }
 
 std::unique_ptr<worker::TransferData>

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -68,8 +68,10 @@ CFunction IntervalHistogram::fast_start_(
     CFunction::Make(&IntervalHistogram::FastStart));
 CFunction IntervalHistogram::fast_stop_(
     CFunction::Make(&IntervalHistogram::FastStop));
-CFunction ELDHistogram::fast_start_(CFunction::Make(&ELDHistogram::FastStart));
-CFunction ELDHistogram::fast_stop_(CFunction::Make(&ELDHistogram::FastStop));
+CFunction IterationHistogram::fast_start_(
+    CFunction::Make(&IterationHistogram::FastStart));
+CFunction IterationHistogram::fast_stop_(
+    CFunction::Make(&IterationHistogram::FastStop));
 
 void HistogramImpl::AddMethods(Isolate* isolate, Local<FunctionTemplate> tmpl) {
   // TODO(@jasnell): The bigint API variations do not yet support fast
@@ -446,24 +448,24 @@ void IntervalHistogram::FastStop(Local<Value> receiver) {
   histogram->OnStop();
 }
 
-Local<FunctionTemplate> ELDHistogram::GetConstructorTemplate(Environment* env) {
-  Local<FunctionTemplate> tmpl = env->eldhistogram_constructor_template();
+Local<FunctionTemplate> IterationHistogram::GetConstructorTemplate(Environment* env) {
+  Local<FunctionTemplate> tmpl = env->iterationhistogram_constructor_template();
   if (tmpl.IsEmpty()) {
     Isolate* isolate = env->isolate();
     tmpl = NewFunctionTemplate(isolate, nullptr);
     tmpl->Inherit(HandleWrap::GetConstructorTemplate(env));
     tmpl->SetClassName(FIXED_ONE_BYTE_STRING(isolate, "Histogram"));
     auto instance = tmpl->InstanceTemplate();
-    instance->SetInternalFieldCount(ELDHistogram::kInternalFieldCount);
+    instance->SetInternalFieldCount(IterationHistogram::kInternalFieldCount);
     HistogramImpl::AddMethods(isolate, tmpl);
     SetFastMethod(isolate, instance, "start", Start, &fast_start_);
     SetFastMethod(isolate, instance, "stop", Stop, &fast_stop_);
-    env->set_eldhistogram_constructor_template(tmpl);
+    env->set_iterationhistogram_constructor_template(tmpl);
   }
   return tmpl;
 }
 
-void ELDHistogram::RegisterExternalReferences(
+void IterationHistogram::RegisterExternalReferences(
     ExternalReferenceRegistry* registry) {
   registry->Register(Start);
   registry->Register(Stop);
@@ -472,10 +474,10 @@ void ELDHistogram::RegisterExternalReferences(
   HistogramImpl::RegisterExternalReferences(registry);
 }
 
-ELDHistogram::ELDHistogram(Environment* env,
-                           Local<Object> wrap,
-                           AsyncWrap::ProviderType type,
-                           const Histogram::Options& options)
+IterationHistogram::IterationHistogram(Environment* env,
+                                       Local<Object> wrap,
+                                       AsyncWrap::ProviderType type,
+                                       const Histogram::Options& options)
     : HandleWrap(
           env, wrap, reinterpret_cast<uv_handle_t*>(&check_handle_), type),
       HistogramImpl(options) {
@@ -491,7 +493,7 @@ ELDHistogram::ELDHistogram(Environment* env,
   prepare_handle_.data = this;
 }
 
-BaseObjectPtr<ELDHistogram> ELDHistogram::Create(
+BaseObjectPtr<IterationHistogram> IterationHistogram::Create(
     Environment* env, const Histogram::Options& options) {
   Local<Object> obj;
   if (!GetConstructorTemplate(env)
@@ -501,19 +503,19 @@ BaseObjectPtr<ELDHistogram> ELDHistogram::Create(
     return nullptr;
   }
 
-  return MakeBaseObject<ELDHistogram>(
+  return MakeBaseObject<IterationHistogram>(
       env, obj, AsyncWrap::PROVIDER_ELDHISTOGRAM, options);
 }
 
-void ELDHistogram::PrepareCB(uv_prepare_t* handle) {
-  ELDHistogram* self = static_cast<ELDHistogram*>(handle->data);
+void IterationHistogram::PrepareCB(uv_prepare_t* handle) {
+  IterationHistogram* self = static_cast<IterationHistogram*>(handle->data);
   if (!self->enabled_) return;
   self->prepare_time_ = uv_hrtime();
   self->timeout_ = uv_backend_timeout(handle->loop);
 }
 
-void ELDHistogram::CheckCB(uv_check_t* handle) {
-  ELDHistogram* self = ContainerOf(&ELDHistogram::check_handle_, handle);
+void IterationHistogram::CheckCB(uv_check_t* handle) {
+  IterationHistogram* self = ContainerOf(&IterationHistogram::check_handle_, handle);
   if (!self->enabled_) return;
 
   uint64_t check_time = uv_hrtime();
@@ -531,11 +533,11 @@ void ELDHistogram::CheckCB(uv_check_t* handle) {
   self->check_time_ = check_time;
 }
 
-void ELDHistogram::MemoryInfo(MemoryTracker* tracker) const {
+void IterationHistogram::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("histogram", histogram());
 }
 
-void ELDHistogram::OnStart(StartFlags flags) {
+void IterationHistogram::OnStart(StartFlags flags) {
   if (enabled_ || IsHandleClosing()) return;
   enabled_ = true;
   if (flags == StartFlags::RESET) histogram()->Reset();
@@ -548,42 +550,42 @@ void ELDHistogram::OnStart(StartFlags flags) {
   uv_unref(reinterpret_cast<uv_handle_t*>(&prepare_handle_));
 }
 
-void ELDHistogram::OnStop() {
+void IterationHistogram::OnStop() {
   if (!enabled_ || IsHandleClosing()) return;
   enabled_ = false;
   uv_check_stop(&check_handle_);
   uv_prepare_stop(&prepare_handle_);
 }
 
-void ELDHistogram::Close(Local<Value> close_callback) {
+void IterationHistogram::Close(Local<Value> close_callback) {
   if (IsHandleClosing()) return;
   OnStop();
   HandleWrap::Close(close_callback);
   uv_close(reinterpret_cast<uv_handle_t*>(&prepare_handle_), nullptr);
 }
 
-void ELDHistogram::Start(const FunctionCallbackInfo<Value>& args) {
-  ELDHistogram* histogram;
+void IterationHistogram::Start(const FunctionCallbackInfo<Value>& args) {
+  IterationHistogram* histogram;
   ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
   histogram->OnStart(args[0]->IsTrue() ? StartFlags::RESET : StartFlags::NONE);
 }
 
-void ELDHistogram::FastStart(Local<Value> receiver, bool reset) {
+void IterationHistogram::FastStart(Local<Value> receiver, bool reset) {
   TRACK_V8_FAST_API_CALL("histogram.eventLoopDelay.start");
-  ELDHistogram* histogram;
+  IterationHistogram* histogram;
   ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
   histogram->OnStart(reset ? StartFlags::RESET : StartFlags::NONE);
 }
 
-void ELDHistogram::Stop(const FunctionCallbackInfo<Value>& args) {
-  ELDHistogram* histogram;
+void IterationHistogram::Stop(const FunctionCallbackInfo<Value>& args) {
+  IterationHistogram* histogram;
   ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
   histogram->OnStop();
 }
 
-void ELDHistogram::FastStop(Local<Value> receiver) {
+void IterationHistogram::FastStop(Local<Value> receiver) {
   TRACK_V8_FAST_API_CALL("histogram.eventLoopDelay.stop");
-  ELDHistogram* histogram;
+  IterationHistogram* histogram;
   ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
   histogram->OnStop();
 }
@@ -751,7 +753,7 @@ HistogramImpl* HistogramImpl::FromJSObject(Local<Value> value) {
       HistogramImpl::kImplField, EmbedderDataTag::kDefault));
 }
 
-std::unique_ptr<worker::TransferData> ELDHistogram::CloneForMessaging() const {
+std::unique_ptr<worker::TransferData> IterationHistogram::CloneForMessaging() const {
   return std::make_unique<HistogramBase::HistogramTransferData>(histogram());
 }
 

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -555,25 +555,11 @@ void ELDHistogram::OnStop() {
   uv_prepare_stop(&prepare_handle_);
 }
 
-void ELDHistogram::PrepareCloseCB(uv_handle_t* handle) {
-  ELDHistogram* self = static_cast<ELDHistogram*>(handle->data);
-  uv_close(reinterpret_cast<uv_handle_t*>(&self->check_handle_),
-           HandleWrap::OnClose);
-}
-
 void ELDHistogram::Close(Local<Value> close_callback) {
   if (IsHandleClosing()) return;
   OnStop();
-  state_ = kClosing;
-
-  if (!close_callback.IsEmpty() && close_callback->IsFunction() &&
-      !persistent().IsEmpty()) {
-    object()
-        ->Set(env()->context(), env()->handle_onclose_symbol(), close_callback)
-        .Check();
-  }
-
-  uv_close(reinterpret_cast<uv_handle_t*>(&prepare_handle_), PrepareCloseCB);
+  HandleWrap::Close(close_callback);
+  uv_close(reinterpret_cast<uv_handle_t*>(&prepare_handle_), nullptr);
 }
 
 void ELDHistogram::Start(const FunctionCallbackInfo<Value>& args) {

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -596,7 +596,7 @@ void ELDHistogram::Start(const FunctionCallbackInfo<Value>& args) {
 }
 
 void ELDHistogram::FastStart(Local<Value> receiver, bool reset) {
-  TRACK_V8_FAST_API_CALL("histogram.start");
+  TRACK_V8_FAST_API_CALL("histogram.eventLoopDelay.start");
   ELDHistogram* histogram;
   ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
   histogram->OnStart(reset ? StartFlags::RESET : StartFlags::NONE);
@@ -609,7 +609,7 @@ void ELDHistogram::Stop(const FunctionCallbackInfo<Value>& args) {
 }
 
 void ELDHistogram::FastStop(Local<Value> receiver) {
-  TRACK_V8_FAST_API_CALL("histogram.stop");
+  TRACK_V8_FAST_API_CALL("histogram.eventLoopDelay.stop");
   ELDHistogram* histogram;
   ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
   histogram->OnStop();

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -25,6 +25,20 @@ using v8::String;
 using v8::Uint32;
 using v8::Value;
 
+template <typename T>
+void StartHandleHistogram(Local<Value> receiver, bool reset) {
+  T* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
+  histogram->OnStart(reset ? T::StartFlags::RESET : T::StartFlags::NONE);
+}
+
+template <typename T>
+void StopHandleHistogram(Local<Value> receiver) {
+  T* histogram;
+  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
+  histogram->OnStop();
+}
+
 Histogram::Histogram(const Options& options) {
   hdr_histogram* histogram;
   CHECK_EQ(0, hdr_init(options.lowest,
@@ -423,32 +437,25 @@ void IntervalHistogram::OnStop() {
 }
 
 void IntervalHistogram::Start(const FunctionCallbackInfo<Value>& args) {
-  IntervalHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
-  histogram->OnStart(args[0]->IsTrue() ? StartFlags::RESET : StartFlags::NONE);
+  StartHandleHistogram<IntervalHistogram>(args.This(), args[0]->IsTrue());
 }
 
 void IntervalHistogram::FastStart(Local<Value> receiver, bool reset) {
   TRACK_V8_FAST_API_CALL("histogram.start");
-  IntervalHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
-  histogram->OnStart(reset ? StartFlags::RESET : StartFlags::NONE);
+  StartHandleHistogram<IntervalHistogram>(receiver, reset);
 }
 
 void IntervalHistogram::Stop(const FunctionCallbackInfo<Value>& args) {
-  IntervalHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
-  histogram->OnStop();
+  StopHandleHistogram<IntervalHistogram>(args.This());
 }
 
 void IntervalHistogram::FastStop(Local<Value> receiver) {
   TRACK_V8_FAST_API_CALL("histogram.stop");
-  IntervalHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
-  histogram->OnStop();
+  StopHandleHistogram<IntervalHistogram>(receiver);
 }
 
-Local<FunctionTemplate> IterationHistogram::GetConstructorTemplate(Environment* env) {
+Local<FunctionTemplate> IterationHistogram::GetConstructorTemplate(
+    Environment* env) {
   Local<FunctionTemplate> tmpl = env->iterationhistogram_constructor_template();
   if (tmpl.IsEmpty()) {
     Isolate* isolate = env->isolate();
@@ -515,7 +522,8 @@ void IterationHistogram::PrepareCB(uv_prepare_t* handle) {
 }
 
 void IterationHistogram::CheckCB(uv_check_t* handle) {
-  IterationHistogram* self = ContainerOf(&IterationHistogram::check_handle_, handle);
+  IterationHistogram* self =
+      ContainerOf(&IterationHistogram::check_handle_, handle);
   if (!self->enabled_) return;
 
   uint64_t check_time = uv_hrtime();
@@ -565,29 +573,21 @@ void IterationHistogram::Close(Local<Value> close_callback) {
 }
 
 void IterationHistogram::Start(const FunctionCallbackInfo<Value>& args) {
-  IterationHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
-  histogram->OnStart(args[0]->IsTrue() ? StartFlags::RESET : StartFlags::NONE);
+  StartHandleHistogram<IterationHistogram>(args.This(), args[0]->IsTrue());
 }
 
 void IterationHistogram::FastStart(Local<Value> receiver, bool reset) {
   TRACK_V8_FAST_API_CALL("histogram.eventLoopDelay.start");
-  IterationHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
-  histogram->OnStart(reset ? StartFlags::RESET : StartFlags::NONE);
+  StartHandleHistogram<IterationHistogram>(receiver, reset);
 }
 
 void IterationHistogram::Stop(const FunctionCallbackInfo<Value>& args) {
-  IterationHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, args.This());
-  histogram->OnStop();
+  StopHandleHistogram<IterationHistogram>(args.This());
 }
 
 void IterationHistogram::FastStop(Local<Value> receiver) {
   TRACK_V8_FAST_API_CALL("histogram.eventLoopDelay.stop");
-  IterationHistogram* histogram;
-  ASSIGN_OR_RETURN_UNWRAP(&histogram, receiver);
-  histogram->OnStop();
+  StopHandleHistogram<IterationHistogram>(receiver);
 }
 
 void HistogramImpl::GetCount(const FunctionCallbackInfo<Value>& args) {
@@ -753,7 +753,8 @@ HistogramImpl* HistogramImpl::FromJSObject(Local<Value> value) {
       HistogramImpl::kImplField, EmbedderDataTag::kDefault));
 }
 
-std::unique_ptr<worker::TransferData> IterationHistogram::CloneForMessaging() const {
+std::unique_ptr<worker::TransferData> IterationHistogram::CloneForMessaging()
+    const {
   return std::make_unique<HistogramBase::HistogramTransferData>(histogram());
 }
 

--- a/src/histogram.cc
+++ b/src/histogram.cc
@@ -68,10 +68,8 @@ CFunction IntervalHistogram::fast_start_(
     CFunction::Make(&IntervalHistogram::FastStart));
 CFunction IntervalHistogram::fast_stop_(
     CFunction::Make(&IntervalHistogram::FastStop));
-CFunction ELDHistogram::fast_start_(
-    CFunction::Make(&ELDHistogram::FastStart));
-CFunction ELDHistogram::fast_stop_(
-    CFunction::Make(&ELDHistogram::FastStop));
+CFunction ELDHistogram::fast_start_(CFunction::Make(&ELDHistogram::FastStart));
+CFunction ELDHistogram::fast_stop_(CFunction::Make(&ELDHistogram::FastStop));
 
 void HistogramImpl::AddMethods(Isolate* isolate, Local<FunctionTemplate> tmpl) {
   // TODO(@jasnell): The bigint API variations do not yet support fast
@@ -448,8 +446,7 @@ void IntervalHistogram::FastStop(Local<Value> receiver) {
   histogram->OnStop();
 }
 
-Local<FunctionTemplate> ELDHistogram::GetConstructorTemplate(
-    Environment* env) {
+Local<FunctionTemplate> ELDHistogram::GetConstructorTemplate(Environment* env) {
   Local<FunctionTemplate> tmpl = env->eldhistogram_constructor_template();
   if (tmpl.IsEmpty()) {
     Isolate* isolate = env->isolate();
@@ -475,16 +472,12 @@ void ELDHistogram::RegisterExternalReferences(
   HistogramImpl::RegisterExternalReferences(registry);
 }
 
-ELDHistogram::ELDHistogram(
-    Environment* env,
-    Local<Object> wrap,
-    AsyncWrap::ProviderType type,
-    const Histogram::Options& options)
+ELDHistogram::ELDHistogram(Environment* env,
+                           Local<Object> wrap,
+                           AsyncWrap::ProviderType type,
+                           const Histogram::Options& options)
     : HandleWrap(
-          env,
-          wrap,
-          reinterpret_cast<uv_handle_t*>(&check_handle_),
-          type),
+          env, wrap, reinterpret_cast<uv_handle_t*>(&check_handle_), type),
       HistogramImpl(options) {
   MakeWeak();
   wrap->SetAlignedPointerInInternalField(
@@ -499,20 +492,17 @@ ELDHistogram::ELDHistogram(
 }
 
 BaseObjectPtr<ELDHistogram> ELDHistogram::Create(
-    Environment* env,
-    const Histogram::Options& options) {
+    Environment* env, const Histogram::Options& options) {
   Local<Object> obj;
   if (!GetConstructorTemplate(env)
-          ->InstanceTemplate()
-          ->NewInstance(env->context()).ToLocal(&obj)) {
+           ->InstanceTemplate()
+           ->NewInstance(env->context())
+           .ToLocal(&obj)) {
     return nullptr;
   }
 
   return MakeBaseObject<ELDHistogram>(
-      env,
-      obj,
-      AsyncWrap::PROVIDER_ELDHISTOGRAM,
-      options);
+      env, obj, AsyncWrap::PROVIDER_ELDHISTOGRAM, options);
 }
 
 void ELDHistogram::PrepareCB(uv_prepare_t* handle) {
@@ -523,8 +513,7 @@ void ELDHistogram::PrepareCB(uv_prepare_t* handle) {
 }
 
 void ELDHistogram::CheckCB(uv_check_t* handle) {
-  ELDHistogram* self =
-      ContainerOf(&ELDHistogram::check_handle_, handle);
+  ELDHistogram* self = ContainerOf(&ELDHistogram::check_handle_, handle);
   if (!self->enabled_) return;
 
   uint64_t check_time = uv_hrtime();
@@ -549,8 +538,7 @@ void ELDHistogram::MemoryInfo(MemoryTracker* tracker) const {
 void ELDHistogram::OnStart(StartFlags flags) {
   if (enabled_ || IsHandleClosing()) return;
   enabled_ = true;
-  if (flags == StartFlags::RESET)
-    histogram()->Reset();
+  if (flags == StartFlags::RESET) histogram()->Reset();
   check_time_ = uv_hrtime();
   prepare_time_ = check_time_;
   timeout_ = 0;
@@ -580,13 +568,12 @@ void ELDHistogram::Close(Local<Value> close_callback) {
 
   if (!close_callback.IsEmpty() && close_callback->IsFunction() &&
       !persistent().IsEmpty()) {
-    object()->Set(env()->context(),
-                  env()->handle_onclose_symbol(),
-                  close_callback).Check();
+    object()
+        ->Set(env()->context(), env()->handle_onclose_symbol(), close_callback)
+        .Check();
   }
 
-  uv_close(reinterpret_cast<uv_handle_t*>(&prepare_handle_),
-           PrepareCloseCB);
+  uv_close(reinterpret_cast<uv_handle_t*>(&prepare_handle_), PrepareCloseCB);
 }
 
 void ELDHistogram::Start(const FunctionCallbackInfo<Value>& args) {
@@ -778,8 +765,7 @@ HistogramImpl* HistogramImpl::FromJSObject(Local<Value> value) {
       HistogramImpl::kImplField, EmbedderDataTag::kDefault));
 }
 
-std::unique_ptr<worker::TransferData>
-ELDHistogram::CloneForMessaging() const {
+std::unique_ptr<worker::TransferData> ELDHistogram::CloneForMessaging() const {
   return std::make_unique<HistogramBase::HistogramTransferData>(histogram());
 }
 

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -266,6 +266,69 @@ class IntervalHistogram final : public HandleWrap, public HistogramImpl {
   static v8::CFunction fast_stop_;
 };
 
+class ELDHistogram final : public HandleWrap, public HistogramImpl {
+ public:
+  enum InternalFields {
+    kInternalFieldCount = std::max<uint32_t>(
+        HandleWrap::kInternalFieldCount, HistogramImpl::kInternalFieldCount),
+  };
+
+  enum class StartFlags {
+    NONE,
+    RESET
+  };
+
+  static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
+
+  static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
+      Environment* env);
+
+  static BaseObjectPtr<ELDHistogram> Create(
+      Environment* env,
+      const Histogram::Options& options);
+
+  ELDHistogram(
+      Environment* env,
+      v8::Local<v8::Object> wrap,
+      AsyncWrap::ProviderType type,
+      const Histogram::Options& options = Histogram::Options {});
+
+  static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
+  static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
+
+  static void FastStart(v8::Local<v8::Value> receiver, bool reset);
+  static void FastStop(v8::Local<v8::Value> receiver);
+
+  BaseObject::TransferMode GetTransferMode() const override {
+    return TransferMode::kCloneable;
+  }
+  std::unique_ptr<worker::TransferData> CloneForMessaging() const override;
+
+  void Close(v8::Local<v8::Value> close_callback =
+                 v8::Local<v8::Value>()) override;
+
+  void MemoryInfo(MemoryTracker* tracker) const override;
+  SET_MEMORY_INFO_NAME(ELDHistogram)
+  SET_SELF_SIZE(ELDHistogram)
+
+ private:
+  static void PrepareCB(uv_prepare_t* handle);
+  static void CheckCB(uv_check_t* handle);
+  static void PrepareCloseCB(uv_handle_t* handle);
+  void OnStart(StartFlags flags = StartFlags::RESET);
+  void OnStop();
+
+  bool enabled_ = false;
+  uv_prepare_t prepare_handle_;
+  uv_check_t check_handle_;
+  uint64_t prepare_time_ = 0;
+  uint64_t check_time_ = 0;
+  int64_t timeout_ = 0;
+
+  static v8::CFunction fast_start_;
+  static v8::CFunction fast_stop_;
+};
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -266,7 +266,7 @@ class IntervalHistogram final : public HandleWrap, public HistogramImpl {
   static v8::CFunction fast_stop_;
 };
 
-class ELDHistogram final : public HandleWrap, public HistogramImpl {
+class IterationHistogram final : public HandleWrap, public HistogramImpl {
  public:
   enum InternalFields {
     kInternalFieldCount = std::max<uint32_t>(
@@ -280,13 +280,13 @@ class ELDHistogram final : public HandleWrap, public HistogramImpl {
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
 
-  static BaseObjectPtr<ELDHistogram> Create(Environment* env,
-                                            const Histogram::Options& options);
+  static BaseObjectPtr<IterationHistogram> Create(
+      Environment* env, const Histogram::Options& options);
 
-  ELDHistogram(Environment* env,
-               v8::Local<v8::Object> wrap,
-               AsyncWrap::ProviderType type,
-               const Histogram::Options& options = Histogram::Options{});
+  IterationHistogram(Environment* env,
+                     v8::Local<v8::Object> wrap,
+                     AsyncWrap::ProviderType type,
+                     const Histogram::Options& options = Histogram::Options{});
 
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -303,8 +303,8 @@ class ELDHistogram final : public HandleWrap, public HistogramImpl {
       v8::Local<v8::Value> close_callback = v8::Local<v8::Value>()) override;
 
   void MemoryInfo(MemoryTracker* tracker) const override;
-  SET_MEMORY_INFO_NAME(ELDHistogram)
-  SET_SELF_SIZE(ELDHistogram)
+  SET_MEMORY_INFO_NAME(IterationHistogram)
+  SET_SELF_SIZE(IterationHistogram)
 
  private:
   static void PrepareCB(uv_prepare_t* handle);

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -273,25 +273,20 @@ class ELDHistogram final : public HandleWrap, public HistogramImpl {
         HandleWrap::kInternalFieldCount, HistogramImpl::kInternalFieldCount),
   };
 
-  enum class StartFlags {
-    NONE,
-    RESET
-  };
+  enum class StartFlags { NONE, RESET };
 
   static void RegisterExternalReferences(ExternalReferenceRegistry* registry);
 
   static v8::Local<v8::FunctionTemplate> GetConstructorTemplate(
       Environment* env);
 
-  static BaseObjectPtr<ELDHistogram> Create(
-      Environment* env,
-      const Histogram::Options& options);
+  static BaseObjectPtr<ELDHistogram> Create(Environment* env,
+                                            const Histogram::Options& options);
 
-  ELDHistogram(
-      Environment* env,
-      v8::Local<v8::Object> wrap,
-      AsyncWrap::ProviderType type,
-      const Histogram::Options& options = Histogram::Options {});
+  ELDHistogram(Environment* env,
+               v8::Local<v8::Object> wrap,
+               AsyncWrap::ProviderType type,
+               const Histogram::Options& options = Histogram::Options{});
 
   static void Start(const v8::FunctionCallbackInfo<v8::Value>& args);
   static void Stop(const v8::FunctionCallbackInfo<v8::Value>& args);
@@ -304,8 +299,8 @@ class ELDHistogram final : public HandleWrap, public HistogramImpl {
   }
   std::unique_ptr<worker::TransferData> CloneForMessaging() const override;
 
-  void Close(v8::Local<v8::Value> close_callback =
-                 v8::Local<v8::Value>()) override;
+  void Close(
+      v8::Local<v8::Value> close_callback = v8::Local<v8::Value>()) override;
 
   void MemoryInfo(MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(ELDHistogram)

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -309,7 +309,6 @@ class ELDHistogram final : public HandleWrap, public HistogramImpl {
  private:
   static void PrepareCB(uv_prepare_t* handle);
   static void CheckCB(uv_check_t* handle);
-  static void PrepareCloseCB(uv_handle_t* handle);
   void OnStart(StartFlags flags = StartFlags::RESET);
   void OnStop();
 

--- a/src/histogram.h
+++ b/src/histogram.h
@@ -20,6 +20,11 @@ namespace node {
 
 class ExternalReferenceRegistry;
 
+template <typename T>
+void StartHandleHistogram(v8::Local<v8::Value> receiver, bool reset);
+template <typename T>
+void StopHandleHistogram(v8::Local<v8::Value> receiver);
+
 constexpr int kDefaultHistogramFigures = 3;
 
 class Histogram : public MemoryRetainer {
@@ -257,6 +262,11 @@ class IntervalHistogram final : public HandleWrap, public HistogramImpl {
   void OnStart(StartFlags flags = StartFlags::RESET);
   void OnStop();
 
+  template <typename T>
+  friend void StartHandleHistogram(v8::Local<v8::Value>, bool);
+  template <typename T>
+  friend void StopHandleHistogram(v8::Local<v8::Value>);
+
   bool enabled_ = false;
   int32_t interval_ = 0;
   std::function<void(Histogram&)> on_interval_;
@@ -311,6 +321,11 @@ class IterationHistogram final : public HandleWrap, public HistogramImpl {
   static void CheckCB(uv_check_t* handle);
   void OnStart(StartFlags flags = StartFlags::RESET);
   void OnStop();
+
+  template <typename T>
+  friend void StartHandleHistogram(v8::Local<v8::Value>, bool);
+  template <typename T>
+  friend void StopHandleHistogram(v8::Local<v8::Value>);
 
   bool enabled_ = false;
   uv_prepare_t prepare_handle_;

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -282,6 +282,12 @@ void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   int64_t interval = args[0].As<Integer>()->Value();
   CHECK_GT(interval, 0);
+  if (args[1]->IsTrue()) {
+    BaseObjectPtr<ELDHistogram> histogram =
+        ELDHistogram::Create(env, Histogram::Options { 1 });
+    args.GetReturnValue().Set(histogram->object());
+    return;
+  }
   BaseObjectPtr<IntervalHistogram> histogram =
       IntervalHistogram::Create(env, interval, [](Histogram& histogram) {
         uint64_t delta = histogram.RecordDelta();
@@ -414,6 +420,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(fast_performance_now);
   HistogramBase::RegisterExternalReferences(registry);
   IntervalHistogram::RegisterExternalReferences(registry);
+  ELDHistogram::RegisterExternalReferences(registry);
 }
 }  // namespace performance
 }  // namespace node

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -284,7 +284,7 @@ void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {
   CHECK_GT(interval, 0);
   if (args[1]->IsTrue()) {
     BaseObjectPtr<ELDHistogram> histogram =
-        ELDHistogram::Create(env, Histogram::Options { 1 });
+        ELDHistogram::Create(env, Histogram::Options{1});
     args.GetReturnValue().Set(histogram->object());
     return;
   }

--- a/src/node_perf.cc
+++ b/src/node_perf.cc
@@ -283,8 +283,8 @@ void CreateELDHistogram(const FunctionCallbackInfo<Value>& args) {
   int64_t interval = args[0].As<Integer>()->Value();
   CHECK_GT(interval, 0);
   if (args[1]->IsTrue()) {
-    BaseObjectPtr<ELDHistogram> histogram =
-        ELDHistogram::Create(env, Histogram::Options{1});
+    BaseObjectPtr<IterationHistogram> histogram =
+        IterationHistogram::Create(env, Histogram::Options{1});
     args.GetReturnValue().Set(histogram->object());
     return;
   }
@@ -420,7 +420,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(fast_performance_now);
   HistogramBase::RegisterExternalReferences(registry);
   IntervalHistogram::RegisterExternalReferences(registry);
-  ELDHistogram::RegisterExternalReferences(registry);
+  IterationHistogram::RegisterExternalReferences(registry);
 }
 }  // namespace performance
 }  // namespace node

--- a/src/node_task_queue.cc
+++ b/src/node_task_queue.cc
@@ -76,9 +76,11 @@ void PromiseRejectCallback(PromiseRejectMessage message) {
     value = Undefined(isolate);
     rejectionsHandledAfter++;
     TRACE_COUNTER2(TRACING_CATEGORY_NODE2(promises, rejections),
-                  "rejections",
-                  "unhandled", unhandledRejections,
-                  "handledAfter", rejectionsHandledAfter);
+                   "rejections",
+                   "unhandled",
+                   unhandledRejections,
+                   "handledAfter",
+                   rejectionsHandledAfter);
   } else {
     return;
   }

--- a/test/parallel/test-perf-hooks-monitor-event-loop-delay-fast-calls.js
+++ b/test/parallel/test-perf-hooks-monitor-event-loop-delay-fast-calls.js
@@ -1,0 +1,26 @@
+// Flags: --allow-natives-syntax --expose-internals --no-warnings
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+
+const { internalBinding } = require('internal/test/binding');
+const { createELDHistogram } = internalBinding('performance');
+
+const histogram = createELDHistogram(1, true);
+
+function testFastMethods() {
+  histogram.start(true);
+  histogram.stop();
+}
+
+eval('%PrepareFunctionForOptimization(testFastMethods)');
+testFastMethods();
+eval('%OptimizeFunctionOnNextCall(testFastMethods)');
+testFastMethods();
+
+if (common.isDebug) {
+  const { getV8FastApiCallCount } = internalBinding('debug');
+  assert.strictEqual(getV8FastApiCallCount('histogram.eventLoopDelay.start'), 1);
+  assert.strictEqual(getV8FastApiCallCount('histogram.eventLoopDelay.stop'), 1);
+}

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -153,9 +153,9 @@ const { sleep } = require('internal/util');
   // enable()/disable() return values for ELDHistogram (samplePerIteration: true)
   const histogram = monitorEventLoopDelay({ samplePerIteration: true });
   assert.strictEqual(histogram.enable(), true);
-  assert.strictEqual(histogram.enable(), false);  // already enabled, no-op
+  assert.strictEqual(histogram.enable(), false);  // Already enabled, no-op
   assert.strictEqual(histogram.disable(), true);
-  assert.strictEqual(histogram.disable(), false); // already disabled, no-op
+  assert.strictEqual(histogram.disable(), false); // Already disabled, no-op
   // Re-enabling after disable should work
   assert.strictEqual(histogram.enable(), true);
   setTimeout(common.mustCall(() => {

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -49,6 +49,16 @@ const { sleep } = require('internal/util');
       }
     );
   });
+
+  [null, 'a', 1, {}, []].forEach((i) => {
+    assert.throws(
+      () => monitorEventLoopDelay({ samplePerIteration: i }),
+      {
+        name: 'TypeError',
+        code: 'ERR_INVALID_ARG_TYPE',
+      }
+    );
+  });
 }
 
 {
@@ -112,6 +122,18 @@ const { sleep } = require('internal/util');
     }
   }
   spinAWhile();
+}
+
+{
+  const histogram = monitorEventLoopDelay({ samplePerIteration: true });
+  histogram.enable();
+  setTimeout(common.mustCall(() => {
+    histogram.disable();
+    assert(histogram.count > 0,
+           `Expected samples to be recorded, got count=${histogram.count}`);
+    assert(histogram.min > 0);
+    assert(histogram.max > 0);
+  }), common.platformTimeout(20));
 }
 
 // Make sure that the histogram instances can be garbage-collected without

--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -133,7 +133,90 @@ const { sleep } = require('internal/util');
            `Expected samples to be recorded, got count=${histogram.count}`);
     assert(histogram.min > 0);
     assert(histogram.max > 0);
+    assert(histogram.mean > 0);
+    assert(histogram.percentiles.size > 0);
+    for (let n = 1; n < 100; n = n + 10) {
+      assert(histogram.percentile(n) >= 0);
+    }
+    // reset() should restore the histogram to its initial state
+    histogram.reset();
+    assert.strictEqual(histogram.count, 0);
+    assert.strictEqual(histogram.max, 0);
+    assert.strictEqual(histogram.min, 9223372036854776000);
+    assert(Number.isNaN(histogram.mean));
+    assert(Number.isNaN(histogram.stddev));
+    assert.strictEqual(histogram.percentiles.size, 1);
   }), common.platformTimeout(20));
+}
+
+{
+  // enable()/disable() return values for ELDHistogram (samplePerIteration: true)
+  const histogram = monitorEventLoopDelay({ samplePerIteration: true });
+  assert.strictEqual(histogram.enable(), true);
+  assert.strictEqual(histogram.enable(), false);  // already enabled, no-op
+  assert.strictEqual(histogram.disable(), true);
+  assert.strictEqual(histogram.disable(), false); // already disabled, no-op
+  // Re-enabling after disable should work
+  assert.strictEqual(histogram.enable(), true);
+  setTimeout(common.mustCall(() => {
+    histogram.disable();
+    assert(histogram.count > 0,
+           `Expected samples after re-enable, got count=${histogram.count}`);
+  }), common.platformTimeout(20));
+}
+
+{
+  // Verify that samplePerIteration records exactly one sample per event loop iteration.
+  const N = 10;
+  const histogram = monitorEventLoopDelay({ samplePerIteration: true });
+  histogram.enable();
+
+  let iterations = 0;
+  const verify = common.mustCall(() => {
+    histogram.disable();
+    assert(
+      histogram.count >= N - 1,
+      `Expected at least ${N - 1} samples for ${N} iterations, got ${histogram.count}`
+    );
+  });
+
+  function tick() {
+    if (++iterations < N) {
+      setImmediate(tick);
+    } else {
+      verify();
+    }
+  }
+  setImmediate(tick);
+}
+
+{
+  // samplePerIteration should sample per event loop iteration, independent of
+  // the timer resolution used by the legacy monitorEventLoopDelay path.
+  const N = 10;
+  const histogram = monitorEventLoopDelay({
+    samplePerIteration: true,
+    resolution: 60 * 1000,
+  });
+  histogram.enable();
+
+  let iterations = 0;
+  const verify = common.mustCall(() => {
+    histogram.disable();
+    assert(
+      histogram.count >= N - 1,
+      `Expected samples despite large resolution, got count=${histogram.count}`
+    );
+  });
+
+  function tick() {
+    if (++iterations < N) {
+      setImmediate(tick);
+    } else {
+      verify();
+    }
+  }
+  setImmediate(tick);
 }
 
 // Make sure that the histogram instances can be garbage-collected without


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Adds an opt in into monitorEventLoopDelay(), this option adds support for per iteration sampling using libuv hooks, while preserving the existing timer based approach.

When the new samplePerIteration option is set to true, monitorEventLoopDelay() samples directly from event loop iterations instead of using the interval timer. When samplePerIteration is omitted or false, the existing interval based implementation remains unchanged, including resolution handling and the older interval based trace counters.

**Motivation**
The interval based implementation has two limitations that the new option addresses:

- Inaccurate measurements. Delay was approximated from a timer dispatch jitter (RecordDelta() between timer ticks) rather than measured from the loop itself. Samples had an implicit floor of resolution ms and could miss delays that didn't happen to coincide with a timer tick.
- Wasteful wake ups. The timer forced the event loop to iterate every resolution ms just to record a sample, even when the application was otherwise idle and no one was reading the histogram.

This is an alternative implementation to the one in #62934 

This PR directly addresses the following issue #56064 