### PR TITLE
tools: use lts node in notify-on-push workflow

### DIFF
--- a/.github/workflows/notify-on-push.yml
+++ b/.github/workflows/notify-on-push.yml
@@ -7,6 +7,9 @@ name: Notify on Push
 permissions:
   contents: read
 
+env:
+  NODE_VERSION: lts/*
+
 jobs:
   notifyOnForcePush:
     name: Notify on Force Push on `main`
@@ -33,6 +36,10 @@ jobs:
     # cannot use ubuntu-slim here because rtCamp/action-slack-notify is dockerized
     runs-on: ubuntu-24.04-arm
     steps:
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: ${{ env.NODE_VERSION }}
       - name: Validate commits
         run: echo "$COMMITS" | npx -q core-validate-commit -
         id: commit-check


### PR DESCRIPTION
Without pinning Node.js, the runner defaults to Node 20 and npx falls back to `core-validate-commit@5.0.1` instead of `6.0.0` (requires Node 22+). Version 5 doesn't recognise the `ffi` subsystem, causing false invalid-commit alerts.

Fixes: https://github.com/nodejs/node/issues/63070
