### PR TITLE
tools: reuse V8 builds even without Cachix on test-shared

### DIFF
--- a/.github/actions/build-shared/action.yml
+++ b/.github/actions/build-shared/action.yml
@@ -5,11 +5,8 @@ description: >
   test suite inside the pinned nix-shell.
 
 inputs:
-  system:
-    description: System label (e.g. x86_64-linux, aarch64-darwin).
-    required: true
-  extra-nix-args:
-    description: Additional arguments appended to the nix-shell invocation.
+  extra-nix-flags:
+    description: Additional CLI arguments appended to the nix-shell invocation.
     required: false
     default: ''
   cachix-auth-token:
@@ -21,13 +18,11 @@ runs:
   using: composite
   steps:
     - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-      if: ${{ github.event_name != 'workflow_dispatch' }}
       with:
         name: tarballs
         path: tarballs
 
     - name: Extract tarball
-      if: ${{ github.event_name != 'workflow_dispatch' }}
       shell: bash
       run: |
         tar xzf tarballs/*.tar.gz -C "$RUNNER_TEMP"
@@ -61,12 +56,10 @@ runs:
           --pure --keep TAR_DIR --keep FLAKY_TESTS \
           --keep SCCACHE_GHA_ENABLED --keep ACTIONS_CACHE_SERVICE_V2 --keep ACTIONS_RESULTS_URL --keep ACTIONS_RUNTIME_TOKEN \
           --arg loadJSBuiltinsDynamically false \
-          --arg useSeparateDerivationForV8 true \
           --arg ccache "${NIX_SCCACHE:-null}" \
           --arg devTools '[]' \
           --arg benchmarkTools '[]' \
-          ${{ endsWith(inputs.system, '-darwin') && '--arg withAmaro false --arg withLief false --arg withSQLite false --arg withFFI false --arg extraConfigFlags ''["--without-inspector" "--without-node-options"]'' \' || '\' }}
-          ${{ inputs.extra-nix-args }} \
+          ${{ inputs.extra-nix-flags }} \
           --run '
               make -C "$TAR_DIR" run-ci -j4 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9 --skip-tests=$CI_SKIP_TESTS"
           ' "$TAR_DIR/shell.nix"

--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -117,12 +117,10 @@ jobs:
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           persist-credentials: false
 
       - name: Make tarball
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           export DATESTRING=$(date "+%Y-%m-%d")
           export COMMIT=$(git rev-parse --short=10 "$GITHUB_SHA")
@@ -131,7 +129,6 @@ jobs:
           DISTTYPE: nightly
 
       - name: Upload tarball artifact
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: tarballs
@@ -157,55 +154,78 @@ jobs:
     runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: false
       - uses: ./.github/actions/build-shared
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        name: Build and test Node.js
         with:
-          system: ${{ matrix.system }}
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
+          extra-nix-flags: |
+            --arg useSeparateDerivationForV8 true \
+            ${{ endsWith(matrix.system, '-darwin') && '--arg withAmaro false --arg withLief false --arg withSQLite false --arg withFFI false --arg extraConfigFlags ''["--without-inspector" "--without-node-options"]'' \' || '\' }}
 
   build-aarch64-linux-v8:
     needs: build-tarball
     runs-on: ubuntu-24.04-arm
     name: 'aarch64-linux: Cache V8 build'
+    outputs:
+      local-cache: ${{ steps.upload.outcome != 'skipped' && 'true' || '' }}
     steps:
-      - name: Check if Cachix is available
-        id: cachix-check
-        run: echo 'IS_AVAILABLE=${{ secrets.CACHIX_AUTH_TOKEN && 'true' }}' >> "$GITHUB_OUTPUT"
-
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
-        if: ${{ steps.cachix-check.outputs.IS_AVAILABLE == 'true' }}
         with:
           name: tarballs
           path: tarballs
 
       - name: Extract tarball
-        if: ${{ steps.cachix-check.outputs.IS_AVAILABLE == 'true' }}
         shell: bash
         run: |
           tar xzf tarballs/*.tar.gz -C "$RUNNER_TEMP"
           echo "TAR_DIR=$RUNNER_TEMP/$(basename tarballs/*.tar.gz .tar.gz)" >> "$GITHUB_ENV"
 
       - uses: cachix/install-nix-action@ab739621df7a23f52766f9ccc97f38da6b7af14f  # v31.10.5
-        if: ${{ steps.cachix-check.outputs.IS_AVAILABLE == 'true' }}
         with:
           extra_nix_config: sandbox = true
 
+      - name: Evaluate V8 derivation
+        id: v8-drv
+        run: |
+          V8_DRV=$(
+            nix-instantiate -E "builtins.filter (p: p.pname == ''v8'') (import $TAR_DIR/shell.nix { useSeparateDerivationForV8=true; }).buildInputs"
+          )
+          echo "V8_DRV=$V8_DRV" >> "$GITHUB_OUTPUT"
+          echo "STORE_PATH=$(nix-store -q --outputs "$V8_DRV")" >> "$GITHUB_OUTPUT"
+
+      - name: Check if available on Cachix
+        id: cachix-check
+        run: |
+          echo 'HAS_WRITE_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN && 'true' }}' >> "$GITHUB_OUTPUT"
+          set -x
+          [ "$(curl -ISsw "%{http_code}" -o /dev/null "https://nodejs.cachix.org/$(basename ${V8_STORE_PATH%-v8-*}).narinfo")" != "200" ] ||
+            echo "ALREADY_CACHED=true" >> "$GITHUB_OUTPUT"
+        env:
+          V8_STORE_PATH: ${{ steps.v8-drv.outputs.STORE_PATH }}
+
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c  # v17
-        if: ${{ steps.cachix-check.outputs.IS_AVAILABLE == 'true' }}
+        if: ${{ steps.cachix-check.outputs.ALREADY_CACHED != 'true' }}
         with:
           name: nodejs
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
       - name: Build V8 derivation
-        if: ${{ steps.cachix-check.outputs.IS_AVAILABLE == 'true' }}
-        run: |
-          nix-build "$(
-            nix-instantiate -E "builtins.filter (p: p.pname == ''v8'') (import $TAR_DIR/shell.nix { useSeparateDerivationForV8=true; }).buildInputs"
-          )"
+        if: ${{ steps.cachix-check.outputs.ALREADY_CACHED != 'true' }}
+        run: nix-store --export "$(nix-build "$V8_DRV")" > libv8
+        env:
+          V8_DRV: ${{ steps.v8-drv.outputs.V8_DRV }}
+
+      - name: Upload libv8
+        if: ${{ steps.cachix-check.outputs.ALREADY_CACHED != 'true' && steps.cachix-check.outputs.HAS_WRITE_TOKEN != 'true' }}
+        id: upload
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
+        with:
+          name: libv8
+          path: libv8
 
   # Builds the matrix for `build-openssl` from tools/nix/openssl-matrix.json.
   # Output shape:
@@ -253,9 +273,16 @@ jobs:
         with:
           persist-credentials: false
           sparse-checkout: .github/actions
-      - uses: ./.github/actions/build-shared
+          sparse-checkout-cone-mode: false
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        if: ${{ needs.build-aarch64-linux-v8.outputs.local-cache }}
         with:
-          system: aarch64-linux
+          name: libv8
+
+      - uses: ./.github/actions/build-shared
+        name: Build and test Node.js
+        with:
           cachix-auth-token: ${{ secrets.CACHIX_AUTH_TOKEN }}
           # Override just the `openssl` attr of the default shared-lib set with
           # the matrix-selected nixpkgs attribute (e.g. `openssl_3_6`). All
@@ -263,4 +290,8 @@ jobs:
           # `permittedInsecurePackages` whitelists just the matrix-selected
           # release (e.g. `openssl-1.1.1w`) so EOL-with-extended-support
           # cycles evaluate without relaxing nixpkgs' meta check globally.
-          extra-nix-args: --arg sharedLibDeps "(import $TAR_DIR/tools/nix/sharedLibDeps.nix {}) // { openssl = (import $TAR_DIR/tools/nix/pkgs.nix { config.permittedInsecurePackages = [ \"openssl-$OPENSSL_VERSION\" ]; }).$OPENSSL_ATTR; }"
+          extra-nix-flags: |
+            --arg useSeparateDerivationForV8 ${{ needs.build-aarch64-linux-v8.outputs.local-cache && '"$(nix-store --import < libv8)"' || 'true' }} \
+            --arg sharedLibDeps "(import $TAR_DIR/tools/nix/sharedLibDeps.nix {}) // {
+                openssl = (import $TAR_DIR/tools/nix/pkgs.nix { config.permittedInsecurePackages = [ \"openssl-$OPENSSL_VERSION\" ]; }).$OPENSSL_ATTR;
+              }" \


### PR DESCRIPTION
Follow up to https://github.com/nodejs/node/pull/62862, this should help avoiding building same V8 version several times – because PRs do not have write access to Cachix, we need to fallback to using action artifacts, test run can be found in https://github.com/aduh95/node/actions/runs/24967350421.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
