### PR TITLE
stream: fix Writable.toWeb() desiredSize for non-object-mode

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -185,7 +185,12 @@ function newWritableStreamFromStreamWritable(streamWritable, options = kEmptyObj
   const strategy =
     streamWritable.writableObjectMode ?
       new CountQueuingStrategy({ highWaterMark }) :
-      { highWaterMark };
+      {
+        highWaterMark,
+        size(chunk) {
+          return chunk?.byteLength ?? chunk?.length ?? 1;
+        },
+      };
 
   let controller;
   let backpressurePromise;


### PR DESCRIPTION
Writable.toWeb() used a plain `{ highWaterMark }` as the queuing strategy for non-object-mode streams, which meant no `size` function was provided. The WritableStream defaulted to counting each chunk as size 1, so `desiredSize` was incorrect (e.g. a 3-byte `Uint8Array` was counted as size 1 instead of 3).

Add a `size()` function to the strategy that mirrors how the Node.js stream computes chunk length: `byteLength` for typed arrays, `length` for strings/buffers, falling back to 1.

Fixes: https://github.com/nodejs/node/issues/56269
