### PR TITLE
build,win: build,win: replace LTCG with Thin LTO for releases

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -272,6 +272,13 @@
                   },
                 },
               },],
+              ['(enable_thin_lto=="true" or enable_lto=="true") and lto_jobs!=""', {
+                'msvs_settings': {
+                  'VCLinkerTool': {
+                    'AdditionalOptions': ['/opt:lldltojobs=<(lto_jobs)'],
+                  },
+                },
+              },],
             ],
             'target_conditions': [
               ['_toolset=="target"', {

--- a/configure.py
+++ b/configure.py
@@ -225,6 +225,14 @@ parser.add_argument("--enable-thin-lto",
     help="Enable compiling with thin lto of a binary. This feature is only available "
          "on windows.")
 
+parser.add_argument("--lto-jobs",
+    action="store",
+    dest="lto_jobs",
+    default=None,
+    help="Set the number of parallel LTO code generation jobs during linking. "
+         "Defaults to the number of CPU cores. Lower values reduce peak memory "
+         "usage at the cost of longer link times. Only effective with LTO enabled.")
+
 parser.add_argument("--link-module",
     action="append",
     dest="linked_module",
@@ -1995,6 +2003,7 @@ def configure_node(o):
 
   o['variables']['enable_lto'] = b(options.enable_lto)
   o['variables']['enable_thin_lto'] = b(options.enable_thin_lto)
+  o['variables']['lto_jobs'] = options.lto_jobs or ''
 
   if options.node_use_large_pages or options.node_use_large_pages_script_lld:
     warn('''The `--use-largepages` and `--use-largepages-script-lld` options

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -26,6 +26,7 @@ set target_arch=x64
 set ltcg=
 set thin_lto=
 set lto=
+set lto_jobs=
 set pgo_generate=
 set pgo_use=
 set target_env=
@@ -110,6 +111,7 @@ if /i "%1"=="nonpm"         set nonpm=1&goto arg-ok
 if /i "%1"=="ltcg"          set ltcg=1&goto arg-ok
 if /i "%1"=="thin-lto"      set thin_lto=1&goto arg-ok
 if /i "%1"=="lto"           set lto=1&goto arg-ok
+if /i "%1"=="lto-jobs"      set "lto_jobs=%2"&goto arg-ok-2
 if /i "%1"=="pgo-generate"  set pgo_generate=1&goto arg-ok
 if /i "%1"=="pgo-use"       set pgo_use=1&goto arg-ok
 if /i "%1"=="v8temporal"    set v8temporal=1&goto arg-ok
@@ -197,6 +199,8 @@ if defined build_release (
   set projgen=1
   set cctest=1
   set thin_lto=1
+  @REM Parallel LTO link jobs can cause OOM issues, so we limit it to 2 by default for release builds in the release CI.
+  set lto_jobs=2
 )
 
 :: LTO mutual exclusion
@@ -243,6 +247,7 @@ if defined nonpm            set configure_flags=%configure_flags% --without-npm
 if defined ltcg             set configure_flags=%configure_flags% --with-ltcg
 if defined thin_lto         set configure_flags=%configure_flags% --enable-thin-lto
 if defined lto              set configure_flags=%configure_flags% --enable-lto
+if defined lto_jobs         set configure_flags=%configure_flags% --lto-jobs=%lto_jobs%
 if defined pgo_generate     set configure_flags=%configure_flags% --enable-pgo-generate
 if defined pgo_use          set configure_flags=%configure_flags% --enable-pgo-use
 if defined release_urlbase  set configure_flags=%configure_flags% --release-urlbase=%release_urlbase%
@@ -908,7 +913,7 @@ set exit_code=1
 goto exit
 
 :help
-echo vcbuild.bat [debug/release] [msi] [doc] [test/test-all/test-addons/test-doc/test-js-native-api/test-node-api/test-internet/test-tick-processor/test-known-issues/test-node-inspect/test-check-deopts/test-npm/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [build-addons/build-js-native-api-tests/build-node-api-tests/build-ffi-tests] [ignore-flaky] [static/dll] [noprojgen] [projgen] [clang-cl] [ccache path-to-ccache] [small-icu/full-icu/without-intl] [nobuild] [nosnapshot] [nonpm] [ltcg] [thin-lto] [lto] [pgo-generate] [pgo-use] [licensetf] [sign] [x64/arm64] [vs2022/vs2026] [download-all] [enable-vtune] [lint/lint-ci/lint-js/lint-md] [lint-md-build] [format-md] [package] [build-release] [upload] [no-NODE-OPTIONS] [link-module path-to-module] [debug-http2] [debug-nghttp2] [clean] [cctest] [no-cctest] [openssl-no-asm]
+echo vcbuild.bat [debug/release] [msi] [doc] [test/test-all/test-addons/test-doc/test-js-native-api/test-node-api/test-internet/test-tick-processor/test-known-issues/test-node-inspect/test-check-deopts/test-npm/test-v8/test-v8-intl/test-v8-benchmarks/test-v8-all] [build-addons/build-js-native-api-tests/build-node-api-tests/build-ffi-tests] [ignore-flaky] [static/dll] [noprojgen] [projgen] [clang-cl] [ccache path-to-ccache] [small-icu/full-icu/without-intl] [nobuild] [nosnapshot] [nonpm] [ltcg] [thin-lto] [lto] [lto-jobs number-of-jobs] [pgo-generate] [pgo-use] [licensetf] [sign] [x64/arm64] [vs2022/vs2026] [download-all] [enable-vtune] [lint/lint-ci/lint-js/lint-md] [lint-md-build] [format-md] [package] [build-release] [upload] [no-NODE-OPTIONS] [link-module path-to-module] [debug-http2] [debug-nghttp2] [clean] [cctest] [no-cctest] [openssl-no-asm]
 echo Examples:
 echo   vcbuild.bat                          : builds release build
 echo   vcbuild.bat debug                    : builds debug build
@@ -922,6 +927,7 @@ echo   vcbuild.bat no-cctest                : skip building cctest.exe
 echo   vcbuild.bat ccache c:\ccache\        : use ccache to speed build
 echo   vcbuild.bat thin-lto                 : builds with Thin LTO applied globally to all targets
 echo   vcbuild.bat lto                      : builds with Full LTO applied globally to all targets
+echo   vcbuild.bat thin-lto lto-jobs 2      : builds with Thin LTO applied globally to all targets and limits parallel LTO link jobs (reduces peak memory usage)
 echo   vcbuild.bat pgo-generate             : builds instrumented binary for PGO (profile first, then rebuild with pgo-use)
 echo   vcbuild.bat pgo-use                  : builds optimized binary using PGO profile data
 goto exit

--- a/vcbuild.bat
+++ b/vcbuild.bat
@@ -187,6 +187,18 @@ goto next-arg
 
 :args-done
 
+if defined build_release (
+  set config=Release
+  set package=1
+  set msi=1
+  set licensertf=1
+  set download_arg="--download=all"
+  set i18n_arg=full-icu
+  set projgen=1
+  set cctest=1
+  set thin_lto=1
+)
+
 :: LTO mutual exclusion
 set lto_count=0
 if defined ltcg       set /a lto_count+=1
@@ -206,18 +218,6 @@ if defined pgo_generate if defined pgo_use (
   echo   pgo-generate : build instrumented binary, then profile it
   echo   pgo-use      : rebuild using the collected profile data
   exit /b 1
-)
-
-if defined build_release (
-  set config=Release
-  set package=1
-  set msi=1
-  set licensertf=1
-  set download_arg="--download=all"
-  set i18n_arg=full-icu
-  set projgen=1
-  set cctest=1
-  set ltcg=1
 )
 
 if defined msi     set stage_package=1


### PR DESCRIPTION
This PR continues the work started in https://github.com/nodejs/node/pull/62761, by using Thin LTO instead of LTCG for Node.js release builds on Windows.

The original idea was to switch from LTCG to Thin LTO, but it was noticed that this led to OOM errors on the release CI machines. As a result, a new option `lto-jobs` was added to limit the LTO job parallelisation, thus decreasing peak memory usage. That meant making the compilation (linker step) longer, but doable.

I've run benchmarks (10 runs each, on Windows x64) from Node.js, and the results are [here](https://github.com/JaneaSystems/node-thin-lto-perf). They show that this change improves performance in some cases, while some stay unaffected.

The second thing is the build time. I've had a few successful runs building this in the release CI ([run1](https://ci-release.nodejs.org/job/iojs+release/11755/), [run2](https://ci-release.nodejs.org/job/iojs+release/11757/)), and the times were around 3 hours and 10 minutes on both x64 and arm64. This is quite an increase in what we see with LTCG, which is around 1 hour 10 minutes for x64and 1 hour 40 minutes for arm64. The main reason for this is the decreased linker parallelisation, which was needed because the machines we use for compilation have only 8GB of RAM. However, given the number of runs we have in the release CI and the number of machines we have there, this should be acceptable. (We have 3 machines, and each job does 2 Windows compilations).

cc @nodejs/releasers @nodejs/build 

Refs: https://github.com/nodejs/node/issues/61964