### PR TITLE
test: reduce flakiness of `different-registry-per-thread`

### DIFF
--- a/test/fixtures/process/different-registry-per-thread.mjs
+++ b/test/fixtures/process/different-registry-per-thread.mjs
@@ -1,15 +1,26 @@
 import { isMainThread, Worker } from 'node:worker_threads';
 
+const registeredRefs = [];
+
+const ref = { foo: 'foo' };
+registeredRefs.push(ref);
+
 if (isMainThread) {
-  process.finalization.register({ foo: 'foo' }, () => {
+  process.finalization.register(ref, () => {
     process.stdout.write('shutdown on main thread\n');
   });
 
   const worker = new Worker(import.meta.filename);
 
+  worker.on('error', (err) => {
+    // Referencing `registeredRefs` here to avoid `ref` being GCed before the worker exits.
+    console.log(registeredRefs);
+    throw err;
+  });
+
   worker.postMessage('ping');
 } else {
-  process.finalization.register({ foo: 'bar' }, () => {
+  process.finalization.register(ref, () => {
     process.stdout.write('shutdown on worker\n');
   });
 }

--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -44,6 +44,8 @@ if (r.arrayBuffers > 0) {
   const after = process.memoryUsage();
   assert.ok(after.external - r.external >= size,
             `${after.external} - ${r.external} >= ${size}`);
-  assert.strictEqual(after.arrayBuffers - r.arrayBuffers, size,
-                     `${after.arrayBuffers} - ${r.arrayBuffers} === ${size}`);
+  // `arrayBuffers` is process-wide, so unrelated backing stores may be freed
+  // between the two snapshots. Check that the live ArrayBuffer is included.
+  assert.ok(after.arrayBuffers >= size,
+            `${after.arrayBuffers} >= ${size}`);
 }


### PR DESCRIPTION
There was an assumption that the `WeakRef` would be kept alive but it seems to not always be true on Windows. This commit makes sure it's kept alive.

Refs: https://github.com/nodejs/node/pull/63057#issuecomment-4366638735
Fixes: https://github.com/nodejs/node/issues/63056

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
