### PR TITLE
doc: fix deprecation list in 26.0.0 changelog

### DIFF
--- a/doc/changelogs/CHANGELOG_V26.md
+++ b/doc/changelogs/CHANGELOG_V26.md
@@ -79,17 +79,21 @@ Undici has been updated to version 8.0.2, bringing new features and improvements
 #### Deprecations and Removals
 
 * \[[`dff46c07c3`](https://github.com/nodejs/node/commit/dff46c07c3)] - **(SEMVER-MAJOR)** **crypto**: move DEP0182 to End-of-Life (Tobias Nießen) [#61084](https://github.com/nodejs/node/pull/61084)
+
 * \[[`93c25815ee`](https://github.com/nodejs/node/commit/93c25815ee)] - **(SEMVER-MAJOR)** **http**: move writeHeader to end-of-life (Sebastian Beltran) [#60635](https://github.com/nodejs/node/pull/60635)
 
-`http.Server.prototype.writeHeader()` is now fully removed. Use `http.Server.prototype.writeHead()` instead.
+  `http.Server.prototype.writeHeader()` is now fully removed. Use `http.Server.prototype.writeHead()` instead.
 
 * \[[`c755b0113c`](https://github.com/nodejs/node/commit/c755b0113c)] - **(SEMVER-MAJOR)** **stream**: move \_stream\_\* to end-of-life (Sebastian Beltran) [#60657](https://github.com/nodejs/node/pull/60657)
 
-The legacy `_stream_wrap`, `_stream_readable`, `_stream_writable`, `_stream_duplex`, `_stream_transform`, and `_stream_passthrough` modules are now fully removed.
+  The legacy `_stream_wrap`, `_stream_readable`, `_stream_writable`, `_stream_duplex`, `_stream_transform`, and `_stream_passthrough` modules are now fully removed.
 
 * \[[`adac077484`](https://github.com/nodejs/node/commit/adac077484)] - **(SEMVER-MAJOR)** **crypto**: runtime-deprecate DEP0203 and DEP0204 (Filip Skokan) [#62453](https://github.com/nodejs/node/pull/62453)
+
 * \[[`ac6375417a`](https://github.com/nodejs/node/commit/ac6375417a)] - **(SEMVER-MAJOR)** **stream**: promote DEP0201 to runtime deprecation (René) [#62173](https://github.com/nodejs/node/pull/62173)
+
 * \[[`98907f560f`](https://github.com/nodejs/node/commit/98907f560f)] - **(SEMVER-MAJOR)** **module**: runtime-deprecate module.register() (Geoffrey Booth) [#62401](https://github.com/nodejs/node/pull/62401)
+
 * \[[`89f4b6cddb`](https://github.com/nodejs/node/commit/89f4b6cddb)] - **(SEMVER-MAJOR)** **module**: remove --experimental-transform-types (Marco Ippolito) [#61803](https://github.com/nodejs/node/pull/61803)
 
 ### Semver-Major Commits


### PR DESCRIPTION
Without those spaces, those text block appear as paragraph, breaking up the list into three lists.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
