### PR TITLE
test: fix cp.exec-any-shells test on windows with wsl

### DIFF
--- a/test/parallel/test-child-process-exec-any-shells-windows.js
+++ b/test/parallel/test-child-process-exec-any-shells-windows.js
@@ -61,7 +61,14 @@ cp.exec('where bash', common.mustCall((error, stdout) => {
   const lines = stdout.trim().split(/[\r\n]+/g);
   for (let i = 0; i < lines.length; ++i) {
     const bashPath = lines[i].trim();
+    const bashPathLower = bashPath.toLowerCase();
+
+    const isWSLBash =
+      bashPathLower.includes('windowsapps') ||
+      bashPathLower.includes('\\system32\\bash.exe');
+
     test(bashPath);
-    testCopy(`bash_${i}.exe`, bashPath);
+    // Skip WSL bash (cannot be symlinked)
+    if (!isWSLBash) testCopy(`bash_${i}.exe`, bashPath);
   }
 }));


### PR DESCRIPTION
`test-child-process-exec-any-shells-windows` tries to symlink any bash executable it finds on PATH.
However, if WSL is installed on the system, it'll try to symlink `C:\Users\<user>\AppData\Local\Microsoft\WindowsApps\bash.exe` and `C:\Windows\System32\bash.exe` and will fail.
The former is a virtual file that can't be symlinked, and the latter won't work as expected from the symlink.