### PR TITLE
doc: recommend explicitly Tier 1 or 2 for production applications

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -98,7 +98,7 @@ and libc version. The table below lists the support tier for each supported
 combination. A list of [supported compile toolchains](#supported-toolchains) is
 also supplied for tier 1 platforms.
 
-**For production applications, run Node.js on supported platforms only.**
+**For production applications, run Node.js on supported platforms only (Tier 1 or 2).**
 
 Node.js does not support a platform version if a vendor has expired support
 for it. In other words, Node.js does not support running on End-of-Life (EoL)


### PR DESCRIPTION
In the [BUILDING > Platform list](https://github.com/nodejs/node/blob/main/BUILDING.md#platform-list) document section, make the production applications advice explicitly apply to Tier 1 & 2 to remove room for different interpretation:

> For production applications, run Node.js on supported platforms only (Tier 1 or 2).

"Experimental" is defined as a support tier and it does not specifically say "Experimental" is unsupported, it only implies a lower and less predictable level of support.