### PR TITLE
build: add temporary workaround for Rust on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1175,6 +1175,8 @@ endif
 			| sed -E "s/\\{npmversion\\}/$(NPMVERSION)/g"  \
 		>$(MACOSOUTDIR)/installer/productbuild/Resources/$$lang/conclusion.html ; \
 	done
+	# TODO(richardlau) remove once target is added to the underlying macOS VMs. 
+	rustup target add x86_64-apple-darwin
 	CC_host="cc -arch x86_64" CXX_host="c++ -arch x86_64"  \
 	CC_target="cc -arch x86_64" CXX_target="c++ -arch x86_64" \
 	CC="cc -arch x86_64" CXX="c++ -arch x86_64" $(PYTHON) ./configure \


### PR DESCRIPTION
Temporarily install the x64 Rust target on macOS at build time. To be removed when the target is installed at the macOS VM level.

Refs: https://github.com/nodejs/node/pull/63015
Refs: https://github.com/nodejs/build/pull/4316

---

This can land independently of https://github.com/nodejs/build/pull/4316, but if it does land it should be reverted once https://github.com/nodejs/build/pull/4316 is deployed onto the macOS VMs.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
