### PR TITLE
test: relax test-memory-usage arrayBuffers check

### DIFF
--- a/test/parallel/test-memory-usage.js
+++ b/test/parallel/test-memory-usage.js
@@ -44,6 +44,8 @@ if (r.arrayBuffers > 0) {
   const after = process.memoryUsage();
   assert.ok(after.external - r.external >= size,
             `${after.external} - ${r.external} >= ${size}`);
-  assert.strictEqual(after.arrayBuffers - r.arrayBuffers, size,
-                     `${after.arrayBuffers} - ${r.arrayBuffers} === ${size}`);
+  // `arrayBuffers` is process-wide, so unrelated backing stores may be freed
+  // between the two snapshots. Check that the live ArrayBuffer is included.
+  assert.ok(after.arrayBuffers >= size,
+            `${after.arrayBuffers} >= ${size}`);
 }


### PR DESCRIPTION
The previous GC-before-baseline approach did not make the exact `arrayBuffers` delta stable in CI.
Refs: https://github.com/nodejs/node/pull/63214#issuecomment-4413260011

`process.memoryUsage().arrayBuffers` is process-wide, so unrelated ArrayBuffer/Buffer backing stores may be freed between snapshots. This keeps the test checking that the live 10 MiB `ArrayBuffer` is included, without requiring an exact process-wide delta.

Fixes: https://github.com/nodejs/node/issues/63210