### PR TITLE
webstreams: narrow ReadableStreamBYOBRequest.view type

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -672,7 +672,7 @@ class ReadableStreamBYOBRequest {
 
   /**
    * @readonly
-   * @type {ArrayBufferView}
+   * @type {Uint8Array}
    */
   get view() {
     if (!isReadableStreamBYOBRequest(this))


### PR DESCRIPTION
Summary:\n- update JSDoc type of ReadableStreamBYOBRequest.view from ArrayBufferView to Uint8Array\n- aligns docs with spec direction and runtime behavior discussed in issue #62952\n\nCloses #62952