### PR TITLE
stream: copyedit `webstreams/adapter.js`

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -2,13 +2,11 @@
 
 const {
   ArrayPrototypeFilter,
-  ArrayPrototypeMap,
-  Boolean,
-  ObjectEntries,
+  ObjectKeys,
   PromisePrototypeThen,
   PromiseResolve,
   PromiseWithResolvers,
-  SafePromiseAll,
+  SafePromiseAllReturnVoid,
   SafePromisePrototypeFinally,
   SafeSet,
   StringPrototypeStartsWith,
@@ -74,6 +72,7 @@ const {
   getDeprecationWarningEmitter,
   kEmptyObject,
   normalizeEncoding,
+  setOwnProperty,
 } = require('internal/util');
 
 const {
@@ -93,6 +92,7 @@ const {
 
 const { eos } = require('internal/streams/end-of-stream');
 
+const { zlib } = internalBinding('constants');
 const { UV_EOF } = internalBinding('uv');
 
 const encoder = new TextEncoder();
@@ -101,37 +101,34 @@ const kValidateChunk = Symbol('kValidateChunk');
 const kDestroyOnSyncError = Symbol('kDestroyOnSyncError');
 
 // Collect all negative (error) ZLIB codes and Z_NEED_DICT
-const ZLIB_FAILURES = new SafeSet([
-  ...ArrayPrototypeFilter(
-    ArrayPrototypeMap(
-      ObjectEntries(internalBinding('constants').zlib),
-      ({ 0: code, 1: value }) => (value < 0 ? code : null),
-    ),
-    Boolean,
+const ZLIB_FAILURES = new SafeSet(
+  ArrayPrototypeFilter(
+    ObjectKeys(zlib),
+    (code) => code === 'Z_NEED_DICT' || zlib[code] < 0,
   ),
-  'Z_NEED_DICT',
-]);
+);
 
 /**
  * @param {Error|null} cause
  * @returns {Error|null}
  */
 function handleKnownInternalErrors(cause) {
+  const causeCode = cause?.code;
   switch (true) {
-    case cause?.code === 'ERR_STREAM_PREMATURE_CLOSE': {
+    case causeCode === 'ERR_STREAM_PREMATURE_CLOSE': {
       return new AbortError(undefined, { cause });
     }
-    case ZLIB_FAILURES.has(cause?.code):
+    case ZLIB_FAILURES.has(causeCode):
     // Brotli decoder error codes are formatted as 'ERR_' +
     // BrotliDecoderErrorString(), where the latter returns strings like
     // '_ERROR_FORMAT_...', '_ERROR_ALLOC_...', '_ERROR_UNREACHABLE', etc.
     // The resulting JS error codes all start with 'ERR__ERROR_'.
     // Falls through
-    case cause?.code != null &&
-      StringPrototypeStartsWith(cause.code, 'ERR__ERROR_'): {
+    case causeCode != null &&
+      StringPrototypeStartsWith(causeCode, 'ERR__ERROR_'): {
       // eslint-disable-next-line no-restricted-syntax
       const error = new TypeError(undefined, { cause });
-      error.code = cause.code;
+      setOwnProperty(error, 'code', causeCode);
       return error;
     }
     default:
@@ -190,8 +187,7 @@ function newWritableStreamFromStreamWritable(streamWritable, options = kEmptyObj
   let closed;
 
   function onDrain() {
-    if (backpressurePromise !== undefined)
-      backpressurePromise.resolve();
+    backpressurePromise?.resolve();
   }
 
   const cleanup = eos(streamWritable, (error) => {
@@ -202,8 +198,7 @@ function newWritableStreamFromStreamWritable(streamWritable, options = kEmptyObj
     // that happen to emit an error event again after finished is called.
     streamWritable.on('error', () => {});
     if (error != null) {
-      if (backpressurePromise !== undefined)
-        backpressurePromise.reject(error);
+      backpressurePromise?.reject(error);
       // If closed is not undefined, the error is happening
       // after the WritableStream close has already started.
       // We need to reject it here.
@@ -330,10 +325,10 @@ function newStreamWritableFromWritableStream(writableStream, options = kEmptyObj
         writer.ready,
         () => {
           return PromisePrototypeThen(
-            SafePromiseAll(
+            SafePromiseAllReturnVoid(
               chunks,
               (data) => writer.write(data.chunk)),
-            () => done(),
+            done,
             done);
         },
         done);
@@ -802,10 +797,10 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
         writer.ready,
         () => {
           return PromisePrototypeThen(
-            SafePromiseAll(
+            SafePromiseAllReturnVoid(
               chunks,
               (data) => writer.write(data.chunk)),
-            () => done(),
+            done,
             done);
         },
         done);
@@ -907,7 +902,7 @@ function newStreamDuplexFromReadableWritablePair(pair = kEmptyObject, options = 
 
       if (!writableClosed || !readableClosed) {
         PromisePrototypeThen(
-          SafePromiseAll([
+          SafePromiseAllReturnVoid([
             closeWriter(),
             closeReader(),
           ]),


### PR DESCRIPTION
- Simplify `ZLIB_FAILURES` creation.
- Cache `cause.code` in `handleKnownInternalErrors` in case of a getter.
- Replace `SafePromiseAll` with `SafePromiseAllReturnVoid` to reduce the number of allocated promises.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
