### PR TITLE
http2: add writableObjectMode and writableNeedDrain getters to Http2ServerResponse

### DIFF
--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -555,6 +555,14 @@ class Http2ServerResponse extends Stream {
     return this[kStream].writableFinished;
   }
 
+  get writableObjectMode() {
+    return this[kStream].writableObjectMode;
+  }
+
+  get writableNeedDrain() {
+    return this[kStream].writableNeedDrain;
+  }
+
   get writableLength() {
     return this[kStream].writableLength;
   }

--- a/test/fixtures/http2/test-writable-props.js
+++ b/test/fixtures/http2/test-writable-props.js
@@ -1,0 +1,31 @@
+'use strict';
+
+const { createServer } = require('http2');
+const { mustCall } = require('../common');
+
+const server = createServer();
+server.on('stream', (stream) => {
+  // writableObjectMode and writableNeedDrain should be defined (boolean)
+  console.log('writableObjectMode:', stream.writableObjectMode);
+  console.log('writableNeedDrain:', stream.writableNeedDrain);
+  if (typeof stream.writableObjectMode !== 'boolean') {
+    throw new Error(`writableObjectMode should be boolean, got ${stream.writableObjectMode}`);
+  }
+  if (typeof stream.writableNeedDrain !== 'boolean') {
+    throw new Error(`writableNeedDrain should be boolean, got ${stream.writableNeedDrain}`);
+  }
+  stream.respond();
+  stream.end('ok');
+});
+server.listen(0, mustCall(() => {
+  const client = require('http2').connect(`http://localhost:${server.address().port}`);
+  const req = client.request();
+  req.on('response', () => {
+    req.on('data', () => {});
+    req.on('end', () => {
+      client.close();
+      server.close();
+      console.log('PASS: writableObjectMode and writableNeedDrain are booleans');
+    });
+  });
+}));

--- a/test/parallel/test-http2-res-writable-properties.js
+++ b/test/parallel/test-http2-res-writable-properties.js
@@ -8,6 +8,8 @@ const server = http2.createServer(common.mustCall((req, res) => {
   const hwm = req.socket.writableHighWaterMark;
   assert.strictEqual(res.writableHighWaterMark, hwm);
   assert.strictEqual(res.writableLength, 0);
+  assert.strictEqual(typeof res.writableObjectMode, 'boolean');
+  assert.strictEqual(typeof res.writableNeedDrain, 'boolean');
   res.write('');
   const len = res.writableLength;
   res.write('asd');


### PR DESCRIPTION
Fixes nodejs/node#63000.

Http2ServerResponse was missing these two properties that exist on OutgoingMessage and are documented as returning boolean values.

Added getters mirroring the pattern already used for writableFinished, writableCorked, writableHighWaterMark, etc. in compat.js.