### PR TITLE
test: migrate buffer encoding tests to node:test

### DIFF
--- a/test/parallel/test-bad-unicode.js
+++ b/test/parallel/test-bad-unicode.js
@@ -21,13 +21,17 @@
 
 'use strict';
 require('../common');
+const { test } = require('node:test');
 const assert = require('assert');
-let exception = null;
 
-try {
-  eval('"\\uc/ef"');
-} catch (e) {
-  exception = e;
-}
+test('invalid unicode escape throws SyntaxError', () => {
+  let exception = null;
 
-assert(exception instanceof SyntaxError);
+  try {
+    eval('"\\uc/ef"');
+  } catch (e) {
+    exception = e;
+  }
+
+  assert(exception instanceof SyntaxError);
+});

--- a/test/parallel/test-buffer-badhex.js
+++ b/test/parallel/test-buffer-badhex.js
@@ -1,48 +1,51 @@
 'use strict';
 require('../common');
+const { test } = require('node:test');
 const assert = require('assert');
 
-// Test hex strings and bad hex strings
-{
-  const buf = Buffer.alloc(4);
-  assert.strictEqual(buf.length, 4);
-  assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
-  assert.strictEqual(buf.write('abcdxx', 0, 'hex'), 2);
-  assert.deepStrictEqual(buf, Buffer.from([0xab, 0xcd, 0x00, 0x00]));
-  assert.strictEqual(buf.toString('hex'), 'abcd0000');
-  assert.strictEqual(buf.write('abcdef01', 0, 'hex'), 4);
-  assert.deepStrictEqual(buf, Buffer.from([0xab, 0xcd, 0xef, 0x01]));
-  assert.strictEqual(buf.toString('hex'), 'abcdef01');
+test('Buffer handles invalid hex input', () => {
+  // Test hex strings and bad hex strings
+  {
+    const buf = Buffer.alloc(4);
+    assert.strictEqual(buf.length, 4);
+    assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
+    assert.strictEqual(buf.write('abcdxx', 0, 'hex'), 2);
+    assert.deepStrictEqual(buf, Buffer.from([0xab, 0xcd, 0x00, 0x00]));
+    assert.strictEqual(buf.toString('hex'), 'abcd0000');
+    assert.strictEqual(buf.write('abcdef01', 0, 'hex'), 4);
+    assert.deepStrictEqual(buf, Buffer.from([0xab, 0xcd, 0xef, 0x01]));
+    assert.strictEqual(buf.toString('hex'), 'abcdef01');
 
-  const copy = Buffer.from(buf.toString('hex'), 'hex');
-  assert.strictEqual(buf.toString('hex'), copy.toString('hex'));
-}
+    const copy = Buffer.from(buf.toString('hex'), 'hex');
+    assert.strictEqual(buf.toString('hex'), copy.toString('hex'));
+  }
 
-{
-  const buf = Buffer.alloc(5);
-  assert.strictEqual(buf.write('abcdxx', 1, 'hex'), 2);
-  assert.strictEqual(buf.toString('hex'), '00abcd0000');
-}
+  {
+    const buf = Buffer.alloc(5);
+    assert.strictEqual(buf.write('abcdxx', 1, 'hex'), 2);
+    assert.strictEqual(buf.toString('hex'), '00abcd0000');
+  }
 
-{
-  const buf = Buffer.alloc(4);
-  assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
-  assert.strictEqual(buf.write('xxabcd', 0, 'hex'), 0);
-  assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
-  assert.strictEqual(buf.write('xxab', 1, 'hex'), 0);
-  assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
-  assert.strictEqual(buf.write('cdxxab', 0, 'hex'), 1);
-  assert.deepStrictEqual(buf, Buffer.from([0xcd, 0, 0, 0]));
-}
+  {
+    const buf = Buffer.alloc(4);
+    assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
+    assert.strictEqual(buf.write('xxabcd', 0, 'hex'), 0);
+    assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
+    assert.strictEqual(buf.write('xxab', 1, 'hex'), 0);
+    assert.deepStrictEqual(buf, Buffer.from([0, 0, 0, 0]));
+    assert.strictEqual(buf.write('cdxxab', 0, 'hex'), 1);
+    assert.deepStrictEqual(buf, Buffer.from([0xcd, 0, 0, 0]));
+  }
 
-{
-  const buf = Buffer.alloc(256);
-  for (let i = 0; i < 256; i++)
-    buf[i] = i;
+  {
+    const buf = Buffer.alloc(256);
+    for (let i = 0; i < 256; i++)
+      buf[i] = i;
 
-  const hex = buf.toString('hex');
-  assert.deepStrictEqual(Buffer.from(hex, 'hex'), buf);
+    const hex = buf.toString('hex');
+    assert.deepStrictEqual(Buffer.from(hex, 'hex'), buf);
 
-  const badHex = `${hex.slice(0, 256)}xx${hex.slice(256, 510)}`;
-  assert.deepStrictEqual(Buffer.from(badHex, 'hex'), buf.slice(0, 128));
-}
+    const badHex = `${hex.slice(0, 256)}xx${hex.slice(256, 510)}`;
+    assert.deepStrictEqual(Buffer.from(badHex, 'hex'), buf.slice(0, 128));
+  }
+});


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/47707

Migrate two small legacy script-style parallel tests to `node:test`:

- `test-buffer-badhex.js`
- `test-bad-unicode.js`

The assertions and behavior are unchanged; the test bodies are wrapped in named `test()` calls.

Validation:
- `node --test test/parallel/test-buffer-badhex.js test/parallel/test-bad-unicode.js`
- `node -c test/parallel/test-buffer-badhex.js`
- `node -c test/parallel/test-bad-unicode.js`
- `node tools/eslint/node_modules/eslint/bin/eslint.js test/parallel/test-buffer-badhex.js test/parallel/test-bad-unicode.js`

I could not run the project `tools/test.py` harness in this checkout because there is no built `node.exe` present.