### PR TITLE
Change view type annotation to Uint8Array

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -664,9 +664,9 @@ class ReadableStreamBYOBRequest {
   }
 
   /**
-   * @readonly
-   * @type {ArrayBufferView}
-   */
+    * @readonly
+    * @type {Uint8Array}
+    */
   get view() {
     if (!isReadableStreamBYOBRequest(this))
       throw new ERR_INVALID_THIS('ReadableStreamBYOBRequest');

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -664,9 +664,9 @@ class ReadableStreamBYOBRequest {
   }
 
   /**
-    * @readonly
-    * @type {Uint8Array}
-    */
+   * @readonly
+   * @type {Uint8Array}
+   */
   get view() {
     if (!isReadableStreamBYOBRequest(this))
       throw new ERR_INVALID_THIS('ReadableStreamBYOBRequest');


### PR DESCRIPTION
This change narrows the documented return type of 
ReadableStreamBYOBRequest.view from ArrayBufferView to Uint8Array,
reflecting the specification update in whatwg/streams#1367.

Closes #62952