### PR TITLE
build: add shim to call node from wsl

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@ vcbuild.bat text eol=crlf
 deps/crates/vendor/**/* -text
 deps/npm/bin/npm text eol=lf
 deps/npm/bin/npx text eol=lf
+tools/msvs/shims/node text eol=lf
 deps/corepack/shims/corepack text eol=lf
 tools/msvs/find_python.cmd text eol=crlf
 doc/**/*.md text eol=lf

--- a/tools/msvs/msi/nodemsi/product.wxs
+++ b/tools/msvs/msi/nodemsi/product.wxs
@@ -66,6 +66,7 @@
              Description="!(loc.NodeRuntime_Description)"
              AllowAbsent="no">
       <ComponentRef Id="NodeExecutable"/>
+      <ComponentRef Id="NodeBashShim"/>
       <ComponentRef Id="NodeRegistryEntries"/>
       <ComponentRef Id="NodeVarsScript"/>
       <ComponentRef Id="NodeStartMenu"/>
@@ -140,6 +141,10 @@
                        Name="Version"
                        Type="string"
                        Value="$(var.ProductVersion)"/>
+      </Component>
+
+      <Component Id="NodeBashShim">
+        <File Id="node" KeyPath="yes" Source="$(var.RepoDir)\tools\msvs\shims\node"/>
       </Component>
 
       <Component Id="NodeVarsScript">

--- a/tools/msvs/shims/node
+++ b/tools/msvs/shims/node
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# This allows calling node (without .exe) from WSL bash
+
+WIN_NODE_DIR=$(cd "$(dirname "$0")" && pwd)
+WIN_NODE_EXE="$WIN_NODE_DIR/node.exe"
+
+exec "$WIN_NODE_EXE" "$@"

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -553,6 +553,8 @@ copy /Y ..\tools\msvs\nodevars.bat %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy nodevars.bat && goto package_error
 copy /Y ..\tools\msvs\install_tools\*.* %TARGET_NAME%\ > nul
 if errorlevel 1 echo Cannot copy install_tools scripts && goto package_error
+copy /Y ..\tools\msvs\shims\*.* %TARGET_NAME%\ > nul
+if errorlevel 1 echo Cannot copy shims && goto package_error
 if defined dll (
   copy /Y libnode.dll %TARGET_NAME%\ > nul
   if errorlevel 1 echo Cannot copy libnode.dll && goto package_error


### PR DESCRIPTION
On Windows installation of node.exe, WSL shells cannot call `node` without the extension `.exe`.
This PR adds a minimal shim to the installation directory that calls the main binary node.exe
Resolves conflicts from and closes #43948