### PR TITLE
tools: update sccache to v0.16.0

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -123,7 +123,7 @@ jobs:
         if: github.base_ref == 'main' || github.ref_name == 'main'
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
-          version: v0.12.0
+          version: v0.16.0
       - name: Environment Information
         run: npx envinfo
       - name: Download tarball

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -66,7 +66,7 @@ jobs:
         if: github.base_ref == 'main' || github.ref_name == 'main'
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
-          version: v0.12.0
+          version: v0.16.0
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -66,7 +66,7 @@ jobs:
         if: github.base_ref == 'main' || github.ref_name == 'main'
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
-          version: v0.12.0
+          version: v0.16.0
       - name: Environment Information
         run: npx envinfo
       - name: Install gcovr

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -63,7 +63,7 @@ jobs:
         if: github.base_ref == 'main' || github.ref_name == 'main'
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
-          version: v0.12.0
+          version: v0.16.0
       - name: Environment Information
         run: npx envinfo
       - name: Build

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -79,7 +79,7 @@ jobs:
         if: github.base_ref == 'main' || github.ref_name == 'main'
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
-          version: v0.12.0
+          version: v0.16.0
       - name: Environment Information
         run: npx envinfo
       - name: Build

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -102,7 +102,7 @@ jobs:
         if: github.base_ref == 'main' || github.ref_name == 'main'
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
-          version: v0.12.0
+          version: v0.16.0
       - name: Environment Information
         run: npx envinfo
       # The `npm ci` for this step fails a lot as part of the Test step. Run it


### PR DESCRIPTION
- https://github.com/mozilla/sccache/releases/tag/v0.13.0
- https://github.com/mozilla/sccache/releases/tag/v0.14.0
- https://github.com/mozilla/sccache/releases/tag/v0.15.0
- https://github.com/mozilla/sccache/releases/tag/v0.16.0