### PR TITLE
tools: implements a few nits on `build-aarch64-linux-v8`

### DIFF
--- a/.github/workflows/test-shared.yml
+++ b/.github/workflows/test-shared.yml
@@ -173,6 +173,8 @@ jobs:
     outputs:
       local-cache: ${{ steps.upload.outcome != 'skipped' && 'true' || '' }}
       matrix: ${{ steps.query.outputs.matrix }}
+    env:
+      HAS_CACHIX_AUTH_TOKEN: ${{ secrets.CACHIX_AUTH_TOKEN && 'true' }}
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
@@ -189,58 +191,49 @@ jobs:
         with:
           extra_nix_config: sandbox = true
 
-      - name: Evaluate V8 derivation
+      - name: Evaluate V8 derivation, check its cache status
         id: v8-drv
         run: |
           V8_DRV=$(
             nix-instantiate -E "builtins.filter (p: p.pname == ''v8'') (import $TAR_DIR/shell.nix { useSeparateDerivationForV8=true; }).buildInputs"
           )
+          V8_STORE_PATH=$(nix-store -q --outputs "$V8_DRV")
           echo "V8_DRV=$V8_DRV" >> "$GITHUB_OUTPUT"
-          echo "STORE_PATH=$(nix-store -q --outputs "$V8_DRV")" >> "$GITHUB_OUTPUT"
-
-      - name: Check if available on Cachix
-        id: cachix-check
-        run: |
-          echo 'HAS_WRITE_TOKEN=${{ secrets.CACHIX_AUTH_TOKEN && 'true' }}' >> "$GITHUB_OUTPUT"
           set -x
           [ "$(curl -ISsw "%{http_code}" -o /dev/null "https://nodejs.cachix.org/$(basename ${V8_STORE_PATH%-v8-*}).narinfo")" != "200" ] ||
             echo "ALREADY_CACHED=true" >> "$GITHUB_OUTPUT"
-        env:
-          V8_STORE_PATH: ${{ steps.v8-drv.outputs.STORE_PATH }}
 
       - uses: cachix/cachix-action@1eb2ef646ac0255473d23a5907ad7b04ce94065c  # v17
-        if: ${{ steps.cachix-check.outputs.ALREADY_CACHED != 'true' }}
+        if: ${{ steps.v8-drv.outputs.ALREADY_CACHED != 'true' }}
         with:
           name: nodejs
           authToken: ${{ secrets.CACHIX_AUTH_TOKEN }}
 
-      - name: Build V8 derivation
-        if: ${{ steps.cachix-check.outputs.ALREADY_CACHED != 'true' }}
-        run: nix-store --export "$(nix-build "$V8_DRV")" > libv8
+      - name: Build V8 to cache it
+        if: ${{ steps.v8-drv.outputs.ALREADY_CACHED != 'true' }}
+        run: nix-store --export "$(nix-build "$V8_DRV")" > libv8-aarch64-linux.nar
         env:
           V8_DRV: ${{ steps.v8-drv.outputs.V8_DRV }}
 
-      - name: Upload libv8
-        if: ${{ steps.cachix-check.outputs.ALREADY_CACHED != 'true' && steps.cachix-check.outputs.HAS_WRITE_TOKEN != 'true' }}
+      - name: Upload libv8-aarch64-linux.nar
+        if: ${{ steps.v8-drv.outputs.ALREADY_CACHED != 'true' && env.HAS_CACHIX_AUTH_TOKEN != 'true' }}
         id: upload
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: libv8
-          path: libv8
+          name: libv8-aarch64-linux.nar
+          path: libv8-aarch64-linux.nar
 
       - name: Collect matrix of support OpenSSL versions
         id: query
         run: |
-          {
-            echo 'matrix<<EOF'
+          echo "matrix=$(
             nix-instantiate --eval --strict --json -E "
               let
                 matrix = import $TAR_DIR/tools/nix/openssl-matrix.nix {};
               in
               builtins.map (attr: { inherit attr; inherit (builtins.getAttr attr matrix) name; }) (builtins.attrNames matrix)
             "
-            echo 'EOF'
-          } >> "$GITHUB_OUTPUT"
+          )" >> "$GITHUB_OUTPUT"
 
   # Builds and tests Node.js with shared libraries against every supported
   # OpenSSL release version available in the repo-pinned nixpkgs. The default
@@ -268,7 +261,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         if: ${{ needs.build-aarch64-linux-v8.outputs.local-cache }}
         with:
-          name: libv8
+          name: libv8-aarch64-linux.nar
 
       - uses: ./.github/actions/build-shared
         name: Build and test Node.js
@@ -281,7 +274,7 @@ jobs:
           # release (e.g. `openssl-1.1.1w`) so EOL-with-extended-support
           # cycles evaluate without relaxing nixpkgs' meta check globally.
           extra-nix-flags: |
-            --arg useSeparateDerivationForV8 ${{ needs.build-aarch64-linux-v8.outputs.local-cache && '"$(nix-store --import < libv8)"' || 'true' }} \
+            --arg useSeparateDerivationForV8 ${{ needs.build-aarch64-linux-v8.outputs.local-cache && '"$(nix-store --import < libv8-aarch64-linux.nar)"' || 'true' }} \
             --arg sharedLibDeps "(import $TAR_DIR/tools/nix/sharedLibDeps.nix {}) // {
                 openssl = (import $TAR_DIR/tools/nix/openssl-matrix.nix {}).$OPENSSL_ATTR;
               }" \


### PR DESCRIPTION
Using `libv8` for the Nix export was not very informative, adding the arch and OS to make it clear it's platform specific, also a file extension, that should help folks understand what they're dealing with. (info about Nix ARchive format can be found at https://nix.dev/manual/nix/2.28/store/file-system-object/content-address#serial-nix-archive)

Also, renaming some variables and steps, and merging `cachix-check` with `v8-drv` to improve the general readability of the workflow IMO.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
