### PR TITLE
doc,sqlite: document entryPoint argument for loadExtension

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -298,7 +298,7 @@ added: v22.5.0
 Closes the database connection. An exception is thrown if the database is not
 open. This method is a wrapper around [`sqlite3_close_v2()`][].
 
-### `database.loadExtension(path)`
+### `database.loadExtension(path[, entryPoint])`
 
 <!-- YAML
 added:
@@ -307,10 +307,36 @@ added:
 -->
 
 * `path` {string} The path to the shared library to load.
+* `entryPoint` {string} The name of the extension's entry-point function. When
+  omitted, SQLite derives the entry point from the shared library's filename;
+  pass this argument explicitly when the derived name does not match.
 
 Loads a shared library into the database connection. This method is a wrapper
 around [`sqlite3_load_extension()`][]. It is required to enable the
 `allowExtension` option when constructing the `DatabaseSync` instance.
+
+```mjs
+import { DatabaseSync } from 'node:sqlite';
+const database = new DatabaseSync(':memory:', { allowExtension: true });
+
+// Load using the entry point derived from the filename.
+database.loadExtension('./decimal.dylib');
+
+// Override the entry point when the derived name does not match.
+database.loadExtension('./base64.dylib', 'sqlite3_base64_init');
+```
+
+```cjs
+'use strict';
+const { DatabaseSync } = require('node:sqlite');
+const database = new DatabaseSync(':memory:', { allowExtension: true });
+
+// Load using the entry point derived from the filename.
+database.loadExtension('./decimal.dylib');
+
+// Override the entry point when the derived name does not match.
+database.loadExtension('./base64.dylib', 'sqlite3_base64_init');
+```
 
 ### `database.enableLoadExtension(allow)`
 


### PR DESCRIPTION
This PR adds the missing information about [entryPoint](https://github.com/nodejs/node/blob/main/src/node_sqlite.cc#L2422C15-L2422C20) argument in `loadExtension`.