### PR TITLE
build: add rust target for macOS cross compiles

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -1855,6 +1855,10 @@ def configure_node(o):
   if flavor == 'win':
     o['variables']['cargo_rust_target'] = \
       'aarch64-pc-windows-msvc' if target_arch == 'arm64' else 'x86_64-pc-windows-msvc'
+  # Always set the Rust target for x64 macOS in case we will be building
+  # under Rosetta 2.
+  if flavor == 'mac' and target_arch == 'x64':
+    o['variables']['cargo_rust_target'] = 'x86_64-apple-darwin'
 
   # Allow overriding the compiler - needed by embedders.
   if options.use_clang:

--- a/deps/crates/crates.gyp
+++ b/deps/crates/crates.gyp
@@ -12,11 +12,16 @@
       'conditions': [
         ['cargo_rust_target!=""', {
           'variables': {
+            'cargo_build_flags': ['--target', '<(cargo_rust_target)'],
+          }
+        }],
+        ['OS=="win"', {
+          'variables': {
             'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/$(Platform)/release/node_crates.lib',
           },
         }, {
           'variables': {
-            'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/release/<(STATIC_LIB_PREFIX)node_crates<(STATIC_LIB_SUFFIX)',
+            'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/<(cargo_rust_target)/release/<(STATIC_LIB_PREFIX)node_crates<(STATIC_LIB_SUFFIX)',
           },
         }],
       ],
@@ -25,13 +30,13 @@
         'cargo_build_flags': [],
       },
       'conditions': [
-        ['cargo_rust_target!=""', {
+        ['OS=="win"', {
           'variables': {
             'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/$(Platform)/debug/node_crates.lib',
           },
         }, {
           'variables': {
-            'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/debug/<(STATIC_LIB_PREFIX)node_crates<(STATIC_LIB_SUFFIX)',
+            'node_crates_libpath': '<(SHARED_INTERMEDIATE_DIR)/<(cargo_rust_target)/debug/<(STATIC_LIB_PREFIX)node_crates<(STATIC_LIB_SUFFIX)',
           },
         }],
       ],
@@ -62,7 +67,7 @@
         ],
       },
       'conditions': [
-        ['cargo_rust_target!=""', {
+        ['OS=="win"', {
           'actions': [
             {
               'action_name': 'cargo_build',


### PR DESCRIPTION
When we build the macOS pkg, we build Node.js twice (on arm64):
- Once for arm64 (native)
- Once for x64, using a combination of Rosetta 2 and compiler flags

before combining both into a universal binary.

For the x64 case, pass target flag to `rustc` so that the binary is built for the correct target architecture.

---

This is a "blind" attempt to address pkg build failures in the Node.js release CI -- I'm not a macOS user, nor do I have access to a macOS environment outside of the Node.js CI, so opening as a draft to test out.

It's quite possible that even if this is the "correct" fix, we'll need x64 rustc libraries installed on the release macOS VMs (CI run will indicate).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
