### PR TITLE
quic: add proper error codes & messages for QUIC failures

### DIFF
--- a/lib/eslint.config_partial.mjs
+++ b/lib/eslint.config_partial.mjs
@@ -23,7 +23,7 @@ const noRestrictedSyntax = [
     message: "`btoa` supports only latin-1 charset, use Buffer.from(str).toString('base64') instead",
   },
   {
-    selector: 'NewExpression[callee.name=/Error$/]:not([callee.name=/^(AssertionError|NghttpError|AbortError|NodeAggregateError|QuotaExceededError)$/])',
+    selector: 'NewExpression[callee.name=/Error$/]:not([callee.name=/^(AssertionError|NghttpError|AbortError|NodeAggregateError|QuicError|QuotaExceededError)$/])',
     message: "Use an error exported by 'internal/errors' instead.",
   },
   {

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1689,14 +1689,12 @@ E('ERR_PERFORMANCE_INVALID_TIMESTAMP',
 E('ERR_PERFORMANCE_MEASURE_INVALID_OPTIONS', '%s', TypeError);
 E('ERR_PROXY_INVALID_CONFIG', '%s', Error);
 E('ERR_PROXY_TUNNEL', '%s', Error);
-E('ERR_QUIC_APPLICATION_ERROR', '%s', Error);
 E('ERR_QUIC_CONNECTION_FAILED', 'QUIC connection failed', Error);
 E('ERR_QUIC_ENDPOINT_CLOSED', 'QUIC endpoint closed: %s (%d)', Error);
 E('ERR_QUIC_OPEN_STREAM_FAILED', 'Failed to open QUIC stream', Error);
 E('ERR_QUIC_STREAM_ABORTED', '%s', Error);
 E('ERR_QUIC_STREAM_RESET',
   'The QUIC stream was reset by the peer with error code %d', Error);
-E('ERR_QUIC_TRANSPORT_ERROR', '%s', Error);
 E('ERR_QUIC_VERSION_NEGOTIATION_ERROR', 'The QUIC session requires version negotiation', Error);
 E('ERR_REQUIRE_ASYNC_MODULE', function(filename, parentFilename) {
   let message = 'require() cannot be used on an ESM ' +

--- a/lib/internal/errors.js
+++ b/lib/internal/errors.js
@@ -1689,14 +1689,14 @@ E('ERR_PERFORMANCE_INVALID_TIMESTAMP',
 E('ERR_PERFORMANCE_MEASURE_INVALID_OPTIONS', '%s', TypeError);
 E('ERR_PROXY_INVALID_CONFIG', '%s', Error);
 E('ERR_PROXY_TUNNEL', '%s', Error);
-E('ERR_QUIC_APPLICATION_ERROR', 'A QUIC application error occurred. %d [%s]', Error);
+E('ERR_QUIC_APPLICATION_ERROR', '%s', Error);
 E('ERR_QUIC_CONNECTION_FAILED', 'QUIC connection failed', Error);
 E('ERR_QUIC_ENDPOINT_CLOSED', 'QUIC endpoint closed: %s (%d)', Error);
 E('ERR_QUIC_OPEN_STREAM_FAILED', 'Failed to open QUIC stream', Error);
 E('ERR_QUIC_STREAM_ABORTED', '%s', Error);
 E('ERR_QUIC_STREAM_RESET',
   'The QUIC stream was reset by the peer with error code %d', Error);
-E('ERR_QUIC_TRANSPORT_ERROR', 'A QUIC transport error occurred. %d [%s]', Error);
+E('ERR_QUIC_TRANSPORT_ERROR', '%s', Error);
 E('ERR_QUIC_VERSION_NEGOTIATION_ERROR', 'The QUIC session requires version negotiation', Error);
 E('ERR_REQUIRE_ASYNC_MODULE', function(filename, parentFilename) {
   let message = 'require() cannot be used on an ESM ' +

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -108,13 +108,11 @@ const {
     ERR_INVALID_THIS,
     ERR_MISSING_ARGS,
     ERR_OUT_OF_RANGE,
-    ERR_QUIC_APPLICATION_ERROR,
     ERR_QUIC_CONNECTION_FAILED,
     ERR_QUIC_ENDPOINT_CLOSED,
     ERR_QUIC_OPEN_STREAM_FAILED,
     ERR_QUIC_STREAM_ABORTED,
     ERR_QUIC_STREAM_RESET,
-    ERR_QUIC_TRANSPORT_ERROR,
     ERR_QUIC_VERSION_NEGOTIATION_ERROR,
   },
 } = require('internal/errors');
@@ -1070,11 +1068,10 @@ function quicErrorMessage(prefix, errorCode, reason, errorName) {
   return msg;
 }
 
-function makeQuicError(ErrorClass, prefix, type, errorCode, reason, errorName) {
-  const err = new ErrorClass(
-    quicErrorMessage(prefix, errorCode, reason, errorName));
-  err.errorCode = errorCode;
-  err.type = type;
+function makeQuicError(code, prefix, type, errorCode, reason, errorName) {
+  const err = new QuicError(
+    quicErrorMessage(prefix, errorCode, reason, errorName),
+    { errorCode, code, type });
   if (reason) err.reason = reason;
   if (errorName) err.errorName = errorName;
   return err;
@@ -1087,17 +1084,17 @@ function convertQuicError(error) {
   const errorName = error[3];
   switch (type) {
     case 'transport':
-      return makeQuicError(ERR_QUIC_TRANSPORT_ERROR,
+      return makeQuicError('ERR_QUIC_TRANSPORT_ERROR',
                            'QUIC transport error',
                            'transport', code, reason, errorName);
     case 'application':
-      return makeQuicError(ERR_QUIC_APPLICATION_ERROR,
+      return makeQuicError('ERR_QUIC_APPLICATION_ERROR',
                            'QUIC application error',
                            'application', code, reason, errorName);
     case 'version_negotiation':
       return new ERR_QUIC_VERSION_NEGOTIATION_ERROR();
     default:
-      return makeQuicError(ERR_QUIC_TRANSPORT_ERROR,
+      return makeQuicError('ERR_QUIC_TRANSPORT_ERROR',
                            'QUIC transport error',
                            'transport', code, reason, errorName);
   }
@@ -3643,12 +3640,12 @@ class QuicSession {
     // session would leak with `closed` hanging forever.
     switch (errorType) {
       case 0: /* Transport Error */
-        this.destroy(makeQuicError(ERR_QUIC_TRANSPORT_ERROR,
+        this.destroy(makeQuicError('ERR_QUIC_TRANSPORT_ERROR',
                                    'QUIC transport error',
                                    'transport', code, reason, errorName));
         break;
       case 1: /* Application Error */
-        this.destroy(makeQuicError(ERR_QUIC_APPLICATION_ERROR,
+        this.destroy(makeQuicError('ERR_QUIC_APPLICATION_ERROR',
                                    'QUIC application error',
                                    'application', code, reason, errorName));
         break;
@@ -3659,7 +3656,7 @@ class QuicSession {
         this.destroy();
         break;
       default:
-        this.destroy(makeQuicError(ERR_QUIC_TRANSPORT_ERROR,
+        this.destroy(makeQuicError('ERR_QUIC_TRANSPORT_ERROR',
                                    'QUIC transport error',
                                    'transport', code, reason, errorName));
         break;

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -9,6 +9,7 @@ const {
   ArrayPrototypePush,
   BigInt,
   DataViewPrototypeGetByteLength,
+  ErrorCaptureStackTrace,
   FunctionPrototypeBind,
   Number,
   ObjectDefineProperties,
@@ -1072,6 +1073,7 @@ function makeQuicError(code, prefix, type, errorCode, reason, errorName) {
   const err = new QuicError(
     quicErrorMessage(prefix, errorCode, reason, errorName),
     { errorCode, code, type });
+  ErrorCaptureStackTrace(err, makeQuicError);
   if (reason) err.reason = reason;
   if (errorName) err.errorName = errorName;
   return err;

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -738,10 +738,12 @@ setCallbacks({
    * @param {number} errorType
    * @param {number} code
    * @param {string} [reason]
+   * @param {string} [errorName] Decoded TLS alert name when `code` is a
+   *   CRYPTO_ERROR; otherwise undefined.
    */
-  onSessionClose(errorType, code, reason) {
-    debug('session close callback', errorType, code, reason);
-    this[kOwner][kFinishClose](errorType, code, reason);
+  onSessionClose(errorType, code, reason, errorName) {
+    debug('session close callback', errorType, code, reason, errorName);
+    this[kOwner][kFinishClose](errorType, code, reason, errorName);
   },
 
   /**
@@ -1054,21 +1056,50 @@ class QuicError extends Error {
   }
 }
 
-// Converts a raw QuicError array [type, code, reason] from C++ into a
-// proper Node.js Error object.
+// Build the human-readable message for an ERR_QUIC_TRANSPORT_ERROR or
+// ERR_QUIC_APPLICATION_ERROR. `errorName` is the symbolic name for
+// the wire code when known: either the OpenSSL-decoded TLS alert
+// (CRYPTO_ERROR; 0x100..0x1ff) or one of the named transport codes
+// from RFC 9000 (e.g. PROTOCOL_VIOLATION). Otherwise undefined.
+// `reason` is the peer-supplied UTF-8 reason string from the
+// CONNECTION_CLOSE / RESET_STREAM frame, often empty.
+function quicErrorMessage(prefix, errorCode, reason, errorName) {
+  let msg = `${prefix} `;
+  msg += errorName ? `${errorName} (${errorCode})` : `${errorCode}`;
+  if (reason) msg += `: ${reason}`;
+  return msg;
+}
+
+function makeQuicError(ErrorClass, prefix, type, errorCode, reason, errorName) {
+  const err = new ErrorClass(
+    quicErrorMessage(prefix, errorCode, reason, errorName));
+  err.errorCode = errorCode;
+  err.type = type;
+  if (reason) err.reason = reason;
+  if (errorName) err.errorName = errorName;
+  return err;
+}
+
 function convertQuicError(error) {
   const type = error[0];
   const code = error[1];
   const reason = error[2];
+  const errorName = error[3];
   switch (type) {
     case 'transport':
-      return new ERR_QUIC_TRANSPORT_ERROR(code, reason);
+      return makeQuicError(ERR_QUIC_TRANSPORT_ERROR,
+                           'QUIC transport error',
+                           'transport', code, reason, errorName);
     case 'application':
-      return new ERR_QUIC_APPLICATION_ERROR(code, reason);
+      return makeQuicError(ERR_QUIC_APPLICATION_ERROR,
+                           'QUIC application error',
+                           'application', code, reason, errorName);
     case 'version_negotiation':
       return new ERR_QUIC_VERSION_NEGOTIATION_ERROR();
     default:
-      return new ERR_QUIC_TRANSPORT_ERROR(code, reason);
+      return makeQuicError(ERR_QUIC_TRANSPORT_ERROR,
+                           'QUIC transport error',
+                           'transport', code, reason, errorName);
   }
 }
 
@@ -3575,7 +3606,7 @@ class QuicSession {
    * @param {number} code
    * @param {string} [reason]
    */
-  [kFinishClose](errorType, code, reason) {
+  [kFinishClose](errorType, code, reason, errorName) {
     // If code is zero, then we closed without an error. Yay! We can destroy
     // safely without specifying an error.
     if (code === 0n) {
@@ -3584,7 +3615,8 @@ class QuicSession {
       return;
     }
 
-    debug('finishing closing the session with an error', errorType, code, reason);
+    debug('finishing closing the session with an error',
+          errorType, code, reason, errorName);
 
     // If the local side initiated this close with an error code (via
     // close({ code })), this is an intentional shutdown; not an error.
@@ -3611,10 +3643,14 @@ class QuicSession {
     // session would leak with `closed` hanging forever.
     switch (errorType) {
       case 0: /* Transport Error */
-        this.destroy(new ERR_QUIC_TRANSPORT_ERROR(code, reason));
+        this.destroy(makeQuicError(ERR_QUIC_TRANSPORT_ERROR,
+                                   'QUIC transport error',
+                                   'transport', code, reason, errorName));
         break;
       case 1: /* Application Error */
-        this.destroy(new ERR_QUIC_APPLICATION_ERROR(code, reason));
+        this.destroy(makeQuicError(ERR_QUIC_APPLICATION_ERROR,
+                                   'QUIC application error',
+                                   'application', code, reason, errorName));
         break;
       case 2: /* Version Negotiation Error */
         this.destroy(new ERR_QUIC_VERSION_NEGOTIATION_ERROR());
@@ -3623,7 +3659,9 @@ class QuicSession {
         this.destroy();
         break;
       default:
-        this.destroy(new ERR_QUIC_TRANSPORT_ERROR(code, reason));
+        this.destroy(makeQuicError(ERR_QUIC_TRANSPORT_ERROR,
+                                   'QUIC transport error',
+                                   'transport', code, reason, errorName));
         break;
     }
   }

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -932,8 +932,12 @@ setCallbacks({
       // was an abnormal termination even if the session closed cleanly.
       const resetCode = getQuicStreamState(this[kOwner]).resetCode;
       if (resetCode !== undefined && resetCode > 0n) {
-        error = new ERR_QUIC_APPLICATION_ERROR(
-          resetCode, `stream reset with code ${resetCode}`);
+        error = makeQuicError(
+          'ERR_QUIC_APPLICATION_ERROR',
+          'QUIC application error',
+          'application',
+          resetCode,
+          `stream reset with code ${resetCode}`);
       }
     }
     debug(`stream ${this[kOwner].id} closed callback with error: ${error}`);
@@ -3911,9 +3915,13 @@ class QuicSession {
     // decide. In 'strict' mode, the handshake already failed at the C++
     // level (SSL_VERIFY_PEER) so we won't reach here.
     if (inner.verifyPeer === 'auto' && validationErrorReason !== undefined) {
-      const err = new ERR_QUIC_TRANSPORT_ERROR(
-        0, `Peer certificate validation failed: ${validationErrorReason}` +
-           ` [${validationErrorCode}]`);
+      const err = makeQuicError(
+        'ERR_QUIC_TRANSPORT_ERROR',
+        'QUIC transport error',
+        'transport',
+        0n,
+        `Peer certificate validation failed: ${validationErrorReason}` +
+          ` [${validationErrorCode}]`);
       inner.pendingOpen.reject?.(err);
       inner.pendingOpen.resolve = undefined;
       inner.pendingOpen.reject = undefined;

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -435,6 +435,14 @@ QUIC_JS_CALLBACKS(V)
 
 #undef V
 
+Local<String> BindingData::error_name_string(const char* name) {
+  auto& slot = error_name_strings_[name];
+  if (slot.IsEmpty()) {
+    slot.Set(env()->isolate(), OneByteString(env()->isolate(), name));
+  }
+  return slot.Get(env()->isolate());
+}
+
 JS_METHOD_IMPL(BindingData::SetCallbacks) {
   auto env = Environment::GetCurrent(args);
   auto isolate = env->isolate();

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -305,6 +305,8 @@ class BindingData final
 
   std::unordered_map<Endpoint*, BaseObjectPtr<BaseObject>> listening_endpoints;
 
+  v8::Local<v8::String> error_name_string(const char* name);
+
   size_t current_ngtcp2_memory_ = 0;
 
   // The following set up various storage and accessors for common strings,
@@ -356,6 +358,9 @@ class BindingData final
 #define V(name, _) mutable v8::Eternal<v8::String> on_##name##_string_;
   QUIC_JS_CALLBACKS(V)
 #undef V
+
+  // Lazy cache backing error_name_string()
+  std::unordered_map<const char*, v8::Eternal<v8::String>> error_name_strings_;
 
   std::unique_ptr<SessionManager> session_manager_;
 

--- a/src/quic/data.cc
+++ b/src/quic/data.cc
@@ -1,13 +1,14 @@
 #if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC
-#include "data.h"
 #include <env-inl.h>
 #include <memory_tracker-inl.h>
 #include <ngtcp2/ngtcp2.h>
 #include <node_sockaddr-inl.h>
+#include <openssl/ssl.h>
 #include <string_bytes.h>
 #include <v8.h>
+#include "data.h"
 #include "defs.h"
 #include "util.h"
 
@@ -363,6 +364,62 @@ std::optional<int> QuicError::get_crypto_error() const {
   return code() & ~NGTCP2_CRYPTO_ERROR;
 }
 
+const char* QuicError::name() const {
+  // CRYPTO_ERROR carries a TLS alert in its low byte (RFC 9001 sec. 4.8).
+  // OpenSSL's SSL_alert_desc_string_long owns a stable string for every
+  // alert it knows about; we filter out the "unknown" placeholder so the
+  // JS side can present `errorName` as undefined for unrecognised alerts.
+  if (auto alert = get_crypto_error()) {
+    const char* n = SSL_alert_desc_string_long(*alert);
+    if (n != nullptr && std::string_view(n) != "unknown") return n;
+    return nullptr;
+  }
+  // Named transport-layer error codes from RFC 9000 sec. 20.1 (and the
+  // RFC 9368 version-negotiation extension). Application error codes are
+  // opaque to QUIC, so we only decode for transport.
+  if (type() != Type::TRANSPORT) return nullptr;
+  switch (code()) {
+    case NGTCP2_NO_ERROR:
+      return "NO_ERROR";
+    case NGTCP2_INTERNAL_ERROR:
+      return "INTERNAL_ERROR";
+    case NGTCP2_CONNECTION_REFUSED:
+      return "CONNECTION_REFUSED";
+    case NGTCP2_FLOW_CONTROL_ERROR:
+      return "FLOW_CONTROL_ERROR";
+    case NGTCP2_STREAM_LIMIT_ERROR:
+      return "STREAM_LIMIT_ERROR";
+    case NGTCP2_STREAM_STATE_ERROR:
+      return "STREAM_STATE_ERROR";
+    case NGTCP2_FINAL_SIZE_ERROR:
+      return "FINAL_SIZE_ERROR";
+    case NGTCP2_FRAME_ENCODING_ERROR:
+      return "FRAME_ENCODING_ERROR";
+    case NGTCP2_TRANSPORT_PARAMETER_ERROR:
+      return "TRANSPORT_PARAMETER_ERROR";
+    case NGTCP2_CONNECTION_ID_LIMIT_ERROR:
+      return "CONNECTION_ID_LIMIT_ERROR";
+    case NGTCP2_PROTOCOL_VIOLATION:
+      return "PROTOCOL_VIOLATION";
+    case NGTCP2_INVALID_TOKEN:
+      return "INVALID_TOKEN";
+    case NGTCP2_APPLICATION_ERROR:
+      return "APPLICATION_ERROR";
+    case NGTCP2_CRYPTO_BUFFER_EXCEEDED:
+      return "CRYPTO_BUFFER_EXCEEDED";
+    case NGTCP2_KEY_UPDATE_ERROR:
+      return "KEY_UPDATE_ERROR";
+    case NGTCP2_AEAD_LIMIT_REACHED:
+      return "AEAD_LIMIT_REACHED";
+    case NGTCP2_NO_VIABLE_PATH:
+      return "NO_VIABLE_PATH";
+    case NGTCP2_VERSION_NEGOTIATION_ERROR:
+      return "VERSION_NEGOTIATION_ERROR";
+    default:
+      return nullptr;
+  }
+}
+
 MaybeLocal<Value> QuicError::ToV8Value(Environment* env) const {
   if ((type() == Type::TRANSPORT && code() == NGTCP2_NO_ERROR) ||
       (type() == Type::APPLICATION &&
@@ -384,6 +441,7 @@ MaybeLocal<Value> QuicError::ToV8Value(Environment* env) const {
       type_str,
       BigInt::NewFromUnsigned(env->isolate(), code()),
       Undefined(env->isolate()),
+      Undefined(env->isolate()),
   };
 
   // Note that per the QUIC specification, the reason, if present, is
@@ -395,6 +453,15 @@ MaybeLocal<Value> QuicError::ToV8Value(Environment* env) const {
   if (reason_.length() > 0 &&
       !node::ToV8Value(env->context(), reason()).ToLocal(&argv[2])) {
     return {};
+  }
+
+  // Attach a human-readable name for known wire codes (RFC 9000 sec. 20.1
+  // names and OpenSSL TLS alert descriptions for CRYPTO_ERROR). Unknown
+  // codes leave the slot as undefined.
+  if (const char* n = name()) {
+    if (!node::ToV8Value(env->context(), n).ToLocal(&argv[3])) {
+      return {};
+    }
   }
 
   return Array::New(env->isolate(), argv, arraysize(argv)).As<Value>();

--- a/src/quic/data.cc
+++ b/src/quic/data.cc
@@ -26,7 +26,9 @@ using v8::Just;
 using v8::Local;
 using v8::Maybe;
 using v8::MaybeLocal;
+using v8::NewStringType;
 using v8::Nothing;
+using v8::String;
 using v8::Uint8Array;
 using v8::Undefined;
 using v8::Value;
@@ -459,7 +461,8 @@ MaybeLocal<Value> QuicError::ToV8Value(Environment* env) const {
   // names and OpenSSL TLS alert descriptions for CRYPTO_ERROR). Unknown
   // codes leave the slot as undefined.
   if (const char* n = name()) {
-    if (!node::ToV8Value(env->context(), n).ToLocal(&argv[3])) {
+    if (!String::NewFromUtf8(env->isolate(), n, NewStringType::kInternalized)
+             .ToLocal(&argv[3])) {
       return {};
     }
   }

--- a/src/quic/data.cc
+++ b/src/quic/data.cc
@@ -8,6 +8,7 @@
 #include <openssl/ssl.h>
 #include <string_bytes.h>
 #include <v8.h>
+#include "bindingdata.h"
 #include "data.h"
 #include "defs.h"
 #include "util.h"
@@ -26,9 +27,7 @@ using v8::Just;
 using v8::Local;
 using v8::Maybe;
 using v8::MaybeLocal;
-using v8::NewStringType;
 using v8::Nothing;
-using v8::String;
 using v8::Uint8Array;
 using v8::Undefined;
 using v8::Value;
@@ -461,10 +460,7 @@ MaybeLocal<Value> QuicError::ToV8Value(Environment* env) const {
   // names and OpenSSL TLS alert descriptions for CRYPTO_ERROR). Unknown
   // codes leave the slot as undefined.
   if (const char* n = name()) {
-    if (!String::NewFromUtf8(env->isolate(), n, NewStringType::kInternalized)
-             .ToLocal(&argv[3])) {
-      return {};
-    }
+    argv[3] = BindingData::Get(env).error_name_string(n);
   }
 
   return Array::New(env->isolate(), argv, arraysize(argv)).As<Value>();

--- a/src/quic/data.h
+++ b/src/quic/data.h
@@ -265,6 +265,9 @@ class QuicError final : public MemoryRetainer {
   bool is_crypto_error() const;
   std::optional<int> get_crypto_error() const;
 
+  // Returns a human-readable name for this error if known, or nullptr
+  const char* name() const;
+
   // Note that since application errors are application-specific and we
   // don't know which application is being used here, it is possible that
   // the comparing two different QuicError instances from different applications

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -51,7 +51,6 @@ using v8::Local;
 using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
-using v8::NewStringType;
 using v8::Nothing;
 using v8::Number;
 using v8::Object;
@@ -3464,10 +3463,7 @@ void Session::EmitClose(const QuicError& error) {
   // codes leave the slot as undefined. See QuicError::name() for the
   // matching path on stream-level errors.
   if (const char* n = error.name()) {
-    if (!String::NewFromUtf8(env()->isolate(), n, NewStringType::kInternalized)
-             .ToLocal(&argv[3])) {
-      return;
-    }
+    argv[3] = BindingData::Get(env()).error_name_string(n);
   }
 
   MakeCallback(

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -3065,7 +3065,7 @@ void Session::CheckStreamIdleTimeout(uint64_t now) {
       // Without this, the peer's stream sits orphaned until the
       // session closes.
       auto error =
-          QuicError::ForTransport(NGTCP2_ERR_PROTO, "stream idle timeout");
+          QuicError::ForNgtcp2Error(NGTCP2_ERR_PROTO, "stream idle timeout");
       ShutdownStream(id, error);
       stream->Destroy(error);
       STAT_INCREMENT(Stats, streams_idle_timed_out);

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -51,6 +51,7 @@ using v8::Local;
 using v8::LocalVector;
 using v8::Maybe;
 using v8::MaybeLocal;
+using v8::NewStringType;
 using v8::Nothing;
 using v8::Number;
 using v8::Object;
@@ -3463,7 +3464,8 @@ void Session::EmitClose(const QuicError& error) {
   // codes leave the slot as undefined. See QuicError::name() for the
   // matching path on stream-level errors.
   if (const char* n = error.name()) {
-    if (!ToV8Value(env()->context(), n).ToLocal(&argv[3])) {
+    if (!String::NewFromUtf8(env()->isolate(), n, NewStringType::kInternalized)
+             .ToLocal(&argv[3])) {
       return;
     }
   }

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -3451,10 +3451,21 @@ void Session::EmitClose(const QuicError& error) {
       Integer::New(env()->isolate(), static_cast<int>(error.type())),
       BigInt::NewFromUnsigned(env()->isolate(), error.code()),
       Undefined(env()->isolate()),
+      Undefined(env()->isolate()),
   };
   if (error.reason().length() > 0 &&
       !ToV8Value(env()->context(), error.reason()).ToLocal(&argv[2])) {
     return;
+  }
+
+  // Attach a human-readable name for known wire codes (RFC 9000 sec. 20.1
+  // names and OpenSSL TLS alert descriptions for CRYPTO_ERROR). Unknown
+  // codes leave the slot as undefined. See QuicError::name() for the
+  // matching path on stream-level errors.
+  if (const char* n = error.name()) {
+    if (!ToV8Value(env()->context(), n).ToLocal(&argv[3])) {
+      return;
+    }
   }
 
   MakeCallback(

--- a/test/parallel/test-quic-alpn-mismatch.mjs
+++ b/test/parallel/test-quic-alpn-mismatch.mjs
@@ -6,9 +6,7 @@
 //
 // The QUIC transport error code for a CRYPTO_ERROR carrying a TLS alert is
 // 0x100 | <tls_alert>. For `no_application_protocol` (alert 120 / 0x78) this
-// is 0x178 == 376. ERR_QUIC_TRANSPORT_ERROR formats the wire code into its
-// message as a bigint, so we match `376n` to assert the specific alert was
-// sent rather than some other handshake failure.
+// is 0x178 == 376.
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
@@ -23,12 +21,14 @@ const { listen, connect } = await import('../common/quic.mjs');
 
 const expected = {
   code: 'ERR_QUIC_TRANSPORT_ERROR',
-  message: /\b376n\b/,
+  errorCode: 376n,
+  message: /no application protocol/
 };
 
 const onerror = mustCall((err) => {
   strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
-  match(err.message, /\b376n\b/);
+  strictEqual(err.errorCode, 376n);
+  match(err.message, /no application protocol/);
 }, 2);
 const transportParams = { maxIdleTimeout: 1 };
 

--- a/test/parallel/test-quic-session-close-error-code.mjs
+++ b/test/parallel/test-quic-session-close-error-code.mjs
@@ -29,13 +29,18 @@ const { listen, connect } = await import('../common/quic.mjs');
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onerror = mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
-      strictEqual(err.message.includes('42n'), true,
+      strictEqual(err.message.includes('42'), true,
                   'error message should contain the code');
       strictEqual(err.message.includes('client shutdown'), true,
                   'error message should contain the reason');
+      strictEqual(err.errorCode, 42n);
+      strictEqual(err.type, 'application');
+      strictEqual(err.reason, 'client shutdown');
     });
     await rejects(serverSession.closed, {
       code: 'ERR_QUIC_APPLICATION_ERROR',
+      errorCode: 42n,
+      reason: 'client shutdown',
     });
     serverGot.resolve();
   }));
@@ -71,8 +76,10 @@ const { listen, connect } = await import('../common/quic.mjs');
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onerror = mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
-      strictEqual(err.message.includes('1n'), true,
+      strictEqual(err.message.includes('1'), true,
                   'error message should contain the code');
+      strictEqual(err.errorCode, 1n);
+      strictEqual(err.type, 'transport');
     });
     await rejects(serverSession.closed, {
       code: 'ERR_QUIC_TRANSPORT_ERROR',
@@ -102,7 +109,10 @@ const { listen, connect } = await import('../common/quic.mjs');
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onerror = mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
-      strictEqual(err.message.includes('99n'), true);
+      strictEqual(err.message.includes('99'), true);
+      strictEqual(err.errorCode, 99n);
+      strictEqual(err.type, 'application');
+      strictEqual(err.reason, 'destroy with code');
     });
     await rejects(serverSession.closed, {
       code: 'ERR_QUIC_APPLICATION_ERROR',

--- a/test/parallel/test-quic-stream-destroy-emits-reset.mjs
+++ b/test/parallel/test-quic-stream-destroy-emits-reset.mjs
@@ -12,12 +12,12 @@
 // code is the negotiated application's "internal error" code: for
 // the test fixture's non-h3 ALPN (`quic-test`) the C++
 // DefaultApplication reports `1n`, which propagates to the server
-// as `ERR_QUIC_APPLICATION_ERROR` carrying `1n` in its message.
+// as `ERR_QUIC_APPLICATION_ERROR` exposing `errorCode === 1n`.
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, ok, rejects } = assert;
+const { strictEqual, rejects } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -31,10 +31,8 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     stream.onreset = mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
-      // The DefaultApplication's internal error code is 0x1n, which
-      // util.format renders as `1n` (BigInt) in the message text.
-      ok(err.message.includes('1n'),
-         `expected '1n' in message, got: ${err.message}`);
+      // The DefaultApplication's internal error code is 0x1n.
+      strictEqual(err.errorCode, 1n);
       serverResetSeen.resolve();
     });
 

--- a/test/parallel/test-quic-stream-destroy-options-code.mjs
+++ b/test/parallel/test-quic-stream-destroy-options-code.mjs
@@ -13,7 +13,7 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, ok, rejects } = assert;
+const { strictEqual, rejects } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -27,8 +27,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     stream.onreset = mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
-      ok(err.message.includes('66n'),
-         `expected '66n' in message, got: ${err.message}`);
+      strictEqual(err.errorCode, 66n);
       serverResetSeen.resolve();
     });
 

--- a/test/parallel/test-quic-stream-writer-fail-error-code.mjs
+++ b/test/parallel/test-quic-stream-writer-fail-error-code.mjs
@@ -17,11 +17,8 @@
 //      the QuicError fast path.
 //
 // The peer-side observation goes through `stream.onreset(err)` where
-// `err` is `ERR_QUIC_APPLICATION_ERROR` carrying the wire code in its
-// message string. We extract the code via regex; once
-// `ERR_QUIC_APPLICATION_ERROR` exposes the numeric code as a property
-// (a planned follow-up), this test can switch to direct property
-// access.
+// `err` is `ERR_QUIC_APPLICATION_ERROR` exposing the wire code on
+// `err.errorCode` (a BigInt).
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
@@ -35,19 +32,9 @@ if (!hasQuic) {
 const { listen, connect } = await import('../common/quic.mjs');
 const { QuicError } = await import('node:quic');
 
-// Extract the numeric wire code from an ERR_QUIC_APPLICATION_ERROR
-// message of the form
-//   "A QUIC application error occurred. <code>n [<reason>]"
-// where the trailing `n` on the code is the BigInt formatting from
-// `util.format('%d', bigint)`. RESET_STREAM frames do not carry a
-// reason string, so the bracketed value is typically `undefined`.
 function wireCodeOf(err) {
   strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
-  const match = err.message.match(/A QUIC application error occurred\. (\d+)n /);
-  if (!match) {
-    throw new Error(`Could not extract code from message: ${err.message}`);
-  }
-  return BigInt(match[1]);
+  return err.errorCode;
 }
 
 // Server: capture the next two streams. Each stream receives an


### PR DESCRIPTION
This wraps QUIC errors, providing useful error codes and messages for the defined error code cases from both OpenSSL and ngtcp2.

Before this, QUIC errors looked like:

```js
// Application error with an explicit reason string:
Error [ERR_QUIC_APPLICATION_ERROR]: A QUIC application error occurred. 42n [client shutdown]
    at [kFinishClose] (node:internal/quic/quic:3505:22)
    at Session.onSessionClose (node:internal/quic/quic:679:31) {
  code: 'ERR_QUIC_APPLICATION_ERROR'
}

// All our internal errors:
Error [ERR_QUIC_TRANSPORT_ERROR]: A QUIC transport error occurred. 296n [undefined]
    at [kFinishClose] (node:internal/quic/quic:3502:22)
    at Session.onSessionClose (node:internal/quic/quic:679:31) {
  code: 'ERR_QUIC_TRANSPORT_ERROR'
}
```

Now they look like:

```js
Error [ERR_QUIC_APPLICATION_ERROR]: QUIC application error 42: client shutdown
    at makeQuicError (node:internal/quic/quic:999:15)
    at [kFinishClose] (node:internal/quic/quic:3552:22)
    at Session.onSessionClose (node:internal/quic/quic:681:31) {
  code: 'ERR_QUIC_APPLICATION_ERROR',
  errorCode: 42n,
  type: 'application',
  reason: 'client shutdown'
}

Error [ERR_QUIC_TRANSPORT_ERROR]: QUIC transport error handshake failure (296)
    at makeQuicError (node:internal/quic/quic:988:15)
    at [kFinishClose] (node:internal/quic/quic:3534:22)
    at Session.onSessionClose (node:internal/quic/quic:681:31) {
  code: 'ERR_QUIC_TRANSPORT_ERROR',
  errorCode: 296n,
  type: 'transport',
  errorName: 'handshake failure'
}
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
