### PR TITLE
Fix windows DNS server resolution

### DIFF
--- a/deps/cares/src/lib/ares_sysconfig_win.c
+++ b/deps/cares/src/lib/ares_sysconfig_win.c
@@ -638,11 +638,9 @@ ares_status_t ares_init_sysconfig_windows(const ares_channel_t *channel,
   if (get_SuffixList_Windows(&line)) {
     sysconfig->domains = ares_strsplit(line, ", ", &sysconfig->ndomains);
     ares_free(line);
+    /* Keep discovered DNS servers even if suffix parsing fails. */
     if (sysconfig->domains == NULL) {
-      status = ARES_EFILE;
-    }
-    if (status != ARES_SUCCESS) {
-      goto done;
+      sysconfig->ndomains = 0;
     }
   }
 


### PR DESCRIPTION
## Summary

This PR addresses a Windows DNS regression observed after the c-ares update in the following nodejs versions:
- Node.js >= 20.20.0
- Node.js >= 22.22.0
- Node.js >= 24.13.0
- Node.js >= 25.3.0

Where I first realized when trying to connect to MongoDB atlas through VPN in Windows failed.

- Restore Windows DNS resolver server ordering parity with the previous version for this setup:
  - before fix (regressed): `['127.0.0.1']`
  - after fix: `['::ffff:127.0.2.2', '::ffff:127.0.2.3', '127.0.2.2', '127.0.2.3']`
- Keep discovered DNS servers even if Windows suffix parsing fails, preventing
  fallback to loopback-only resolver configuration
- Windows DNS discovery behavior in `get_DNS_Windows()` (e.g. `GetNetworkParams`,
  ordering) as needed for this setup

I believe it was regressed after the c-ares update to v1.34.6:
- #60997

## Testing

Windows validation performed with:

```powershell
./vcbuild.bat release openssl-no-asm
./Release/node.exe -e "console.log(require('node:dns').getServers())"
```

Observed results:

- `dns.getServers()` now returns:
  `['::ffff:127.0.2.2', '::ffff:127.0.2.3', '127.0.2.2', '127.0.2.3']` just like was before the regression
- Successfully connects to MongoDB Atlas through VPN with `mongodb+srv://`

It could also be tested with switching between 24.12 to 24.13 and observing the DNS servers.

## Notes

Ideally, the fix would be backdated for all the affected versions (v20, v22, v24, v25)

Thank you for your time and consideration on looking into this 🙏.
