### PR TITLE
crypto: move DEP0203 and DEP0204 to End-of-Life

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -2256,6 +2256,10 @@ be listed in the `transferList` argument.
 <!-- YAML
 added: v15.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a non-extractable CryptoKey as `key` is no longer
+                 supported.
   - version: v26.0.0
     pr-url: https://github.com/nodejs/node/pull/62453
     description: Passing a non-extractable CryptoKey as `key` is deprecated.
@@ -2264,11 +2268,11 @@ changes:
 * `key` {CryptoKey}
 * Returns: {KeyObject}
 
-Returns the underlying {KeyObject} of a {CryptoKey}. The returned {KeyObject}
-does not retain any of the restrictions imposed by the Web Crypto API on the
-original {CryptoKey}, such as the allowed key usages, the algorithm or hash
-algorithm bindings, and the extractability flag. In particular, the underlying
-key material of the returned {KeyObject} can always be exported.
+Returns a {KeyObject} representation of the underlying key material of an
+extractable {CryptoKey}.
+The returned {KeyObject} does not retain any of the restrictions imposed by
+the Web Crypto API on the original {CryptoKey}, such as the allowed key usages,
+the algorithm or hash algorithm bindings.
 
 ```mjs
 const { KeyObject } = await import('node:crypto');
@@ -2622,6 +2626,9 @@ console.log(verify.verify(publicKey, signature));
 <!-- YAML
 added: v0.1.92
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `privateKey` is no longer supported.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The privateKey can also be an ArrayBuffer and CryptoKey.
@@ -2643,7 +2650,7 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `privateKey` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `privateKey` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
   * `dsaEncoding` {string}
   * `padding` {integer}
   * `saltLength` {integer}
@@ -2752,6 +2759,9 @@ This can be called many times with new data as it is streamed.
 <!-- YAML
 added: v0.1.92
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: The key can also be an ArrayBuffer and CryptoKey.
@@ -2773,7 +2783,7 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
   * `dsaEncoding` {string}
   * `padding` {integer}
   * `saltLength` {integer}
@@ -3534,6 +3544,9 @@ operations. The specific constants currently defined are described in
 <!-- YAML
 added: v0.1.94
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version: v26.0.0
     pr-url: https://github.com/nodejs/node/pull/62453
     description: Passing a CryptoKey as `key` is deprecated.
@@ -3570,7 +3583,7 @@ changes:
 -->
 
 * `algorithm` {string}
-* `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
 * `iv` {string|ArrayBuffer|Buffer|TypedArray|DataView|null}
 * `options` {Object} [`stream.transform` options][]
 * Returns: {Cipheriv}
@@ -3611,6 +3624,9 @@ given IV will be.
 <!-- YAML
 added: v0.1.94
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version: v26.0.0
     pr-url: https://github.com/nodejs/node/pull/62453
     description: Passing a CryptoKey as `key` is deprecated.
@@ -3643,7 +3659,7 @@ changes:
 -->
 
 * `algorithm` {string}
-* `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
 * `iv` {string|ArrayBuffer|Buffer|TypedArray|DataView|null}
 * `options` {Object} [`stream.transform` options][]
 * Returns: {Decipheriv}
@@ -3837,6 +3853,9 @@ input.on('readable', () => {
 <!-- YAML
 added: v0.1.94
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version: v26.0.0
     pr-url: https://github.com/nodejs/node/pull/62453
     description: Passing a CryptoKey as `key` is deprecated.
@@ -3851,7 +3870,7 @@ changes:
 -->
 
 * `algorithm` {string}
-* `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
 * `options` {Object} [`stream.transform` options][]
   * `encoding` {string} The string encoding to use when `key` is a string.
 * Returns: {Hmac}
