### PR TITLE
stream: avoid constructing extra promise in `createPromiseCallback`

### DIFF
--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -243,6 +243,7 @@ function copyPrototype(src, dest, prefix) {
   copyPrototype(original.prototype, primordials, `${name}Prototype`);
 });
 
+
 // Create copies of abstract intrinsic objects that are not directly exposed
 // on the global object.
 // Refs: https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object
@@ -273,6 +274,7 @@ const {
   ArrayPrototypePushApply,
   ArrayPrototypeSlice,
   FinalizationRegistry,
+  FunctionPrototypeBind,
   FunctionPrototypeCall,
   Map,
   ObjectDefineProperties,
@@ -434,6 +436,12 @@ const SafePromise = makeSafe(
   Promise,
   class SafePromise extends Promise {},
 );
+
+{
+  // eslint-disable-next-line node-core/prefer-primordials
+  const OriginalPromiseTry = Promise.try;
+  primordials.BindPromiseTry = (fn) => FunctionPrototypeBind(OriginalPromiseTry, Promise, fn);
+}
 
 /**
  * Attaches a callback that is invoked when the Promise is settled (fulfilled or

--- a/lib/internal/per_context/primordials.js
+++ b/lib/internal/per_context/primordials.js
@@ -243,7 +243,6 @@ function copyPrototype(src, dest, prefix) {
   copyPrototype(original.prototype, primordials, `${name}Prototype`);
 });
 
-
 // Create copies of abstract intrinsic objects that are not directly exposed
 // on the global object.
 // Refs: https://tc39.es/ecma262/#sec-%typedarray%-intrinsic-object

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -7,10 +7,11 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeShift,
   AsyncIteratorPrototype,
+  BindPromiseTry,
+  FunctionPrototypeBind,
   MathMax,
   NumberIsNaN,
   PromisePrototypeThen,
-  ReflectApply,
   ReflectGet,
   Symbol,
   Uint8Array,
@@ -164,7 +165,7 @@ function enqueueValueWithSize(controller, value, size) {
 
 function createPromiseCallback(name, fn, thisArg) {
   validateFunction(fn, name);
-  return async (...args) => ReflectApply(fn, thisArg, args);
+  return BindPromiseTry(thisArg === undefined ? fn : FunctionPrototypeBind(fn, thisArg));
 }
 
 function isPromisePending(promise) {


### PR DESCRIPTION
Looking at the spec, I'm not sure `Promise.try` actually avoids the extra promise allocation, converting to draft for now

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
