### PR TITLE
test: avoid truncating watched worker deps

### DIFF
--- a/test/sequential/test-watch-mode-worker.mjs
+++ b/test/sequential/test-watch-mode-worker.mjs
@@ -14,8 +14,13 @@ if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
 
 function restart(file, content = readFileSync(file)) {
-  writeFileSync(file, content);
-  const timer = setInterval(() => writeFileSync(file, content), common.platformTimeout(250));
+  const rewrite = () => {
+    // Avoid truncating files while restarted workers may be reading them.
+    writeFileSync(file, content, { flag: 'r+' });
+  };
+
+  rewrite();
+  const timer = setInterval(rewrite, common.platformTimeout(250));
   return () => clearInterval(timer);
 }
 


### PR DESCRIPTION
This fixes a flaky `sequential/test-watch-mode-worker` failure where the nested CJS worker dependency case can log `{}` instead of `sub-dep v1`.

The test rewrites watched worker dependency files to trigger `--watch` restarts, but default `writeFileSync()` temporarily truncates the file. A restarted worker can read the dependency during that empty-file window.

This change keeps the write-based restart trigger, but uses `r+` to overwrite without truncation.

Reported in: https://github.com/nodejs/reliability/blob/main/reports/2026-05-02.md

```
not ok 5323 sequential/test-watch-mode-worker
  ---
  Test failure: 'should watch changes to nested worker dependencies - cjs'
  AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
    [
      'sub-dep v1',
      "Completed running '/home/iojs/node-tmp/.tmp.5322/2.js'. Waiting for file changes before restarting...",
      "Restarting '/home/iojs/node-tmp/.tmp.5322/2.js'",
  +   '{}',
  -   'sub-dep v1',
      "Completed running '/home/iojs/node-tmp/.tmp.5322/2.js'. Waiting for file changes before restarting..."
    ]
```

Testing:

```
$ ./tools/test.py sequential/test-watch-mode-worker

$ ./tools/test.py -j1 --repeat 20 sequential/test-watch-mode-worker
```

Refs: https://github.com/nodejs/node/pull/62368
