### PR TITLE
[v26.x backport] doc: downgrade macOS x64 to Tier 2

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -117,7 +117,7 @@ platforms. This is true regardless of entries in the table below.
 | GNU/Linux        | riscv64          | kernel >= 5.19, glibc >= 2.36     | Experimental | GCC >= 14 or Clang >= 19 for native builds[^7] |
 | Windows          | x64              | >= Windows 10/Server 2016         | Tier 1       | [^2],[^3]                                      |
 | Windows          | arm64            | >= Windows 10                     | Tier 2       |                                                |
-| macOS            | x64              | >= 13.5                           | Tier 1       | For notes about compilation see [^4]           |
+| macOS            | x64              | >= 13.5                           | Tier 2       | For notes about compilation see [^4]           |
 | macOS            | arm64            | >= 13.5                           | Tier 1       |                                                |
 | SmartOS          | x64              | >= 18                             | Tier 2       |                                                |
 | AIX              | ppc64be >=power9 | >= 7.2 TL04                       | Tier 2       |                                                |


### PR DESCRIPTION
Backport of https://github.com/nodejs/node/pull/63055

Although the original PR was marked semver-major per policy, I don't think landing this would break anyone, on the contrary not landing it would IMO force the project to cut the EOL of Node.js 26 earlier if we're no longer able to build x86_64 binaries for macOS. The intent of this PR is not to stop providing support for Intel on macOS, it's to communicate that there's some uncertainty on the ability for the project to provide the universal binaries.

For reference, Node.js 26 EOL is scheduled on 2029-04-30; Rosetta 2 / macOS 27 EOL is unknown, likely in 2029 based on previous macOS releases.

Refs: https://github.com/nodejs/build/issues/4317