### PR TITLE
http: add writeInformation to send arbitrary 1xx status codes

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2702,6 +2702,35 @@ been transmitted are equal or not.
 Attempting to set a header field name or value that contains invalid characters
 will result in a [`TypeError`][] being thrown.
 
+### `response.writeInformation(statusCode[, headers][, callback])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `statusCode` {number} An HTTP 1xx informational status code, between `100`
+  and `199` inclusive, excluding `101` (Switching Protocols) which is only
+  available through the [`'upgrade'`][] event.
+* `headers` {Object|Array} An optional set of headers to send with the
+  informational response. Accepts the same shapes as
+  [`response.writeHead()`][].
+* `callback` {Function} Optional, called once the message has been written
+  to the socket.
+
+Sends an arbitrary HTTP/1.1 1xx informational response to the client. This
+is a generic equivalent of [`response.writeContinue()`][],
+[`response.writeProcessing()`][] and [`response.writeEarlyHints()`][], and
+can be called multiple times before the final response. After the final
+response headers have been sent (via [`response.writeHead()`][] or an
+implicit header), calling this method throws `ERR_HTTP_HEADERS_SENT`.
+
+Clients receive these responses via the [`'information'`][information event]
+event on `http.ClientRequest`.
+
+```js
+response.writeInformation(110, { 'X-Progress': '50%' });
+```
+
 ### `response.writeProcessing()`
 
 <!-- YAML
@@ -4712,7 +4741,9 @@ const agent2 = new http.Agent({ proxyEnv: process.env });
 [`response.write()`]: #responsewritechunk-encoding-callback
 [`response.write(data, encoding)`]: #responsewritechunk-encoding-callback
 [`response.writeContinue()`]: #responsewritecontinue
+[`response.writeEarlyHints()`]: #responsewriteearlyhintshints-callback
 [`response.writeHead()`]: #responsewriteheadstatuscode-statusmessage-headers
+[`response.writeProcessing()`]: #responsewriteprocessing
 [`server.close()`]: #serverclosecallback
 [`server.headersTimeout`]: #serverheaderstimeout
 [`server.keepAliveTimeoutBuffer`]: #serverkeepalivetimeoutbuffer
@@ -4733,4 +4764,5 @@ const agent2 = new http.Agent({ proxyEnv: process.env });
 [`writable.destroyed`]: stream.md#writabledestroyed
 [`writable.uncork()`]: stream.md#writableuncork
 [`writable.write()`]: stream.md#writablewritechunk-encoding-callback
+[information event]: #event-information
 [initial delay]: net.md#socketsetkeepaliveenable-initialdelay

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -4848,6 +4848,30 @@ response.writeEarlyHints({
 });
 ```
 
+#### `response.writeInformation(statusCode[, headers])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `statusCode` {number} An HTTP 1xx informational status code, between `100`
+  and `199` inclusive, excluding `101` (Switching Protocols) which is not
+  allowed in HTTP/2.
+* `headers` {Object} An optional object of headers to send with the
+  informational response.
+
+Sends an arbitrary HTTP 1xx informational response, equivalent in HTTP/2 to a
+`HEADERS` frame whose `:status` pseudo-header is a 1xx code. May be called
+multiple times before the final response. After the final response headers
+have been sent, this method is a no-op and returns `false`.
+
+This is the generic equivalent of [`response.writeContinue()`][] and
+[`response.writeEarlyHints()`][].
+
+```js
+response.writeInformation(110, { 'X-Progress': '50%' });
+```
+
 #### `response.writeHead(statusCode[, statusMessage][, headers])`
 
 <!-- YAML
@@ -5057,6 +5081,7 @@ you need to implement any fall-back behavior yourself.
 [`response.write()`]: #responsewritechunk-encoding-callback
 [`response.write(data, encoding)`]: http.md#responsewritechunk-encoding-callback
 [`response.writeContinue()`]: #responsewritecontinue
+[`response.writeEarlyHints()`]: #responsewriteearlyhintshints
 [`response.writeHead()`]: #responsewriteheadstatuscode-statusmessage-headers
 [`server.close()`]: #serverclosecallback
 [`server.maxHeadersCount`]: http.md#servermaxheaderscount

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -311,18 +311,66 @@ ServerResponse.prototype.detachSocket = function detachSocket(socket) {
   this.socket = null;
 };
 
