### PR TITLE
doc: remove Node.js 20 link from BUILDING

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -232,7 +232,6 @@ Consult previous versions of this document for older versions of Node.js:
 
 * [Node.js 24](https://github.com/nodejs/node/blob/v24.x/BUILDING.md)
 * [Node.js 22](https://github.com/nodejs/node/blob/v22.x/BUILDING.md)
-* [Node.js 20](https://github.com/nodejs/node/blob/v20.x/BUILDING.md)
 
 ## Building Node.js on supported platforms
 


### PR DESCRIPTION
Remove the link to the [Node.js 20 document](https://github.com/nodejs/node/blob/v20.x/BUILDING.md) in the document section [BUILDING > Previous versions of this document](https://github.com/nodejs/node/blob/main/BUILDING.md#previous-versions-of-this-document) due to past [Node.js 20 EOL](https://github.com/nodejs/release#end-of-life-releases) transition on 2026-04-30.