### PR TITLE
lib: narrow ReadableStreamBYOBRequest.view return type to Uint8Array

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -672,7 +672,7 @@ class ReadableStreamBYOBRequest {
 
   /**
    * @readonly
-   * @type {ArrayBufferView}
+   * @type {Uint8Array}
    */
   get view() {
     if (!isReadableStreamBYOBRequest(this))


### PR DESCRIPTION
## Description
Follow WHATWG streams spec update: https://github.com/whatwg/streams/pull/1367

`ReadableStreamBYOBRequest.view` is always constructed as a `Uint8Array`, and the specification will be updated to enforce this. This changes the documented return type from `ArrayBufferView` to `Uint8Array`.

## Fix
Changed the JSDoc type annotation for `view` getter from `@type {ArrayBufferView}` to `@type {Uint8Array}` in `lib/internal/webstreams/readablestream.js`.

Fixes #62952