### PR TITLE
module: exclude node:ffi from builtinModules when flag is disabled

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -490,6 +490,9 @@ function initializeCJS() {
   if (!getOptionValue('--experimental-quic')) {
     modules = modules.filter((i) => i !== 'node:quic');
   }
+  if (!getOptionValue('--experimental-ffi')) {
+    modules = modules.filter((i) => i !== 'node:ffi');
+  }
   Module.builtinModules = ObjectFreeze(modules);
 
   initializeCjsConditions();

--- a/test/ffi/test-ffi-module.js
+++ b/test/ffi/test-ffi-module.js
@@ -1,6 +1,7 @@
 // Flags: --experimental-ffi
 'use strict';
 const common = require('../common');
+const { spawnSyncAndAssert } = require('../common/child_process');
 const assert = require('node:assert');
 const { spawnSync } = require('node:child_process');
 const { test } = require('node:test');
@@ -32,17 +33,16 @@ test('ffi builtin is unavailable when disabled', () => {
 });
 
 test('ffi builtin is listed', () => {
-  const { stdout, stderr, status, signal } = spawnSync(process.execPath, [
-    '-p',
-    'require("node:module").builtinModules.includes("node:ffi")',
-  ], {
-    encoding: 'utf8',
-  });
-
-  assert.strictEqual(stdout.trim(), 'true');
-  assert.strictEqual(stderr, '');
-  assert.strictEqual(status, 0);
-  assert.strictEqual(signal, null);
+  for (const [flag, stdout] of Object.entries({
+    '--experimental-ffi': 'true\n',
+    '--no-experimental-ffi': 'false\n',
+  })) {
+    spawnSyncAndAssert(process.execPath, [
+      flag,
+      '-p',
+      'require("node:module").builtinModules.includes("node:ffi")',
+    ], { stdout });
+  }
 });
 
 test('ffi can be imported from ESM', () => {


### PR DESCRIPTION
`Module.builtinModules` is supposed to only list modules that are accessible to user code. node:ffi requires `--experimental-ffi` to be required, so filter it out when the flag is not set, mirroring the existing handling for `--experimental-quic`.

Refs: https://github.com/nodejs/node/pull/63137#issuecomment-4390371187, #62072