### PR TITLE
lib: expose `v8.startupSnapshot` functions on `globalThis`

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -1352,6 +1352,24 @@ changes:
 
 A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 
+## `[Symbol.for('startupSnapshot')]`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+An object exposing the `addDeserializeCallback`, `addSerializeCallback`, and `isBuildingSnapshot`
+methods from [`v8.startupSnapshot`][] for usage in libraries that target both Node.js and other
+runtimes and cannot directly rely on the `v8` module.
+
+```js
+const {
+  addDeserializeCallback,
+  addSerializeCallback,
+  isBuildingSnapshot,
+} = globalThis[Symbol.for('startupSnapshot')];
+```
+
 [CommonJS module]: modules.md
 [CommonJS modules]: modules.md
 [ECMAScript module]: esm.md
@@ -1422,6 +1440,7 @@ A browser-compatible implementation of [`WritableStreamDefaultWriter`][].
 [`setInterval`]: timers.md#setintervalcallback-delay-args
 [`setTimeout`]: timers.md#settimeoutcallback-delay-args
 [`structuredClone`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/structuredClone
+[`v8.startupSnapshot`]: v8.md#startup-snapshot-api
 [`window.navigator`]: https://developer.mozilla.org/en-US/docs/Web/API/Window/navigator
 [`worker_threads.locks`]: worker_threads.md#worker_threadslocks
 [browser `LockManager`]: https://developer.mozilla.org/en-US/docs/Web/API/LockManager

--- a/doc/api/v8.md
+++ b/doc/api/v8.md
@@ -1400,6 +1400,10 @@ into a form more suitable for serialization.
 
 Callbacks are run in the order in which they are added.
 
+This function is also available as
+`globalThis[Symbol.for('startupSnapshot')].addSerializeCallback` for use
+in libraries that cannot import the `v8` module.
+
 ### `v8.startupSnapshot.addDeserializeCallback(callback[, data])`
 
 <!-- YAML
@@ -1420,6 +1424,10 @@ of the application or to re-acquire resources that the application needs
 when the application is restarted from the snapshot.
 
 Callbacks are run in the order in which they are added.
+
+This function is also available as
+`globalThis[Symbol.for('startupSnapshot')].addDeserializeCallback` for use
+in libraries that cannot import the `v8` module.
 
 ### `v8.startupSnapshot.setDeserializeMainFunction(callback[, data])`
 
@@ -1452,6 +1460,10 @@ added:
 * Returns: {boolean}
 
 Returns true if the Node.js instance is run to build a snapshot.
+
+This function is also available as
+`globalThis[Symbol.for('startupSnapshot')].isBuildingSnapshot` for use
+in libraries that cannot import the `v8` module.
 
 ## Class: `v8.GCProfiler`
 

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -13,6 +13,7 @@ const {
   ObjectDefineProperty,
   ObjectFreeze,
   String,
+  SymbolFor,
   globalThis,
 } = primordials;
 
@@ -123,6 +124,7 @@ function prepareExecution(options) {
   setupEventsource();
   setupCodeCoverage();
   setupDebugEnv();
+  setupGlobalSnapshotHooks();
   // Process initial diagnostic reporting configuration, if present.
   initializeReport();
 
@@ -376,6 +378,12 @@ function setupNavigator() {
   // https://html.spec.whatwg.org/multipage/system-state.html#the-navigator-object
   exposeLazyInterfaces(globalThis, 'internal/navigator', ['Navigator']);
   defineReplaceableLazyAttribute(globalThis, 'internal/navigator', ['navigator'], false);
+}
+
+function setupGlobalSnapshotHooks() {
+  exposeLazyInterfaces(globalThis, 'internal/v8/startup_snapshot', [
+    SymbolFor('startupSnapshot'),
+  ]);
 }
 
 function setupFFI() {

--- a/lib/internal/v8/startup_snapshot.js
+++ b/lib/internal/v8/startup_snapshot.js
@@ -1,6 +1,10 @@
 'use strict';
 
 const {
+  SymbolFor,
+} = primordials;
+
+const {
   validateFunction,
 } = require('internal/validators');
 const {
@@ -122,6 +126,12 @@ initializeCallbacks();
 module.exports = {
   runDeserializeCallbacks,
   throwIfBuildingSnapshot,
+  // Exposed to globalThis[Symbol.for('startupSnapshot')]
+  [SymbolFor('startupSnapshot')]: {
+    addDeserializeCallback,
+    addSerializeCallback,
+    isBuildingSnapshot,
+  },
   // Exposed to require('v8').startupSnapshot
   namespace: {
     addDeserializeCallback,

--- a/src/node_util.cc
+++ b/src/node_util.cc
@@ -422,10 +422,10 @@ static void DefineLazyProperties(const FunctionCallbackInfo<Value>& args) {
       // V8 will have scheduled an error to be thrown.
       return;
     }
-    CHECK(key->IsString());
+    CHECK(key->IsName());
     if (target
             ->SetLazyDataProperty(context,
-                                  key.As<String>(),
+                                  key.As<Name>(),
                                   DefineLazyPropertiesGetter,
                                   id,
                                   attribute)

--- a/test/parallel/test-v8-startup-snapshot-api.js
+++ b/test/parallel/test-v8-startup-snapshot-api.js
@@ -24,3 +24,11 @@ assert.throws(() => addDeserializeCallback(() => {}), {
 assert.throws(() => setDeserializeMainFunction(() => {}), {
   code: 'ERR_NOT_BUILDING_SNAPSHOT',
 });
+
+// globalThis[Symbol.for('startupSnapshot')] provides access to a subset
+// of functions.
+assert.deepStrictEqual(globalThis[Symbol.for('startupSnapshot')], {
+  addDeserializeCallback,
+  addSerializeCallback,
+  isBuildingSnapshot,
+});


### PR DESCRIPTION
Not necessarily tied to this approach, but we've found this to be a genuine gap when trying to include libraries in startup snapshots. If we're reluctant to place these methods on the global object, I'd also consider the global `process` to be a good venue to expose this.

---

Expose methods from `require('v8').startupSnapshot` which are relevant for isomorphic libraries through a `Symbol`-indexed property on the global object.

This provides a mechanism for using these functions from libraries that do not integrate with Node.js's module system, while still enabling integration with the startup snapshot mechanism. It also provides a path for exposing this feature from other runtimes that support a startup-snapshot-style feature.

We do not typically expose runtime-specific/non-standard capabilities on the global object, so using a `Symbol` property seems like the best way to avoid any potential naming conflicts and its consequences.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
