### PR TITLE
util.inspect: fix numericSeparator for scientific notation numbers

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2198,20 +2198,21 @@ function formatNumber(fn, number, numericSeparator) {
   }
 
   const numberString = String(number);
+
+  // Scientific notation cannot have numeric separators applied sensibly
+  if (StringPrototypeIncludes(numberString, 'e')) {
+    return fn(numberString, 'number');
+  }
+
   const integer = MathTrunc(number);
 
   if (integer === number) {
-    if (!NumberIsFinite(number) || StringPrototypeIncludes(numberString, 'e')) {
+    if (!NumberIsFinite(number)) {
       return fn(numberString, 'number');
     }
     return fn(addNumericSeparator(numberString), 'number');
   }
   if (NumberIsNaN(number)) {
-    return fn(numberString, 'number');
-  }
-
-  // Scientific notation cannot have numeric separators applied sensibly
-  if (StringPrototypeIncludes(numberString, 'e')) {
     return fn(numberString, 'number');
   }
 

--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2210,6 +2210,11 @@ function formatNumber(fn, number, numericSeparator) {
     return fn(numberString, 'number');
   }
 
+  // Scientific notation cannot have numeric separators applied sensibly
+  if (StringPrototypeIncludes(numberString, 'e')) {
+    return fn(numberString, 'number');
+  }
+
   const decimalIndex = StringPrototypeIndexOf(numberString, '.');
   const integerPart = StringPrototypeSlice(numberString, 0, decimalIndex);
   const fractionalPart = StringPrototypeSlice(numberString, decimalIndex + 1);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -3846,6 +3846,43 @@ assert.strictEqual(
   }
 }
 
+// Regression test for https://github.com/nodejs/node/issues/62981
+// numericSeparator should not corrupt scientific notation numbers
+{
+  // Test cases from the bug report
+  assert.strictEqual(
+    util.inspect(1e-7, { numericSeparator: true }),
+    '1e-7'
+  );
+  assert.strictEqual(
+    util.inspect(1.23e-7, { numericSeparator: true }),
+    '1.23e-7'
+  );
+  assert.strictEqual(
+    util.inspect(1.23e+7, { numericSeparator: true }),
+    '1.23e+7'
+  );
+  assert.strictEqual(
+    util.inspect(-1.23e-7, { numericSeparator: true }),
+    '-1.23e-7'
+  );
+  assert.strictEqual(
+    util.inspect(1e10, { numericSeparator: true }),
+    '1e10'
+  );
+  assert.strictEqual(
+    util.inspect(1.2345678901234567e+20, { numericSeparator: true }),
+    '1.2345678901234567e+20'
+  );
+
+  // With default numericSeparator: true
+  const { numericSeparator } = util.inspect.defaultOptions;
+  util.inspect.defaultOptions.numericSeparator = true;
+  assert.strictEqual(util.inspect(1e-7), '1e-7');
+  assert.strictEqual(util.inspect(1.5e-10), '1.5e-10');
+  util.inspect.defaultOptions.numericSeparator = numericSeparator;
+}
+
 // Regression test for https://github.com/nodejs/node/issues/41244
 {
   assert.strictEqual(util.inspect({


### PR DESCRIPTION
Fixes nodejs/node#62981

When numericSeparator: true is set, util.inspect produces corrupted output like '1e-.1e-_7' for numbers in scientific notation (e.g. 1e-7).

The fix adds an early return for scientific notation strings before the decimal-split + numeric separator logic runs.