### PR TITLE
tools: update gr2m/create-or-update-pull-request-action to v1.10.1

### DIFF
--- a/.github/workflows/find-inactive-collaborators.yml
+++ b/.github/workflows/find-inactive-collaborators.yml
@@ -33,7 +33,7 @@ jobs:
         run: tools/find-inactive-collaborators.mjs
 
       - name: Open pull request
-        uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
+        uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b  # v1.10.1
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
         env:

--- a/.github/workflows/find-inactive-tsc.yml
+++ b/.github/workflows/find-inactive-tsc.yml
@@ -42,7 +42,7 @@ jobs:
         run: tools/find-inactive-tsc.mjs >> $GITHUB_ENV
 
       - name: Open pull request
-        uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
+        uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b  # v1.10.1
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
         env:

--- a/.github/workflows/license-builder.yml
+++ b/.github/workflows/license-builder.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           persist-credentials: false
       - run: ./tools/license-builder.sh  # Run the license builder tool
-      - uses: gr2m/create-or-update-pull-request-action@86ec1766034c8173518f61d2075cc2a173fb8c97  # v1.9.4
+      - uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b  # v1.10.1
         # Creates a PR or update the Action's existing PR, or
         # no-op if the base branch is already up-to-date.
         env:

--- a/.github/workflows/timezone-update.yml
+++ b/.github/workflows/timezone-update.yml
@@ -51,7 +51,8 @@ jobs:
 
       - name: Open Pull Request
         if: ${{ env.new_version != env.current_version }}
-        uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5  # Create a PR or update the Action's existing PR
+        # Create a PR or update the Action's existing PR
+        uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b  # v1.10.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         with:

--- a/.github/workflows/update-openssl.yml
+++ b/.github/workflows/update-openssl.yml
@@ -28,7 +28,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
       - name: Create PR with first commit
         if: env.NEW_VERSION
-        uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
+        uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b  # v1.10.1
         # Creates a PR with the new OpenSSL source code committed
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
@@ -51,7 +51,7 @@ jobs:
       - name: Add second commit
         # Adds a second commit to the PR with the generated platform-dependent files
         if: env.NEW_VERSION
-        uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
+        uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b  # v1.10.1
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
         with:

--- a/.github/workflows/update-wpt.yml
+++ b/.github/workflows/update-wpt.yml
@@ -68,7 +68,7 @@ jobs:
           SUBSYSTEM: ${{ matrix.subsystem }}
 
       - name: Open or update PR for the subsystem update
-        uses: gr2m/create-or-update-pull-request-action@77596e3166f328b24613f7082ab30bf2d93079d5
+        uses: gr2m/create-or-update-pull-request-action@b65137ca591da0b9f43bad7b24df13050ea45d1b  # v1.10.1
         with:
           # The create-or-update-pull-request-action matches the branch name by prefix,
           # which is why we need to add the -wpt suffix. If we dont do that, we risk matching wrong PRs,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/62990

## Situation

Dependabot is failing with `unknown_error` when attempting updates to the GitHub Action

[gr2m/create-or-update-pull-request-action](https://github.com/gr2m/create-or-update-pull-request-action)

Several workflows are pinned to https://github.com/gr2m/create-or-update-pull-request-action/commit/77596e3166f328b24613f7082ab30bf2d93079d5 which does not correspond to
any release tag.

## Change

Update all usage of [gr2m/create-or-update-pull-request-action](https://github.com/gr2m/create-or-update-pull-request-action) to

[gr2m/create-or-update-pull-request-action@v1.10.1](https://github.com/gr2m/create-or-update-pull-request-action/releases/tag/v1.10.1) (current `latest`)

using the pinned SHA `b65137ca591da0b9f43bad7b24df13050ea45d1b` https://github.com/gr2m/create-or-update-pull-request-action/commit/b65137ca591da0b9f43bad7b24df13050ea45d1b

With the disclaimer that I'm submitting from a fork and since I'm not a Collaborator in this repo I can't test the workflows.

I'm also not sure if my longer `Signed-off-by` (>72 characters) is going to work, but it's worth a try! Edit: so far, so good!