### PR TITLE
http2: expose writable stream state on compat response

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -551,12 +551,20 @@ class Http2ServerResponse extends Stream {
     return this[kStream].writableHighWaterMark;
   }
 
+  get writableObjectMode() {
+    return this[kStream].writableObjectMode;
+  }
+
   get writableFinished() {
     return this[kStream].writableFinished;
   }
 
   get writableLength() {
     return this[kStream].writableLength;
+  }
+
+  get writableNeedDrain() {
+    return this[kStream].writableNeedDrain;
   }
 
   set statusCode(code) {

--- a/test/parallel/test-http2-res-writable-properties.js
+++ b/test/parallel/test-http2-res-writable-properties.js
@@ -7,11 +7,14 @@ const http2 = require('http2');
 const server = http2.createServer(common.mustCall((req, res) => {
   const hwm = req.socket.writableHighWaterMark;
   assert.strictEqual(res.writableHighWaterMark, hwm);
+  assert.strictEqual(res.writableObjectMode, res.stream.writableObjectMode);
+  assert.strictEqual(res.writableNeedDrain, res.stream.writableNeedDrain);
   assert.strictEqual(res.writableLength, 0);
   res.write('');
   const len = res.writableLength;
   res.write('asd');
   assert.strictEqual(res.writableLength, len + 3);
+  assert.strictEqual(res.writableNeedDrain, res.stream.writableNeedDrain);
   res.end();
   res.on('finish', common.mustCall(() => {
     assert.strictEqual(res.writableLength, 0);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63000

This adds the missing writableObjectMode and writableNeedDrain getters to Http2ServerResponse in the HTTP/2 compatibility layer. The getters mirror the underlying stream, matching the existing writable state properties.

The writable-properties test now covers both properties.

Tests:
- ./configure --ninja
- ninja -C out/Release node
- git diff --check
- ./out/Release/node --check lib/internal/http2/compat.js
- ./out/Release/node --check test/parallel/test-http2-res-writable-properties.js
- python3 tools/test.py --mode=release test/parallel/test-http2-res-writable-properties.js
- python3 tools/test.py --mode=release test/parallel/test-http2-res-writable-properties.js test/parallel/test-http2-compat-serverresponse.js test/parallel/test-http2-compat-serverresponse-finished.js test/parallel/test-http2-compat-serverresponse-drain.js
- make lint-js LINT_JS_TARGETS="lib/internal/http2/compat.js test/parallel/test-http2-res-writable-properties.js"