### PR TITLE
deps: cherry-pick libuv/libuv@a43e543

### DIFF
--- a/deps/uv/src/unix/fs.c
+++ b/deps/uv/src/unix/fs.c
@@ -460,27 +460,28 @@ static ssize_t uv__preadv_or_pwritev(int fd,
                                      off_t off,
                                      _Atomic uintptr_t* cache,
                                      int is_pread) {
-  ssize_t (*f)(int, const struct iovec*, uv__iovcnt, off_t);
-  void* p;
+  union {
+    ssize_t (*f)(int, const struct iovec*, uv__iovcnt, off_t);
+    void* p;
+  } u;
 
-  p = (void*) atomic_load_explicit(cache, memory_order_relaxed);
-  if (p == NULL) {
+  u.p = (void*) atomic_load_explicit(cache, memory_order_relaxed);
+  if (u.p == NULL) {
 #ifdef RTLD_DEFAULT
     /* Try _LARGEFILE_SOURCE version of preadv/pwritev first,
      * then fall back to the plain version, for libcs like musl.
      */
-    p = dlsym(RTLD_DEFAULT, is_pread ? "preadv64" : "pwritev64");
-    if (p == NULL)
-      p = dlsym(RTLD_DEFAULT, is_pread ? "preadv" : "pwritev");
+    u.p = dlsym(RTLD_DEFAULT, is_pread ? "preadv64" : "pwritev64");
+    if (u.p == NULL)
+      u.p = dlsym(RTLD_DEFAULT, is_pread ? "preadv" : "pwritev");
     dlerror();  /* Clear errors. */
 #endif  /* RTLD_DEFAULT */
-    if (p == NULL)
-      p = is_pread ? uv__preadv_emul : uv__pwritev_emul;
-    atomic_store_explicit(cache, (uintptr_t) p, memory_order_relaxed);
+    if (u.p == NULL)
+      u.f = is_pread ? uv__preadv_emul : uv__pwritev_emul;
+    atomic_store_explicit(cache, (uintptr_t) u.p, memory_order_relaxed);
   }
 
-  f = p;
-  return f(fd, bufs, nbufs, off);
+  return u.f(fd, bufs, nbufs, off);
 }
 
 

--- a/deps/uv/src/uv-common.c
+++ b/deps/uv/src/uv-common.c
@@ -957,7 +957,7 @@ void uv_free_cpu_info(uv_cpu_info_t* cpu_infos, int count) {
   int i;
 
   for (i = 0; i < count; i++)
-    uv__free(cpu_infos[i].model);
+    uv__free((char*) cpu_infos[i].model);
 
   uv__free(cpu_infos);
 #endif  /* __linux__ */


### PR DESCRIPTION
Cherry-picks the upstream libuv fix for two pedantic-clang warnings. 

Without this `deps/uv/src/uv-common.c:960` fails to compile under stricter clang configurations (bundled Chromium clang under `-Werror`) because `uv__free(cpu_infos[i].model)` discards the `const` qualifier on `uv_cpu_info_t::model`.

Fixes: https://github.com/nodejs/node/issues/63196
Refs: https://github.com/libuv/libuv/pull/5052

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
