### PR TITLE
src: skip duplicate UTF-8 validation in TextDecoder fatal path

### DIFF
--- a/benchmark/util/text-decoder.js
+++ b/benchmark/util/text-decoder.js
@@ -6,26 +6,42 @@ const bench = common.createBenchmark(main, {
   encoding: ['utf-8', 'windows-1252', 'iso-8859-3'],
   ignoreBOM: [0, 1],
   fatal: [0, 1],
+  type: ['SharedArrayBuffer', 'ArrayBuffer', 'Buffer'],
+  content: ['ascii', 'one-byte-string', 'two-byte-string'],
   len: [256, 1024 * 16, 1024 * 128],
   n: [1e3],
-  type: ['SharedArrayBuffer', 'ArrayBuffer', 'Buffer'],
 });
 
-function main({ encoding, len, n, ignoreBOM, type, fatal }) {
+function buildContent(content, len) {
+  let base;
+  switch (content) {
+    case 'ascii': base = 'a'; break;
+    case 'one-byte-string': base = '\xff'; break;
+    case 'two-byte-string': base = 'ğ'; break;
+  }
+  const unitBytes = Buffer.byteLength(base, 'utf8');
+  const copies = Math.max(1, Math.floor(len / unitBytes));
+  return Buffer.from(base.repeat(copies));
+}
+
+function main({ encoding, len, n, ignoreBOM, type, fatal, content }) {
   const decoder = new TextDecoder(encoding, { ignoreBOM, fatal });
+  const seed = buildContent(content, len);
   let buf;
 
   switch (type) {
     case 'SharedArrayBuffer': {
-      buf = new SharedArrayBuffer(len);
+      buf = new SharedArrayBuffer(seed.length);
+      new Uint8Array(buf).set(seed);
       break;
     }
     case 'ArrayBuffer': {
-      buf = new ArrayBuffer(len);
+      buf = new ArrayBuffer(seed.length);
+      new Uint8Array(buf).set(seed);
       break;
     }
     case 'Buffer': {
-      buf = Buffer.allocUnsafe(len);
+      buf = seed;
       break;
     }
   }

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -459,14 +459,16 @@ void BindingData::DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
       return node::THROW_ERR_ENCODING_INVALID_ENCODED_DATA(
           env->isolate(), "The encoded data was not valid for encoding utf-8");
     }
-
-    // TODO(chalker): save on utf8 validity recheck in StringBytes::Encode()
   }
 
   if (length == 0) return args.GetReturnValue().SetEmptyString();
 
   Local<Value> ret;
-  if (StringBytes::Encode(env->isolate(), data, length, UTF8).ToLocal(&ret)) {
+  v8::MaybeLocal<Value> encoded =
+      has_fatal
+          ? StringBytes::EncodeValidUtf8(env->isolate(), data, length)
+          : StringBytes::Encode(env->isolate(), data, length, UTF8);
+  if (encoded.ToLocal(&ret)) {
     args.GetReturnValue().Set(ret);
   }
 }

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -465,9 +465,8 @@ void BindingData::DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
 
   Local<Value> ret;
   v8::MaybeLocal<Value> encoded =
-      has_fatal
-          ? StringBytes::EncodeValidUtf8(env->isolate(), data, length)
-          : StringBytes::Encode(env->isolate(), data, length, UTF8);
+      has_fatal ? StringBytes::EncodeValidUtf8(env->isolate(), data, length)
+                : StringBytes::Encode(env->isolate(), data, length, UTF8);
   if (encoded.ToLocal(&ret)) {
     args.GetReturnValue().Set(ret);
   }

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -671,6 +671,40 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
   }
 }
 
+MaybeLocal<Value> StringBytes::EncodeValidUtf8(Isolate* isolate,
+                                               const char* buf,
+                                               size_t buflen) {
+  CHECK_BUFLEN_IN_RANGE(buflen);
+  if (!buflen) return String::Empty(isolate);
+  buflen = keep_buflen_in_range(buflen);
+
+  // ASCII fast path
+  if (!simdutf::validate_ascii_with_errors(buf, buflen).error) {
+    return ExternOneByteString::NewFromCopy(isolate, buf, buflen);
+  }
+
+  if (buflen >= 32) {
+    size_t u16size = simdutf::utf16_length_from_utf8(buf, buflen);
+    if (u16size > static_cast<size_t>(v8::String::kMaxLength)) {
+      isolate->ThrowException(ERR_STRING_TOO_LONG(isolate));
+      return MaybeLocal<Value>();
+    }
+    return EncodeTwoByteString(
+        isolate, u16size, [buf, buflen, u16size](uint16_t* dst) {
+          size_t written = simdutf::convert_valid_utf8_to_utf16(
+              buf, buflen, reinterpret_cast<char16_t*>(dst));
+          CHECK_EQ(written, u16size);
+        });
+  }
+
+  Local<String> str;
+  if (!String::NewFromUtf8(isolate, buf, v8::NewStringType::kNormal, buflen)
+           .ToLocal(&str)) {
+    isolate->ThrowException(node::ERR_STRING_TOO_LONG(isolate));
+  }
+  return str;
+}
+
 MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
                                       const uint16_t* buf,
                                       size_t buflen) {

--- a/src/string_bytes.h
+++ b/src/string_bytes.h
@@ -83,6 +83,11 @@ class StringBytes {
                                           size_t buflen,
                                           enum encoding encoding);
 
+  // Like Encode(..., UTF8) but does not re-validate. Input must be valid UTF-8.
+  static v8::MaybeLocal<v8::Value> EncodeValidUtf8(v8::Isolate* isolate,
+                                                   const char* buf,
+                                                   size_t buflen);
+
   // Warning: This reverses endianness on BE platforms, even though the
   // signature using uint16_t implies that it should not.
   // However, the brokenness is already public API and can't therefore


### PR DESCRIPTION
In TextDecoder's strict mode, the utf-8 buffer was being validated twice, I removed the second validation, non-asci decoding in strict mode is now 27–34% faster 

Bench results (verry long, I wrote a gist file):

https://gist.github.com/mertcanaltin/42f2fe0808e85741bcc76e7f59a4229e

Short results:

```
util/text-decoder.js fatal=1 encoding='utf-8' content='one-byte-string'
  len=131072 ArrayBuffer       +31.14% ±1.90%
  len=131072 Buffer            +32.05% ±1.31%
  len=131072 SharedArrayBuffer +31.54% ±0.75%
  len=16384  ArrayBuffer       +28.06% ±1.73%
  len=16384  Buffer            +27.49% ±2.92%
  len=16384  SharedArrayBuffer +28.03% ±1.77%

util/text-decoder.js fatal=1 encoding='utf-8' content='two-byte-string'
  len=131072 ArrayBuffer       +33.67% ±1.17%
  len=131072 Buffer            +34.15% ±1.73%
  len=131072 SharedArrayBuffer +34.03% ±1.12%
  len=16384  ArrayBuffer       +31.13% ±1.71%
  len=16384  Buffer            +29.02% ±1.73%
  len=16384  SharedArrayBuffer +28.34% ±2.12%

util/text-decoder-stream.js unicode=1 fatal=1 encoding='utf-8'
  len=131072 Buffer            +11.66%
  len=131072 SharedArrayBuffer  +9.36%
  len=16384  Buffer             +8.08%
  len=16384  SharedArrayBuffer  +6.65%
```



