### PR TITLE
quic: expose QUIC certificates as JS X509Certificate, not raw handles

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1424,11 +1424,12 @@ what this endpoint advertises to the peer as its own maximum.
 added: v26.2.0
 -->
 
-* Type: {Object|undefined}
+* Type: {crypto.X509Certificate|undefined}
 
-The local certificate as an object with properties such as `subject`,
-`issuer`, `valid_from`, `valid_to`, `fingerprint`, etc. Returns `undefined`
-if the session is destroyed or no certificate is available.
+The local certificate as a [`crypto.X509Certificate`][] instance. Server
+sessions return the certificate configured for the negotiated SNI host.
+Client sessions return `undefined` unless a client certificate was sent.
+Returns `undefined` if the session is destroyed.
 
 ### `session.peerCertificate`
 
@@ -1436,11 +1437,11 @@ if the session is destroyed or no certificate is available.
 added: v26.2.0
 -->
 
-* Type: {Object|undefined}
+* Type: {crypto.X509Certificate|undefined}
 
-The peer's certificate as an object with properties such as `subject`,
-`issuer`, `valid_from`, `valid_to`, `fingerprint`, etc. Returns `undefined`
-if the session is destroyed or the peer did not present a certificate.
+The peer's certificate as a [`crypto.X509Certificate`][] instance. Returns
+`undefined` if the peer did not present a certificate or the session is
+destroyed.
 
 ### `session.ephemeralKeyInfo`
 
@@ -4450,6 +4451,7 @@ throughput issues caused by flow control.
 [`application.enableConnectProtocol`]: #sessionoptionsapplication
 [`application.enableDatagrams`]: #sessionoptionsapplication
 [`application.qpackMaxDTableCapacity`]: #sessionoptionsapplication
+[`crypto.X509Certificate`]: crypto.md#class-x509certificate
 [`endpoint.busy`]: #endpointbusy
 [`endpoint.maxConnectionsPerHost`]: #endpointmaxconnectionsperhost
 [`endpoint.maxConnectionsTotal`]: #endpointmaxconnectionstotal

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -153,6 +153,10 @@ const {
 } = require('internal/crypto/keys');
 
 const {
+  InternalX509Certificate,
+} = require('internal/crypto/x509');
+
+const {
   FileHandle,
   kHandle: kFileHandle,
   kLocked: kFileLocked,
@@ -3180,24 +3184,37 @@ class QuicSession {
   }
 
   /**
-   * The local certificate as an object, or undefined if not available.
-   * @type {object|undefined}
+   * The local certificate as a {@link crypto.X509Certificate}, or undefined
+   * if no local certificate is available. Server sessions return their
+   * configured certificate; client sessions return undefined unless a
+   * client certificate was sent.
+   * @type {crypto.X509Certificate|undefined}
    */
   get certificate() {
     assertIsQuicSession(this);
     if (this.destroyed) return undefined;
-    return this.#inner.certificate ??= this.#handle.getCertificate();
+    if (this.#inner.certificate === undefined) {
+      const handle = this.#handle.getCertificate();
+      this.#inner.certificate = handle ? new InternalX509Certificate(handle) : null;
+    }
+    return this.#inner.certificate ?? undefined;
   }
 
   /**
-   * The peer's certificate as an object, or undefined if the peer did
-   * not present a certificate or the session is destroyed.
-   * @type {object|undefined}
+   * The peer's certificate as a {@link crypto.X509Certificate}, or undefined
+   * if the peer did not present a certificate or the session is destroyed.
+   * @type {crypto.X509Certificate|undefined}
    */
   get peerCertificate() {
     assertIsQuicSession(this);
     if (this.destroyed) return undefined;
-    return this.#inner.peerCertificate ??= this.#handle.getPeerCertificate();
+    if (this.#inner.peerCertificate === undefined) {
+      const handle = this.#handle.getPeerCertificate();
+      this.#inner.peerCertificate = handle ?
+        new InternalX509Certificate(handle) :
+        null;
+    }
+    return this.#inner.peerCertificate ?? undefined;
   }
 
   /**

--- a/test/parallel/test-quic-session-properties.mjs
+++ b/test/parallel/test-quic-session-properties.mjs
@@ -12,9 +12,14 @@
 // All three return undefined after destroy.
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
+import { X509Certificate } from 'node:crypto';
 
 const { ok, strictEqual } = assert;
+
+// The QUIC test helpers configure both sides with the agent1 fixture cert,
+const expectedCert = new X509Certificate(fixtures.readKey('agent1-cert.pem'));
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -38,7 +43,10 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
   // Own certificate.
   const cert = serverSession.certificate;
-  ok(cert);
+  ok(cert instanceof X509Certificate);
+  strictEqual(cert.subject, expectedCert.subject);
+  strictEqual(cert.issuer, expectedCert.issuer);
+  strictEqual(cert.fingerprint256, expectedCert.fingerprint256);
 
   // Peer certificate (client's cert — not set in this
   // test since we don't use verifyClient, so it's undefined).
@@ -65,7 +73,10 @@ strictEqual(clientSession.path, path);
 
 // Peer certificate (server's cert).
 const peerCert = clientSession.peerCertificate;
-ok(peerCert);
+ok(peerCert instanceof X509Certificate);
+strictEqual(peerCert.subject, expectedCert.subject);
+strictEqual(peerCert.issuer, expectedCert.issuer);
+strictEqual(peerCert.fingerprint256, expectedCert.fingerprint256);
 
 // Ephemeral key info (client only).
 const keyInfo = clientSession.ephemeralKeyInfo;

--- a/test/parallel/test-quic-session-properties.mjs
+++ b/test/parallel/test-quic-session-properties.mjs
@@ -11,12 +11,16 @@
 // All three cached.
 // All three return undefined after destroy.
 
-import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import { hasQuic, skip, mustCall, hasCrypto } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
-import { X509Certificate } from 'node:crypto';
 
 const { ok, strictEqual } = assert;
+
+if (!hasCrypto)
+  skip('missing crypto');
+
+const { X509Certificate } = await import('node:crypto');
 
 // The QUIC test helpers configure both sides with the agent1 fixture cert,
 const expectedCert = new X509Certificate(fixtures.readKey('agent1-cert.pem'));


### PR DESCRIPTION
Starting to work through the TLS implementation in QUIC, one nice small standalone fix here.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