+ServerResponse.prototype.writeInformation = function writeInformation(
+  statusCode, headers, cb) {
+  if (this._header) {
+    throw new ERR_HTTP_HEADERS_SENT('write');
+  }
+
+  validateInteger(statusCode, 'statusCode', 100, 199);
+  if (statusCode === 101) {
+    throw new ERR_HTTP_INVALID_STATUS_CODE(statusCode);
+  }
+
+  const statusMessage = STATUS_CODES[statusCode] || 'unknown';
+  let head = `HTTP/1.1 ${statusCode} ${statusMessage}\r\n`;
+
+  if (headers !== undefined && headers !== null) {
+    if (ArrayIsArray(headers)) {
+      if (headers.length && ArrayIsArray(headers[0])) {
+        for (let i = 0; i < headers.length; i++) {
+          const entry = headers[i];
+          head += processInformationHeader(entry[0], entry[1]);
+        }
+      } else {
+        if (headers.length % 2 !== 0) {
+          throw new ERR_INVALID_ARG_VALUE('headers', headers);
+        }
+        for (let i = 0; i < headers.length; i += 2) {
+          head += processInformationHeader(headers[i], headers[i + 1]);
+        }
+      }
+    } else {
+      validateObject(headers, 'headers');
+      const keys = ObjectKeys(headers);
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        head += processInformationHeader(key, headers[key]);
+      }
+    }
+  }
+
+  head += '\r\n';
+
+  return this._writeRaw(head, 'ascii', cb);
+};
+
+function processInformationHeader(name, value) {
+  validateHeaderName(name);
+  validateHeaderValue(name, value);
+  return `${name}: ${value}\r\n`;
+}
+
 ServerResponse.prototype.writeContinue = function writeContinue(cb) {
-  this._writeRaw('HTTP/1.1 100 Continue\r\n\r\n', 'ascii', cb);
+  this.writeInformation(100, null, cb);
   this._sent100 = true;
 };
 
 ServerResponse.prototype.writeProcessing = function writeProcessing(cb) {
-  this._writeRaw('HTTP/1.1 102 Processing\r\n\r\n', 'ascii', cb);
+  this.writeInformation(102, null, cb);
 };
 
 ServerResponse.prototype.writeEarlyHints = function writeEarlyHints(hints, cb) {
-  let head = 'HTTP/1.1 103 Early Hints\r\n';
-
   validateObject(hints, 'hints');
 
   if (hints.link === null || hints.link === undefined) {
@@ -339,22 +387,16 @@ ServerResponse.prototype.writeEarlyHints = function writeEarlyHints(hints, cb) {
     throw new ERR_INVALID_CHAR('header content', 'Link');
   }
 
-  head += 'Link: ' + link + '\r\n';
-
+  const headers = { __proto__: null, Link: link };
   const keys = ObjectKeys(hints);
   for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     if (key !== 'link') {
-      validateHeaderName(key);
-      const value = hints[key];
-      validateHeaderValue(key, value);
-      head += key + ': ' + value + '\r\n';
+      headers[key] = hints[key];
     }
   }
 
-  head += '\r\n';
-
-  this._writeRaw(head, 'ascii', cb);
+  this.writeInformation(103, headers, cb);
 };
 
 ServerResponse.prototype._implicitHeader = function _implicitHeader() {

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -901,15 +901,37 @@ class Http2ServerResponse extends Stream {
     this[kStream].respond(headers, options);
   }
 
-  // TODO doesn't support callbacks
-  writeContinue() {
+  writeInformation(statusCode, headers) {
+    if (typeof statusCode !== 'number' ||
+        statusCode < 100 || statusCode > 199) {
+      throw new ERR_HTTP2_STATUS_INVALID(statusCode);
+    }
+    if (statusCode === 101) {
+      throw new ERR_HTTP2_STATUS_INVALID(statusCode);
+    }
+
     const stream = this[kStream];
+
     if (stream.headersSent || this[kState].closed)
       return false;
-    stream.additionalHeaders({
-      [HTTP2_HEADER_STATUS]: HTTP_STATUS_CONTINUE,
-    });
+
+    const outHeaders = { __proto__: null };
+    if (headers !== undefined && headers !== null) {
+      validateObject(headers, 'headers');
+      const keys = ObjectKeys(headers);
+      for (let i = 0; i < keys.length; i++) {
+        outHeaders[keys[i]] = headers[keys[i]];
+      }
+    }
+    outHeaders[HTTP2_HEADER_STATUS] = statusCode;
+
+    stream.additionalHeaders(outHeaders);
     return true;
+  }
+
+  // TODO doesn't support callbacks
+  writeContinue() {
+    return this.writeInformation(HTTP_STATUS_CONTINUE);
   }
 
   writeEarlyHints(hints) {
@@ -929,18 +951,9 @@ class Http2ServerResponse extends Stream {
       return false;
     }
 
-    const stream = this[kStream];
+    headers.Link = linkHeaderValue;
 
-    if (stream.headersSent || this[kState].closed)
-      return false;
-
-    stream.additionalHeaders({
-      ...headers,
-      [HTTP2_HEADER_STATUS]: HTTP_STATUS_EARLY_HINTS,
-      'Link': linkHeaderValue,
-    });
-
-    return true;
+    return this.writeInformation(HTTP_STATUS_EARLY_HINTS, headers);
   }
 }
 

--- a/test/parallel/test-http-information-headers.js
+++ b/test/parallel/test-http-information-headers.js
@@ -9,11 +9,7 @@ const countdown = new Countdown(2, () => server.close());
 
 const server = http.createServer(common.mustCallAtLeast((req, res) => {
   console.error('Server sending informational message #1...');
-  // These function calls may rewritten as necessary
-  // to call res.writeHead instead
-  res._writeRaw('HTTP/1.1 102 Processing\r\n');
-  res._writeRaw('Foo: Bar\r\n');
-  res._writeRaw('\r\n', common.mustCall());
+  res.writeInformation(102, { Foo: 'Bar' }, common.mustCall());
   console.error('Server sending full response...');
   res.writeHead(200, {
     'Content-Type': 'text/plain',

--- a/test/parallel/test-http-write-information.js
+++ b/test/parallel/test-http-write-information.js
@@ -1,0 +1,94 @@
+'use strict';
+const common = require('../common');
+const assert = require('node:assert');
+const http = require('node:http');
+
+// Happy flow: arbitrary 1xx status with custom headers, observed by the
+// client's 'information' event.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeInformation(110, { 'X-Progress': '50%', 'X-Stage': 'reading' });
+    res.writeInformation(199, [['X-Custom', 'one'], ['X-Custom-2', 'two']]);
+    res.end('done');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const req = http.request({ port: server.address().port });
+
+    const seen = [];
+    req.on('information', (res) => {
+      seen.push({
+        statusCode: res.statusCode,
+        headers: res.headers,
+      });
+    });
+
+    req.on('response', common.mustCall((res) => {
+      assert.strictEqual(res.statusCode, 200);
+
+      assert.strictEqual(seen.length, 2);
+      assert.strictEqual(seen[0].statusCode, 110);
+      assert.strictEqual(seen[0].headers['x-progress'], '50%');
+      assert.strictEqual(seen[0].headers['x-stage'], 'reading');
+      assert.strictEqual(seen[1].statusCode, 199);
+      assert.strictEqual(seen[1].headers['x-custom'], 'one');
+      assert.strictEqual(seen[1].headers['x-custom-2'], 'two');
+
+      res.resume();
+      res.on('end', common.mustCall(() => server.close()));
+    }));
+
+    req.end();
+  }));
+}
+
+// Headers argument is optional / nullable.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.writeInformation(150);
+    res.writeInformation(151, null);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const req = http.request({ port: server.address().port });
+    let count = 0;
+    req.on('information', () => count++);
+    req.on('response', common.mustCall((res) => {
+      assert.strictEqual(count, 2);
+      res.resume();
+      res.on('end', common.mustCall(() => server.close()));
+    }));
+    req.end();
+  }));
+}
+
+// Error cases.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    assert.throws(() => res.writeInformation(101),
+                  { code: 'ERR_HTTP_INVALID_STATUS_CODE' });
+    assert.throws(() => res.writeInformation(99),
+                  { code: 'ERR_OUT_OF_RANGE' });
+    assert.throws(() => res.writeInformation(200),
+                  { code: 'ERR_OUT_OF_RANGE' });
+    assert.throws(() => res.writeInformation('100'),
+                  { code: 'ERR_INVALID_ARG_TYPE' });
+    assert.throws(() => res.writeInformation(150, { 'X-Bad\n': 'v' }),
+                  { code: 'ERR_INVALID_HTTP_TOKEN' });
+
+    res.writeHead(200);
+    assert.throws(() => res.writeInformation(150),
+                  { code: 'ERR_HTTP_HEADERS_SENT' });
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const req = http.request({ port: server.address().port });
+    req.on('response', common.mustCall((res) => {
+      res.resume();
+      res.on('end', common.mustCall(() => server.close()));
+    }));
+    req.end();
+  }));
+}

