### PR TITLE
quic: send correct OpenSSL alert for ALPN mismatches

### DIFF
--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -338,7 +338,7 @@ int TLSContext::OnSelectAlpn(SSL* ssl,
           in,
           inlen) == OPENSSL_NPN_NO_OVERLAP) {
     Debug(&tls_session.session(), "ALPN negotiation failed");
-    return SSL_TLSEXT_ERR_NOACK;
+    return SSL_TLSEXT_ERR_ALERT_FATAL;
   }
 
   // ALPN negotiated successfully. *out/*outlen point to the selected

--- a/test/parallel/test-quic-alpn-mismatch.mjs
+++ b/test/parallel/test-quic-alpn-mismatch.mjs
@@ -2,12 +2,18 @@
 
 // Test: ALPN mismatch causes connection failure.
 // The server offers 'quic-test' but the client requests 'nonexistent'.
-// The handshake should fail.
+// The handshake should fail with a `no_application_protocol` alert.
+//
+// The QUIC transport error code for a CRYPTO_ERROR carrying a TLS alert is
+// 0x100 | <tls_alert>. For `no_application_protocol` (alert 120 / 0x78) this
+// is 0x178 == 376. ERR_QUIC_TRANSPORT_ERROR formats the wire code into its
+// message as a bigint, so we match `376n` to assert the specific alert was
+// sent rather than some other handshake failure.
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
+const { rejects, strictEqual, match } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -15,18 +21,20 @@ if (!hasQuic) {
 
 const { listen, connect } = await import('../common/quic.mjs');
 
+const expected = {
+  code: 'ERR_QUIC_TRANSPORT_ERROR',
+  message: /\b376n\b/,
+};
+
 const onerror = mustCall((err) => {
   strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+  match(err.message, /\b376n\b/);
 }, 2);
 const transportParams = { maxIdleTimeout: 1 };
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
-  await rejects(serverSession.opened, {
-    code: 'ERR_QUIC_TRANSPORT_ERROR',
-  });
-  await rejects(serverSession.closed, {
-    code: 'ERR_QUIC_TRANSPORT_ERROR',
-  });
+  await rejects(serverSession.opened, expected);
+  await rejects(serverSession.closed, expected);
 }), {
   transportParams,
   onerror,
@@ -39,12 +47,8 @@ const clientSession = await connect(serverEndpoint.address, {
   onerror,
 });
 
-await rejects(clientSession.opened, {
-  code: 'ERR_QUIC_TRANSPORT_ERROR',
-});
+await rejects(clientSession.opened, expected);
 
 // The handshake should fail — opened may reject or never resolve.
 // The session should close with an error.
-await rejects(clientSession.closed, {
-  code: 'ERR_QUIC_TRANSPORT_ERROR',
-});
+await rejects(clientSession.closed, expected);


### PR DESCRIPTION
Currently if the QUIC server doesn't agree with any of the client's proposed protocols, it returns `SSL_TLSEXT_ERR_NOACK` to OpenSSL, which in normal TLS acts as "ignore ALPN". Since it's obligatory in QUIC this doesn't work - the resulting test checking this was actually receiving an `internal_error` alert (`336n`) on the wire when this happened. This does fail the connection, but it's clearly not correct.

We now return `SSL_TLSEXT_ERR_ALERT_FATAL` instead, which sends the proper `no_application_protocol` TLS alert to the client instead, as required by the RFC.

This has notably pointed out to me that we have no nice error messages in here: on the JS side, these just reference the raw error code (now `376n`) with no other info. I'll bring in a general fix for error handling in another PR, watch this space.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
