### PR TITLE
doc: replace Visual Studio 2022 Evergreen version reference with 17.14

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -752,7 +752,7 @@ Refs:
   To install it, select the following two optional components:
   * C++ Clang Compiler for Windows (Microsoft.VisualStudio.Component.VC.Llvm.Clang)
   * MSBuild support for LLVM (clang-cl) toolset (Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset)
-* As an alternative to Visual Studio 2026, download Visual Studio 2022 Current channel Version 17.4 from the
+* As an alternative to Visual Studio 2026, download Visual Studio 2022 Current channel Version 17.14 from the
   [Evergreen bootstrappers](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history#evergreen-bootstrappers)
   table and install using the same workload and optional component selection as described above.
 * Basic Unix tools required for some tests,


### PR DESCRIPTION
[BUILDING > Windows Prerequisites > Manual Install](https://github.com/nodejs/node/blob/main/BUILDING.md#option-1-manual-install)
is corrected to refer to Visual Studio 2022 Current channel Version 17.14, instead of 17.4.

This was a typo from PR https://github.com/nodejs/node/pull/61655

Visual Studio 2022 Current channel according to [Evergreen bootstrappers](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history#evergreen-bootstrappers) is 17.14.

## Backporting

Currently, branches v24.x, v25.x & v26.x contain the incorrect version reference "17.4" in `BUILDING.md`

Does not apply to v22.x.