### PR TITLE
dgram: support UV_UDP_LINUX_RECVERR for udp

### DIFF
--- a/doc/api/dgram.md
+++ b/doc/api/dgram.md
@@ -968,6 +968,9 @@ changes:
     specified by the NAT.
   * `sendBlockList` {net.BlockList} `sendBlockList` can be used for disabling outbound
     access to specific IP addresses, IP ranges, or IP subnets.
+  * `recvErr` {boolean} When `true` the socket will emit an error event
+    if the peer is unreachable(On Linux only).
+    **Default:** `false`.
 * `callback` {Function} Attached as a listener for `'message'` events. Optional.
 * Returns: {dgram.Socket}
 

--- a/lib/dgram.js
+++ b/lib/dgram.js
@@ -76,7 +76,7 @@ const { FastBuffer } = require('internal/buffer');
 const { UV_UDP_REUSEADDR } = internalBinding('constants').os;
 
 const {
-  constants: { UV_UDP_IPV6ONLY, UV_UDP_REUSEPORT },
+  constants: { UV_UDP_IPV6ONLY, UV_UDP_REUSEPORT, UV_UDP_LINUX_RECVERR },
   UDP,
   SendWrap,
 } = internalBinding('udp_wrap');
@@ -157,6 +157,7 @@ function Socket(type, listener) {
     queue: undefined,
     reuseAddr: options?.reuseAddr, // Use UV_UDP_REUSEADDR if true.
     reusePort: options?.reusePort,
+    recvErr: options?.recvErr,
     ipv6Only: options?.ipv6Only,
     recvBufferSize,
     sendBufferSize,
@@ -377,6 +378,9 @@ Socket.prototype.bind = function(port_, address_ /* , callback */) {
     if (state.reusePort) {
       exclusive = true;
       flags |= UV_UDP_REUSEPORT;
+    }
+    if (state.recvErr) {
+      flags |= UV_UDP_LINUX_RECVERR;
     }
 
     if (cluster.isWorker && !exclusive) {

--- a/src/udp_wrap.cc
+++ b/src/udp_wrap.cc
@@ -233,6 +233,7 @@ void UDPWrap::Initialize(Local<Object> target,
   NODE_DEFINE_CONSTANT(constants, UV_UDP_IPV6ONLY);
   NODE_DEFINE_CONSTANT(constants, UV_UDP_REUSEADDR);
   NODE_DEFINE_CONSTANT(constants, UV_UDP_REUSEPORT);
+  NODE_DEFINE_CONSTANT(constants, UV_UDP_LINUX_RECVERR);
   target->Set(context,
               env->constants_string(),
               constants).Check();

--- a/test/parallel/test-dgram-recvErr.js
+++ b/test/parallel/test-dgram-recvErr.js
@@ -1,0 +1,23 @@
+'use strict';
+const common = require('../common');
+const dgram = require('dgram');
+
+if (process.platform !== 'linux') {
+  common.skip('Only Linux is supported');
+}
+
+const socket = dgram.createSocket({ recvErr: true, type: 'udp4' });
+
+function onError(err) {
+  console.error('UV_UDP_LINUX_RECVERR is unsupported: ', err);
+  socket.close();
+}
+
+socket.on('error', onError);
+socket.bind(0, common.mustCall(() => {
+  socket.off('error', onError);
+  socket.on('error', common.mustCall(() => {
+    socket.close();
+  }));
+  socket.send('hello', 9999, '127.0.0.1');
+}));


### PR DESCRIPTION
Previously, it was impossible to know whether the data packet had reached the other end successfully. This PR add a flag to support this.

```
Error: recvmsg ECONNREFUSED
    at UDP.onMessage [as onmessage] (node:dgram:988:31) {
  errno: -111,
  code: 'ECONNREFUSED',
  syscall: 'recvmsg'
}
```

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/master/doc/guides/contributing/pull-requests.md#commit-message-guidelines)
