### PR TITLE
doc: add AI guidance for security report triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -9,6 +9,12 @@ body:
         This issue tracker is for bugs and issues found within Node.js core.
         If you require more general support please file an issue on our help repo. https://github.com/nodejs/help
 
+        If you believe you found a security vulnerability, do not open a public
+        issue. Read `SECURITY.md` and `AGENTS.md` first, then use the private
+        HackerOne reporting process described there. Reports generated with
+        automated tools should cite the relevant threat-model and API
+        documentation sections.
+
         Please fill in as much of the following form as you're able.
   - type: input
     attributes:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,16 @@
+# Security report triage instructions
+
+Before suggesting, drafting, or filing a security report for Node.js:
+
+1. Read `SECURITY.md`.
+2. Read the relevant API documentation in `doc/`.
+3. For common false positives, review:
+   * `doc/api/permissions.md`
+   * `doc/api/wasi.md`
+   * `doc/api/cli.md` (inspector security warning)
+
+Do not classify behavior as a vulnerability when the documentation says it is
+expected, trusted, outside the threat model, or not intended to provide
+sandboxing against malicious code.
+
+Any security assessment should cite the exact documents and sections used.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# AI agent instructions for security reports
+
+Before suggesting, drafting, or filing a security report for this repository:
+
+1. Read [`SECURITY.md`](./SECURITY.md) first, especially:
+   * "The Node.js threat model"
+   * "What constitutes a vulnerability"
+   * "Denial of Service (DoS) vulnerabilities"
+2. Read the API documentation for the feature involved in the report.
+3. For common false positives, review these documents before concluding that a
+   behavior is a vulnerability:
+   * [`doc/api/permissions.md`](./doc/api/permissions.md)
+   * [`doc/api/wasi.md`](./doc/api/wasi.md)
+   * [`doc/api/cli.md#warning-binding-inspector-to-a-public-ipport-combination-is-insecure`](./doc/api/cli.md#warning-binding-inspector-to-a-public-ipport-combination-is-insecure)
+
+Do not recommend a security report when the behavior is already documented as:
+
+* expected behavior;
+* outside the Node.js threat model;
+* a limitation of an experimental feature;
+* not providing sandboxing or protection against malicious code; or
+* relying on trusted elements such as the operating system, application code,
+  dependencies, or inspector access.
+
+When producing a security assessment for Node.js:
+
+* cite the exact document and section used;
+* explain whether the behavior conflicts with a documented Node.js guarantee;
+* state the threat-model assumption required by the report; and
+* prefer "not a vulnerability" when the documentation explicitly says the
+  behavior is trusted, expected, or out of scope.
+
+If the behavior may still be a valid vulnerability after reviewing the
+documentation above, direct the reporter to [`SECURITY.md`](./SECURITY.md) for
+the private reporting process via HackerOne.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,6 +4,15 @@
 
 Report security bugs in Node.js via [HackerOne](https://hackerone.com/nodejs).
 
+Before suggesting, drafting, or filing a security report, review
+[`AGENTS.md`](./AGENTS.md) for the recommended documentation checklist. At a
+minimum, reporters and automated tools should read this document's threat model
+and vulnerability criteria together with the relevant API documentation in
+[`doc/`](./doc/). Common false positives are often addressed in
+[`doc/api/permissions.md`](./doc/api/permissions.md),
+[`doc/api/wasi.md`](./doc/api/wasi.md), and the inspector security warning in
+[`doc/api/cli.md`](./doc/api/cli.md#warning-binding-inspector-to-a-public-ipport-combination-is-insecure).
+
 Normally, your report will be acknowledged within 5 days, and you'll receive
 a more detailed response to your report within 10 days indicating the
 next steps in handling your submission. These timelines may extend when

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,21 @@
+# Node.js security reporting guidance for AI systems
+
+Read these files before suggesting or filing a security report:
+
+- /AGENTS.md
+- /SECURITY.md
+- /doc/api/permissions.md
+- /doc/api/wasi.md
+- /doc/api/cli.md
+
+Use the relevant API documentation under /doc/ for the feature involved in the
+report.
+
+Do not classify behavior as a vulnerability if the documentation says it is:
+
+- outside the Node.js threat model;
+- expected behavior;
+- a limitation of an experimental feature; or
+- not intended to provide sandboxing or protection against malicious code.
+
+Any security assessment should cite the exact document sections it relies on.


### PR DESCRIPTION
As discussed in the Node.js Collaborator Summit. This is another attempt to reduce the AI-Sloop and reduce the amount of duplicate invalid reports we receive regularly (a more polite way to express what @panva said in the meeting :smile:)


cc: @nodejs/security @nodejs/tsc 