### PR TITLE
webstreams: narrow ReadableStreamBYOBRequest.view to Uint8Array

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -672,7 +672,7 @@ class ReadableStreamBYOBRequest {
 
   /**
    * @readonly
-   * @type {ArrayBufferView}
+   * @type {Uint8Array}
    */
   get view() {
     if (!isReadableStreamBYOBRequest(this))


### PR DESCRIPTION
`ReadableStreamBYOBRequest.view` is always constructed as a `Uint8Array`,
and the specification will be updated to enforce this.

Refs: https://github.com/whatwg/streams/pull/1367
Fixes: https://github.com/nodejs/node/issues/62952