### PR TITLE
doc: clarify SEA platform support excludes darwin-x64

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -630,7 +630,8 @@ Single-executable support is tested regularly on CI only on the following
 platforms:
 
 * Windows
-* macOS
+* macOS (arm64 only; x64 is not currently supported and is skipped in the
+  tests)
 * Linux (all distributions [supported by Node.js][] except Alpine and all
   architectures [supported by Node.js][] except s390x)
 


### PR DESCRIPTION
The "Platform support" section of `doc/api/single-executable-applications.md` previously listed `macOS` without qualifying which architecture is supported. Per a maintainer comment on #62893, SEA on x64 macOS is not supported and is skipped in CI; only arm64 macOS is exercised. This updates the doc to clarify that.

Refs: #62893