### PR TITLE
fs: prevent spurious recursive watch events on prefix siblings

### DIFF
--- a/lib/internal/fs/recursive_watch.js
+++ b/lib/internal/fs/recursive_watch.js
@@ -25,6 +25,7 @@ const {
   join: pathJoin,
   relative: pathRelative,
   resolve: pathResolve,
+  sep: pathSep,
 } = require('path');
 
 let internalSync;
@@ -106,8 +107,10 @@ class FSWatcher extends EventEmitter {
   #unwatchFiles(file) {
     this.#symbolicFiles.delete(file);
 
+    const childPrefix = file + pathSep;
     for (const filename of this.#files.keys()) {
-      if (StringPrototypeStartsWith(filename, file)) {
+      if (filename === file ||
+          StringPrototypeStartsWith(filename, childPrefix)) {
         this.#files.delete(filename);
         this.#watchers.get(filename)?.close();
         this.#watchers.delete(filename);

--- a/test/parallel/test-fs-watch-recursive-prefix-sibling.js
+++ b/test/parallel/test-fs-watch-recursive-prefix-sibling.js
@@ -28,12 +28,19 @@ tmpdir.refresh();
 (async () => {
   const root = fs.mkdtempSync(path.join(tmpdir.path, 'watch-prefix-'));
 
-  // Sibling names that share the prefix `foo` with the entry to delete.
+  // Sibling names that share the prefix `foo` with the entries to delete.
   fs.mkdirSync(path.join(root, 'foo_bar'));
   fs.writeFileSync(path.join(root, 'foo_bar', 'file.txt'), '');
   fs.mkdirSync(path.join(root, 'foo_bar', 'somedir'));
-  fs.mkdirSync(path.join(root, 'foo'));
   fs.writeFileSync(path.join(root, 'foo_'), '');
+
+  // `foo` (empty) exercises the exact-match branch of `#unwatchFiles`.
+  fs.mkdirSync(path.join(root, 'foo'));
+
+  // `foo2` has descendants and exercises the `file + sep` prefix branch.
+  fs.mkdirSync(path.join(root, 'foo2'));
+  fs.writeFileSync(path.join(root, 'foo2', 'inside.txt'), '');
+  fs.mkdirSync(path.join(root, 'foo2', 'sub'));
 
   const events = [];
   const watcher = fs.watch(root, { recursive: true }, (eventType, filename) => {
@@ -44,6 +51,7 @@ tmpdir.refresh();
   await setTimeout(common.platformTimeout(200));
 
   fs.rmdirSync(path.join(root, 'foo'));
+  fs.rmSync(path.join(root, 'foo2'), { recursive: true });
 
   // Wait long enough to capture any spurious follow-up events.
   await setTimeout(common.platformTimeout(500));

--- a/test/parallel/test-fs-watch-recursive-prefix-sibling.js
+++ b/test/parallel/test-fs-watch-recursive-prefix-sibling.js
@@ -1,0 +1,62 @@
+'use strict';
+
+// Regression test for https://github.com/nodejs/node/issues/58868
+
+const common = require('../common');
+
+if (common.isIBMi) {
+  common.skip('IBMi does not support `fs.watch()`');
+}
+
+if (common.isAIX) {
+  common.skip('folder watch capability is limited in AIX.');
+}
+
+// macOS and Windows use the native recursive watcher and are unaffected.
+if (common.isMacOS || common.isWindows) {
+  common.skip('regression specific to the JS-based recursive watcher');
+}
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { setTimeout } = require('timers/promises');
+
+const tmpdir = require('../common/tmpdir');
+tmpdir.refresh();
+
+(async () => {
+  const root = fs.mkdtempSync(path.join(tmpdir.path, 'watch-prefix-'));
+
+  // Sibling names that share the prefix `foo` with the entry to delete.
+  fs.mkdirSync(path.join(root, 'foo_bar'));
+  fs.writeFileSync(path.join(root, 'foo_bar', 'file.txt'), '');
+  fs.mkdirSync(path.join(root, 'foo_bar', 'somedir'));
+  fs.mkdirSync(path.join(root, 'foo'));
+  fs.writeFileSync(path.join(root, 'foo_'), '');
+
+  const events = [];
+  const watcher = fs.watch(root, { recursive: true }, (eventType, filename) => {
+    events.push({ eventType, filename });
+  });
+
+  // Allow the watcher to fully attach to existing entries.
+  await setTimeout(common.platformTimeout(200));
+
+  fs.rmdirSync(path.join(root, 'foo'));
+
+  // Wait long enough to capture any spurious follow-up events.
+  await setTimeout(common.platformTimeout(500));
+
+  watcher.close();
+
+  const isSibling = (f) =>
+    f === 'foo_' || f === 'foo_bar' ||
+    f.startsWith('foo_bar' + path.sep);
+  const spurious = events.filter((e) => isSibling(e.filename));
+  assert.deepStrictEqual(
+    spurious,
+    [],
+    `unexpected events for prefix-sibling entries: ${JSON.stringify(spurious)}`,
+  );
+})().then(common.mustCall());


### PR DESCRIPTION
Fix a bug in the JS-based recursive `fs.watch` (used on Linux) where deleting an entry caused spurious `rename` events to be emitted for unrelated sibling entries whose names share a prefix with the deleted entry.

`FSWatcher#unwatchFiles(file)` in `lib/internal/fs/recursive_watch.js` used `StringPrototypeStartsWith(filename, file)` to find the watched entries to remove. This match is a raw string prefix, so deleting `foo` also unwatched `foo_`, `foo_bar`, `foo_bar/file.txt`, and so on. The next time `#watchFolder` walked the parent directory, those still-on-disk siblings were missing from `#files` and were treated as newly created, firing extra `rename` events and re-attaching watchers redundantly.

## Fix
Match by exact path, or by `deletedPath + path.sep` prefix, so only the deleted entry and its actual descendants are unwatched.

Fixes: https://github.com/nodejs/node/issues/58868