### PR TITLE
crypto: fix unhandled error in Hash._transform

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -122,7 +122,8 @@ Hash.prototype.copy = function copy(options) {
 };
 
 Hash.prototype._transform = function _transform(chunk, encoding, callback) {
-  this[kHandle].update(chunk, encoding);
+  if (!this[kHandle].update(chunk, encoding))
+    return callback(new ERR_CRYPTO_HASH_UPDATE_FAILED());
   callback();
 };
 

--- a/test/parallel/test-crypto-hash-stream-error.js
+++ b/test/parallel/test-crypto-hash-stream-error.js
@@ -1,0 +1,32 @@
+'use strict';
+
+// Flags: --expose-internals
+
+const common = require('../common');
+if (!common.hasCrypto) common.skip('missing crypto');
+
+const assert = require('assert');
+const crypto = require('crypto');
+const { kHandle } = require('internal/crypto/util');
+
+/**
+ * This test verifies that the Hash stream properly surfaces an error
+ * when the underlying native update fails.
+ */
+
+const h = crypto.createHash('sha256');
+
+// Simulate native update failure by replacing the internal handle
+const fakeHandle = {
+  update: () => false,
+  digest: () => Buffer.from('')
+};
+
+h[kHandle] = fakeHandle;
+
+h.on('error', common.mustCall((err) => {
+  assert.strictEqual(err.code, 'ERR_CRYPTO_HASH_UPDATE_FAILED');
+}));
+
+h.write('test data');
+h.end();


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
### Description

This PR fixes a bug where errors occurring during `Hash.prototype.write()` were silently swallowed instead of being surfaced.

#### Problem
In `lib/internal/crypto/hash.js`, the `_transform` implementation did not check the return value of `this[kHandle].update()`. While the synchronous `update()` method correctly throws `ERR_CRYPTO_HASH_UPDATE_FAILED` on failure, the streaming interface continued execution even if the underlying ncrypto binding returned `false`. This resulted in incorrect hash outputs without any error notification to the user.

#### Solution
Updated `Hash.prototype._transform` to check the return value of the internal `update()` call. If it returns `false`, the error is passed to the stream callback, triggering an `'error'` event as expected for a `stream.Transform` instance.

#### Validation
- Added a regression test `test/parallel/test-crypto-hash-stream-error.js`. 
- The test mocks the internal handle using `kHandle` to simulate an `update` failure and verifies that an `'error'` event with `ERR_CRYPTO_HASH_UPDATE_FAILED` is emitted.
- Verified that the test fails without this change and passes with it.
- Verified that existing crypto tests (`test/parallel/test-crypto-hash.js`) still pass.

### Checklist
- [x] `make lint-js` passes
- [x] `make test-parallel` (relevant to crypto) passes
- [x] Commit message follows the [Node.js guidelines](https://github.com/nodejs/node/blob/main/doc/contributing/commits.md)

Fixes: #63258