### PR TITLE
test: migrate internal assert fail message test

### DIFF
--- a/test/fixtures/errors/internal_assert_fail.js
+++ b/test/fixtures/errors/internal_assert_fail.js
@@ -1,7 +1,7 @@
 'use strict';
 
 // Flags: --expose-internals
-require('../common');
+require('../../common');
 
 const assert = require('internal/assert');
 assert.fail('Unreachable!');

--- a/test/fixtures/errors/internal_assert_fail.snapshot
+++ b/test/fixtures/errors/internal_assert_fail.snapshot
@@ -1,4 +1,4 @@
-node:internal/assert:*
+node:internal/assert:<line>
   throw new ERR_INTERNAL_ASSERTION(message);
   ^
 
@@ -6,16 +6,11 @@ Error [ERR_INTERNAL_ASSERTION]: Unreachable!
 This is caused by either a bug in Node.js or incorrect usage of Node.js internals.
 Please open an issue with this stack trace at https://github.com/nodejs/node/issues
 
-    at assert.fail (node:internal/assert:*:*)
-    at * (*test*message*internal_assert_fail.js:7:8)
-    at *
-    at *
-    at *
-    at *
-    at *
-    at *
-    at * {
+    at <node-internal-frames>
+    at Object.<anonymous> (<project-root>/test/fixtures/errors/internal_assert_fail.js:7:8)
+    at <node-internal-frames>
+    at <node-internal-frames> {
   code: 'ERR_INTERNAL_ASSERTION'
 }
 
-Node.js *
+Node.js <node-version>

--- a/test/parallel/test-node-output-errors.mjs
+++ b/test/parallel/test-node-output-errors.mjs
@@ -25,6 +25,7 @@ describe('errors output', { concurrency: !process.env.TEST_PARALLEL }, () => {
     { name: 'errors/events_unhandled_error_sameline.js' },
     { name: 'errors/events_unhandled_error_subclass.js' },
     { name: 'errors/if-error-has-good-stack.js' },
+    { name: 'errors/internal_assert_fail.js' },
     { name: 'errors/throw_custom_error.js' },
     { name: 'errors/throw_error_with_getter_throw.js' },
     { name: 'errors/throw_in_eval_anonymous.js' },


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/47707

Migrate the `internal_assert_fail` message test from the legacy Python message runner to the snapshot-based JS output suite.

The fixture now lives under `test/fixtures/errors`, has a `.snapshot` file, and is covered by `test/parallel/test-node-output-errors.mjs`.

Testing:
- `node --test --test-name-pattern internal_assert_fail test/parallel/test-node-output-errors.mjs`
- `node tools/eslint/node_modules/eslint/bin/eslint.js --max-warnings=0 --report-unused-disable-directives --rule "@stylistic/js/linebreak-style: 0" test/fixtures/errors/internal_assert_fail.js test/parallel/test-node-output-errors.mjs`