### PR TITLE
quic: remove unused binding variable in session.cc

### DIFF
--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -225,7 +225,7 @@ BindingData::BindingData(Realm* realm, Local<Object> object)
 
 SessionManager& BindingData::session_manager() {
   if (!session_manager_) {
-    session_manager_ = std::make_unique<SessionManager>(env());
+    session_manager_ = std::make_unique<SessionManager>();
   }
   return *session_manager_;
 }

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -1660,7 +1660,6 @@ Session::Session(Endpoint* endpoint,
 
   MakeWeak();
   Debug(this, "Session created.");
-  auto& binding = BindingData::Get(env());
 
   JS_DEFINE_READONLY_PROPERTY(
       env(), object, env()->stats_string(), impl_->stats_.GetArrayBuffer());

--- a/src/quic/session_manager.cc
+++ b/src/quic/session_manager.cc
@@ -10,10 +10,6 @@
 
 namespace node::quic {
 
-SessionManager::SessionManager(Environment* env) : env_(env) {}
-
-SessionManager::~SessionManager() = default;
-
 BaseObjectPtr<Session> SessionManager::FindSession(const CID& cid) {
   // Direct SCID match.
   auto it = sessions_.find(cid);

--- a/src/quic/session_manager.h
+++ b/src/quic/session_manager.h
@@ -24,8 +24,8 @@ class Session;
 // It is not exposed to JavaScript.
 class SessionManager final {
  public:
-  explicit SessionManager(Environment* env);
-  ~SessionManager();
+  explicit SessionManager() = default;
+  ~SessionManager() = default;
 
   // Session routing. The sessions_ map holds BaseObjectPtr<Session> (owning
   // references). SessionManager is the single authority for session ownership.
@@ -78,8 +78,6 @@ class SessionManager final {
   bool is_empty() const;
 
  private:
-  Environment* env_;
-
   // The sessions_ map holds strong owning references keyed by locally-
   // generated SCIDs. This is the single source of truth for session
   // ownership.


### PR DESCRIPTION
Removing a couple stray unused variables.

@nodejs/quic 