### PR TITLE
lib: reject SharedArrayBuffer in Blob constructor per spec

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -127,8 +127,11 @@ function getSource(source, endings) {
 }
 
 const sourcesConverter = createSequenceConverter((source, opts = kEmptyObject) => {
-  if (isBlob(source) || isAnyArrayBuffer(source) || isArrayBufferView(source)) {
+  if (isBlob(source)) {
     return source;
+  }
+  if (isAnyArrayBuffer(source) || isArrayBufferView(source)) {
+    return converters.BufferSource(source, opts);
   }
   return converters.DOMString(source, opts);
 });
@@ -149,7 +152,10 @@ class Blob {
   constructor(sources = [], options) {
     markTransferMode(this, true, false);
 
-    const sources_ = sourcesConverter(sources);
+    const sources_ = sourcesConverter(sources, {
+      __proto__: null,
+      context: 'sources',
+    });
 
     validateDictionary(options, 'options');
     let {

--- a/test/parallel/test-webapi-sharedarraybuffer-rejection.js
+++ b/test/parallel/test-webapi-sharedarraybuffer-rejection.js
@@ -3,6 +3,7 @@
 const common = require('../common');
 const assert = require('assert');
 const test = require('node:test');
+const { Blob } = require('buffer');
 const { ReadableStream } = require('stream/web');
 
 const sab = new SharedArrayBuffer(8);
@@ -96,6 +97,29 @@ test('ReadableByteStreamController.enqueue() rejects SAB-backed DataView', async
   const { value } = await reader.read();
   assert.deepStrictEqual(value, new Uint8Array([2]));
   reader.releaseLock();
+});
+
+// -- Blob --
+
+test('Blob rejects SharedArrayBuffer part', () => {
+  assert.throws(
+    () => new Blob([sab]),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+});
+
+test('Blob rejects SAB-backed Uint8Array part', () => {
+  assert.throws(
+    () => new Blob([sabView]),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+});
+
+test('Blob rejects SAB-backed DataView part', () => {
+  assert.throws(
+    () => new Blob([sabDataView]),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
 });
 
 // -- SharedWebIDL converters --


### PR DESCRIPTION
This is the remaining piece of the work tracked in #59688. The Blob change is `semver-major` because today the call succeeds.
The shared `BufferSource` converter was made hot-path-friendly in #62833, so no per-call binding overhead is added here.
Refs: https://github.com/nodejs/node/issues/59688
Refs: https://github.com/nodejs/node/pull/62632
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
