### PR TITLE
lib: fix modulo sign in webidl convertToInt

### DIFF
--- a/lib/internal/webidl.js
+++ b/lib/internal/webidl.js
@@ -106,17 +106,6 @@ function pow2(exponent) {
   return MathPow(2, exponent);
 }
 
-// https://tc39.es/ecma262/#eqn-modulo
-// The notation “x modulo y” computes a value k of the same sign as y.
-function modulo(x, y) {
-  const r = x % y;
-  // Convert -0 to +0.
-  if (r === 0) {
-    return 0;
-  }
-  return r;
-}
-
 // https://webidl.spec.whatwg.org/#abstract-opdef-converttoint
 function convertToInt(name, value, bitLength, options = kEmptyObject) {
   const { signed = false, enforceRange = false, clamp = false } = options;
@@ -192,16 +181,35 @@ function convertToInt(name, value, bitLength, options = kEmptyObject) {
   // 9. Set x to IntegerPart(x).
   x = integerPart(x);
 
+  // Following the exact algorithm looses precision on signed modulo in 64-bit
+  // as we operate in doubles. modulo(-1, 2**64) should be 2**64 - 1, but for
+  // signed -1 that gives -1 + 2**64 - 2**64 = 0, instead of -1. Original steps:
   // 10. Set x to x modulo 2^bitLength.
-  x = modulo(x, pow2(bitLength));
-
+  // The notation “x modulo y” computes a value k of the same sign as y.
   // 11. If signedness is "signed" and x ≥ 2^(bitLength − 1), then return x −
   // 2^bitLength.
-  if (signed && x >= pow2(bitLength - 1)) {
-    return x - pow2(bitLength);
+  // 12. Otherwise, return x.
+
+  // We can skip this if we have an in-range integer
+  if (x >= lowerBound && x <= upperBound) {
+    return x === 0 ? 0 : x;
   }
 
-  // 12. Otherwise, return x.
+  const fullRange = pow2(bitLength);
+  x %= fullRange; // Has the sign of x
+  if (x === 0) return 0; // Censor -0
+
+  if (signed) {
+    const halfRange = pow2(bitLength - 1);
+    if (x >= halfRange) {
+      return x - fullRange;
+    } else if (x < -halfRange) {
+      return x + fullRange;
+    }
+  } else if (x < 0) {
+    x += fullRange; // This is what modulo would have returned
+  }
+
   return x;
 }
 

--- a/test/parallel/test-internal-webidl-converttoint.js
+++ b/test/parallel/test-internal-webidl-converttoint.js
@@ -56,3 +56,17 @@ assert.strictEqual(convertToInt('x', 0xFFFF_FFFF, 32), 0xFFFF_FFFF);
 // Out of range, step 11.
 assert.strictEqual(convertToInt('x', 0x8000_0000, 32, { signed: true }), -0x8000_0000);
 assert.strictEqual(convertToInt('x', 0xFFF_FFFF, 32, { signed: true }), 0xFFF_FFFF);
+
+// Negative values must wrap as two's-complement, matching typed-array behavior.
+assert.strictEqual(convertToInt('x', -3, 8), 253);
+assert.strictEqual(convertToInt('x', -3, 8), new Uint8Array([-3])[0]);
+assert.strictEqual(convertToInt('x', -1, 32), 0xFFFF_FFFF);
+assert.strictEqual(convertToInt('x', -1, 32), new Uint32Array([-1])[0]);
+assert.strictEqual(convertToInt('x', -200, 8, { signed: true }), 56);
+assert.strictEqual(convertToInt('x', -200, 8, { signed: true }), new Int8Array([-200])[0]);
+
+assert.strictEqual(convertToInt('x', -8192, 64), 2 ** 64 - 8192);
+assert.strictEqual(convertToInt('x', -8192, 64, { signed: true }), -8192);
+assert.strictEqual(convertToInt('x', -8193, 64, { signed: true }), -8193);
+assert.strictEqual(convertToInt('x', 2 ** 64 + 8192, 64), 8192);
+assert.strictEqual(convertToInt('x', 2 ** 64 + 8192, 64, { signed: true }), 8192);


### PR DESCRIPTION
The modulo() helper in lib/internal/webidl.js is documented to implement ECMA-262's "x modulo y" (result has the same sign as y), but it used the JS % operator directly, whose result takes the sign of x. convertToInt step 10 relies on modulo(x, 2^bitLength) producing a non-negative representative in [0, 2^bitLength); step 11 only handles the signed upper half, so negative results of % were returned unchanged.

As a result, negative inputs to unsigned WebIDL integer types returned the original negative value instead of the two's-complement wrap (e.g. convertToInt('v', -3, 8) returned -3 instead of 253), and signed inputs in the one-wrap band below the lower bound were returned as-is (convertToInt('v', -200, 8, { signed: true }) returned -200 instead of 56). This diverged from typed-array coercion.