### PR TITLE
test_runner: prevent infinite loop on malformed v8 header

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -364,7 +364,25 @@ class FileTest extends Test {
   }
   #drainRawBuffer() {
     while (this.#rawBuffer.length > 0) {
+      const sizeBefore = this.#rawBufferSize;
+      const lengthBefore = this.#rawBuffer.length;
       this.#processRawBuffer();
+      if (this.#rawBufferSize === sizeBefore && this.#rawBuffer.length === lengthBefore) {
+        // The head matches the v8 serializer header but its declared payload
+        // size exceeds the buffered data and no more data will arrive, so
+        // flush the leftover bytes as stdout instead of looping forever.
+        const remaining = this.#rawBuffer.length === 1 ?
+          this.#rawBuffer[0] :
+          Buffer.concat(this.#rawBuffer, this.#rawBufferSize);
+        this.addToReport({
+          __proto__: null,
+          type: 'test:stdout',
+          data: { __proto__: null, file: this.name, message: remaining.toString('utf-8') },
+        });
+        this.#rawBuffer = [];
+        this.#rawBufferSize = 0;
+        break;
+      }
     }
   }
   #processRawBuffer() {

--- a/test/parallel/test-runner-v8-deserializer.mjs
+++ b/test/parallel/test-runner-v8-deserializer.mjs
@@ -77,6 +77,17 @@ describe('v8 deserializer', common.mustCall(() => {
     ]);
   });
 
+  it('should not loop forever on v8 header followed by an oversized length', async () => {
+    // Refs: https://github.com/nodejs/node/issues/62693
+    // FF 0F is the v8 serializer header; the following four bytes encode a
+    // big-endian uint32 payload size that exceeds the buffer.
+    const malformed = Buffer.from([0xff, 0x0f, 0x7f, 0xff, 0xff, 0xff]);
+    const reported = await collectReported([malformed]);
+    assert.deepStrictEqual(reported, [
+      { data: { __proto__: null, file: 'filetest', message: malformed.toString('utf-8') }, type: 'test:stdout' },
+    ]);
+  });
+
   const headerPosition = headerLength * 2 + 4;
   for (let i = 0; i < headerPosition + 5; i++) {
     const message = `should deserialize a serialized message split into two chunks {...${i},${i + 1}...}`;


### PR DESCRIPTION
A child process emitting the v8 serializer header (FF 0F) followed by a payload length larger than the buffered data caused `#drainRawBuffer()` to spin forever. Detect the no-progress case and flush the remaining bytes as a `test:stdout` event.

Refs: https://github.com/nodejs/node/issues/62693