### PR TITLE
doc: add Hmac.digest() documentation-only deprecation (DEP0206)

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4558,6 +4558,22 @@ that have proven unresolveable. See [caveats of asynchronous customization hooks
 `module.registerHooks()` as soon as possible as `module.register()` will be
 removed in a future version of Node.js.
 
+### DEP0206: Calling `digest()` on an already-finalized `Hmac` instance
+
+<!-- YAML
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63121
+    description: Documentation-only deprecation.
+-->
+
+Type: Documentation-only
+
+Calling `hmac.digest()` more than once returns an empty buffer instead of
+throwing an error. This behavior is inconsistent with `hash.digest()` and
+may lead to subtle bugs. Calling `hmac.digest()` on a finalized `Hmac` instance
+will throw an error in a future version.
+
 [DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
 [RFC 6066]: https://tools.ietf.org/html/rfc6066#section-3


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/62838

Situation

Calling `digest()` on an already-finalized `Hmac` instance currently returns an empty buffer silently instead of throwing an error. This is inconsistent with `Hash` behavior which throws `ERR_CRYPTO_HASH_FINALIZED` and is a potential security footgun.

Change

Add a runtime deprecation warning (DEP0206) when `digest()` is called more than once on an `Hmac` instance. The existing behavior (returning an empty buffer) is preserved during the deprecation cycle to avoid breaking changes.