@@ -3930,6 +3949,9 @@ input.on('readable', () => {
 <!-- YAML
 added: v11.6.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version: v26.1.0
     pr-url: https://github.com/nodejs/node/pull/62706
     description: Added JWK format support for ML-KEM and SLH-DSA
@@ -3985,6 +4007,9 @@ of the passphrase is limited to 1024 bytes.
 <!-- YAML
 added: v11.6.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version: v26.1.0
     pr-url: https://github.com/nodejs/node/pull/62706
     description: Added JWK format support for ML-KEM and SLH-DSA
@@ -5220,6 +5245,9 @@ An array of supported digest functions can be retrieved using
 <!-- YAML
 added: v0.11.14
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `privateKey` is no longer supported.
   - version:
       - v21.6.2
       - v20.11.1
@@ -5246,7 +5274,7 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `privateKey` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `privateKey` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
   * `oaepHash` {string} The hash function to use for OAEP padding and MGF1.
     **Default:** `'sha1'`
   * `oaepLabel` {string|ArrayBuffer|Buffer|TypedArray|DataView} The label to
@@ -5278,6 +5306,9 @@ attempting to use `RSA_PKCS1_PADDING` will fail.
 <!-- YAML
 added: v1.1.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `privateKey` is no longer supported.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: Added string, ArrayBuffer, and CryptoKey as allowable key
@@ -5291,8 +5322,8 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `privateKey` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
-  * `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `privateKey` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
+  * `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
     A PEM encoded private key.
   * `passphrase` {string|ArrayBuffer|Buffer|TypedArray|DataView} An optional
     passphrase for the private key.
@@ -5319,6 +5350,9 @@ object, the `padding` property can be passed. Otherwise, this function uses
 <!-- YAML
 added: v1.1.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: Added string, ArrayBuffer, and CryptoKey as allowable key
@@ -5332,7 +5366,7 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
   * `passphrase` {string|ArrayBuffer|Buffer|TypedArray|DataView} An optional
     passphrase for the private key.
   * `padding` {crypto.constants} An optional padding value defined in
@@ -5361,6 +5395,9 @@ be passed instead of a public key.
 <!-- YAML
 added: v0.11.14
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version: v15.0.0
     pr-url: https://github.com/nodejs/node/pull/35093
     description: Added string, ArrayBuffer, and CryptoKey as allowable key
@@ -5380,9 +5417,9 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
-  * `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
-    A PEM encoded public or private key, {KeyObject}, or {CryptoKey}.
+* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
+  * `key` {string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
+    A PEM encoded public or private key, or {KeyObject}.
   * `oaepHash` {string} The hash function to use for OAEP padding and MGF1.
     **Default:** `'sha1'`
   * `oaepLabel` {string|ArrayBuffer|Buffer|TypedArray|DataView} The label to
@@ -6104,6 +6141,9 @@ Throws an error if FIPS mode is not available.
 <!-- YAML
 added: v12.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version:
      - v26.1.0
      - v24.16.0
@@ -6137,7 +6177,7 @@ changes:
 
 * `algorithm` {string | null | undefined}
 * `data` {ArrayBuffer|Buffer|SharedArrayBuffer|TypedArray|DataView|string}
-* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
 * `callback` {Function}
   * `err` {Error}
   * `signature` {Buffer}
@@ -6235,6 +6275,9 @@ not introduce timing vulnerabilities.
 <!-- YAML
 added: v12.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: Passing a CryptoKey as `key` is no longer supported.
   - version:
      - v26.1.0
      - v24.16.0
@@ -6271,7 +6314,7 @@ changes:
 
 * `algorithm` {string|null|undefined}
 * `data` {ArrayBuffer|Buffer|SharedArrayBuffer|TypedArray|DataView|string}
-* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
+* `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject}
 * `signature` {ArrayBuffer|Buffer|SharedArrayBuffer|TypedArray|DataView}
 * `callback` {Function}
   * `err` {Error}

--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4489,6 +4489,9 @@ const server = http2.createSecureServer({
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: End-of-Life.
   - version: v26.0.0
     pr-url: https://github.com/nodejs/node/pull/62453
     description: Runtime deprecation.
@@ -4499,23 +4502,17 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
-Passing a [`CryptoKey`][] to `node:crypto` functions is deprecated and
-will throw an error in a future version. This includes
-[`crypto.createPublicKey()`][], [`crypto.createPrivateKey()`][],
-[`crypto.sign()`][], [`crypto.verify()`][],
-[`crypto.publicEncrypt()`][], [`crypto.publicDecrypt()`][],
-[`crypto.privateEncrypt()`][], [`crypto.privateDecrypt()`][],
-[`Sign.prototype.sign()`][], [`Verify.prototype.verify()`][],
-[`crypto.createHmac()`][], [`crypto.createCipheriv()`][],
-[`crypto.createDecipheriv()`][], [`crypto.encapsulate()`][], and
-[`crypto.decapsulate()`][].
+Passing a [`CryptoKey`][] to `node:crypto` functions is no longer supported.
 
 ### DEP0204: `KeyObject.from()` with non-extractable `CryptoKey`
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63188
+    description: End-of-Life.
   - version: v26.0.0
     pr-url: https://github.com/nodejs/node/pull/62453
     description: Runtime deprecation.
@@ -4526,10 +4523,10 @@ changes:
     description: Documentation-only deprecation.
 -->
 
-Type: Runtime
+Type: End-of-Life
 
 Passing a non-extractable [`CryptoKey`][] to [`KeyObject.from()`][] is
-deprecated and will throw an error in a future version.
+no longer supported.
 
 ### DEP0205: `module.register()`
 
@@ -4655,9 +4652,7 @@ successfully before the response closed.
 [`ReadStream.open()`]: fs.md#class-fsreadstream
 [`Server.getConnections()`]: net.md#servergetconnectionscallback
 [`Server.listen({fd: <number>})`]: net.md#serverlistenhandle-backlog-callback
-[`Sign.prototype.sign()`]: crypto.md#signsignprivatekey-outputencoding
 [`String.prototype.toWellFormed`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toWellFormed
-[`Verify.prototype.verify()`]: crypto.md#verifyverifyobject-signature-signatureencoding
 [`WriteStream.open()`]: fs.md#class-fswritestream
 [`assert`]: assert.md
 [`asyncResource.runInAsyncScope()`]: async_context.md#asyncresourceruninasyncscopefn-thisarg-args
@@ -4675,21 +4670,11 @@ successfully before the response closed.
 [`crypto.createDecipheriv()`]: crypto.md#cryptocreatedecipherivalgorithm-key-iv-options
 [`crypto.createHash()`]: crypto.md#cryptocreatehashalgorithm-options
 [`crypto.createHmac()`]: crypto.md#cryptocreatehmacalgorithm-key-options
-[`crypto.createPrivateKey()`]: crypto.md#cryptocreateprivatekeykey
-[`crypto.createPublicKey()`]: crypto.md#cryptocreatepublickeykey
-[`crypto.decapsulate()`]: crypto.md#cryptodecapsulatekey-ciphertext-callback
-[`crypto.encapsulate()`]: crypto.md#cryptoencapsulatekey-callback
 [`crypto.fips`]: crypto.md#cryptofips
 [`crypto.pbkdf2()`]: crypto.md#cryptopbkdf2password-salt-iterations-keylen-digest-callback
-[`crypto.privateDecrypt()`]: crypto.md#cryptoprivatedecryptprivatekey-buffer
-[`crypto.privateEncrypt()`]: crypto.md#cryptoprivateencryptprivatekey-buffer
-[`crypto.publicDecrypt()`]: crypto.md#cryptopublicdecryptkey-buffer
-[`crypto.publicEncrypt()`]: crypto.md#cryptopublicencryptkey-buffer
 [`crypto.randomBytes()`]: crypto.md#cryptorandombytessize-callback
 [`crypto.scrypt()`]: crypto.md#cryptoscryptpassword-salt-keylen-options-callback
 [`crypto.setEngine()`]: crypto.md#cryptosetengineengine-flags
-[`crypto.sign()`]: crypto.md#cryptosignalgorithm-data-key-callback
-[`crypto.verify()`]: crypto.md#cryptoverifyalgorithm-data-key-signature-callback
 [`decipher.final()`]: crypto.md#decipherfinaloutputencoding
 [`decipher.setAuthTag()`]: crypto.md#deciphersetauthtagbuffer-encoding
 [`dirent.parentPath`]: fs.md#direntparentpath

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -74,26 +74,12 @@ const {
 
 const {
   customInspectSymbol: kInspect,
-  getDeprecationWarningEmitter,
   kEnumerableProperty,
   kEmptyObject,
   lazyDOMException,
 } = require('internal/util');
 
 const { inspect } = require('internal/util/inspect');
-
-const emitDEP0203 = getDeprecationWarningEmitter(
-  'DEP0203',
-  'Passing a CryptoKey to node:crypto functions is deprecated.',
-);
-
-const maybeEmitDEP0204 = getDeprecationWarningEmitter(
-  'DEP0204',
-  'Passing a non-extractable CryptoKey to KeyObject.from() is deprecated.',
-  undefined,
-  false,
-  (key) => !getCryptoKeyExtractable(key),
-);
 
 // Key input contexts.
 const kConsumePublic = 0;
@@ -191,7 +177,12 @@ const {
     static from(key) {
       if (!isCryptoKey(key))
         throw new ERR_INVALID_ARG_TYPE('key', 'CryptoKey', key);
-      maybeEmitDEP0204(key);
+      if (!getCryptoKeyExtractable(key)) {
+        throw new ERR_INVALID_ARG_VALUE(
+          'key',
+          key,
+          'must be an extractable CryptoKey');
+      }
       const handle = getCryptoKeyHandle(key);
       switch (getCryptoKeyType(key)) {
         /* eslint-disable no-use-before-define */
@@ -538,7 +529,6 @@ function getKeyTypes(allowKeyObject, bufferOnly = false) {
     'DataView',
     'string', // Only if bufferOnly == false
     'KeyObject', // Only if allowKeyObject == true && bufferOnly == false
-    'CryptoKey', // Only if allowKeyObject == true && bufferOnly == false
   ];
   if (bufferOnly) {
     return ArrayPrototypeSlice(types, 0, 4);
@@ -556,11 +546,6 @@ function prepareAsymmetricKey(key, ctx, name = 'key') {
     validateAsymmetricKeyType(type, ctx, key);
     return { data: getKeyObjectHandle(key) };
   }
-  if (isCryptoKey(key)) {
-    emitDEP0203();
-    validateAsymmetricKeyType(getCryptoKeyType(key), ctx, key);
-    return { data: getCryptoKeyHandle(key) };
-  }
   if (isStringOrBuffer(key)) {
     // Expect PEM by default, mostly for backward compatibility.
     return { format: kKeyFormatPEM, data: getArrayBufferOrView(key, name) };
@@ -574,11 +559,6 @@ function prepareAsymmetricKey(key, ctx, name = 'key') {
       const type = getKeyObjectType(data);
       validateAsymmetricKeyType(type, ctx, data);
       return { data: getKeyObjectHandle(data) };
-    }
-    if (isCryptoKey(data)) {
-      emitDEP0203();
-      validateAsymmetricKeyType(getCryptoKeyType(data), ctx, data);
-      return { data: getCryptoKeyHandle(data) };
     }
     if (format === 'jwk') {
       validateObject(data, `${name}.key`);
@@ -645,13 +625,6 @@ function prepareSecretKey(key, encoding, bufferOnly = false) {
       if (type !== 'secret')
         throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(type, 'secret');
       return getKeyObjectHandle(key);
-    }
-    if (isCryptoKey(key)) {
-      emitDEP0203();
-      const type = getCryptoKeyType(key);
-      if (type !== 'secret')
-        throw new ERR_CRYPTO_INVALID_KEY_OBJECT_TYPE(type, 'secret');
-      return getCryptoKeyHandle(key);
     }
   }
   if (typeof key !== 'string' &&

--- a/test/parallel/test-crypto-dep0203.js
+++ b/test/parallel/test-crypto-dep0203.js
@@ -4,20 +4,52 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const crypto = require('crypto');
 
-common.expectWarning({
-  DeprecationWarning: {
-    DEP0203: 'Passing a CryptoKey to node:crypto functions is deprecated.',
-  },
-});
-
 (async () => {
-  const key = await globalThis.crypto.subtle.generateKey(
+  const secretKey = await globalThis.crypto.subtle.generateKey(
     { name: 'AES-CBC', length: 128 },
     true,
     ['encrypt'],
   );
 
-  crypto.createCipheriv('aes-128-cbc', key, Buffer.alloc(16));
+  assert.throws(() => {
+    crypto.createCipheriv('aes-128-cbc', secretKey, Buffer.alloc(16));
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+
+  const { publicKey } = await globalThis.crypto.subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify'],
+  );
+
+  assert.throws(() => {
+    crypto.createPublicKey(publicKey);
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+
+  assert.throws(() => {
+    crypto.publicEncrypt({ key: publicKey }, Buffer.alloc(0));
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
+
+  const ecdh = await globalThis.crypto.subtle.generateKey(
+    { name: 'ECDH', namedCurve: 'P-256' },
+    true,
+    ['deriveBits'],
+  );
+
+  assert.throws(() => {
+    crypto.diffieHellman({
+      privateKey: ecdh.privateKey,
+      publicKey: ecdh.publicKey,
+    });
+  }, {
+    code: 'ERR_INVALID_ARG_TYPE',
+  });
 })().then(common.mustCall());

--- a/test/parallel/test-crypto-dep0204.js
+++ b/test/parallel/test-crypto-dep0204.js
@@ -4,13 +4,8 @@ const common = require('../common');
 if (!common.hasCrypto)
   common.skip('missing crypto');
 
+const assert = require('assert');
 const { KeyObject } = require('crypto');
-
-common.expectWarning({
-  DeprecationWarning: {
-    DEP0204: 'Passing a non-extractable CryptoKey to KeyObject.from() is deprecated.',
-  },
-});
 
 (async () => {
   const key = await globalThis.crypto.subtle.generateKey(
@@ -19,5 +14,42 @@ common.expectWarning({
     ['encrypt'],
   );
 
-  KeyObject.from(key);
+  assert.throws(() => {
+    KeyObject.from(key);
+  }, {
+    code: 'ERR_INVALID_ARG_VALUE',
+    message: /must be an extractable CryptoKey/,
+  });
+
+  let proto = Object.getPrototypeOf(key);
+  while (proto && !Object.getOwnPropertyDescriptor(proto, 'extractable')) {
+    proto = Object.getPrototypeOf(proto);
+  }
+  assert.ok(proto, 'could not find CryptoKey.prototype');
+  const descriptor = Object.getOwnPropertyDescriptor(proto, 'extractable');
+  Object.defineProperty(proto, 'extractable', {
+    __proto__: null,
+    configurable: true,
+    get() { return true; },
+  });
+
+  try {
+    assert.strictEqual(key.extractable, true);
+    assert.throws(() => {
+      KeyObject.from(key);
+    }, {
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: /must be an extractable CryptoKey/,
+    });
+  } finally {
+    Object.defineProperty(proto, 'extractable', descriptor);
+  }
+
+  const extractableKey = await globalThis.crypto.subtle.generateKey(
+    { name: 'AES-CBC', length: 128 },
+    true,
+    ['encrypt'],
+  );
+
+  assert.strictEqual(KeyObject.from(extractableKey).type, 'secret');
 })().then(common.mustCall());

--- a/test/parallel/test-crypto-key-objects-messageport.js
+++ b/test/parallel/test-crypto-key-objects-messageport.js
@@ -48,7 +48,7 @@ process.env.HAS_STARTED_WORKER = 1;
     modulusLength: 1024
   });
   const cryptoKey = await subtle.generateKey(
-    { name: 'AES-CBC', length: 128 }, false, ['encrypt']);
+    { name: 'AES-CBC', length: 128 }, true, ['encrypt']);
 
   // Get immutable representations of all keys.
   const keys = [secretKey, publicKey, privateKey, cryptoKey]

--- a/test/parallel/test-crypto-key-objects-to-crypto-key.js
+++ b/test/parallel/test-crypto-key-objects-to-crypto-key.js
@@ -42,7 +42,14 @@ function assertCryptoKey(cryptoKey, keyObject, algorithm, extractable, usages) {
   assert.strictEqual(cryptoKey.algorithm.name, algorithm);
   assert.strictEqual(cryptoKey.extractable, extractable);
   assert.deepStrictEqual(cryptoKey.usages, usages);
-  assert.strictEqual(keyObject.equals(KeyObject.from(cryptoKey)), true);
+  if (extractable) {
+    assert.strictEqual(keyObject.equals(KeyObject.from(cryptoKey)), true);
+  } else {
+    assert.throws(() => KeyObject.from(cryptoKey), {
+      code: 'ERR_INVALID_ARG_VALUE',
+      message: /must be an extractable CryptoKey/,
+    });
+  }
 }
 
 function algorithmName(algorithm) {

--- a/test/parallel/test-webcrypto-cryptokey-hidden-slots.js
+++ b/test/parallel/test-webcrypto-cryptokey-hidden-slots.js
@@ -21,19 +21,10 @@ if (!common.hasCrypto)
 
 const assert = require('node:assert');
 const {
-  createHmac,
   KeyObject,
-  sign: cryptoSign,
-  verify: cryptoVerify,
 } = require('node:crypto');
 const { inspect } = require('node:util');
 const { subtle } = globalThis.crypto;
-
-common.expectWarning({
-  DeprecationWarning: {
-    DEP0203: 'Passing a CryptoKey to node:crypto functions is deprecated.',
-  },
-});
 
 (async () => {
   const key = await subtle.generateKey(
@@ -41,12 +32,6 @@ common.expectWarning({
     true,
     ['sign', 'verify'],
   );
-  const { publicKey: ecPublicKey, privateKey: ecPrivateKey } =
-    await subtle.generateKey(
-      { name: 'ECDSA', namedCurve: 'P-256' },
-      false,
-      ['sign', 'verify'],
-    );
   const { publicKey: rsaPublicKey } = await subtle.generateKey(
     {
       name: 'RSA-PSS',
@@ -182,23 +167,10 @@ common.expectWarning({
     assert.strictEqual(jwk.ext, true);
     assert.deepStrictEqual(jwk.key_ops.sort(), ['sign', 'verify']);
 
-    // 4) The Node.js crypto bridge must also read the real native
-    //    slots directly, both for KeyObject.from() and for deprecated
-    //    direct CryptoKey consumption.
+    // 4) KeyObject.from() must also read the real native slots directly.
     const keyObject = KeyObject.from(key);
     assert.strictEqual(keyObject.type, 'secret');
     assert.deepStrictEqual(keyObject.export(), Buffer.from(jwk.k, 'base64url'));
-
-    const payload = Buffer.from('payload');
-    const digest = createHmac('sha256', key).update(payload).digest('hex');
-    const expectedDigest =
-      createHmac('sha256', keyObject).update(payload).digest('hex');
-    assert.strictEqual(digest, expectedDigest);
-
-    const signature = cryptoSign('sha256', payload, ecPrivateKey);
-    assert.strictEqual(
-      cryptoVerify('sha256', payload, ecPublicKey, signature),
-      true);
 
     // 5) Importing back from the exported JWK must yield an equivalent
     //    key, i.e. the real algorithm and usages round-trip.

--- a/test/parallel/test-webcrypto-derivekey.js
+++ b/test/parallel/test-webcrypto-derivekey.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');
@@ -9,7 +10,7 @@ const { hasOpenSSL } = require('../common/crypto');
 
 const assert = require('assert');
 const { subtle } = globalThis.crypto;
-const { KeyObject } = require('crypto');
+const { getCryptoKeyHandle } = require('internal/crypto/keys');
 
 // This is only a partial test. The WebCrypto Web Platform Tests
 // will provide much greater coverage.
@@ -211,8 +212,8 @@ const { KeyObject } = require('crypto');
           assert.strictEqual(derived.algorithm.length, expected);
         } else {
           // KDFs cannot be exportable and do not indicate their length
-          const secretKey = KeyObject.from(derived);
-          assert.strictEqual(secretKey.symmetricKeySize, expected / 8);
+          assert.strictEqual(getCryptoKeyHandle(derived).getSymmetricKeySize(),
+                             expected / 8);
         }
       }
     }

--- a/test/parallel/test-webcrypto-encap-decap-ml-kem.js
+++ b/test/parallel/test-webcrypto-encap-decap-ml-kem.js
@@ -1,3 +1,4 @@
+// Flags: --expose-internals
 'use strict';
 
 const common = require('../common');
@@ -12,10 +13,14 @@ if (!hasOpenSSL(3, 5) && !process.features.openssl_is_boringssl)
 
 const assert = require('assert');
 const crypto = require('crypto');
-const { KeyObject } = crypto;
+const { getCryptoKeyHandle } = require('internal/crypto/keys');
 const { subtle } = globalThis.crypto;
 
 const vectors = require('../fixtures/crypto/ml-kem')();
+
+function getCryptoKeyData(key) {
+  return getCryptoKeyHandle(key).export();
+}
 
 async function testEncapsulateKey({ name, publicKeyPem, privateKeyPem, results }) {
   const [
@@ -154,9 +159,9 @@ async function testDecapsulateKey({ name, publicKeyPem, privateKeyPem, results }
   assert.strictEqual(decapsulatedKey.extractable, false);
   assert.deepStrictEqual(decapsulatedKey.usages, ['deriveBits']);
 
-  // Verify the keys are the same by using KeyObject.from() and comparing
-  const originalKeyData = KeyObject.from(encapsulated.sharedKey).export();
-  const decapsulatedKeyData = KeyObject.from(decapsulatedKey).export();
+  // Verify the non-extractable keys are the same.
+  const originalKeyData = getCryptoKeyData(encapsulated.sharedKey);
+  const decapsulatedKeyData = getCryptoKeyData(decapsulatedKey);
   assert(originalKeyData.equals(decapsulatedKeyData));
 
   // Test with test vector ciphertext and expected shared key
@@ -169,7 +174,7 @@ async function testDecapsulateKey({ name, publicKeyPem, privateKeyPem, results }
     ['deriveBits']
   );
 
-  const vectorKeyData = KeyObject.from(vectorDecapsulatedKey).export();
+  const vectorKeyData = getCryptoKeyData(vectorDecapsulatedKey);
   assert(vectorKeyData.equals(results.sharedKey));
 
   // Test failure when using wrong key type


### PR DESCRIPTION
Moves support for passing CryptoKey instances to node:crypto APIs to End-of-Life status (DEP0203).

Moves support for passing a non-extractable CryptoKey instances to KeyObject.from() to End-of-Life status (DEP0204).

Closes #55293

---

doc-deprecation is since 24
runtime-deprecation is since 26
this eol is for 27