### PR TITLE
test: migrate nexttick message test to JS

### DIFF
--- a/test/fixtures/errors/nexttick_throw.js
+++ b/test/fixtures/errors/nexttick_throw.js
@@ -20,7 +20,7 @@
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 'use strict';
-require('../common');
+require('../../common');
 
 process.nextTick(function() {
   process.nextTick(function() {

--- a/test/fixtures/errors/nexttick_throw.snapshot
+++ b/test/fixtures/errors/nexttick_throw.snapshot
@@ -1,0 +1,9 @@
+<project-root>/test/fixtures/errors/nexttick_throw.js:30
+        undefined_reference_error_maker;
+        ^
+
+ReferenceError: undefined_reference_error_maker is not defined
+    at <project-root>/test/fixtures/errors/nexttick_throw.js:30:9
+    at <node-internal-frames>
+
+Node.js <node-version>

--- a/test/message/nexttick_throw.out
+++ b/test/message/nexttick_throw.out
@@ -1,9 +1,0 @@
-
-*test*message*nexttick_throw.js:*
-        undefined_reference_error_maker;
-        ^
-ReferenceError: undefined_reference_error_maker is not defined
-    at *test*message*nexttick_throw.js:*:*
-    at process.processTicksAndRejections (node:internal/process/task_queues:*:*)
-
-Node.js *

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -25,6 +25,7 @@ describe('errors output', { concurrency: !process.env.TEST_PARALLEL }, () => {
     { name: 'errors/events_unhandled_error_sameline.js' },
     { name: 'errors/events_unhandled_error_subclass.js' },
     { name: 'errors/if-error-has-good-stack.js' },
+    { name: 'errors/nexttick_throw.js' },
     { name: 'errors/throw_custom_error.js' },
     { name: 'errors/throw_error_with_getter_throw.js' },
     { name: 'errors/throw_in_eval_anonymous.js' },


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/47707

Migrate the `nexttick_throw` message test from the legacy Python message runner to the snapshot-based JS output suite.

The fixture now lives under `test/fixtures/errors`, has a `.snapshot` file, and is covered by `test/parallel/test-node-output-errors.mjs`.

Testing:
- `node --test --test-name-pattern nexttick_throw test/parallel/test-node-output-errors.mjs`
- `node tools/eslint/node_modules/eslint/bin/eslint.js --max-warnings=0 --report-unused-disable-directives --rule "@stylistic/js/linebreak-style: 0" test/fixtures/errors/nexttick_throw.js test/parallel/test-node-output-errors.mjs`