### PR TITLE
tools: filter V8 scripts for build toolchain

### DIFF
--- a/tools/make-v8.sh
+++ b/tools/make-v8.sh
@@ -35,6 +35,32 @@ if [ "$ARCH" = "s390x" ] || [ "$ARCH" = "ppc64le" ]; then
       GN_COMPILER_OPTS="is_clang=true clang_base_path=\"/usr\" clang_use_chrome_plugins=false treat_warnings_as_errors=false use_custom_libcxx=false clang_version=\"${CLANG_VERSION}\""
       GN_RUST_ARGS="rustc_version=\"${RUST_VERSION}\" rust_sysroot_absolute=\"/usr\" rust_bindgen_root=\"/usr\""
       export RUSTC_BOOTSTRAP=1
+
+      # Filter out options supported in clang >= 20 when using clang 19.
+      if [ "${CLANG_VERSION}" -eq "19" ]; then
+        find build/ \( -name "*.gn" -o -name "*.gni" \) -exec sed -i \
+          -e '/-Wno-nontrivial-memcall/d' {} \;
+      fi
+      # Filter out compiler options not supported by non-nightly clang builds
+      if [ "${CLANG_VERSION}" -ge "19" ]; then
+        find build/ \( -name "*.gn" -o -name "*.gni" \) -exec sed -i \
+          -e '/-Wno-unsafe-buffer-usage-in-static-sized-array/d' \
+          -e '/-Wno-uninitialized-const-pointer/d' \
+          -e '/-Wno-unused-but-set-global/d' \
+          -e '/-fno-lifetime-dse/d' \
+          -e '/-fsanitize-ignore-for-ubsan-feature/d' \
+          -e '/-fdiagnostics-show-inlining-chain/d' {} \;
+      fi
+      # Patch to match libadler/libadler2 based on what is present.
+      LIBADLER=$(basename "$(find "$(rustc --print sysroot)/lib/rustlib/" -type f -name "libadler*")" | cut -d '-' -f 1) || true
+      case "$LIBADLER" in
+        libadler2) sed -i -e 's/"adler"/"adler2"/g' build/rust/std/BUILD.gn
+          ;;
+        libadler) sed -i -e 's/"adler2"/"adler"/g' build/rust/std/BUILD.gn
+          ;;
+        *) echo "Warning: unable to detect libadler/libadler2 (found ${LIBADLER})"
+          ;;
+      esac
       ;;
     *) GN_COMPILER_OPTS="treat_warnings_as_errors=false use_custom_libcxx=false" ;;
   esac


### PR DESCRIPTION
Patch the build scripts for V8 when running the V8 CI for Linux on ppc64le and s390x to workaround inconsistencies between the nightly build toolchain used by V8 and the released versions that we use from the Linux distribution.

Refs: https://github.com/nodejs/node/pull/62572#issuecomment-4314052296
Refs: https://github.com/ibmruntimes/v8-build/blob/49b55c036da148bd18b546f19b731a0fe92b6a33/bin/v8.sh#L62-L71
Refs: https://github.com/nodejs/build/issues/4265

--- 

Opening this as separate from the V8 14.8 update as I want to cherry-pick it across to v26.x. The plan is to update [clang and rustc on the RHEL machines](https://github.com/nodejs/build/issues/4265) and this patch should keep the V8 CI working on v26.x and main during the transition. Without this patch V8 CI would break on Linux on ppc64le and s390x when we update Rust to 1.88 as "adler" has been replaced with "adler2".


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
