### PR TITLE
test: migrate node --run message test

### DIFF
--- a/test/fixtures/run-script/node_run_non_existent.js
+++ b/test/fixtures/run-script/node_run_non_existent.js
@@ -1,9 +1,9 @@
 'use strict';
 
-require('../common');
+require('../../common');
 const assert = require('node:assert/strict');
 const childProcess = require('node:child_process');
-const fixtures = require('../common/fixtures');
+const fixtures = require('../../common/fixtures');
 
 const child = childProcess.spawnSync(
   process.execPath,

--- a/test/fixtures/run-script/node_run_non_existent.snapshot
+++ b/test/fixtures/run-script/node_run_non_existent.snapshot
@@ -1,4 +1,4 @@
-Missing script: "non-existent-command" for *
+Missing script: "non-existent-command" for <project-root>/test/fixtures/run-script/package.json
 
 Available scripts are:
   test: echo "Error: no test specified" && exit 1
@@ -14,3 +14,4 @@ Available scripts are:
   special-env-variables-windows: special-env-variables.bat
   pwd: pwd
   pwd-windows: cd
+

--- a/test/parallel/test-node-output-run.mjs
+++ b/test/parallel/test-node-output-run.mjs
@@ -1,0 +1,15 @@
+import '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import * as snapshot from '../common/assertSnapshot.js';
+import { describe, it } from 'node:test';
+
+describe('node --run output', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  const tests = [
+    { name: 'run-script/node_run_non_existent.js' },
+  ];
+  for (const { name } of tests) {
+    it(name, async () => {
+      await snapshot.spawnAndAssert(fixtures.path(name), snapshot.defaultTransform);
+    });
+  }
+});


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/47707

Migrate the `node_run_non_existent` message test from the legacy Python message runner to the snapshot-based JS output suite.

The fixture now lives under `test/fixtures/run-script`, has a `.snapshot` file, and is covered by a `node --run` output snapshot test.

Testing:
- `node --test test/parallel/test-node-output-run.mjs`
- `node tools/eslint/node_modules/eslint/bin/eslint.js --max-warnings=0 --report-unused-disable-directives --rule "@stylistic/js/linebreak-style: 0" test/parallel/test-node-output-run.mjs`