### PR TITLE
doc: fix the TypeScript Execute (tsx) project link

### DIFF
--- a/doc/api/typescript.md
+++ b/doc/api/typescript.md
@@ -229,7 +229,7 @@ with `#`.
 [`--no-strip-types`]: cli.md#--no-strip-types
 [`ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX`]: errors.md#err_unsupported_typescript_syntax
 [`tsconfig` "paths"]: https://www.typescriptlang.org/tsconfig/#paths
-[`tsx`]: https://tsx.is/
+[`tsx`]: https://tsx.hirok.io/
 [`verbatimModuleSyntax`]: https://www.typescriptlang.org/tsconfig/#verbatimModuleSyntax
 [file extensions are mandatory]: esm.md#mandatory-file-extensions
 [full support]: #full-typescript-support


### PR DESCRIPTION
This is a minor change to the documentation which fixes a link to the TypeScript Execute (tsx) project. The URL of that project appears to be different now.