### PR TITLE
test: relax min assertion in test-performance-eventloopdelay

### DIFF
--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -71,7 +71,11 @@ const { sleep } = require('internal/util');
         // The values are non-deterministic, so we just check that a value is
         // present, as opposed to a specific value.
         assert(histogram.count > 0, `Expected samples to be recorded, got count=${histogram.count}`);
-        assert(histogram.min > 0);
+        // Min can legitimately be 0: the underlying HDR histogram has a
+        // lowest discernible value of 1us, so samples whose delta falls in
+        // the [0, 1us) bucket are reported as 0. A negative value would
+        // indicate a bug.
+        assert(histogram.min >= 0);
         assert(histogram.max > 0);
         assert(histogram.stddev > 0);
         assert(histogram.mean > 0);


### PR DESCRIPTION
Fixes this flacky test issue: https://github.com/nodejs/node/issues/41286 

I think the test is wrong and it should check min >= 0.
monitorEventLoopDelay configures the histogram with `lowest_discernible_value` = 1000 ns. hdr_min() returns the lower bound of the bucket the smallest sample landed in, and for that config the first bucket is [0, 512) ns — lower bound 0.

So min === 0 just means the smallest sample fell into the first bucket.
In other words, seems to me that the assert is wrong, and `min` === 0 is legit 

This PR fixes the assert.