### PR TITLE
test: cover sqlite statements after database close

### DIFF
--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -341,6 +341,7 @@ suite('DatabaseSync.prototype.close()', () => {
 
     const select = db.prepare('SELECT * FROM data');
     const insert = db.prepare('INSERT INTO data (key, val) VALUES (?, ?)');
+    const iterator = select.iterate();
 
     t.assert.strictEqual(db.close(), undefined);
     t.assert.strictEqual(db.isOpen, false);
@@ -367,7 +368,19 @@ suite('DatabaseSync.prototype.close()', () => {
       message: /statement has been finalized/,
     });
     t.assert.throws(() => {
+      select.iterate();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
       insert.run(2, 4);
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      iterator.next();
     }, {
       code: 'ERR_INVALID_STATE',
       message: /statement has been finalized/,
@@ -387,6 +400,7 @@ suite('DatabaseSync.prototype.close()', () => {
 
     const select = db.prepare('SELECT * FROM data');
     const insert = db.prepare('INSERT INTO data (key, val) VALUES (?, ?)');
+    const iterator = select.iterate();
 
     db.close();
     db.open();
@@ -404,7 +418,19 @@ suite('DatabaseSync.prototype.close()', () => {
       message: /statement has been finalized/,
     });
     t.assert.throws(() => {
+      select.iterate();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
       insert.run(2, 4);
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      iterator.next();
     }, {
       code: 'ERR_INVALID_STATE',
       message: /statement has been finalized/,
@@ -620,6 +646,7 @@ suite('DatabaseSync.prototype[Symbol.dispose]', () => {
 
     const select = db.prepare('SELECT * FROM data');
     const insert = db.prepare('INSERT INTO data (key, val) VALUES (?, ?)');
+    const iterator = select.iterate();
 
     db[Symbol.dispose]();
     t.assert.strictEqual(db.isOpen, false);
@@ -646,7 +673,19 @@ suite('DatabaseSync.prototype[Symbol.dispose]', () => {
       message: /statement has been finalized/,
     });
     t.assert.throws(() => {
+      select.iterate();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
       insert.run(2, 4);
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      iterator.next();
     }, {
       code: 'ERR_INVALID_STATE',
       message: /statement has been finalized/,

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -331,6 +331,94 @@ suite('DatabaseSync.prototype.close()', () => {
     });
     t.assert.strictEqual(db.isOpen, false);
   });
+
+  test('invalidates prepared statements', (t) => {
+    const db = new DatabaseSync(nextDb());
+    db.exec(`
+      CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER);
+      INSERT INTO data (key, val) VALUES (1, 2);
+    `);
+
+    const select = db.prepare('SELECT * FROM data');
+    const insert = db.prepare('INSERT INTO data (key, val) VALUES (?, ?)');
+
+    t.assert.strictEqual(db.close(), undefined);
+    t.assert.strictEqual(db.isOpen, false);
+
+    for (const method of ['prepare', 'exec']) {
+      t.assert.throws(() => {
+        db[method]('SELECT 1');
+      }, {
+        code: 'ERR_INVALID_STATE',
+        message: /database is not open/,
+      });
+    }
+
+    t.assert.throws(() => {
+      select.get();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      select.all();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      insert.run(2, 4);
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+  });
+
+  test('keeps prepared statements invalid after reopening', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => {
+      if (db.isOpen) db.close();
+    });
+
+    db.exec(`
+      CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER);
+      INSERT INTO data (key, val) VALUES (1, 2);
+    `);
+
+    const select = db.prepare('SELECT * FROM data');
+    const insert = db.prepare('INSERT INTO data (key, val) VALUES (?, ?)');
+
+    db.close();
+    db.open();
+
+    t.assert.throws(() => {
+      select.get();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      select.all();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      insert.run(2, 4);
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+
+    t.assert.deepStrictEqual(
+      db.prepare('SELECT * FROM data').all(),
+      [{ __proto__: null, key: 1, val: 2 }],
+    );
+    t.assert.strictEqual(
+      db.exec('INSERT INTO data (key, val) VALUES (2, 4)'),
+      undefined,
+    );
+  });
 });
 
 suite('DatabaseSync.prototype.prepare()', () => {
@@ -521,5 +609,47 @@ suite('DatabaseSync.prototype[Symbol.dispose]', () => {
     const db = new DatabaseSync(nextDb(), { open: false });
     t.assert.strictEqual(db.isOpen, false);
     db[Symbol.dispose]();
+  });
+
+  test('invalidates prepared statements', (t) => {
+    const db = new DatabaseSync(nextDb());
+    db.exec(`
+      CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER);
+      INSERT INTO data (key, val) VALUES (1, 2);
+    `);
+
+    const select = db.prepare('SELECT * FROM data');
+    const insert = db.prepare('INSERT INTO data (key, val) VALUES (?, ?)');
+
+    db[Symbol.dispose]();
+    t.assert.strictEqual(db.isOpen, false);
+
+    for (const method of ['prepare', 'exec']) {
+      t.assert.throws(() => {
+        db[method]('SELECT 1');
+      }, {
+        code: 'ERR_INVALID_STATE',
+        message: /database is not open/,
+      });
+    }
+
+    t.assert.throws(() => {
+      select.get();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      select.all();
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
+    t.assert.throws(() => {
+      insert.run(2, 4);
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /statement has been finalized/,
+    });
   });
 });


### PR DESCRIPTION
This PR adds coverage for `DatabaseSync` closing behavior with existing prepared statements.

The tests verify that after `close()` or `[Symbol.dispose]()`:
  - database methods such as `prepare()` and `exec()` report that the database is not open
  - existing `StatementSync` instances report that the statement has been finalized
  - reopening the database does not make old statements usable again