### PR TITLE
test: migrate buffer compare tests to node:test

### DIFF
--- a/test/parallel/test-buffer-compare-offset.js
+++ b/test/parallel/test-buffer-compare-offset.js
@@ -1,94 +1,97 @@
 'use strict';
 
 require('../common');
+const { test } = require('node:test');
 const assert = require('assert');
 
-const a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
-const b = Buffer.from([5, 6, 7, 8, 9, 0, 1, 2, 3, 4]);
+test('Buffer.prototype.compare() handles offset arguments', () => {
+  const a = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 0]);
+  const b = Buffer.from([5, 6, 7, 8, 9, 0, 1, 2, 3, 4]);
 
-assert.strictEqual(a.compare(b), -1);
+  assert.strictEqual(a.compare(b), -1);
 
-// Equivalent to a.compare(b).
-assert.strictEqual(a.compare(b, 0), -1);
-assert.throws(() => a.compare(b, '0'), { code: 'ERR_INVALID_ARG_TYPE' });
-assert.strictEqual(a.compare(b, undefined), -1);
+  // Equivalent to a.compare(b).
+  assert.strictEqual(a.compare(b, 0), -1);
+  assert.throws(() => a.compare(b, '0'), { code: 'ERR_INVALID_ARG_TYPE' });
+  assert.strictEqual(a.compare(b, undefined), -1);
 
-// Equivalent to a.compare(b).
-assert.strictEqual(a.compare(b, 0, undefined, 0), -1);
+  // Equivalent to a.compare(b).
+  assert.strictEqual(a.compare(b, 0, undefined, 0), -1);
 
