### PR TITLE
[v24.x backport] doc: fix typos and inconsistencies in crypto.md and webcrypto.md

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -1172,7 +1172,7 @@ changes:
 * `options` {Object} [`stream.transform` options][]
   * `plaintextLength` {number}
   * `encoding` {string} String encoding to use when `buffer` is a string.
-* Returns: {Decipheriv} The same Decipher for method chaining.
+* Returns: {Decipheriv} The same `Decipheriv` instance for method chaining.
 
 When using an authenticated encryption mode (`GCM`, `CCM`, `OCB`, and
 `chacha20-poly1305` are
@@ -1214,7 +1214,7 @@ changes:
 
 * `buffer` {string|Buffer|ArrayBuffer|TypedArray|DataView}
 * `encoding` {string} String encoding to use when `buffer` is a string.
-* Returns: {Decipheriv} The same Decipher for method chaining.
+* Returns: {Decipheriv} The same `Decipheriv` instance for method chaining.
 
 When using an authenticated encryption mode (`GCM`, `CCM`, `OCB`, and
 `chacha20-poly1305` are
@@ -1249,7 +1249,7 @@ added: v0.7.1
 -->
 
 * `autoPadding` {boolean} **Default:** `true`
-* Returns: {Decipheriv} The same Decipher for method chaining.
+* Returns: {Decipheriv} The same `Decipheriv` instance for method chaining.
 
 When data has been encrypted without standard block padding, calling
 `decipher.setAutoPadding(false)` will disable automatic padding to prevent
@@ -5305,7 +5305,7 @@ changes:
 
 <!--lint enable maximum-line-length remark-lint-->
 
-Decrypts `buffer` with `key`.`buffer` was previously encrypted using
+Decrypts `buffer` with `key`. `buffer` was previously encrypted using
 the corresponding private key, for example using [`crypto.privateEncrypt()`][].
 
 If `key` is not a [`KeyObject`][], this function behaves as if

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -504,8 +504,8 @@ const decrypted = new TextDecoder().decode(await crypto.subtle.decrypt(
 
 ## Algorithm matrix
 
-The tables details the algorithms supported by the Node.js Web Crypto API
-implementation and the APIs supported for each:
+The following tables detail the algorithms supported by the Node.js Web
+Crypto API implementation and the APIs supported for each:
 
 ### Key Management APIs
 
@@ -742,7 +742,7 @@ Valid key usages depend on the key algorithm (identified by
 | `'ECDSA'`                            |            | ✔                  |                        |              |                   |
 | `'Ed25519'`                          |            | ✔                  |                        |              |                   |
 | `'Ed448'`[^secure-curves]            |            | ✔                  |                        |              |                   |
-| `'HDKF'`                             |            |                    | ✔                      |              |                   |
+| `'HKDF'`                             |            |                    | ✔                      |              |                   |
 | `'HMAC'`                             |            | ✔                  |                        |              |                   |
 | `'KMAC128'`[^modern-algos]           |            | ✔                  |                        |              |                   |
 | `'KMAC256'`[^modern-algos]           |            | ✔                  |                        |              |                   |
@@ -979,7 +979,7 @@ a new {CryptoKey} based on the method and parameters in `derivedKeyAlgorithm`.
 
 Calling this method is equivalent to calling [`subtle.deriveBits()`][] to
 generate raw keying material, then passing the result into the
-[`subtle.importKey()`][] method using the `deriveKeyAlgorithm`, `extractable`, and
+[`subtle.importKey()`][] method using the `derivedKeyAlgorithm`, `extractable`, and
 `keyUsages` parameters as input.
 
 The algorithms currently supported include:
@@ -1325,7 +1325,7 @@ The algorithms currently supported include:
 | `'ECDSA'`                            | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
 | `'Ed25519'`                          | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
 | `'Ed448'`[^secure-curves]            | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'HDKF'`                             |          |           |         | ✔       | ✔              |                |              |
+| `'HKDF'`                             |          |           |         | ✔       | ✔              |                |              |
 | `'HMAC'`                             |          |           | ✔       | ✔       | ✔              |                |              |
 | `'KMAC128'`[^modern-algos]           |          |           | ✔       |         | ✔              |                |              |
 | `'KMAC256'`[^modern-algos]           |          |           | ✔       |         | ✔              |                |              |
@@ -1449,14 +1449,14 @@ The unwrapped key algorithms supported include:
 * `'Ed25519'`
 * `'Ed448'`[^secure-curves]
 * `'HMAC'`
-* `'KMAC128'`[^secure-curves]
-* `'KMAC256'`[^secure-curves]
+* `'KMAC128'`[^modern-algos]
+* `'KMAC256'`[^modern-algos]
 * `'ML-DSA-44'`[^modern-algos]
 * `'ML-DSA-65'`[^modern-algos]
 * `'ML-DSA-87'`[^modern-algos]
 * `'ML-KEM-512'`[^modern-algos]
 * `'ML-KEM-768'`[^modern-algos]
-* `'ML-KEM-1024'`[^modern-algos]v
+* `'ML-KEM-1024'`[^modern-algos]
 * `'RSA-OAEP'`
 * `'RSA-PSS'`
 * `'RSASSA-PKCS1-v1_5'`
@@ -1502,8 +1502,8 @@ The algorithms currently supported include:
 * `'Ed25519'`
 * `'Ed448'`[^secure-curves]
 * `'HMAC'`
-* `'KMAC128'`[^secure-curves]
-* `'KMAC256'`[^secure-curves]
+* `'KMAC128'`[^modern-algos]
+* `'KMAC256'`[^modern-algos]
 * `'ML-DSA-44'`[^modern-algos]
 * `'ML-DSA-65'`[^modern-algos]
 * `'ML-DSA-87'`[^modern-algos]
@@ -1850,7 +1850,7 @@ added: v24.7.0
 added: v24.7.0
 -->
 
-* Type: {string} Must be `Ed448`[^secure-curves], `'ML-DSA-44'`[^modern-algos],
+* Type: {string} Must be `'Ed448'`[^secure-curves], `'ML-DSA-44'`[^modern-algos],
   `'ML-DSA-65'`[^modern-algos], or `'ML-DSA-87'`[^modern-algos].
 
 #### `contextParams.context`
@@ -1884,7 +1884,7 @@ changes:
 added: v24.7.0
 -->
 
-* Type: {string} Must be `'cSHAKE128'`[^modern-algos] or `'cSHAKE256'`[^modern-algos]
+* Type: {string} Must be `'cSHAKE128'`[^modern-algos] or `'cSHAKE256'`[^modern-algos].
 
 #### `cShakeParams.outputLength`
 
@@ -1902,7 +1902,7 @@ added: v24.7.0
 
 * Type: {ArrayBuffer|TypedArray|DataView|Buffer|undefined}
 
-The `functionName` member represents represents the function name, used by NIST to define
+The `functionName` member represents the function name, used by NIST to define
 functions based on cSHAKE.
 The Node.js Web Crypto API implementation only supports zero-length functionName
 which is equivalent to not providing functionName at all.
@@ -1941,9 +1941,9 @@ added: v15.0.0
 
 * Type: {CryptoKey}
 
-ECDH key derivation operates by taking as input one parties private key and
-another parties public key -- using both to generate a common shared secret.
-The `ecdhKeyDeriveParams.public` property is set to the other parties public
+ECDH key derivation operates by taking as input one party's private key and
+another party's public key -- using both to generate a common shared secret.
+The `ecdhKeyDeriveParams.public` property is set to the other party's public
 key.
 
 ### Class: `EcdsaParams`


### PR DESCRIPTION
Backports https://github.com/nodejs/node/pull/62828 to v24.x (conflict was missing TurboSHAKE and KangarooTwelve on 24.x)