--- a/test/parallel/test-http2-compat-write-information.js
+++ b/test/parallel/test-http2-compat-write-information.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+
+const assert = require('node:assert');
+const http2 = require('node:http2');
+
+{
+  const server = http2.createServer();
+
+  server.on('request', common.mustCall((req, res) => {
+    res.writeInformation(110, { 'X-Progress': '50%' });
+    res.writeInformation(199, { 'X-Custom': 'one' });
+    res.end('done');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+
+    const seen = [];
+    req.on('headers', (headers) => {
+      seen.push({
+        status: headers[':status'],
+        headers,
+      });
+    });
+
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[':status'], 200);
+      assert.strictEqual(seen.length, 2);
+      assert.strictEqual(seen[0].status, 110);
+      assert.strictEqual(seen[0].headers['x-progress'], '50%');
+      assert.strictEqual(seen[1].status, 199);
+      assert.strictEqual(seen[1].headers['x-custom'], 'one');
+    }));
+
+    req.resume();
+    req.on('end', common.mustCall(() => {
+      client.close();
+      server.close();
+    }));
+  }));
+}
+
+// Error cases.
+{
+  const server = http2.createServer();
+
+  server.on('request', common.mustCall((req, res) => {
+    assert.throws(() => res.writeInformation(101),
+                  { code: 'ERR_HTTP2_STATUS_INVALID' });
+    assert.throws(() => res.writeInformation(200),
+                  { code: 'ERR_HTTP2_STATUS_INVALID' });
+    assert.throws(() => res.writeInformation('100'),
+                  { code: 'ERR_HTTP2_STATUS_INVALID' });
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.resume();
+    req.on('end', common.mustCall(() => {
+      client.close();
+      server.close();
+    }));
+  }));
+}


