### PR TITLE
test: gc before test-memory-usage baseline

### DIFF
--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -19,10 +19,14 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-// Flags: --predictable-gc-schedule
+// Flags: --expose-gc --predictable-gc-schedule
 'use strict';
 const common = require('../common');
 const assert = require('assert');
+
+// Clear stale ArrayBuffer backing stores before taking the baseline so the
+// exact allocation delta below is not affected by unrelated cleanup.
+globalThis.gc();
 
 const r = process.memoryUsage();
 // On IBMi, the rss memory always returns zero


### PR DESCRIPTION
Call gc() before taking the test-memory-usage baseline so stale ArrayBuffer backing stores are cleared before the strict delta check.

This keeps the exact 10 MiB assertion while avoiding unrelated cleanup between snapshots.

Fixes: https://github.com/nodejs/node/issues/63210