### PR TITLE
doc: correct diagnostics_channel built-in channel names

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -1713,7 +1713,7 @@ closing the stream can be retrieved using the `stream.rstCode` property.
 
 > Stability: 1 - Experimental
 
-##### Event: `'module.require.start'`
+##### Event: `'tracing:module.require:start'`
 
 * `event` {Object} containing the following properties
   * `id` Argument passed to `require()`. Module name.
@@ -1721,7 +1721,7 @@ closing the stream can be retrieved using the `stream.rstCode` property.
 
 Emitted when `require()` is executed. See [`start` event][].
 
-##### Event: `'module.require.end'`
+##### Event: `'tracing:module.require:end'`
 
 * `event` {Object} containing the following properties
   * `id` Argument passed to `require()`. Module name.
@@ -1729,7 +1729,7 @@ Emitted when `require()` is executed. See [`start` event][].
 
 Emitted when a `require()` call returns. See [`end` event][].
 
-##### Event: `'module.require.error'`
+##### Event: `'tracing:module.require:error'`
 
 * `event` {Object} containing the following properties
   * `id` Argument passed to `require()`. Module name.
@@ -1738,7 +1738,7 @@ Emitted when a `require()` call returns. See [`end` event][].
 
 Emitted when a `require()` throws an error. See [`error` event][].
 
-##### Event: `'module.import.asyncStart'`
+##### Event: `'tracing:module.import:asyncStart'`
 
 * `event` {Object} containing the following properties
   * `id` Argument passed to `import()`. Module name.
@@ -1746,7 +1746,7 @@ Emitted when a `require()` throws an error. See [`error` event][].
 
 Emitted when `import()` is invoked. See [`asyncStart` event][].
 
-##### Event: `'module.import.asyncEnd'`
+##### Event: `'tracing:module.import:asyncEnd'`
 
 * `event` {Object} containing the following properties
   * `id` Argument passed to `import()`. Module name.
@@ -1754,7 +1754,7 @@ Emitted when `import()` is invoked. See [`asyncStart` event][].
 
 Emitted when `import()` has completed. See [`asyncEnd` event][].
 
-##### Event: `'module.import.error'`
+##### Event: `'tracing:module.import:error'`
 
 * `event` {Object} containing the following properties
   * `id` Argument passed to `import()`. Module name.
@@ -1845,7 +1845,7 @@ process has been created.
 
 Emitted when [`child_process.spawn()`][] encounters an error.
 
-##### Event: `'execve'`
+##### Event: `'process.execve'`
 
 * `execPath` {string}
 * `args` {string\[]}


### PR DESCRIPTION
The names listed under the Modules and Process built-in channel sections did not match the channel names actually published by the runtime, so subscribing with the documented names produced no events.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