### PR DESCRIPTION
This provides a generic HTTP/1 API for 1xx responses, equivalent to our existing HTTP/2 additionalHeaders API. This supports any 1xx status code, except 101, which I've intentionally excluded - since it changes the protocol entirely, there's no possible way to unilaterally send that without breaking things later in our current API, so you just have to use 'upgrade' in that case.

This fixes various past requests like:

* https://github.com/nodejs/node/issues/22624
* https://github.com/nodejs/node/issues/27921

And acts as a nice workaround to solve:

* https://github.com/nodejs/node/issues/7588

(All 3 closed as stale, not fixed)

I'm also hoping it'll discourage usage of the private `res._writeRaw` method as a workaround for the existing limitations. We even did this in our own tests, see test/parallel/test-http-information-headers.js here.

This is useful to support custom 1xx values (perfectly valid AFAICT, if unusual), proxies (who want to pass through data in a standard way, without having to separately handle each case individually as today) and to give us trivial general support for future standardized 1xx values, without needing a whole separate PR to add a new per-status API every time.

The existing methods are refactored to use the generic method under the hood, and HTTP/2 compat uses additionalHeaders.

There's one annoying inconsistency here: the H1 methods throw if we've already sent a final status code, while the H2 methods just no-op. I've kept that as-is and matched this in the new method to avoid a breaking change, but it would probably be best to align on throwing in both cases in a separate major bump.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
