### PR TITLE
src: add missing <cstdlib> for abort() declaration

### DIFF
--- a/src/builtin_info.cc
+++ b/src/builtin_info.cc
@@ -1,4 +1,5 @@
 #include "builtin_info.h"
+#include <cstdlib>
 
 namespace node {
 namespace builtins {
@@ -41,7 +42,7 @@ std::string GetBuiltinSourceTypeName(BuiltinSourceType type) {
     case BuiltinSourceType::kSourceTextModule:
       return "kSourceTextModule";
   }
-  abort();
+  std::abort();
 }
 
 }  // namespace builtins


### PR DESCRIPTION
Small PR to add `#include <cstdlib>` in `src/builtin_info.cc` because it uses `abort()`.

This has been compiling up until now because `abort()` got picked up by a transitive declaration from another header. I noticed this when it broke in Electron today when we rolled our LLVM libc++ snapshot. Looks like LLVM libc++ cleaned up the transitive include that made this work for Electron before.