### PR TITLE
fs: open symlinks O_RDONLY in lchmod

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -55,7 +55,7 @@ const {
   S_IFREG,
   S_IFSOCK,
   F_OK,
-  O_WRONLY,
+  O_RDONLY,
   O_SYMLINK,
 } = constants;
 
@@ -1971,7 +1971,7 @@ function fchmodSync(fd, mode) {
 function lchmod(path, mode, callback) {
   validateFunction(callback, 'cb');
   mode = parseFileMode(mode, 'mode');
-  fs.open(path, O_WRONLY | O_SYMLINK, (err, fd) => {
+  fs.open(path, O_RDONLY | O_SYMLINK, (err, fd) => {
     if (err) {
       callback(err);
       return;
@@ -1993,7 +1993,7 @@ function lchmod(path, mode, callback) {
  * @returns {void}
  */
 function lchmodSync(path, mode) {
-  const fd = fs.openSync(path, O_WRONLY | O_SYMLINK);
+  const fd = fs.openSync(path, O_RDONLY | O_SYMLINK);
 
   // Prefer to return the chmod error, if one occurs,
   // but still try to close, and report closing errors if they occur.

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -26,8 +26,8 @@ const {
 const { fs: constants } = internalBinding('constants');
 const {
   F_OK,
+  O_RDONLY,
   O_SYMLINK,
-  O_WRONLY,
   S_IFMT,
   S_IFREG,
 } = constants;
@@ -1742,7 +1742,7 @@ async function lchmod(path, mode) {
   if (O_SYMLINK === undefined)
     throw new ERR_METHOD_NOT_IMPLEMENTED('lchmod()');
 
-  const fd = await open(path, O_WRONLY | O_SYMLINK);
+  const fd = await open(path, O_RDONLY | O_SYMLINK);
   return handleFdClose(fchmod(fd, mode), fd.close);
 }
 


### PR DESCRIPTION
`fchmod` does not require write access, so opening the symlink with
`O_RDONLY` is sufficient.

Refs: #23736