### PR TITLE
ffi: prevent premature GC of DynamicLibrary

### DIFF
--- a/src/node_ffi.cc
+++ b/src/node_ffi.cc
@@ -194,6 +194,7 @@ void DynamicLibrary::CleanupFunctionInfo(
   FFIFunctionInfo* info = data.GetParameter();
   info->fn.reset();
   info->self.Reset();
+  info->library.Reset();
   delete info;
 }
 
@@ -313,6 +314,7 @@ MaybeLocal<Function> DynamicLibrary::CreateFunction(
   }
 
   info->self.Reset(isolate, ret);
+  info->library.Reset(isolate, object());
   info->self.SetWeak(info.release(),
                      DynamicLibrary::CleanupFunctionInfo,
                      WeakCallbackType::kParameter);

--- a/src/node_ffi.h
+++ b/src/node_ffi.h
@@ -33,6 +33,8 @@ struct FFIFunctionInfo {
   std::shared_ptr<FFIFunction> fn;
   v8::Global<v8::Function> self;
   std::shared_ptr<v8::BackingStore> sb_backing;
+  // Keep the owning DynamicLibrary alive while the generated function is alive.
+  v8::Global<v8::Object> library;
 };
 
 struct FFICallback {

--- a/test/ffi/test-ffi-dynamic-library.js
+++ b/test/ffi/test-ffi-dynamic-library.js
@@ -1,7 +1,8 @@
-// Flags: --experimental-ffi
+// Flags: --experimental-ffi --expose-gc
 'use strict';
 const common = require('../common');
 common.skipIfFFIMissing();
+const { gcUntil } = require('../common/gc');
 const assert = require('node:assert');
 const { test } = require('node:test');
 const ffi = require('node:ffi');
@@ -115,6 +116,27 @@ test('getFunction caches signatures consistently', () => {
   } finally {
     lib.close();
   }
+});
+
+test('FFI functions keep their owning library alive', async () => {
+  let lib = new ffi.DynamicLibrary(libraryPath);
+  const addI32 = lib.getFunction('add_i32', fixtureSymbols.add_i32);
+  const ref = new WeakRef(lib);
+
+  lib = null;
+
+  for (let i = 0; i < 5; i++) {
+    await gcUntil(
+      'FFI function keeps its owning library alive',
+      () => true,
+      1,
+    );
+    assert.ok(ref.deref() instanceof ffi.DynamicLibrary);
+    assert.strictEqual(addI32(20, 22), 42);
+  }
+
+  ref.deref().close();
+  assert.throws(() => addI32(20, 22), /Library is closed/);
 });
 
 test('closed libraries reject subsequent operations', () => {


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fixes: https://github.com/nodejs/node/issues/63010

  Functions created by `getFunction()` do not hold a strong reference
  to the owning `DynamicLibrary`. V8 may garbage-collect the library
  while derived functions are still in use, causing spurious
  `ERR_FFI_LIBRARY_CLOSED` errors in tight loops.

  Store a `Global<Object>` reference to the library in
  `FFIFunctionInfo` so the library remains alive as long as any
  derived function exists. The reference is released when the
  function is garbage-collected via `CleanupFunctionInfo`.

  ## Verification

  ```console
  $ # reproduce issue #63010 with the test script from the report
  $ out/Release/node --experimental-ffi test_ffi_gc.js

  No errors. Script runs to completion.
  ```