### PR TITLE
util: create hex style cache and fast path

### DIFF
--- a/benchmark/util/style-text.js
+++ b/benchmark/util/style-text.js
@@ -5,9 +5,22 @@ const common = require('../common.js');
 const { styleText } = require('node:util');
 const assert = require('node:assert');
 
+// 1000 distinct hex colors to exercise the cache under high-miss conditions.
+// Spread evenly across hue space so colors are valid and maximally varied.
+const kHexColorCount = 1000;
+const toHex = (n) => n.toString(16).padStart(2, '0');
+const hexColors = Array.from({ length: kHexColorCount }, (_, i) => {
+  const r = (i * 37) & 0xff;
+  const g = (i * 73) & 0xff;
+  const b = (i * 137) & 0xff;
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+});
+
 const bench = common.createBenchmark(main, {
   messageType: ['string', 'number', 'boolean', 'invalid'],
-  format: ['red', 'italic', 'invalid', '#ff0000'],
+  // '#rotating' cycles through kHexColorCount distinct colors to simulate
+  // the high-miss-rate / large-cache scenario (e.g. user-randomised colors).
+  format: ['red', 'italic', 'invalid', '#ff0000', '#rotating'],
   validateStream: [1, 0],
   n: [1e3],
 });
@@ -31,9 +44,10 @@ function main({ messageType, format, validateStream, n }) {
 
   bench.start();
   for (let i = 0; i < n; i++) {
+    const fmt = format === '#rotating' ? hexColors[i % kHexColorCount] : format;
     let colored = '';
     try {
-      colored = styleText(format, str, { validateStream });
+      colored = styleText(fmt, str, { validateStream });
       assert.ok(colored); // Attempt to avoid dead-code elimination
     } catch {
       // eslint-disable no-empty

--- a/lib/util.js
+++ b/lib/util.js
@@ -114,7 +114,11 @@ const kEscapeEnd = 'm';
 const kDimCode = 2;
 const kBoldCode = 1;
 
+// Close sequence for 24-bit foreground colors (reset to default foreground)
+const kHexCloseSeq = kEscape + '39' + kEscapeEnd;
+
 let styleCache;
+const hexStyleCache = { __proto__: null };
 
 function getStyleCache() {
   if (styleCache === undefined) {
@@ -135,6 +139,25 @@ function getStyleCache() {
     }
   }
   return styleCache;
+}
+
+/**
+ * Returns the cached ANSI escape sequences for a hex color.
+ * Computes and caches on first use to avoid repeated Buffer allocations.
+ * @param {string} hex A valid hex color string (#RGB or #RRGGBB)
+ * @returns {{openSeq: string, closeSeq: string}}
+ */
+function getHexStyle(hex) {
+  const cached = hexStyleCache[hex];
+  if (cached !== undefined) return cached;
+  const { 0: r, 1: g, 2: b } = hexToRgb(hex);
+  const style = {
+    __proto__: null,
+    openSeq: kEscape + rgbToAnsi24Bit(r, g, b) + kEscapeEnd,
+    closeSeq: kHexCloseSeq,
+  };
+  hexStyleCache[hex] = style;
+  return style;
 }
 
 function replaceCloseCode(str, closeSeq, openSeq, keepClose) {
@@ -162,15 +185,6 @@ function replaceCloseCode(str, closeSeq, openSeq, keepClose) {
 
 // Matches #RGB or #RRGGBB
 const hexColorRegExp = /^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/;
-
-/**
- * Validates whether a string is a valid hex color code.
- * @param {string} hex The hex string to validate (e.g., '#fff' or '#ffffff')
- * @returns {boolean} True if valid hex color, false otherwise
- */
-function isValidHexColor(hex) {
-  return typeof hex === 'string' && RegExpPrototypeExec(hexColorRegExp, hex) !== null;
-}
 
 /**
  * Parses a hex color string into RGB components.
@@ -225,6 +239,17 @@ function styleText(format, text, options) {
       const processed = replaceCloseCode(text, style.closeSeq, style.openSeq, style.keepClose);
       return style.openSeq + processed + style.closeSeq;
     }
+
+    if (format[0] === '#') {
+      let hexStyle = hexStyleCache[format];
+      if (hexStyle === undefined && RegExpPrototypeExec(hexColorRegExp, format) !== null) {
+        hexStyle = getHexStyle(format);
+      }
+      if (hexStyle !== undefined) {
+        const processed = replaceCloseCode(text, hexStyle.closeSeq, hexStyle.openSeq, false);
+        return hexStyle.openSeq + processed + hexStyle.closeSeq;
+      }
+    }
   }
 
   validateString(text, 'text');
@@ -255,24 +280,24 @@ function styleText(format, text, options) {
   for (const key of formatArray) {
     if (key === 'none') continue;
 
-    if (isValidHexColor(key)) {
+    if (typeof key === 'string' && key[0] === '#') {
+      let hexStyle = hexStyleCache[key];
+      if (hexStyle === undefined) {
+        if (RegExpPrototypeExec(hexColorRegExp, key) === null) {
+          throw new ERR_INVALID_ARG_VALUE('format', key,
+                                          'must be a valid hex color (#RGB or #RRGGBB)');
+        }
+        hexStyle = getHexStyle(key);
+      }
       if (skipColorize) continue;
-      const { 0: r, 1: g, 2: b } = hexToRgb(key);
-      const openSeq = kEscape + rgbToAnsi24Bit(r, g, b) + kEscapeEnd;
-      const closeSeq = kEscape + '39' + kEscapeEnd;
-      openCodes += openSeq;
-      closeCodes = closeSeq + closeCodes;
-      processedText = replaceCloseCode(processedText, closeSeq, openSeq, false);
+      openCodes += hexStyle.openSeq;
+      closeCodes = hexStyle.closeSeq + closeCodes;
+      processedText = replaceCloseCode(processedText, hexStyle.closeSeq, hexStyle.openSeq, false);
       continue;
     }
 
     const style = cache[key];
     if (style === undefined) {
-      // Check if it looks like an invalid hex color (starts with #)
-      if (typeof key === 'string' && key[0] === '#') {
-        throw new ERR_INVALID_ARG_VALUE('format', key,
-                                        'must be a valid hex color (#RGB or #RRGGBB)');
-      }
       validateOneOf(key, 'format', ObjectGetOwnPropertyNames(inspect.colors));
     }
     openCodes += style.openSeq;

--- a/lib/util.js
+++ b/lib/util.js
@@ -287,9 +287,11 @@ function styleText(format, text, options) {
           throw new ERR_INVALID_ARG_VALUE('format', key,
                                           'must be a valid hex color (#RGB or #RRGGBB)');
         }
+        if (skipColorize) continue;
         hexStyle = getHexStyle(key);
+      } else if (skipColorize) {
+        continue;
       }
-      if (skipColorize) continue;
       openCodes += hexStyle.openSeq;
       closeCodes = hexStyle.closeSeq + closeCodes;
       processedText = replaceCloseCode(processedText, hexStyle.closeSeq, hexStyle.openSeq, false);

--- a/lib/util.js
+++ b/lib/util.js
@@ -38,6 +38,7 @@ const {
   ObjectValues,
   ReflectApply,
   RegExpPrototypeExec,
+  SafeMap,
   StringPrototypeSlice,
   StringPrototypeToWellFormed,
 } = primordials;
@@ -118,7 +119,29 @@ const kBoldCode = 1;
 const kHexCloseSeq = kEscape + '39' + kEscapeEnd;
 
 let styleCache;
-const hexStyleCache = { __proto__: null };
+
+const kHexStyleCacheMax = 256;
+
+class HexStyleFIFOCache {
+  #cache = new SafeMap();
+
+  get(key) {
+    return this.#cache.get(key);
+  }
+
+  set(key, value) {
+    if (this.#cache.size >= kHexStyleCacheMax)
+      this.#cache.delete(this.#cache.keys().next().value);
+    this.#cache.set(key, value);
+  }
+}
+
+let hexStyleCache;
+
+function getHexStyleCache() {
+  hexStyleCache ??= new HexStyleFIFOCache();
+  return hexStyleCache;
+}
 
 function getStyleCache() {
   if (styleCache === undefined) {
@@ -148,7 +171,8 @@ function getStyleCache() {
  * @returns {{openSeq: string, closeSeq: string}}
  */
 function getHexStyle(hex) {
-  const cached = hexStyleCache[hex];
+  const cache = getHexStyleCache();
+  const cached = cache.get(hex);
   if (cached !== undefined) return cached;
   const { 0: r, 1: g, 2: b } = hexToRgb(hex);
   const style = {
@@ -156,7 +180,7 @@ function getHexStyle(hex) {
     openSeq: kEscape + rgbToAnsi24Bit(r, g, b) + kEscapeEnd,
     closeSeq: kHexCloseSeq,
   };
-  hexStyleCache[hex] = style;
+  cache.set(hex, style);
   return style;
 }
 
@@ -241,7 +265,7 @@ function styleText(format, text, options) {
     }
 
     if (format[0] === '#') {
-      let hexStyle = hexStyleCache[format];
+      let hexStyle = getHexStyleCache().get(format);
       if (hexStyle === undefined && RegExpPrototypeExec(hexColorRegExp, format) !== null) {
         hexStyle = getHexStyle(format);
       }
@@ -281,7 +305,7 @@ function styleText(format, text, options) {
     if (key === 'none') continue;
 
     if (typeof key === 'string' && key[0] === '#') {
-      let hexStyle = hexStyleCache[key];
+      let hexStyle = getHexStyleCache().get(key);
       if (hexStyle === undefined) {
         if (RegExpPrototypeExec(hexColorRegExp, key) === null) {
           throw new ERR_INVALID_ARG_VALUE('format', key,

--- a/lib/util.js
+++ b/lib/util.js
@@ -122,24 +122,10 @@ let styleCache;
 
 const kHexStyleCacheMax = 256;
 
-class HexStyleFIFOCache {
-  #cache = new SafeMap();
-
-  get(key) {
-    return this.#cache.get(key);
-  }
-
-  set(key, value) {
-    if (this.#cache.size >= kHexStyleCacheMax)
-      this.#cache.delete(this.#cache.keys().next().value);
-    this.#cache.set(key, value);
-  }
-}
-
 let hexStyleCache;
 
 function getHexStyleCache() {
-  hexStyleCache ??= new HexStyleFIFOCache();
+  hexStyleCache ??= new SafeMap();
   return hexStyleCache;
 }
 
@@ -180,6 +166,8 @@ function getHexStyle(hex) {
     openSeq: kEscape + rgbToAnsi24Bit(r, g, b) + kEscapeEnd,
     closeSeq: kHexCloseSeq,
   };
+  if (cache.size >= kHexStyleCacheMax)
+    cache.delete(cache.keys().next().value);
   cache.set(hex, style);
   return style;
 }


### PR DESCRIPTION
Improve `styleText` performance by caching and fast-path

<details>
  <summary>Benchmark</summary>

```
util/style-text.js n=1000 validateStream=0 format='#ff0000' messageType='boolean'                -0.71 %       ±1.04%  ±1.38%  ±1.80%
util/style-text.js n=1000 validateStream=0 format='#ff0000' messageType='invalid'                 0.80 %       ±0.86%  ±1.14%  ±1.49%
util/style-text.js n=1000 validateStream=0 format='#ff0000' messageType='number'                 -0.59 %       ±0.93%  ±1.24%  ±1.62%
util/style-text.js n=1000 validateStream=0 format='#ff0000' messageType='string'         ***   1135.88 %      ±31.19% ±42.04% ±55.81%
util/style-text.js n=1000 validateStream=0 format='invalid' messageType='boolean'                -0.09 %       ±1.43%  ±1.90%  ±2.47%
util/style-text.js n=1000 validateStream=0 format='invalid' messageType='invalid'                -0.02 %       ±0.98%  ±1.30%  ±1.69%
util/style-text.js n=1000 validateStream=0 format='invalid' messageType='number'                  0.83 %       ±1.79%  ±2.40%  ±3.15%
util/style-text.js n=1000 validateStream=0 format='invalid' messageType='string'           *     -1.19 %       ±0.97%  ±1.29%  ±1.68%
util/style-text.js n=1000 validateStream=0 format='italic' messageType='boolean'                 -0.24 %       ±1.16%  ±1.55%  ±2.02%
util/style-text.js n=1000 validateStream=0 format='italic' messageType='invalid'                  0.60 %       ±0.92%  ±1.23%  ±1.60%
util/style-text.js n=1000 validateStream=0 format='italic' messageType='number'                   0.81 %       ±1.22%  ±1.63%  ±2.14%
util/style-text.js n=1000 validateStream=0 format='italic' messageType='string'                   1.47 %       ±3.09%  ±4.12%  ±5.36%
util/style-text.js n=1000 validateStream=0 format='red' messageType='boolean'              *      1.17 %       ±1.03%  ±1.37%  ±1.79%
util/style-text.js n=1000 validateStream=0 format='red' messageType='invalid'                     0.73 %       ±0.99%  ±1.32%  ±1.72%
util/style-text.js n=1000 validateStream=0 format='red' messageType='number'                     -0.34 %       ±0.94%  ±1.25%  ±1.63%
util/style-text.js n=1000 validateStream=0 format='red' messageType='string'                      4.92 %       ±6.11%  ±8.17% ±10.72%
util/style-text.js n=1000 validateStream=1 format='#ff0000' messageType='boolean'                -0.50 %       ±1.32%  ±1.76%  ±2.29%
util/style-text.js n=1000 validateStream=1 format='#ff0000' messageType='invalid'                 0.62 %       ±0.89%  ±1.19%  ±1.56%
util/style-text.js n=1000 validateStream=1 format='#ff0000' messageType='number'                 -0.14 %       ±0.79%  ±1.06%  ±1.37%
util/style-text.js n=1000 validateStream=1 format='#ff0000' messageType='string'                 -0.27 %       ±1.23%  ±1.64%  ±2.14%
util/style-text.js n=1000 validateStream=1 format='invalid' messageType='boolean'                -0.31 %       ±0.97%  ±1.29%  ±1.68%
util/style-text.js n=1000 validateStream=1 format='invalid' messageType='invalid'                 0.61 %       ±0.85%  ±1.13%  ±1.48%
util/style-text.js n=1000 validateStream=1 format='invalid' messageType='number'                 -0.05 %       ±0.78%  ±1.04%  ±1.35%
util/style-text.js n=1000 validateStream=1 format='invalid' messageType='string'                  0.69 %       ±1.55%  ±2.07%  ±2.70%
util/style-text.js n=1000 validateStream=1 format='italic' messageType='boolean'                 -0.01 %       ±1.07%  ±1.42%  ±1.85%
util/style-text.js n=1000 validateStream=1 format='italic' messageType='invalid'                 -0.27 %       ±1.09%  ±1.45%  ±1.90%
util/style-text.js n=1000 validateStream=1 format='italic' messageType='number'                   0.04 %       ±1.04%  ±1.38%  ±1.80%
util/style-text.js n=1000 validateStream=1 format='italic' messageType='string'                  -0.41 %       ±0.91%  ±1.21%  ±1.58%
util/style-text.js n=1000 validateStream=1 format='red' messageType='boolean'                     0.56 %       ±1.18%  ±1.57%  ±2.05%
util/style-text.js n=1000 validateStream=1 format='red' messageType='invalid'                    -0.41 %       ±0.94%  ±1.26%  ±1.64%
util/style-text.js n=1000 validateStream=1 format='red' messageType='number'                     -0.88 %       ±0.96%  ±1.28%  ±1.67%
util/style-text.js n=1000 validateStream=1 format='red' messageType='string'                     -0.04 %       ±1.00%  ±1.33%  ±1.73%
```
</details>