### PR TITLE
crypto: runtime-deprecate calling Hmac.digest() more than once (DEP0206)

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4563,16 +4563,31 @@ removed in a future version of Node.js.
 <!-- YAML
 changes:
   - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63162
+    description: Runtime deprecation.
+  - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/63121
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Calling `hmac.digest()` more than once returns an empty buffer instead of
 throwing an error. This behavior is inconsistent with `hash.digest()` and
 may lead to subtle bugs. Calling `hmac.digest()` on a finalized `Hmac` instance
 will throw an error in a future version.
+
+```js
+const crypto = require('node:crypto');
+
+const hmac = crypto.createHmac('sha256', 'secret');
+
+hmac.update('hello');
+
+console.log(hmac.digest('hex')); // Works
+
+console.log(hmac.digest('hex')); // Returns empty string/buffer
+```
 
 [DEP0142]: #dep0142-repl_builtinlibs
 [NIST SP 800-38D]: https://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -87,6 +87,13 @@ const maybeEmitDeprecationWarning = getDeprecationWarningEmitter(
   },
 );
 
+const emitHmacDoubleDigestDeprecation = getDeprecationWarningEmitter(
+  'DEP0206',
+  'Calling digest() on an already-finalized Hmac instance is deprecated.',
+  undefined,
+  false,
+);
+
 function Hash(algorithm, options) {
   if (!new.target)
     return new Hash(algorithm, options);
@@ -183,6 +190,7 @@ Hmac.prototype.digest = function digest(outputEncoding) {
   const state = this[kState];
 
   if (state[kFinalized]) {
+    emitHmacDoubleDigestDeprecation();
     const buf = Buffer.from('');
     if (outputEncoding && outputEncoding !== 'buffer')
       return buf.toString(outputEncoding);

--- a/test/parallel/test-crypto-dep0206.js
+++ b/test/parallel/test-crypto-dep0206.js
@@ -1,0 +1,19 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { createHmac } = require('crypto');
+
+common.expectWarning({
+  DeprecationWarning: {
+    DEP0206: 'Calling digest() on an already-finalized Hmac instance is deprecated.',
+  },
+});
+
+const hmac = createHmac('sha256', 'key').update('data');
+hmac.digest();
+const second = hmac.digest();
+assert.deepStrictEqual(second, Buffer.from(''));

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -7,6 +7,13 @@ if (!common.hasCrypto) {
 const assert = require('assert');
 const crypto = require('crypto');
 
+common.expectWarning({
+  DeprecationWarning: {
+    DEP0181: 'crypto.Hmac constructor is deprecated.',
+    DEP0206: 'Calling digest() on an already-finalized Hmac instance is deprecated.',
+  },
+});
+
 {
   const Hmac = crypto.Hmac;
   const instance = crypto.Hmac('sha256', 'Node');
@@ -459,14 +466,4 @@ assert.strictEqual(
     crypto.createHmac('sha256', buf).update('foo').digest(),
     crypto.createHmac('sha256', keyObject).update('foo').digest(),
   );
-}
-
-{
-  crypto.Hmac('sha256', 'Node');
-  common.expectWarning({
-    DeprecationWarning: [
-      ['crypto.Hmac constructor is deprecated.',
-       'DEP0181'],
-    ]
-  });
 }


### PR DESCRIPTION
Refs: #62838
Refs: #63121

Situation

Calling `digest()` on an already-finalized `Hmac` instance currently returns an empty buffer silently instead of throwing an error. This is inconsistent with `Hash` behavior which throws `ERR_CRYPTO_HASH_FINALIZED` and is a potential security footgun.

Change

Add a runtime deprecation warning (DEP0206) when `digest()` is called more than once on an `Hmac` instance. The existing behavior (returning an empty buffer) is preserved during the deprecation cycle to avoid breaking changes. docs-only deprecation was introduced in #63121.