-// Zero-length target, return 1
-assert.strictEqual(a.compare(b, 0, 0, 0), 1);
-assert.throws(
-  () => a.compare(b, 0, '0', '0'),
-  { code: 'ERR_INVALID_ARG_TYPE' }
-);
+  // Zero-length target, return 1
+  assert.strictEqual(a.compare(b, 0, 0, 0), 1);
+  assert.throws(
+    () => a.compare(b, 0, '0', '0'),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
 
-// Equivalent to Buffer.compare(a, b.slice(6, 10))
-assert.strictEqual(a.compare(b, 6, 10), 1);
+  // Equivalent to Buffer.compare(a, b.slice(6, 10))
+  assert.strictEqual(a.compare(b, 6, 10), 1);
 
-// Zero-length source, return -1
-assert.strictEqual(a.compare(b, 6, 10, 0, 0), -1);
+  // Zero-length source, return -1
+  assert.strictEqual(a.compare(b, 6, 10, 0, 0), -1);
 
-// Zero-length source and target, return 0
-assert.strictEqual(a.compare(b, 0, 0, 0, 0), 0);
-assert.strictEqual(a.compare(b, 1, 1, 2, 2), 0);
+  // Zero-length source and target, return 0
+  assert.strictEqual(a.compare(b, 0, 0, 0, 0), 0);
+  assert.strictEqual(a.compare(b, 1, 1, 2, 2), 0);
 
-// Equivalent to Buffer.compare(a.slice(4), b.slice(0, 5))
-assert.strictEqual(a.compare(b, 0, 5, 4), 1);
+  // Equivalent to Buffer.compare(a.slice(4), b.slice(0, 5))
+  assert.strictEqual(a.compare(b, 0, 5, 4), 1);
 
-// Equivalent to Buffer.compare(a.slice(1), b.slice(5))
-assert.strictEqual(a.compare(b, 5, undefined, 1), 1);
+  // Equivalent to Buffer.compare(a.slice(1), b.slice(5))
+  assert.strictEqual(a.compare(b, 5, undefined, 1), 1);
 
-// Equivalent to Buffer.compare(a.slice(2), b.slice(2, 4))
-assert.strictEqual(a.compare(b, 2, 4, 2), -1);
+  // Equivalent to Buffer.compare(a.slice(2), b.slice(2, 4))
+  assert.strictEqual(a.compare(b, 2, 4, 2), -1);
 
-// Equivalent to Buffer.compare(a.slice(4), b.slice(0, 7))
-assert.strictEqual(a.compare(b, 0, 7, 4), -1);
+  // Equivalent to Buffer.compare(a.slice(4), b.slice(0, 7))
+  assert.strictEqual(a.compare(b, 0, 7, 4), -1);
 
-// Equivalent to Buffer.compare(a.slice(4, 6), b.slice(0, 7));
-assert.strictEqual(a.compare(b, 0, 7, 4, 6), -1);
+  // Equivalent to Buffer.compare(a.slice(4, 6), b.slice(0, 7));
+  assert.strictEqual(a.compare(b, 0, 7, 4, 6), -1);
 
-// Null is ambiguous.
-assert.throws(
-  () => a.compare(b, 0, null),
-  { code: 'ERR_INVALID_ARG_TYPE' }
-);
+  // Null is ambiguous.
+  assert.throws(
+    () => a.compare(b, 0, null),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
 
-// Values do not get coerced.
-assert.throws(
-  () => a.compare(b, 0, { valueOf: () => 5 }),
-  { code: 'ERR_INVALID_ARG_TYPE' }
-);
+  // Values do not get coerced.
+  assert.throws(
+    () => a.compare(b, 0, { valueOf: () => 5 }),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
 
-// Infinity should not be coerced.
-assert.throws(
-  () => a.compare(b, Infinity, -Infinity),
-  { code: 'ERR_OUT_OF_RANGE' }
-);
+  // Infinity should not be coerced.
+  assert.throws(
+    () => a.compare(b, Infinity, -Infinity),
+    { code: 'ERR_OUT_OF_RANGE' }
+  );
 
-// Zero length target because default for targetEnd <= targetSource
-assert.strictEqual(a.compare(b, 0xff), 1);
+  // Zero length target because default for targetEnd <= targetSource
+  assert.strictEqual(a.compare(b, 0xff), 1);
 
-assert.throws(
-  () => a.compare(b, '0xff'),
-  { code: 'ERR_INVALID_ARG_TYPE' }
-);
-assert.throws(
-  () => a.compare(b, 0, '0xff'),
-  { code: 'ERR_INVALID_ARG_TYPE' }
-);
+  assert.throws(
+    () => a.compare(b, '0xff'),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
+  assert.throws(
+    () => a.compare(b, 0, '0xff'),
+    { code: 'ERR_INVALID_ARG_TYPE' }
+  );
 
-const oor = { code: 'ERR_OUT_OF_RANGE' };
+  const oor = { code: 'ERR_OUT_OF_RANGE' };
 
-assert.throws(() => a.compare(b, 0, 100, 0), oor);
-assert.throws(() => a.compare(b, 0, 1, 0, 100), oor);
-assert.throws(() => a.compare(b, -1), oor);
-assert.throws(() => a.compare(b, 0, Infinity), oor);
-assert.throws(() => a.compare(b, 0, 1, -1), oor);
-assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
-assert.throws(() => a.compare(), {
-  code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError',
-  message: 'The "target" argument must be an instance of ' +
-           'Buffer or Uint8Array. Received undefined'
+  assert.throws(() => a.compare(b, 0, 100, 0), oor);
+  assert.throws(() => a.compare(b, 0, 1, 0, 100), oor);
+  assert.throws(() => a.compare(b, -1), oor);
+  assert.throws(() => a.compare(b, 0, Infinity), oor);
+  assert.throws(() => a.compare(b, 0, 1, -1), oor);
+  assert.throws(() => a.compare(b, -Infinity, Infinity), oor);
+  assert.throws(() => a.compare(), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "target" argument must be an instance of ' +
+             'Buffer or Uint8Array. Received undefined'
+  });
 });

--- a/test/parallel/test-buffer-compare.js
+++ b/test/parallel/test-buffer-compare.js
@@ -1,47 +1,50 @@
 'use strict';
 
 require('../common');
+const { test } = require('node:test');
 const assert = require('assert');
 
-const b = Buffer.alloc(1, 'a');
-const c = Buffer.alloc(1, 'c');
-const d = Buffer.alloc(2, 'aa');
-const e = new Uint8Array([ 0x61, 0x61 ]); // ASCII 'aa', same as d
+test('Buffer.compare() compares buffers and Uint8Arrays', () => {
+  const b = Buffer.alloc(1, 'a');
+  const c = Buffer.alloc(1, 'c');
+  const d = Buffer.alloc(2, 'aa');
+  const e = new Uint8Array([ 0x61, 0x61 ]); // ASCII 'aa', same as d
 
-assert.strictEqual(b.compare(c), -1);
-assert.strictEqual(c.compare(d), 1);
-assert.strictEqual(d.compare(b), 1);
-assert.strictEqual(d.compare(e), 0);
-assert.strictEqual(b.compare(d), -1);
-assert.strictEqual(b.compare(b), 0);
+  assert.strictEqual(b.compare(c), -1);
+  assert.strictEqual(c.compare(d), 1);
+  assert.strictEqual(d.compare(b), 1);
+  assert.strictEqual(d.compare(e), 0);
+  assert.strictEqual(b.compare(d), -1);
+  assert.strictEqual(b.compare(b), 0);
 
-assert.strictEqual(Buffer.compare(b, c), -1);
-assert.strictEqual(Buffer.compare(c, d), 1);
-assert.strictEqual(Buffer.compare(d, b), 1);
-assert.strictEqual(Buffer.compare(b, d), -1);
-assert.strictEqual(Buffer.compare(c, c), 0);
-assert.strictEqual(Buffer.compare(e, e), 0);
-assert.strictEqual(Buffer.compare(d, e), 0);
-assert.strictEqual(Buffer.compare(d, b), 1);
+  assert.strictEqual(Buffer.compare(b, c), -1);
+  assert.strictEqual(Buffer.compare(c, d), 1);
+  assert.strictEqual(Buffer.compare(d, b), 1);
+  assert.strictEqual(Buffer.compare(b, d), -1);
+  assert.strictEqual(Buffer.compare(c, c), 0);
+  assert.strictEqual(Buffer.compare(e, e), 0);
+  assert.strictEqual(Buffer.compare(d, e), 0);
+  assert.strictEqual(Buffer.compare(d, b), 1);
 
-assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
-assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
-assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
+  assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(0)), 0);
+  assert.strictEqual(Buffer.compare(Buffer.alloc(0), Buffer.alloc(1)), -1);
+  assert.strictEqual(Buffer.compare(Buffer.alloc(1), Buffer.alloc(0)), 1);
 
-assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), {
-  code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "buf2" argument must be an instance of Buffer or Uint8Array. ' +
-           "Received type string ('abc')"
-});
-assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), {
-  code: 'ERR_INVALID_ARG_TYPE',
-  message: 'The "buf1" argument must be an instance of Buffer or Uint8Array. ' +
-           "Received type string ('abc')"
-});
+  assert.throws(() => Buffer.compare(Buffer.alloc(1), 'abc'), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "buf2" argument must be an instance of Buffer or Uint8Array. ' +
+             "Received type string ('abc')"
+  });
+  assert.throws(() => Buffer.compare('abc', Buffer.alloc(1)), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: 'The "buf1" argument must be an instance of Buffer or Uint8Array. ' +
+             "Received type string ('abc')"
+  });
 
-assert.throws(() => Buffer.alloc(1).compare('abc'), {
-  code: 'ERR_INVALID_ARG_TYPE',
-  name: 'TypeError',
-  message: 'The "target" argument must be an instance of ' +
-           "Buffer or Uint8Array. Received type string ('abc')"
+  assert.throws(() => Buffer.alloc(1).compare('abc'), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "target" argument must be an instance of ' +
+             "Buffer or Uint8Array. Received type string ('abc')"
+  });
 });


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/47707

Migrate two Buffer comparison parallel tests to `node:test`:

- `test-buffer-compare.js`
- `test-buffer-compare-offset.js`

The assertions and behavior are unchanged; the test bodies are wrapped in named `test()` calls.

Validation:
- `node --test test/parallel/test-buffer-compare.js test/parallel/test-buffer-compare-offset.js`
- `node -c test/parallel/test-buffer-compare.js`
- `node -c test/parallel/test-buffer-compare-offset.js`
- `node tools/eslint/node_modules/eslint/bin/eslint.js test/parallel/test-buffer-compare.js test/parallel/test-buffer-compare-offset.js`

I could not run the project `tools/test.py` harness in this checkout because there is no built `node.exe` present.