### PR TITLE
stream: remove redundant method check from iter.pipeToSync

### DIFF
--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -764,7 +764,6 @@ function pipeToSync(source, ...args) {
     normalized;
 
   let totalBytes = 0;
-  const hasWriteSync = typeof writer.writeSync === 'function';
   const hasWritevSync = typeof writer.writevSync === 'function';
   const hasEndSync = typeof writer.endSync === 'function';
 
@@ -778,11 +777,7 @@ function pipeToSync(source, ...args) {
       } else {
         for (let i = 0; i < batch.length; i++) {
           const chunk = batch[i];
-          if (hasWriteSync) {
-            writer.writeSync(chunk);
-          } else {
-            writer.write(chunk);
-          }
+          writer.writeSync(chunk);
           totalBytes += TypedArrayPrototypeGetByteLength(chunk);
         }
       }


### PR DESCRIPTION
The presence of the writeSync method is already validated by parsePipeToArgs, as per the spec, so this is redundant.