### PR TITLE
quic: apply multiple quic performance and packet handling improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 /tags
 /tags.*
 /doc/api.xml
+/docs/
 /node
 /node_g
 /gon-config.json

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -2743,6 +2743,23 @@ added: v23.8.0
 Specifies the maximum number of milliseconds a TLS handshake is permitted to take
 to complete before timing out.
 
+#### `sessionOptions.initialRtt`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {bigint|number}
+* **Default:** `0` (use ngtcp2 default of 333ms)
+
+Specifies the initial round-trip time estimate in milliseconds. This value is
+used for probe timeout (PTO) computation, initial pacing, and early loss
+detection before the first actual RTT sample is collected from the connection.
+The default of 333ms is appropriate for the general internet. For low-latency
+environments such as loopback or same-rack deployments, setting a value closer
+to the actual RTT (e.g., `1`) avoids unnecessarily conservative initial
+behavior.
+
 #### `sessionOptions.keepAlive`
 
 <!-- YAML

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -2286,6 +2286,23 @@ added: v23.8.0
 
 When `true`, indicates that the endpoint should bind only to IPv6 addresses.
 
+#### `endpointOptions.reusePort`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {boolean}
+* Default: `false`
+
+When `true`, allows multiple endpoints (across separate processes) to bind to
+the same address and port. The kernel will load-balance incoming UDP datagrams
+across all sockets bound with this option. This enables horizontal scaling of
+QUIC servers by running multiple Node.js processes on the same port.
+
+Supported on Linux 3.9+ and DragonFlyBSD 3.6+. On unsupported platforms, the
+bind will fail with an error.
+
 #### `endpointOptions.maxConnectionsPerHost`
 
 <!-- YAML

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -2094,6 +2094,20 @@ added: v23.8.0
 
 * Type: {bigint}
 
+### `streamStats.bytesAccumulated`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {bigint}
+
+The current number of bytes sitting in the stream's receive accumulation
+buffer, awaiting delivery to the application. A value near zero indicates
+the reader is keeping up with incoming data. A value near the stream's
+flow control window indicates the application is not consuming data fast
+enough.
+
 ### `streamStats.bytesReceived`
 
 <!-- YAML
@@ -2141,6 +2155,20 @@ added: v23.8.0
 -->
 
 * Type: {bigint}
+
+### `streamStats.maxBytesAccumulated`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {bigint}
+
+The peak number of bytes that were accumulated in the stream's receive
+buffer at any point during the stream's lifetime. This value only
+increases monotonically. It is useful for diagnosing whether a stream
+experienced backpressure episodes and whether the accumulation buffer
+sizing is appropriate for the workload.
 
 ### `streamStats.maxOffset`
 

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -742,6 +742,18 @@ added: v23.8.0
 
 A `QuicSession` represents the local side of a QUIC connection.
 
+### `session.applicationOptions`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {quic.ApplicationOptions}
+
+The current application-level options for this session. These include settings
+that are specific to the negotiated application protocol (e.g. HTTP/3) and may
+be negotiated separately from the transport parameters. Read only.
+
 ### `session.close([options])`
 
 <!-- YAML
@@ -2236,6 +2248,70 @@ added: v23.8.0
 
 ## Types
 
+### type: `ApplicationOptions`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {Object}
+
+The application specific options.
+
+#### `applicationOptions.maxHeaderPairs`
+
+* Type: {bigint|number}
+
+Maximum number of header name-value pairs accepted per header block.
+Headers beyond this limit are silently dropped. **Default:** `128`
+
+#### `applicationOptions.maxHeaderLength`
+
+* Type: {bigint|number}
+
+Maximum total byte length of all header names and values combined per header
+block. Headers that would push the total over this limit are silently
+dropped. **Default:** `8192`
+
+#### `applicationOptions.maxFieldSectionSize`
+
+* Type: {bigint|number}
+
+Maximum size of a compressed header field section (QPACK). `0` means
+unlimited. **Default:** `0`
+
+#### `applicationOptions.qpackMaxDTableCapacity`
+
+* Type: {bigint|number}
+
+QPACK dynamic table capacity in bytes. Set to `0` to disable the dynamic
+table. **Default:** `4096`
+
+#### `applicationOptions.qpackEncoderMaxDTableCapacity`
+
+* Type: {bigint|number}
+
+QPACK encoder maximum dynamic table capacity. **Default:** `4096`
+
+#### `applicationOptions.qpackBlockedStreams`
+
+* Type: {bigint|number}
+
+Maximum number of streams that can e blocked waiting for QPACK dynamic table
+updates. **Default:** `100`
+
+#### `applicationOptions.enableConnectProtocol`
+
+* Type: {boolean}
+
+Enable the extended CONNECT protocol (RFC 9220). **Default:** `false`
+
+#### `applicationOptions.enableDatagrams`
+
+* Type: {boolean}
+
+Enable HTTP/3 datagrams (RFC 9297). **Default:** `false`
+
 ### Type: `EndpointOptions`
 
 <!-- YAML
@@ -2492,30 +2568,9 @@ Default: `'h3'`
 added: REPLACEME
 -->
 
-* Type: {Object}
+* Type: {quic.ApplicationOptions}
 
-HTTP/3 application-specific options. These only apply when the negotiated
-ALPN selects the HTTP/3 application (`'h3'`).
-
-* `maxHeaderPairs` {number} Maximum number of header name-value pairs
-  accepted per header block. Headers beyond this limit are silently
-  dropped. **Default:** `128`
-* `maxHeaderLength` {number} Maximum total byte length of all header
-  names and values combined per header block. Headers that would push
-  the total over this limit are silently dropped. **Default:** `8192`
-* `maxFieldSectionSize` {number} Maximum size of a compressed header
-  field section (QPACK). `0` means unlimited. **Default:** `0`
-* `qpackMaxDTableCapacity` {number} QPACK dynamic table capacity in
-  bytes. Set to `0` to disable the dynamic table. **Default:** `4096`
-* `qpackEncoderMaxDTableCapacity` {number} QPACK encoder maximum
-  dynamic table capacity. **Default:** `4096`
-* `qpackBlockedStreams` {number} Maximum number of streams that can
-  be blocked waiting for QPACK dynamic table updates.
-  **Default:** `100`
-* `enableConnectProtocol` {boolean} Enable the extended CONNECT
-  protocol (RFC 9220). **Default:** `false`
-* `enableDatagrams` {boolean} Enable HTTP/3 datagrams (RFC 9297).
-  **Default:** `false`
+Application-specific options.
 
 ```mjs
 const { listen } = await import('node:quic');

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -851,6 +851,17 @@ added: v23.8.0
 
 True if `session.destroy()` has been called. Read only.
 
+### `session.localTransportParams`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {quic.TransportParams|null}
+
+The transport parameters advertised by the local endpoint during the handshake.
+Returns `null` if the session has been destroyed. Read only.
+
 ### `session.endpoint`
 
 <!-- YAML
@@ -1143,6 +1154,19 @@ added: v23.8.0
   * `remote` {net.SocketAddress}
 
 The local and remote socket addresses associated with the session. Read only.
+
+### `session.remoteTransportParams`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {quic.TransportParams|null|undefined}
+
+The transport parameters advertised by the remote peer during the handshake.
+Returns `null` if the session has been destroyed, `undefined` if the handshake
+has not yet completed and the remote parameters are not yet available. Read
+only.
 
 ### `session.sendDatagram(datagram[, encoding])`
 
@@ -2947,6 +2971,37 @@ won't have need to specify.
 added: v23.8.0
 -->
 
+The `TransportParams` type represents the QUIC transport parameters that are
+negotiated during session establishment. These parameters are used when
+creating a session. The negotiated values can be observed via the
+`session.localTransportParams` and `session.remoteTransportParams` properties.
+
+#### `transportParams.initialSCID`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The initial source connection ID (SCID) specified. This field is ignored on
+creation of the session and is provided for informational purposes only when
+available in the `session.localTransportParams` and
+`session.remoteTransportParams` properties.
+
+#### `transportParams.originalDCID`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The original destination connection ID (DCID) specified. This field is
+ignored on creation of the session and is provided for informational
+purposes only when available in the `session.localTransportParams` and
+`session.remoteTransportParams` properties.
+
 #### `transportParams.preferredAddressIpv4`
 
 <!-- YAML
@@ -3059,6 +3114,19 @@ is willing to receive. Set to `0` to disable datagram support. The peer
 will not send datagrams larger than this value. The actual maximum size of
 a datagram that can be _sent_ is determined by the peer's
 `maxDatagramFrameSize`, not this endpoint's value.
+
+#### `transportParams.retrySCID`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {string}
+
+The retry connection ID specified. This field is ignored on creation
+of the session and is provided for informational purposes only when
+available in the `session.localTransportParams` and
+`session.remoteTransportParams` properties.
 
 ## Callbacks
 

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -178,6 +178,12 @@ function handleErrorFromBinding(error) {
 }
 
 class FileHandle extends EventEmitter {
+  #brandCheck = undefined;
+
+  static isFileHandle(value) {
+    return (value != null && typeof value === 'object' && #brandCheck in value);
+  }
+
   /**
    * @param {InternalFSBinding.FileHandle | undefined} filehandle
    */

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -2678,6 +2678,14 @@ class QuicSession {
     debug('session created');
   }
 
+  get applicationOptions() {
+    // We don't cache application options because they may be updated by the
+    // C++ layer after session creation depending on the behavior of the
+    // application.
+    if (this.destroyed) return null;
+    return this.#handle.applicationOptions();
+  }
+
   get localTransportParams() {
     if (this.#inner.localTransportParams !== undefined) {
       return this.#inner.localTransportParams;

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -2626,6 +2626,8 @@ class QuicSession {
     certificate: undefined,
     peerCertificate: undefined,
     ephemeralKeyInfo: undefined,
+    localTransportParams: undefined,
+    remoteTransportParams: undefined,
   };
 
   static {
@@ -2674,6 +2676,45 @@ class QuicSession {
     }
 
     debug('session created');
+  }
+
+  get localTransportParams() {
+    if (this.#inner.localTransportParams !== undefined) {
+      return this.#inner.localTransportParams;
+    }
+    // If the handle is already gone, we cannot retrieve the transport params.
+    if (this.destroyed) return null;
+    const params = this.#handle.localTransportParams();
+    if (params.preferredAddressIpv4 !== undefined) {
+      params.preferredAddressIpv4 = new InternalSocketAddress(params.preferredAddressIpv4);
+    }
+    if (params.preferredAddressIpv6 !== undefined) {
+      params.preferredAddressIpv6 = new InternalSocketAddress(params.preferredAddressIpv6);
+    }
+    return this.#inner.localTransportParams = params;
+  }
+
+  get remoteTransportParams() {
+    if (this.#inner.remoteTransportParams !== undefined) {
+      return this.#inner.remoteTransportParams;
+    }
+    // If the handle is already gone, we cannot retrieve the transport params.
+    if (this.destroyed) return null;
+    const params = this.#handle.remoteTransportParams();
+    // If params is undefined, the transport parameters have not yet been received.
+    // Note the distinction between this and the case where the handle is gone.
+    // If the handle is gone, we return null because we know the transport
+    // parameters will be unavailable. If the transport parameters have not yet
+    // been received, we return undefined to indicate that they may still become
+    // available in the future.
+    if (params === undefined) return undefined;
+    if (params.preferredAddressIpv4 !== undefined) {
+      params.preferredAddressIpv4 = new InternalSocketAddress(params.preferredAddressIpv4);
+    }
+    if (params.preferredAddressIpv6 !== undefined) {
+      params.preferredAddressIpv6 = new InternalSocketAddress(params.preferredAddressIpv6);
+    }
+    return this.#inner.remoteTransportParams = params;
   }
 
   /** @type {boolean} */

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -404,6 +404,9 @@ const endpointRegistry = new SafeSet();
  * @property {ArrayBufferView} [token] An opaque address validation token
  *   previously received from the server via `onnewtoken` (client only).
  * @property {bigint|number} [handshakeTimeout] The handshake timeout
+ * @property {bigint|number} [initialRtt] The initial round-trip time estimate in milliseconds.
+ *   Used for PTO computation and initial pacing before the first RTT sample. Default uses
+ *   ngtcp2's built-in default of 333ms. Set lower for low-latency environments.
  * @property {bigint|number} [keepAlive] The keep-alive timeout in milliseconds. When set,
  *   PING frames will be sent automatically to prevent idle timeout.
  * @property {bigint|number} [maxStreamWindow] The maximum stream window
@@ -4875,6 +4878,7 @@ function processSessionOptions(options, config = kEmptyObject) {
     maxPayloadSize,
     unacknowledgedPacketThreshold = 0,
     handshakeTimeout,
+    initialRtt,
     keepAlive,
     maxStreamWindow,
     maxWindow,
@@ -4982,6 +4986,7 @@ function processSessionOptions(options, config = kEmptyObject) {
     maxPayloadSize,
     unacknowledgedPacketThreshold,
     handshakeTimeout,
+    initialRtt,
     keepAlive,
     maxStreamWindow,
     maxWindow,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -3943,8 +3943,8 @@ class QuicEndpoint {
     const {
       retryTokenExpiration,
       tokenExpiration,
-      maxConnectionsPerHost = 0,
-      maxConnectionsTotal = 0,
+      maxConnectionsPerHost = 100,
+      maxConnectionsTotal = 10_000,
       maxStatelessResetsPerHost,
       disableStatelessReset,
       addressLRUSize,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -203,14 +203,13 @@ const {
   kTrailers,
   kVersionNegotiation,
   kInspect,
-  kWantsHeaders,
-  kWantsTrailers,
 } = require('internal/quic/symbols');
 
 const {
   QuicEndpointStats,
   QuicStreamStats,
   QuicSessionStats,
+  kCreateDisconnected,
 } = require('internal/quic/stats');
 
 const {
@@ -465,6 +464,51 @@ const endpointRegistry = new SafeSet();
  */
 
 /**
+ * @typedef {object} QuicStreamDestroyOptions
+ * @property {bigint|number} [code] An explicit application
+ *   error code to send on the resulting `RESET_STREAM` /
+ *   `STOP_SENDING` frames. Numbers are coerced to `BigInt`. When
+ *   omitted, the code is derived from `error` per the precedence
+ *   above.
+ * @property {string} [reason] Optional human-readable reason.
+ *   Accepted for symmetry with `session.close()` /
+ *   `session.destroy()`; QUIC `RESET_STREAM` and `STOP_SENDING`
+ *   frames do not themselves carry a reason field over the wire.
+ */
+
+/**
+ * @typedef {object} SendHeadersOptions
+ * @property {boolean} [terminal] When true, indicates that no body data will be
+ *   sent after these headers.
+ */
+
+/**
+ * @typedef {object} StreamPriority
+ * @property {'default' | 'low' | 'high'} level The priority level of the stream.
+ * @property {boolean} incremental Whether to interleave data with same-priority streams.
+ */
+
+/**
+ * @typedef {object} QuicSessionPath
+ * @property {SocketAddress} local The local address for this path
+ * @property {SocketAddress} remote The remote address for this path
+ */
+
+/**
+ * @typedef {object} SNIContextOptions
+ * @property {boolean} [replace] When `true`, the provided SNI context will replace
+ *   the default context for the session. When `false` (default), the provided
+ *   context will be merged with the default context, with precedence given to
+ *   the provided context on any overlapping options.
+ */
+
+/**
+ * @typedef {object} ProcessSessionOptions
+ * @property {boolean} forServer true if processing options for a server session
+ * @property {string} addressFamily the address family to use for validating
+ */
+
+/**
  * Called when the Endpoint receives a new server-side Session.
  * @callback OnSessionCallback
  * @this {QuicEndpoint}
@@ -658,7 +702,7 @@ setCallbacks({
   },
   /**
    * Called when the QuicEndpoint C++ handle receives a new server-side session
-   * @param {*} session The QuicSession C++ handle
+   * @param {object} session The QuicSession C++ handle
    */
   onSessionNew(session) {
     debug('new server session callback', this[kOwner], session);
@@ -792,9 +836,9 @@ setCallbacks({
 
   /**
    * Called when the session receives a session version negotiation request
-   * @param {*} version
-   * @param {*} requestedVersions
-   * @param {*} supportedVersions
+   * @param {number} version
+   * @param {number[]} requestedVersions
+   * @param {number[]} supportedVersions
    */
   onSessionVersionNegotiation(version,
                               requestedVersions,
@@ -885,6 +929,12 @@ setCallbacks({
   },
 });
 
+function assertPrivateSymbol(privateSymbol) {
+  if (privateSymbol !== kPrivateConstructor) {
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
+  }
+}
+
 // QUIC error codes are 62-bit varints (RFC 9000 section 16). The
 // maximum representable code is 2**62 - 1.
 const kMaxQuicErrorCode = (1n << 62n) - 1n;
@@ -910,6 +960,10 @@ class QuicError extends Error {
   #errorCode;
   /** @type {'transport' | 'application'} */
   #type;
+
+  static isQuicError(val) {
+    return val != null && typeof val === 'object' && #errorCode in val;
+  }
 
   /**
    * @param {string} message
@@ -1089,7 +1143,7 @@ function validateBody(body) {
 
   // FileHandle -- lock it and pass the C++ handle to GetDataQueueFromSource
   // which creates an fd-backed DataQueue entry from the file path.
-  if (body instanceof FileHandle) {
+  if (FileHandle.isFileHandle(body)) {
     if (body[kFileLocked]) {
       throw new ERR_INVALID_STATE('FileHandle is locked');
     }
@@ -1166,7 +1220,7 @@ function applyCallbacks(session, cbs) {
  * type and calls the appropriate C++ method.
  * @param {object} handle The C++ stream handle
  * @param {QuicStream} stream The JS stream object
- * @param {*} body The body source
+ * @param {any} body The body source
  */
 const kDefaultHighWaterMark = 65536;
 const kDefaultMaxPendingDatagrams = 128;
@@ -1208,7 +1262,7 @@ function configureOutbound(handle, stream, body) {
   // DataQueue entry from the file path. The FileHandle is locked to
   // prevent concurrent use and closed automatically when the stream
   // finishes.
-  if (body instanceof FileHandle) {
+  if (FileHandle.isFileHandle(body)) {
     if (body[kFileLocked]) {
       throw new ERR_INVALID_STATE('FileHandle is locked');
     }
@@ -1363,8 +1417,14 @@ let getQuicStreamState;
 let getQuicSessionState;
 let getQuicEndpointState;
 let assertIsQuicEndpoint;
+let assertIsQuicStream;
+let assertIsQuicSession;
+let assertHeadersSupported;
 let assertEndpointNotClosedOrClosing;
 let assertEndpointIsNotBusy;
+let isQuicStream;
+let isQuicSession;
+let isQuicEndpoint;
 
 function maybeGetCloseError(context, status, pendingError) {
   switch (context) {
@@ -1391,31 +1451,54 @@ function maybeGetCloseError(context, status, pendingError) {
 }
 
 class QuicStream {
-  // All mutable per-stream state is consolidated into a single object
-  // to minimize the number of V8 private field slots. Only #handle is
-  // kept as a private field for the brand check in #assertIsQuicStream.
-  /** @type {object} */
   #handle;
-  #inner;
+  #inner = {
+    __proto__: null,
+    session: undefined,
+    direction: undefined,
+    isLocal: false,
+    state: undefined,
+    stats: undefined,
+    pendingClose: undefined,
+    reader: undefined,
+    destroying: false,
+    iteratorLocked: false,
+    outboundSet: false,
+    writer: undefined,
+    fileHandle: undefined,
+    headers: undefined,
+    pendingTrailers: undefined,
+    onerror: undefined,
+    onblocked: undefined,
+    onreset: undefined,
+    onheaders: undefined,
+    ontrailers: undefined,
+    oninfo: undefined,
+    onwanttrailers: undefined,
+  };
 
   static {
+    isQuicStream = function(val) {
+      return val != null && typeof val === 'object' && #handle in val;
+    };
+
+    assertIsQuicStream = function(val) {
+      if (!isQuicStream(val)) {
+        throw new ERR_INVALID_THIS('QuicStream');
+      }
+    };
+
+    assertHeadersSupported = function(session) {
+      if (getQuicSessionState(session).headersSupported === 2) {
+        throw new ERR_INVALID_STATE(
+          'The negotiated QUIC application protocol does not support headers');
+      }
+    };
+
     getQuicStreamState = function(stream) {
-      QuicStream.#assertIsQuicStream(stream);
+      assertIsQuicStream(stream);
       return stream.#inner.state;
     };
-  }
-
-  static #assertIsQuicStream(val) {
-    if (val == null || !(#handle in val)) {
-      throw new ERR_INVALID_THIS('QuicStream');
-    }
-  }
-
-  #assertHeadersSupported() {
-    if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
-      throw new ERR_INVALID_STATE(
-        'The negotiated QUIC application protocol does not support headers');
-    }
   }
 
   /**
@@ -1423,41 +1506,19 @@ class QuicStream {
    * @param {object} handle
    * @param {QuicSession} session
    * @param {number} direction
-   * @param {boolean} [isLocal] True for locally-initiated streams
+   * @param {boolean} [isLocal]
    */
-  constructor(privateSymbol, handle, session, direction, isLocal = false) {
-    if (privateSymbol !== kPrivateConstructor) {
-      throw new ERR_ILLEGAL_CONSTRUCTOR();
-    }
+  constructor(privateSymbol, handle, session, direction, isLocal) {
+    assertPrivateSymbol(privateSymbol);
 
     this.#handle = handle;
     handle[kOwner] = this;
-    this.#inner = {
-      __proto__: null,
-      session,
-      direction,
-      isLocal,
-      state: new QuicStreamState(
-        kPrivateConstructor, handle.state, handle.stateByteOffset),
-      stats: undefined,
-      pendingClose: undefined,
-      reader: undefined,
-      destroying: false,
-      iteratorLocked: false,
-      outboundSet: false,
-      writer: undefined,
-      fileHandle: undefined,
-      headers: undefined,
-      pendingTrailers: undefined,
-      // Callback slots
-      onerror: undefined,
-      onblocked: undefined,
-      onreset: undefined,
-      onheaders: undefined,
-      ontrailers: undefined,
-      oninfo: undefined,
-      onwanttrailers: undefined,
-    };
+    const inner = this.#inner;
+    inner.session = session;
+    inner.direction = direction;
+    inner.isLocal = isLocal;
+    inner.state = new QuicStreamState(
+      kPrivateConstructor, handle.state, handle.stateByteOffset);
 
     if (hasObserver('quic')) {
       startPerf(this, kPerfEntry, { type: 'quic', name: 'QuicStream' });
@@ -1475,17 +1536,18 @@ class QuicStream {
    * @yields {Uint8Array[]}
    */
   async *[SymbolAsyncIterator]() {
-    QuicStream.#assertIsQuicStream(this);
-    if (this.#inner.iteratorLocked) {
+    assertIsQuicStream(this);
+    const inner = this.#inner;
+    if (inner.iteratorLocked) {
       throw new ERR_INVALID_STATE('Stream is already being read');
     }
-    this.#inner.iteratorLocked = true;
+    inner.iteratorLocked = true;
 
-    this.#inner.reader ??= this.#handle?.getReader();
+    inner.reader ??= this.#handle?.getReader();
     // Non-readable stream (outbound-only unidirectional, or closed)
-    if (!this.#inner.reader) return;
+    if (!inner.reader) return;
 
-    yield* createBlobReaderIterable(this.#inner.reader, {
+    yield* createBlobReaderIterable(inner.reader, {
       getReadError: () => {
         // The read side ends for one of three reasons:
         //   * Clean FIN received from the peer (state.finReceived
@@ -1499,8 +1561,8 @@ class QuicStream {
         //     stream.stopSending(). Both paths run EndReadable in
         //     C++, setting state.readEnded without setting
         //     state.finReceived. There is no peer code to surface.
-        if (this.#inner.state.readEnded && !this.#inner.state.finReceived) {
-          const peerResetCode = this.#inner.state.resetCode;
+        if (inner.state.readEnded && !inner.state.finReceived) {
+          const peerResetCode = inner.state.resetCode;
           if (peerResetCode !== undefined && peerResetCode > 0n) {
             return new ERR_QUIC_STREAM_RESET(Number(peerResetCode));
           }
@@ -1518,7 +1580,7 @@ class QuicStream {
    * @type {boolean}
    */
   get pending() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.state.pending;
   }
 
@@ -1529,7 +1591,7 @@ class QuicStream {
    * @type {boolean}
    */
   get early() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.state.early;
   }
 
@@ -1540,145 +1602,153 @@ class QuicStream {
    * @type {number}
    */
   get highWaterMark() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.state.highWaterMark;
   }
 
   set highWaterMark(val) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     validateInteger(val, 'highWaterMark', 0, 0xFFFFFFFF);
-    this.#inner.state.highWaterMark = val;
+    const inner = this.#inner;
+    inner.state.highWaterMark = val;
     // If writeDesiredSize hasn't been set yet (still 0 from initialization),
     // initialize it to the highWaterMark so the first write can proceed.
-    if (this.#inner.state.writeDesiredSize === 0 && val > 0) {
-      this.#inner.state.writeDesiredSize = val;
+    if (inner.state.writeDesiredSize === 0 && val > 0) {
+      inner.state.writeDesiredSize = val;
     }
   }
 
   /** @type {Function|undefined} */
   get onerror() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.onerror;
   }
 
   set onerror(fn) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#inner.onerror = undefined;
+      inner.onerror = undefined;
     } else {
       validateFunction(fn, 'onerror');
-      this.#inner.onerror = FunctionPrototypeBind(fn, this);
+      inner.onerror = FunctionPrototypeBind(fn, this);
       // Lazily create the close promise so it can be marked handled.
-      this.#inner.pendingClose ??= PromiseWithResolvers();
-      markPromiseAsHandled(this.#inner.pendingClose.promise);
+      inner.pendingClose ??= PromiseWithResolvers();
+      markPromiseAsHandled(inner.pendingClose.promise);
     }
   }
 
   /** @type {OnBlockedCallback} */
   get onblocked() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.onblocked;
   }
 
   set onblocked(fn) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#inner.onblocked = undefined;
-      this.#inner.state.wantsBlock = false;
+      inner.onblocked = undefined;
+      inner.state.wantsBlock = false;
     } else {
       validateFunction(fn, 'onblocked');
-      this.#inner.onblocked = FunctionPrototypeBind(fn, this);
-      this.#inner.state.wantsBlock = true;
+      inner.onblocked = FunctionPrototypeBind(fn, this);
+      inner.state.wantsBlock = true;
     }
   }
 
   /** @type {OnStreamErrorCallback} */
   get onreset() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.onreset;
   }
 
   set onreset(fn) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#inner.onreset = undefined;
-      this.#inner.state.wantsReset = false;
+      inner.onreset = undefined;
+      inner.state.wantsReset = false;
     } else {
       validateFunction(fn, 'onreset');
-      this.#inner.onreset = FunctionPrototypeBind(fn, this);
-      this.#inner.state.wantsReset = true;
+      inner.onreset = FunctionPrototypeBind(fn, this);
+      inner.state.wantsReset = true;
     }
   }
 
   /** @type {OnHeadersCallback} */
   get onheaders() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.onheaders;
   }
 
   set onheaders(fn) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#inner.onheaders = undefined;
-      this.#inner.state[kWantsHeaders] = false;
+      inner.onheaders = undefined;
+      inner.state.wantsHeaders = false;
     } else {
-      this.#assertHeadersSupported();
       validateFunction(fn, 'onheaders');
-      this.#inner.onheaders = FunctionPrototypeBind(fn, this);
-      this.#inner.state[kWantsHeaders] = true;
+      assertHeadersSupported(inner.session);
+      inner.onheaders = FunctionPrototypeBind(fn, this);
+      inner.state.wantsHeaders = true;
     }
   }
 
   /** @type {Function|undefined} */
   get oninfo() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.oninfo;
   }
 
   set oninfo(fn) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#inner.oninfo = undefined;
+      inner.oninfo = undefined;
     } else {
-      this.#assertHeadersSupported();
       validateFunction(fn, 'oninfo');
-      this.#inner.oninfo = FunctionPrototypeBind(fn, this);
+      assertHeadersSupported(inner.session);
+      inner.oninfo = FunctionPrototypeBind(fn, this);
     }
   }
 
   /** @type {Function|undefined} */
   get ontrailers() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.ontrailers;
   }
 
   set ontrailers(fn) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#inner.ontrailers = undefined;
+      inner.ontrailers = undefined;
     } else {
-      this.#assertHeadersSupported();
       validateFunction(fn, 'ontrailers');
-      this.#inner.ontrailers = FunctionPrototypeBind(fn, this);
+      assertHeadersSupported(inner.session);
+      inner.ontrailers = FunctionPrototypeBind(fn, this);
     }
   }
 
   /** @type {Function|undefined} */
   get onwanttrailers() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.onwanttrailers;
   }
 
   set onwanttrailers(fn) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#inner.onwanttrailers = undefined;
-      this.#inner.state[kWantsTrailers] = false;
+      inner.onwanttrailers = undefined;
+      inner.state.wantsTrailers = false;
     } else {
-      this.#assertHeadersSupported();
       validateFunction(fn, 'onwanttrailers');
-      this.#inner.onwanttrailers = FunctionPrototypeBind(fn, this);
-      this.#inner.state[kWantsTrailers] = true;
+      assertHeadersSupported(inner.session);
+      inner.onwanttrailers = FunctionPrototypeBind(fn, this);
+      inner.state.wantsTrailers = true;
     }
   }
 
@@ -1689,7 +1759,7 @@ class QuicStream {
    * @type {object|undefined}
    */
   get headers() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.headers;
   }
 
@@ -1698,22 +1768,20 @@ class QuicStream {
    * @type {object|undefined}
    */
   get pendingTrailers() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#inner.pendingTrailers;
   }
 
   set pendingTrailers(headers) {
-    QuicStream.#assertIsQuicStream(this);
+    const inner = this.#inner;
+    assertIsQuicStream(this);
+    assertHeadersSupported(inner.session);
     if (headers === undefined) {
-      this.#inner.pendingTrailers = undefined;
+      inner.pendingTrailers = undefined;
       return;
     }
-    if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
-      throw new ERR_INVALID_STATE(
-        'The negotiated QUIC application protocol does not support headers');
-    }
     validateObject(headers, 'headers');
-    this.#inner.pendingTrailers = headers;
+    inner.pendingTrailers = headers;
   }
 
   /**
@@ -1721,12 +1789,12 @@ class QuicStream {
    * @type {QuicStreamStats}
    */
   get stats() {
-    QuicStream.#assertIsQuicStream(this);
-    if (this.#inner.stats === undefined) {
-      this.#inner.stats = new QuicStreamStats(
-        kPrivateConstructor, this.#handle.stats, this.#handle.statsByteOffset);
-    }
-    return this.#inner.stats;
+    assertIsQuicStream(this);
+    const inner = this.#inner;
+    const handle = this.#handle;
+    return inner.stats ??= (handle == null) ?
+      QuicStreamStats[kCreateDisconnected]() :
+      new QuicStreamStats(kPrivateConstructor, handle.stats, handle.statsByteOffset);
   }
 
   /**
@@ -1735,30 +1803,27 @@ class QuicStream {
    * @type {QuicSession | null}
    */
   get session() {
-    QuicStream.#assertIsQuicStream(this);
-    if (this.destroyed) return null;
+    assertIsQuicStream(this);
     return this.#inner.session;
   }
 
   /**
-   * Returns the id for this stream. If the stream is destroyed or still pending,
+   * Returns the id for this stream. If the stream is still pending,
    * `null` will be returned.
    * @type {bigint | null}
    */
   get id() {
-    QuicStream.#assertIsQuicStream(this);
-    if (this.destroyed || this.pending) return null;
+    assertIsQuicStream(this);
+    if (this.pending) return null;
     return this.#inner.state.id;
   }
 
   /**
-   * Returns the directionality of this stream. If the stream is destroyed
-   * or still pending, `null` will be returned.
-   * @type {'bidi'|'uni'|null}
+   * Returns the directionality of this stream.
+   * @type {'bidi'|'uni'}
    */
   get direction() {
-    QuicStream.#assertIsQuicStream(this);
-    if (this.destroyed || this.pending) return null;
+    assertIsQuicStream(this);
     return this.#inner.direction === kStreamDirectionBidirectional ? 'bidi' : 'uni';
   }
 
@@ -1767,7 +1832,7 @@ class QuicStream {
    * @type {boolean}
    */
   get destroyed() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     return this.#handle === undefined;
   }
 
@@ -1776,10 +1841,8 @@ class QuicStream {
    * @type {Promise<void>}
    */
   get closed() {
-    QuicStream.#assertIsQuicStream(this);
-    if (this.#inner.pendingClose === undefined) {
-      this.#inner.pendingClose = PromiseWithResolvers();
-    }
+    assertIsQuicStream(this);
+    this.#inner.pendingClose ??= PromiseWithResolvers();
     return this.#inner.pendingClose.promise;
   }
 
@@ -1794,19 +1857,11 @@ class QuicStream {
    * `QuicError`) -> the negotiated application's "internal error"
    * code from `QuicSessionState.internalErrorCode`.
    * @param {any} error
-   * @param {object} [options]
-   * @param {bigint|number} [options.code] An explicit application
-   *   error code to send on the resulting `RESET_STREAM` /
-   *   `STOP_SENDING` frames. Numbers are coerced to `BigInt`. When
-   *   omitted, the code is derived from `error` per the precedence
-   *   above.
-   * @param {string} [options.reason] Optional human-readable reason.
-   *   Accepted for symmetry with `session.close()` /
-   *   `session.destroy()`; QUIC `RESET_STREAM` and `STOP_SENDING`
-   *   frames do not themselves carry a reason field over the wire.
+   * @param {QuicStreamDestroyOptions} [options]
    */
   destroy(error, options = kEmptyObject) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
+    const inner = this.#inner;
     // Two distinct guards:
     //   * `#destroying` flips synchronously here so any re-entrant call
     //     from inside this method's user callbacks hits the guard and
@@ -1816,7 +1871,7 @@ class QuicStream {
     //     `onStreamClose -> [kFinishClose]` path - which does NOT go
     //     through `destroy()` and therefore never sets `#destroying`.
     //     `[kFinishClose]` clears `#handle` at the end of its work.
-    if (this.#inner.destroying || this.destroyed) return;
+    if (inner.destroying || this.destroyed) return;
     // Validate options up front so a malformed `options` argument
     // throws before any side effects (mutating `#destroying`,
     // emitting wire frames, invoking `onerror`, settling the closed
@@ -1832,16 +1887,16 @@ class QuicStream {
     if (reason !== undefined) {
       validateString(reason, 'options.reason');
     }
-    this.#inner.destroying = true;
+    inner.destroying = true;
     // Resolve the wire error code for any RESET_STREAM / STOP_SENDING
     // frames emitted below.
     let abortCode;
     if (optionCode !== undefined) {
       abortCode = BigInt(optionCode);
     } else if (error !== undefined) {
-      abortCode = error instanceof QuicError ?
+      abortCode = QuicError.isQuicError(error) ?
         error.errorCode :
-        getQuicSessionState(this.#inner.session).internalErrorCode;
+        getQuicSessionState(inner.session).internalErrorCode;
     }
     // When destroying with an error, ensure the peer stops sending
     // data we are about to discard by emitting STOP_SENDING. The
@@ -1850,7 +1905,7 @@ class QuicStream {
     // authoritative -- it is set for locally-initiated uni streams
     // (which have no readable side) and when reading completes.
     if (abortCode !== undefined &&
-        !this.#inner.state.readEnded) {
+        !inner.state.readEnded) {
       this.#handle.stopSending(abortCode);
     }
     // When destroying with an error, ensure the peer learns about
@@ -1861,12 +1916,12 @@ class QuicStream {
     // RESET_STREAM here so the write side does not dangle on the
     // wire. The C++ state.writeEnded flag is authoritative.
     if (abortCode !== undefined &&
-        this.#inner.writer === undefined &&
-        !this.#inner.state.writeEnded) {
+        inner.writer === undefined &&
+        !inner.state.writeEnded) {
       this.#handle.resetStream(abortCode);
     }
-    if (error !== undefined && typeof this.#inner.onerror === 'function') {
-      invokeOnerror(this.#inner.onerror, error);
+    if (error !== undefined && typeof inner.onerror === 'function') {
+      invokeOnerror(inner.onerror, error);
     }
     const handle = this.#handle;
     this[kFinishClose](error);
@@ -1882,7 +1937,7 @@ class QuicStream {
    * @param {ArrayBuffer|SharedArrayBuffer|ArrayBufferView|Blob} outbound
    */
   setOutbound(outbound) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed) {
       throw new ERR_INVALID_STATE('Stream is destroyed');
     }
@@ -1893,14 +1948,12 @@ class QuicStream {
   }
 
   /**
-   * Send initial or response headers on this stream. Throws if the
-   * application does not support headers.
    * @param {object} headers
-   * @param {{ terminal?: boolean }} [options]
+   * @param {SendHeadersOptions} [options]
    * @returns {boolean}
    */
   sendHeaders(headers, options = kEmptyObject) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed) return false;
     if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
@@ -1909,7 +1962,7 @@ class QuicStream {
     validateObject(headers, 'headers');
     const { terminal = false } = options;
     const headerString = buildNgHeaderString(
-      headers, assertValidPseudoHeader, true);
+      headers, assertValidPseudoHeader, true /* strictSingleValueFields */);
     const flags = terminal ? kHeadersFlagsTerminal : kHeadersFlagsNone;
     return this.#handle.sendHeaders(kHeadersKindInitial, headerString, flags);
   }
@@ -1921,7 +1974,7 @@ class QuicStream {
    * @returns {boolean}
    */
   sendInformationalHeaders(headers) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed) return false;
     if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
@@ -1942,7 +1995,7 @@ class QuicStream {
    * @returns {boolean}
    */
   sendTrailers(headers) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed) return false;
     if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
@@ -1961,9 +2014,10 @@ class QuicStream {
    * @type {object}
    */
   get writer() {
-    QuicStream.#assertIsQuicStream(this);
-    if (this.#inner.writer !== undefined) return this.#inner.writer;
-    if (this.#inner.outboundSet) {
+    assertIsQuicStream(this);
+    const inner = this.#inner;
+    if (inner.writer !== undefined) return inner.writer;
+    if (inner.outboundSet) {
       throw new ERR_INVALID_STATE(
         'Stream outbound already configured with a body source');
     }
@@ -2154,7 +2208,7 @@ class QuicStream {
       //      `H3_INTERNAL_ERROR` (0x102); for raw QUIC applications
       //      it falls back to the QUIC transport-layer
       //      `INTERNAL_ERROR` (0x1).
-      const code = error instanceof QuicError ?
+      const code = QuicError.isQuicError(error) ?
         error.errorCode :
         getQuicSessionState(stream.#inner.session).internalErrorCode;
       handle.resetStream(code);
@@ -2198,44 +2252,43 @@ class QuicStream {
     // A remote unidirectional stream is read-only and has no writable
     // side. isLocal distinguishes locally-initiated (writable) from
     // remotely-initiated (read-only) uni streams.
-    if (!handle || this.destroyed || this.#inner.state.writeEnded ||
-        (this.#inner.direction === kStreamDirectionUnidirectional &&
-         !this.#inner.isLocal)) {
+    if (!handle || this.destroyed || inner.state.writeEnded ||
+        (inner.direction === kStreamDirectionUnidirectional &&
+         !inner.isLocal)) {
       closed = true;
-      this.#inner.writer = writer;
-      return this.#inner.writer;
+      return inner.writer = writer;
     }
 
     // Initialize the outbound DataQueue for streaming writes
     handle.initStreamingSource();
     initStreamingBackpressure(this);
 
-    this.#inner.writer = writer;
-    return this.#inner.writer;
+    return inner.writer = writer;
   }
 
   /**
    * Sets the outbound body source for this stream. Accepts all body
    * source types (string, TypedArray, Blob, AsyncIterable, Promise, null).
    * Can only be called once. Mutually exclusive with stream.writer.
-   * @param {*} body
+   * @param {any} body
    */
   setBody(body) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed) {
       throw new ERR_INVALID_STATE('Stream is destroyed');
     }
-    if (this.#inner.outboundSet) {
+    const inner = this.#inner;
+    if (inner.outboundSet) {
       throw new ERR_INVALID_STATE('Stream outbound already configured');
     }
-    if (this.#inner.writer !== undefined) {
+    if (inner.writer !== undefined) {
       throw new ERR_INVALID_STATE('Stream writer already accessed');
     }
-    this.#inner.outboundSet = true;
+    inner.outboundSet = true;
     // If the body is a FileHandle, store it so it is closed
     // automatically when the stream finishes.
-    if (body instanceof FileHandle) {
-      this.#inner.fileHandle = body;
+    if (FileHandle.isFileHandle(body)) {
+      inner.fileHandle = body;
     }
     configureOutbound(this.#handle, this, body);
   }
@@ -2258,7 +2311,7 @@ class QuicStream {
    * @param {number|bigint} code
    */
   stopSending(code = 0n) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed) return;
     this.#handle.stopSending(BigInt(code));
   }
@@ -2271,7 +2324,7 @@ class QuicStream {
    * @param {number|bigint} code
    */
   resetStream(code = 0n) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed) return;
     this.#handle.resetStream(BigInt(code));
   }
@@ -2280,10 +2333,10 @@ class QuicStream {
    * The priority of the stream. If the stream is destroyed or if
    * the session does not support priority, `null` will be
    * returned.
-   * @type {{ level: 'default' | 'low' | 'high', incremental: boolean } | null}
+   * @type {StreamPriority | null}
    */
   get priority() {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed ||
         !getQuicSessionState(this.#inner.session).isPrioritySupported) return null;
     const packed = this.#handle.getPriority();
@@ -2295,13 +2348,10 @@ class QuicStream {
 
   /**
    * Sets the priority of the stream.
-   * @param {{
-   *   level?: 'default' | 'low' | 'high',
-   *   incremental?: boolean,
-   * }} options
+   * @param {StreamPriority} [options]
    */
   setPriority(options = kEmptyObject) {
-    QuicStream.#assertIsQuicStream(this);
+    assertIsQuicStream(this);
     if (this.destroyed) return;
     if (!getQuicSessionState(this.#inner.session).isPrioritySupported) {
       throw new ERR_INVALID_STATE(
@@ -2351,21 +2401,22 @@ class QuicStream {
   }
 
   [kFinishClose](error) {
-    this.#inner.pendingClose ??= PromiseWithResolvers();
+    const inner = this.#inner;
+    inner.pendingClose ??= PromiseWithResolvers();
     if (this.destroyed) {
-      return this.#inner.pendingClose.promise;
+      return inner.pendingClose.promise;
     }
     if (error !== undefined) {
-      this.#inner.pendingClose.reject(error);
+      inner.pendingClose.reject(error);
     } else {
-      this.#inner.pendingClose.resolve();
+      inner.pendingClose.resolve();
     }
     debug('stream closed');
     if (onStreamClosedChannel.hasSubscribers) {
       onStreamClosedChannel.publish({
         __proto__: null,
         stream: this,
-        session: this.#inner.session,
+        session: inner.session,
         error,
         stats: this.stats,
       });
@@ -2378,44 +2429,45 @@ class QuicStream {
         },
       });
     }
-    this.#inner.stats?.[kFinishClose]();
-    this.#inner.state?.[kFinishClose]();
-    this.#inner.session[kRemoveStream](this);
-    this.#inner.writer?.fail(error);
-    this.#inner.session = undefined;
-    this.#inner.pendingClose.reject = undefined;
-    this.#inner.pendingClose.resolve = undefined;
-    this.#inner.onblocked = undefined;
-    this.#inner.onreset = undefined;
-    this.#inner.onheaders = undefined;
-    this.#inner.onerror = undefined;
-    this.#inner.ontrailers = undefined;
-    this.#inner.oninfo = undefined;
-    this.#inner.onwanttrailers = undefined;
-    this.#inner.headers = undefined;
-    this.#inner.pendingTrailers = undefined;
+    inner.stats?.[kFinishClose]();
+    inner.state?.[kFinishClose]();
+    inner.session[kRemoveStream](this);
+    inner.writer?.fail(error);
+    inner.session = undefined;
+    inner.pendingClose.reject = undefined;
+    inner.pendingClose.resolve = undefined;
+    inner.onblocked = undefined;
+    inner.onreset = undefined;
+    inner.onheaders = undefined;
+    inner.onerror = undefined;
+    inner.ontrailers = undefined;
+    inner.oninfo = undefined;
+    inner.onwanttrailers = undefined;
+    inner.headers = undefined;
+    inner.pendingTrailers = undefined;
     this.#handle = undefined;
-    if (this.#inner.fileHandle !== undefined) {
+    if (inner.fileHandle !== undefined) {
       // Close the FileHandle that was used as a body source. The close
       // may fail if the user already closed it -- that's expected and
       // harmless, so mark the promise as handled.
       markPromiseAsHandled(this.#inner.fileHandle.close());
-      this.#inner.fileHandle = undefined;
+      inner.fileHandle = undefined;
     }
   }
 
   [kBlocked]() {
+    const inner = this.#inner;
     // The blocked event should only be called if the stream was created with
     // an onblocked callback. The callback should always exist here.
-    assert(this.#inner.onblocked, 'Unexpected stream blocked event');
+    assert(inner.onblocked, 'Unexpected stream blocked event');
     if (onStreamBlockedChannel.hasSubscribers) {
       onStreamBlockedChannel.publish({
         __proto__: null,
         stream: this,
-        session: this.#inner.session,
+        session: inner.session,
       });
     }
-    safeCallbackInvoke(this.#inner.onblocked, this);
+    safeCallbackInvoke(inner.onblocked, this);
   }
 
   [kDrain]() {
@@ -2424,81 +2476,85 @@ class QuicStream {
   }
 
   [kReset](error) {
+    const inner = this.#inner;
     // The reset event should only be called if the stream was created with
     // an onreset callback. The callback should always exist here.
-    assert(this.#inner.onreset, 'Unexpected stream reset event');
+    assert(inner.onreset, 'Unexpected stream reset event');
     if (onStreamResetChannel.hasSubscribers) {
       onStreamResetChannel.publish({
         __proto__: null,
         stream: this,
-        session: this.#inner.session,
+        session: inner.session,
         error,
       });
     }
-    safeCallbackInvoke(this.#inner.onreset, this, error);
+    safeCallbackInvoke(inner.onreset, this, error);
   }
 
   [kHeaders](headers, kind) {
     const block = parseHeaderPairs(headers);
     const kindName = kHeadersKindName[kind] ?? kind;
+    const inner = this.#inner;
 
     switch (kindName) {
       case 'initial':
-        assert(this.#inner.onheaders, 'Unexpected stream headers event');
-        this.#inner.headers ??= block;
+        assert(inner.onheaders, 'Unexpected stream headers event');
+        inner.headers ??= block;
         if (onStreamHeadersChannel.hasSubscribers) {
           onStreamHeadersChannel.publish({
             __proto__: null,
             stream: this,
-            session: this.#inner.session,
+            session: inner.session,
             headers: block,
           });
         }
-        safeCallbackInvoke(this.#inner.onheaders, this, block);
+        safeCallbackInvoke(inner.onheaders, this, block);
         break;
       case 'trailing':
         if (onStreamTrailersChannel.hasSubscribers) {
           onStreamTrailersChannel.publish({
             __proto__: null,
             stream: this,
-            session: this.#inner.session,
+            session: inner.session,
             trailers: block,
           });
         }
-        if (this.#inner.ontrailers)
-          safeCallbackInvoke(this.#inner.ontrailers, this, block);
+        if (inner.ontrailers)
+          safeCallbackInvoke(inner.ontrailers, this, block);
         break;
       case 'hints':
         if (onStreamInfoChannel.hasSubscribers) {
           onStreamInfoChannel.publish({
             __proto__: null,
             stream: this,
-            session: this.#inner.session,
+            session: inner.session,
             headers: block,
           });
         }
-        if (this.#inner.oninfo)
-          safeCallbackInvoke(this.#inner.oninfo, this, block);
+        if (typeof inner.oninfo === 'function')
+          safeCallbackInvoke(inner.oninfo, this, block);
         break;
     }
   }
 
   [kTrailers]() {
     if (this.destroyed) return;
+    const inner = this.#inner;
 
     // nghttp3 is asking us to provide trailers to send.
     // Check for pre-set pendingTrailers first, then the callback.
-    if (this.#inner.pendingTrailers) {
-      this.sendTrailers(this.#inner.pendingTrailers);
-      this.#inner.pendingTrailers = undefined;
-    } else if (this.#inner.onwanttrailers) {
-      safeCallbackInvoke(this.#inner.onwanttrailers, this);
+    if (inner.pendingTrailers) {
+      this.sendTrailers(inner.pendingTrailers);
+      inner.pendingTrailers = undefined;
+    } else if (typeof inner.onwanttrailers === 'function') {
+      safeCallbackInvoke(inner.onwanttrailers, this);
     }
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
+    if (depth < 0) {
+      return 'QuicStream { }';
+    }
 
     const opts = {
       __proto__: null,
@@ -2506,105 +2562,83 @@ class QuicStream {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      id,
+      direction,
+      pending,
+      stats,
+      session,
+    } = this;
+
     return `QuicStream ${inspect({
       __proto__: null,
-      id: this.id,
-      direction: this.direction,
-      pending: this.pending,
-      stats: this.stats,
+      id,
+      direction,
+      pending,
+      stats,
       state: this.#inner.state,
-      session: this.session,
+      session,
     }, opts)}`;
   }
 }
 
 class QuicSession {
-  /** @type {QuicEndpoint} */
-  #endpoint = undefined;
-  /** @type {boolean} */
-  #isPendingClose = false;
-  /** @type {boolean} */
-  #selfInitiatedClose = false;
-  /**
-   * Flag set at the top of `destroy()` to make the method safely
-   * re-entrant. Distinct from `#handle === undefined` so callbacks
-   * that fire from C++ during teardown (e.g. `onSessionClose` ->
-   * `[kFinishClose]`) still see a live `#handle` and can complete
-   * their work.
-   * @type {boolean}
-   */
-  #destroying = false;
-  /**
-   * Set to `true` once the TLS handshake has completed successfully
-   * (i.e. `[kHandshake]` has fired). Used to gate operations that only
-   * make sense for a fully-opened session - notably, attempting to
-   * send a `CONNECTION_CLOSE` from `endpoint.destroy(error)` cascade.
-   * The C++ side cannot create a valid `CONNECTION_CLOSE` packet
-   * before handshake completion and falls back to a path that
-   * re-enters JS `destroy()` and trips our `#destroying` guard,
-   * leaving the C++ side asserting an inconsistent state.
-   * @type {boolean}
-   */
-  #handshakeCompleted = false;
   /** @type {object|undefined} */
   #handle;
-  /** @type {PromiseWithResolvers<void>} */
-  #pendingClose = PromiseWithResolvers();
-  /** @type {PromiseWithResolvers<QuicSessionInfo>} */
-  #pendingOpen = PromiseWithResolvers();
-  /** @type {QuicSessionState} */
-  #state;
-  /** @type {QuicSessionStats} */
-  #stats;
-  /** @type {Set<QuicStream>} */
-  #streams = new SafeSet();
-  /** @type {Function|undefined} */
-  #onerror = undefined;
-  /** @type {OnStreamCallback} */
-  #onstream = undefined;
-  /** @type {OnDatagramCallback|undefined} */
-  #ondatagram = undefined;
-  /** @type {OnDatagramStatusCallback|undefined} */
-  #ondatagramstatus = undefined;
-  /** @type {Function|undefined} */
-  #onpathvalidation = undefined;
-  /** @type {Function|undefined} */
-  #onsessionticket = undefined;
-  /** @type {Function|undefined} */
-  #onversionnegotiation = undefined;
-  /** @type {Function|undefined} */
-  #onhandshake = undefined;
-  /** @type {Function|undefined} */
-  #onnewtoken = undefined;
-  /** @type {Function|undefined} */
-  #onearlyrejected = undefined;
-  /** @type {Function|undefined} */
-  #onorigin = undefined;
-  /** @type {Function|undefined} */
-  #ongoaway = undefined;
-  /** @type {Function|undefined} */
-  #onkeylog = undefined;
-  /** @type {Function|undefined} */
-  #onqlog = undefined;
-  #pendingQlog = undefined;
-  #handshakeInfo = undefined;
-  /** @type {{ local: SocketAddress, remote: SocketAddress }|undefined} */
-  #path = undefined;
-  #certificate = undefined;
-  #peerCertificate = undefined;
-  #ephemeralKeyInfo = undefined;
+
+  #inner = {
+    __proto__: null,
+    /** @type {QuicEndpoint} */
+    endpoint: undefined,
+    isPendingClose: false,
+    selfInitiatedClose: false,
+    destroying: false,
+    handshakeCompleted: false,
+    pendingClose: PromiseWithResolvers(),
+    pendingOpen: PromiseWithResolvers(),
+    /** @type {QuicSessionState} */
+    state: undefined,
+    /** @type {QuicSessionStats} */
+    stats: undefined,
+    streams: new SafeSet(),
+    onerror: undefined,
+    onstream: undefined,
+    ondatagram: undefined,
+    ondatagramstatus: undefined,
+    onpathvalidation: undefined,
+    onsessionticket: undefined,
+    onversionnegotiation: undefined,
+    onhandshake: undefined,
+    onnewtoken: undefined,
+    onearlyrejected: undefined,
+    onorigin: undefined,
+    ongoaway: undefined,
+    onkeylog: undefined,
+    onqlog: undefined,
+    pendingQlog: undefined,
+    handshakeInfo: undefined,
+    /** @type {QuicSessionPath|undefined} */
+    path: undefined,
+    certificate: undefined,
+    peerCertificate: undefined,
+    ephemeralKeyInfo: undefined,
+  };
 
   static {
-    getQuicSessionState = function(session) {
-      QuicSession.#assertIsQuicSession(session);
-      return session.#state;
+    isQuicSession = function(val) {
+      return val != null && typeof val === 'object' && #handle in val;
     };
-  }
 
-  static #assertIsQuicSession(val) {
-    if (val == null || !(#handle in val)) {
-      throw new ERR_INVALID_THIS('QuicSession');
-    }
+    assertIsQuicSession = function(val) {
+      if (!isQuicSession(val)) {
+        throw new ERR_INVALID_THIS('QuicSession');
+      }
+    };
+
+    getQuicSessionState = function(session) {
+      assertIsQuicSession(session);
+      return session.#inner.state;
+    };
   }
 
   /**
@@ -2614,21 +2648,21 @@ class QuicSession {
    */
   constructor(privateSymbol, handle, endpoint) {
     // Instances of QuicSession can only be created internally.
-    if (privateSymbol !== kPrivateConstructor) {
-      throw new ERR_ILLEGAL_CONSTRUCTOR();
-    }
+    assertPrivateSymbol(privateSymbol);
 
-    this.#endpoint = endpoint;
     this.#handle = handle;
     this.#handle[kOwner] = this;
+
+    const inner = this.#inner;
+    inner.endpoint = endpoint;
     // Move any qlog entries that arrived before the wrapper existed.
     if (handle._pendingQlog !== undefined) {
-      this.#pendingQlog = handle._pendingQlog;
+      inner.pendingQlog = handle._pendingQlog;
       handle._pendingQlog = undefined;
     }
-    this.#stats = new QuicSessionStats(
+    inner.stats = new QuicSessionStats(
       kPrivateConstructor, handle.stats, handle.statsByteOffset);
-    this.#state = new QuicSessionState(
+    inner.state = new QuicSessionState(
       kPrivateConstructor, handle.state, handle.stateByteOffset);
 
     if (hasObserver('quic')) {
@@ -2640,32 +2674,33 @@ class QuicSession {
 
   /** @type {boolean} */
   get #isClosedOrClosing() {
-    return this.#handle === undefined || this.#isPendingClose;
+    return this.#handle === undefined || this.#inner.isPendingClose;
   }
 
   /** @type {Function|undefined} */
   get onerror() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onerror;
+    assertIsQuicSession(this);
+    return this.#inner.onerror;
   }
 
   set onerror(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onerror = undefined;
+      inner.onerror = undefined;
     } else {
       validateFunction(fn, 'onerror');
-      this.#onerror = FunctionPrototypeBind(fn, this);
+      inner.onerror = FunctionPrototypeBind(fn, this);
       // When an onerror handler is provided, mark the pending promises
       // as handled so that rejections from destroy(error) don't surface
       // as unhandled rejections. The onerror callback is the
       // application's error handler for this session.
-      markPromiseAsHandled(this.#pendingClose.promise);
-      markPromiseAsHandled(this.#pendingOpen.promise);
+      markPromiseAsHandled(inner.pendingClose.promise);
+      markPromiseAsHandled(inner.pendingOpen.promise);
       // Also mark existing streams' closed promises. Stream rejections
       // during session destruction are expected collateral when the
       // session has an error handler.
-      for (const stream of this.#streams) {
+      for (const stream of inner.streams) {
         markPromiseAsHandled(stream.closed);
       }
     }
@@ -2673,35 +2708,37 @@ class QuicSession {
 
   /** @type {OnStreamCallback} */
   get onstream() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onstream;
+    assertIsQuicSession(this);
+    return this.#inner.onstream;
   }
 
   set onstream(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onstream = undefined;
+      inner.onstream = undefined;
     } else {
       validateFunction(fn, 'onstream');
-      this.#onstream = FunctionPrototypeBind(fn, this);
+      inner.onstream = FunctionPrototypeBind(fn, this);
     }
   }
 
   /** @type {OnDatagramCallback} */
   get ondatagram() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#ondatagram;
+    assertIsQuicSession(this);
+    return this.#inner.ondatagram;
   }
 
   set ondatagram(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#ondatagram = undefined;
-      this.#state.hasDatagramListener = false;
+      inner.ondatagram = undefined;
+      inner.state.hasDatagramListener = false;
     } else {
       validateFunction(fn, 'ondatagram');
-      this.#ondatagram = FunctionPrototypeBind(fn, this);
-      this.#state.hasDatagramListener = true;
+      inner.ondatagram = FunctionPrototypeBind(fn, this);
+      inner.state.hasDatagramListener = true;
     }
   }
 
@@ -2711,71 +2748,75 @@ class QuicSession {
    * @type {OnDatagramStatusCallback}
    */
   get ondatagramstatus() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#ondatagramstatus;
+    assertIsQuicSession(this);
+    return this.#inner.ondatagramstatus;
   }
 
   set ondatagramstatus(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#ondatagramstatus = undefined;
-      this.#state.hasDatagramStatusListener = false;
+      inner.ondatagramstatus = undefined;
+      inner.state.hasDatagramStatusListener = false;
     } else {
       validateFunction(fn, 'ondatagramstatus');
-      this.#ondatagramstatus = FunctionPrototypeBind(fn, this);
-      this.#state.hasDatagramStatusListener = true;
+      inner.ondatagramstatus = FunctionPrototypeBind(fn, this);
+      inner.state.hasDatagramStatusListener = true;
     }
   }
 
   /** @type {Function|undefined} */
   get onpathvalidation() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onpathvalidation;
+    assertIsQuicSession(this);
+    return this.#inner.onpathvalidation;
   }
 
   set onpathvalidation(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onpathvalidation = undefined;
-      this.#state.hasPathValidationListener = false;
+      inner.onpathvalidation = undefined;
+      inner.state.hasPathValidationListener = false;
     } else {
       validateFunction(fn, 'onpathvalidation');
-      this.#onpathvalidation = FunctionPrototypeBind(fn, this);
-      this.#state.hasPathValidationListener = true;
+      inner.onpathvalidation = FunctionPrototypeBind(fn, this);
+      inner.state.hasPathValidationListener = true;
     }
   }
 
   get onkeylog() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onkeylog;
+    assertIsQuicSession(this);
+    return this.#inner.onkeylog;
   }
 
   set onkeylog(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onkeylog = undefined;
+      inner.onkeylog = undefined;
     } else {
       validateFunction(fn, 'onkeylog');
-      this.#onkeylog = FunctionPrototypeBind(fn, this);
+      inner.onkeylog = FunctionPrototypeBind(fn, this);
     }
   }
 
   get onqlog() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onqlog;
+    assertIsQuicSession(this);
+    return this.#inner.onqlog;
   }
 
   set onqlog(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onqlog = undefined;
+      inner.onqlog = undefined;
     } else {
       validateFunction(fn, 'onqlog');
-      this.#onqlog = FunctionPrototypeBind(fn, this);
+      inner.onqlog = FunctionPrototypeBind(fn, this);
       // Flush any qlog entries that were cached before the callback was set.
-      if (this.#pendingQlog !== undefined) {
-        const pending = this.#pendingQlog;
-        this.#pendingQlog = undefined;
+      if (inner.pendingQlog !== undefined) {
+        const pending = inner.pendingQlog;
+        inner.pendingQlog = undefined;
         for (let i = 0; i < pending.length; i += 2) {
           this[kQlog](pending[i], pending[i + 1]);
         }
@@ -2785,119 +2826,126 @@ class QuicSession {
 
   /** @type {Function|undefined} */
   get onsessionticket() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onsessionticket;
+    assertIsQuicSession(this);
+    return this.#inner.onsessionticket;
   }
 
   set onsessionticket(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onsessionticket = undefined;
-      this.#state.hasSessionTicketListener = false;
+      inner.onsessionticket = undefined;
+      inner.state.hasSessionTicketListener = false;
     } else {
       validateFunction(fn, 'onsessionticket');
-      this.#onsessionticket = FunctionPrototypeBind(fn, this);
-      this.#state.hasSessionTicketListener = true;
+      inner.onsessionticket = FunctionPrototypeBind(fn, this);
+      inner.state.hasSessionTicketListener = true;
     }
   }
 
   /** @type {Function|undefined} */
   get onversionnegotiation() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onversionnegotiation;
+    assertIsQuicSession(this);
+    return this.#inner.onversionnegotiation;
   }
 
   set onversionnegotiation(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onversionnegotiation = undefined;
+      inner.onversionnegotiation = undefined;
     } else {
       validateFunction(fn, 'onversionnegotiation');
-      this.#onversionnegotiation = FunctionPrototypeBind(fn, this);
+      inner.onversionnegotiation = FunctionPrototypeBind(fn, this);
     }
   }
 
   /** @type {Function|undefined} */
   get onhandshake() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onhandshake;
+    assertIsQuicSession(this);
+    return this.#inner.onhandshake;
   }
 
   set onhandshake(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onhandshake = undefined;
+      inner.onhandshake = undefined;
     } else {
       validateFunction(fn, 'onhandshake');
-      this.#onhandshake = FunctionPrototypeBind(fn, this);
+      inner.onhandshake = FunctionPrototypeBind(fn, this);
     }
   }
 
   /** @type {Function|undefined} */
   get onnewtoken() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onnewtoken;
+    assertIsQuicSession(this);
+    return this.#inner.onnewtoken;
   }
 
   set onnewtoken(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onnewtoken = undefined;
-      this.#state.hasNewTokenListener = false;
+      inner.onnewtoken = undefined;
+      inner.state.hasNewTokenListener = false;
     } else {
       validateFunction(fn, 'onnewtoken');
-      this.#onnewtoken = FunctionPrototypeBind(fn, this);
-      this.#state.hasNewTokenListener = true;
+      inner.onnewtoken = FunctionPrototypeBind(fn, this);
+      inner.state.hasNewTokenListener = true;
     }
   }
 
   /** @type {Function|undefined} */
   get onearlyrejected() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onearlyrejected;
+    assertIsQuicSession(this);
+    return this.#inner.onearlyrejected;
   }
 
   set onearlyrejected(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onearlyrejected = undefined;
+      inner.onearlyrejected = undefined;
     } else {
       validateFunction(fn, 'onearlyrejected');
-      this.#onearlyrejected = FunctionPrototypeBind(fn, this);
+      inner.onearlyrejected = FunctionPrototypeBind(fn, this);
     }
   }
 
   /** @type {Function|undefined} */
   get onorigin() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#onorigin;
+    assertIsQuicSession(this);
+    return this.#inner.onorigin;
   }
 
   set onorigin(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#onorigin = undefined;
-      this.#state.hasOriginListener = false;
+      inner.onorigin = undefined;
+      inner.state.hasOriginListener = false;
     } else {
       validateFunction(fn, 'onorigin');
-      this.#onorigin = FunctionPrototypeBind(fn, this);
-      this.#state.hasOriginListener = true;
+      inner.onorigin = FunctionPrototypeBind(fn, this);
+      inner.state.hasOriginListener = true;
     }
   }
 
   /** @type {Function|undefined} */
   get ongoaway() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#ongoaway;
+    assertIsQuicSession(this);
+    return this.#inner.ongoaway;
   }
 
   set ongoaway(fn) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     if (fn === undefined) {
-      this.#ongoaway = undefined;
+      inner.ongoaway = undefined;
     } else {
       validateFunction(fn, 'ongoaway');
-      this.#ongoaway = FunctionPrototypeBind(fn, this);
+      inner.ongoaway = FunctionPrototypeBind(fn, this);
     }
   }
 
@@ -2907,8 +2955,8 @@ class QuicSession {
    * @type {bigint}
    */
   get maxDatagramSize() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#state.maxDatagramSize;
+    assertIsQuicSession(this);
+    return this.#inner.state.maxDatagramSize;
   }
 
   /**
@@ -2918,14 +2966,14 @@ class QuicSession {
    * @type {number}
    */
   get maxPendingDatagrams() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#state.maxPendingDatagrams;
+    assertIsQuicSession(this);
+    return this.#inner.state.maxPendingDatagrams;
   }
 
   set maxPendingDatagrams(val) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     validateInteger(val, 'maxPendingDatagrams', 0, 0xFFFF);
-    this.#state.maxPendingDatagrams = val;
+    this.#inner.state.maxPendingDatagrams = val;
   }
 
   /**
@@ -2933,8 +2981,8 @@ class QuicSession {
    * @type {QuicSessionStats}
    */
   get stats() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#stats;
+    assertIsQuicSession(this);
+    return this.#inner.stats;
   }
 
   /**
@@ -2943,19 +2991,19 @@ class QuicSession {
    * @type {QuicEndpoint|null}
    */
   get endpoint() {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     if (this.destroyed) return null;
-    return this.#endpoint;
+    return this.#inner.endpoint;
   }
 
   /**
    * The local and remote socket addresses associated with the session.
-   * @type {{ local: SocketAddress, remote: SocketAddress } | undefined}
+   * @type {QuicSessionPath | undefined}
    */
   get path() {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     if (this.destroyed) return undefined;
-    return this.#path ??= {
+    return this.#inner.path ??= {
       __proto__: null,
       local: new InternalSocketAddress(this.#handle.getLocalAddress()),
       remote: new InternalSocketAddress(this.#handle.getRemoteAddress()),
@@ -2967,9 +3015,9 @@ class QuicSession {
    * @type {object|undefined}
    */
   get certificate() {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     if (this.destroyed) return undefined;
-    return this.#certificate ??= this.#handle.getCertificate();
+    return this.#inner.certificate ??= this.#handle.getCertificate();
   }
 
   /**
@@ -2978,9 +3026,9 @@ class QuicSession {
    * @type {object|undefined}
    */
   get peerCertificate() {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     if (this.destroyed) return undefined;
-    return this.#peerCertificate ??= this.#handle.getPeerCertificate();
+    return this.#inner.peerCertificate ??= this.#handle.getPeerCertificate();
   }
 
   /**
@@ -2990,9 +3038,9 @@ class QuicSession {
    * @type {object|undefined}
    */
   get ephemeralKeyInfo() {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     if (this.destroyed) return undefined;
-    return this.#ephemeralKeyInfo ??= this.#handle.getEphemeralKey();
+    return this.#inner.ephemeralKeyInfo ??= this.#handle.getEphemeralKey();
   }
 
   /**
@@ -3001,11 +3049,12 @@ class QuicSession {
    * @returns {QuicStream}
    */
   async #createStream(direction, options = kEmptyObject) {
+    const inner = this.#inner;
     if (this.#isClosedOrClosing) {
       throw new ERR_INVALID_STATE('Session is closed. New streams cannot be opened.');
     }
     const dir = direction === kStreamDirectionBidirectional ? 'bidi' : 'uni';
-    if (this.#state.isStreamOpenAllowed) {
+    if (inner.state.isStreamOpenAllowed) {
       debug(`opening new pending ${dir} stream`);
     } else {
       debug(`opening new ${dir} stream`);
@@ -3034,21 +3083,21 @@ class QuicSession {
       throw new ERR_QUIC_OPEN_STREAM_FAILED();
     }
 
-    if (this.#state.isPrioritySupported) {
+    if (inner.state.isPrioritySupported) {
       const urgency = priority === 'high' ? 0 : priority === 'low' ? 7 : 3;
       handle.setPriority((urgency << 1) | (incremental ? 1 : 0));
     }
 
     const stream = new QuicStream(
       kPrivateConstructor, handle, this, direction, true /* isLocal */);
-    this.#streams.add(stream);
-    if (typeof this.#onerror === 'function') {
+    inner.streams.add(stream);
+    if (typeof this.#inner.onerror === 'function') {
       markPromiseAsHandled(stream.closed);
     }
 
     // If the body was a FileHandle, store it on the stream so it is
     // closed automatically when the stream finishes.
-    if (body instanceof FileHandle) {
+    if (FileHandle.isFileHandle(body)) {
       stream[kAttachFileHandle](body);
     }
 
@@ -3083,7 +3132,7 @@ class QuicSession {
    * @returns {Promise<QuicStream>}
    */
   async createBidirectionalStream(options = kEmptyObject) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     return await this.#createStream(kStreamDirectionBidirectional, options);
   }
 
@@ -3094,7 +3143,7 @@ class QuicSession {
    * @returns {Promise<QuicStream>}
    */
   async createUnidirectionalStream(options = kEmptyObject) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     return await this.#createStream(kStreamDirectionUnidirectional, options);
   }
 
@@ -3119,12 +3168,12 @@ class QuicSession {
    * @returns {Promise<bigint>} The datagram ID
    */
   async sendDatagram(datagram, encoding = 'utf8') {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     if (this.#isClosedOrClosing) {
       throw new ERR_INVALID_STATE('Session is closed');
     }
 
-    const maxDatagramSize = this.#state.maxDatagramSize;
+    const maxDatagramSize = this.#inner.state.maxDatagramSize;
 
     // The peer max datagram size is either unknown or they have explicitly
     // indicated that they do not support datagrams by setting it to 0. In
@@ -3177,7 +3226,7 @@ class QuicSession {
    * Initiate a key update.
    */
   updateKey() {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     if (this.#isClosedOrClosing) {
       throw new ERR_INVALID_STATE('Session is closed');
     }
@@ -3211,12 +3260,13 @@ class QuicSession {
    * @returns {Promise<void>}
    */
   close(options = kEmptyObject) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     options = validateCloseOptions(options);
+    const inner = this.#inner;
     if (!this.#isClosedOrClosing) {
-      this.#isPendingClose = true;
+      inner.isPendingClose = true;
       if (options?.code !== undefined) {
-        this.#selfInitiatedClose = true;
+        inner.selfInitiatedClose = true;
       }
 
       debug('gracefully closing the session');
@@ -3234,13 +3284,13 @@ class QuicSession {
 
   /** @type {boolean} */
   get closing() {
-    return this.#isPendingClose;
+    return this.#inner.isPendingClose;
   }
 
   /** @type {Promise<QuicSessionInfo>} */
   get opened() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#pendingOpen.promise;
+    assertIsQuicSession(this);
+    return this.#inner.pendingOpen.promise;
   }
 
   /**
@@ -3249,13 +3299,13 @@ class QuicSession {
    * @type {Promise<void>}
    */
   get closed() {
-    QuicSession.#assertIsQuicSession(this);
-    return this.#pendingClose.promise;
+    assertIsQuicSession(this);
+    return this.#inner.pendingClose.promise;
   }
 
   /** @type {boolean} */
   get destroyed() {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
     return this.#handle === undefined;
   }
 
@@ -3275,7 +3325,8 @@ class QuicSession {
    *   string included in the CONNECTION_CLOSE frame (diagnostic only).
    */
   destroy(error, options) {
-    QuicSession.#assertIsQuicSession(this);
+    assertIsQuicSession(this);
+    const inner = this.#inner;
     // Two distinct guards (see also `QuicStream.destroy`):
     //   * `#destroying` flips synchronously here so any re-entrant call
     //     (e.g. from a user `onerror` callback or from a cascading
@@ -3286,10 +3337,10 @@ class QuicSession {
     //     "fully torn down". Defense-in-depth for paths that may have
     //     finished teardown without setting `#destroying` and for
     //     repeat invocations after this method has fully run.
-    if (this.#destroying || this.destroyed) return;
+    if (inner.destroying || this.destroyed) return;
 
     if (options !== undefined) options = validateCloseOptions(options);
-    this.#destroying = true;
+    inner.destroying = true;
 
     debug('destroying the session');
 
@@ -3301,31 +3352,31 @@ class QuicSession {
           error,
         });
       }
-      if (typeof this.#onerror === 'function') {
-        invokeOnerror(this.#onerror, error);
+      if (typeof inner.onerror === 'function') {
+        invokeOnerror(inner.onerror, error);
       }
     }
 
     // First, forcefully and immediately destroy all open streams, if any.
-    for (const stream of this.#streams) {
+    for (const stream of inner.streams) {
       stream.destroy(error);
     }
     // The streams should remove themselves when they are destroyed but let's
     // be doubly sure.
-    if (this.#streams.size) {
+    if (inner.streams.size) {
       process.emitWarning(
-        `The session is destroyed with ${this.#streams.size} active streams. ` +
+        `The session is destroyed with ${inner.streams.size} active streams. ` +
         'This should not happen and indicates a bug in Node.js. Please open an ' +
         'issue in the Node.js GitHub repository at https://github.com/nodejs/node ' +
         'to report the problem.',
       );
     }
-    this.#streams.clear();
+    inner.streams.clear();
 
     // Remove this session immediately from the endpoint
-    this.#endpoint[kRemoveSession](this);
-    this.#endpoint = undefined;
-    this.#isPendingClose = false;
+    inner.endpoint[kRemoveSession](this);
+    inner.endpoint = undefined;
+    inner.isPendingClose = false;
 
     // If the handshake never completed, reject the opened promise. The
     // session is being destroyed, so the handshake will never complete
@@ -3341,54 +3392,54 @@ class QuicSession {
     // rejection warning - common for server-side sessions delivered via
     // `onsession`, which often do not await opened. The rejection is
     // still observable via `await session.opened`.
-    if (this.#pendingOpen.reject) {
-      markPromiseAsHandled(this.#pendingOpen.promise);
-      this.#pendingOpen.reject(error ?? new ERR_INVALID_STATE(
+    if (inner.pendingOpen.reject) {
+      markPromiseAsHandled(inner.pendingOpen.promise);
+      inner.pendingOpen.reject(error ?? new ERR_INVALID_STATE(
         'Session was destroyed before it opened'));
     }
 
     if (error) {
       // If the session is still waiting to be closed, and error
       // is specified, reject the closed promise.
-      this.#pendingClose.reject?.(error);
+      inner.pendingClose.reject?.(error);
     } else {
-      this.#pendingClose.resolve?.();
+      inner.pendingClose.resolve?.();
     }
 
-    this.#pendingClose.reject = undefined;
-    this.#pendingClose.resolve = undefined;
-    this.#pendingOpen.reject = undefined;
-    this.#pendingOpen.resolve = undefined;
+    inner.pendingClose.reject = undefined;
+    inner.pendingClose.resolve = undefined;
+    inner.pendingOpen.reject = undefined;
+    inner.pendingOpen.resolve = undefined;
 
-    this.#state[kFinishClose]();
-    this.#stats[kFinishClose]();
+    inner.state[kFinishClose]();
+    inner.stats[kFinishClose]();
 
     if (this[kPerfEntry] && hasObserver('quic')) {
       stopPerf(this, kPerfEntry, {
         detail: {
-          stats: this.stats,
-          handshake: this.#handshakeInfo,
-          path: this.#path,
+          stats: inner.stats,
+          handshake: inner.handshakeInfo,
+          path: inner.path,
         },
       });
     }
 
-    this.#onerror = undefined;
-    this.#onstream = undefined;
-    this.#ondatagram = undefined;
-    this.#ondatagramstatus = undefined;
-    this.#onpathvalidation = undefined;
-    this.#onsessionticket = undefined;
-    this.#onkeylog = undefined;
-    this.#onversionnegotiation = undefined;
-    this.#onhandshake = undefined;
-    this.#onnewtoken = undefined;
-    this.#onorigin = undefined;
-    this.#ongoaway = undefined;
-    this.#path = undefined;
-    this.#certificate = undefined;
-    this.#peerCertificate = undefined;
-    this.#ephemeralKeyInfo = undefined;
+    inner.onerror = undefined;
+    inner.onstream = undefined;
+    inner.ondatagram = undefined;
+    inner.ondatagramstatus = undefined;
+    inner.onpathvalidation = undefined;
+    inner.onsessionticket = undefined;
+    inner.onkeylog = undefined;
+    inner.onversionnegotiation = undefined;
+    inner.onhandshake = undefined;
+    inner.onnewtoken = undefined;
+    inner.onorigin = undefined;
+    inner.ongoaway = undefined;
+    inner.path = undefined;
+    inner.certificate = undefined;
+    inner.peerCertificate = undefined;
+    inner.ephemeralKeyInfo = undefined;
 
     // Destroy the underlying C++ handle. Pass close error options if
     // provided so the CONNECTION_CLOSE frame carries the correct code.
@@ -3404,7 +3455,7 @@ class QuicSession {
         __proto__: null,
         session: this,
         error,
-        stats: this.stats,
+        stats: inner.stats,
       });
     }
   }
@@ -3416,7 +3467,8 @@ class QuicSession {
    * @param {bigint} lastStreamId
    */
   [kGoaway](lastStreamId) {
-    this.#isPendingClose = true;
+    const inner = this.#inner;
+    inner.isPendingClose = true;
     if (onSessionClosingChannel.hasSubscribers) {
       onSessionClosingChannel.publish({ __proto__: null, session: this });
     }
@@ -3427,8 +3479,8 @@ class QuicSession {
         lastStreamId,
       });
     }
-    if (this.#ongoaway) {
-      safeCallbackInvoke(this.#ongoaway, this, lastStreamId);
+    if (typeof inner.ongoaway === 'function') {
+      safeCallbackInvoke(inner.ongoaway, this, lastStreamId);
     }
   }
 
@@ -3451,7 +3503,7 @@ class QuicSession {
     // If the local side initiated this close with an error code (via
     // close({ code })), this is an intentional shutdown; not an error.
     // The closed promise should resolve, not reject.
-    if (this.#selfInitiatedClose) {
+    if (this.#inner.selfInitiatedClose) {
       this.destroy();
       return;
     }
@@ -3491,13 +3543,15 @@ class QuicSession {
   }
 
   [kKeylog](line) {
-    if (this.destroyed || this.onkeylog === undefined) return;
-    safeCallbackInvoke(this.#onkeylog, this, line);
+    const inner = this.#inner;
+    if (this.destroyed || inner.onkeylog === undefined) return;
+    safeCallbackInvoke(inner.onkeylog, this, line);
   }
 
   [kQlog](data, fin) {
-    if (this.onqlog === undefined) return;
-    safeCallbackInvoke(this.#onqlog, this, data, fin);
+    const inner = this.#inner;
+    if (inner.onqlog === undefined) return;
+    safeCallbackInvoke(inner.onqlog, this, data, fin);
   }
 
   /**
@@ -3507,7 +3561,8 @@ class QuicSession {
   [kDatagram](u8, early) {
     // The datagram event should only be called if the session has
     // an ondatagram callback. The callback should always exist here.
-    assert(typeof this.#ondatagram === 'function', 'Unexpected datagram event');
+    const inner = this.#inner;
+    assert(typeof inner.ondatagram === 'function', 'Unexpected datagram event');
     if (this.destroyed) return;
     const length = TypedArrayPrototypeGetByteLength(u8);
     if (onSessionReceiveDatagramChannel.hasSubscribers) {
@@ -3518,7 +3573,7 @@ class QuicSession {
         session: this,
       });
     }
-    safeCallbackInvoke(this.#ondatagram, this, u8, early);
+    safeCallbackInvoke(inner.ondatagram, this, u8, early);
   }
 
   /**
@@ -3526,9 +3581,10 @@ class QuicSession {
    * @param {'lost'|'acknowledged'} status
    */
   [kDatagramStatus](id, status) {
+    const inner = this.#inner;
     // The datagram status event should only be called if the session has
     // an ondatagramstatus callback. The callback should always exist here.
-    assert(typeof this.#ondatagramstatus === 'function', 'Unexpected datagram status event');
+    assert(typeof inner.ondatagramstatus === 'function', 'Unexpected datagram status event');
     if (this.destroyed) return;
     if (onSessionReceiveDatagramStatusChannel.hasSubscribers) {
       onSessionReceiveDatagramStatusChannel.publish({
@@ -3538,7 +3594,7 @@ class QuicSession {
         session: this,
       });
     }
-    safeCallbackInvoke(this.#ondatagramstatus, this, id, status);
+    safeCallbackInvoke(inner.ondatagramstatus, this, id, status);
   }
 
   /**
@@ -3551,7 +3607,8 @@ class QuicSession {
    */
   [kPathValidation](result, newLocalAddress, newRemoteAddress, oldLocalAddress,
                     oldRemoteAddress, preferredAddress) {
-    assert(typeof this.#onpathvalidation === 'function',
+    const inner = this.#inner;
+    assert(typeof inner.onpathvalidation === 'function',
            'Unexpected path validation event');
     if (this.destroyed) return;
     const newLocal = new InternalSocketAddress(newLocalAddress);
@@ -3572,7 +3629,7 @@ class QuicSession {
         session: this,
       });
     }
-    safeCallbackInvoke(this.#onpathvalidation, this, result, newLocal, newRemote,
+    safeCallbackInvoke(inner.onpathvalidation, this, result, newLocal, newRemote,
                        oldLocal, oldRemote, preferredAddress);
   }
 
@@ -3580,7 +3637,8 @@ class QuicSession {
    * @param {object} ticket
    */
   [kSessionTicket](ticket) {
-    assert(typeof this.#onsessionticket === 'function',
+    const inner = this.#inner;
+    assert(typeof inner.onsessionticket === 'function',
            'Unexpected session ticket event');
     if (this.destroyed) return;
     if (onSessionTicketChannel.hasSubscribers) {
@@ -3590,7 +3648,7 @@ class QuicSession {
         session: this,
       });
     }
-    safeCallbackInvoke(this.#onsessionticket, this, ticket);
+    safeCallbackInvoke(inner.onsessionticket, this, ticket);
   }
 
   /**
@@ -3598,7 +3656,8 @@ class QuicSession {
    * @param {SocketAddress} address
    */
   [kNewToken](token, address) {
-    assert(typeof this.#onnewtoken === 'function',
+    const inner = this.#inner;
+    assert(typeof inner.onnewtoken === 'function',
            'Unexpected new token event');
     if (this.destroyed) return;
     const addr = new InternalSocketAddress(address);
@@ -3610,7 +3669,7 @@ class QuicSession {
         session: this,
       });
     }
-    safeCallbackInvoke(this.#onnewtoken, this, token, addr);
+    safeCallbackInvoke(inner.onnewtoken, this, token, addr);
   }
 
   [kEarlyDataRejected]() {
@@ -3621,8 +3680,9 @@ class QuicSession {
         session: this,
       });
     }
-    if (typeof this.#onearlyrejected === 'function') {
-      safeCallbackInvoke(this.#onearlyrejected, this);
+    const inner = this.#inner;
+    if (typeof inner.onearlyrejected === 'function') {
+      safeCallbackInvoke(inner.onearlyrejected, this);
     }
   }
 
@@ -3642,8 +3702,9 @@ class QuicSession {
         session: this,
       });
     }
-    if (this.#onversionnegotiation) {
-      safeCallbackInvoke(this.#onversionnegotiation, this,
+    const inner = this.#inner;
+    if (typeof inner.onversionnegotiation === 'function') {
+      safeCallbackInvoke(inner.onversionnegotiation, this,
                          version, requestedVersions, supportedVersions);
     }
     // Version negotiation is always a fatal event - the session must be
@@ -3656,9 +3717,9 @@ class QuicSession {
    * @param {string[]} origins
    */
   [kOrigin](origins) {
-    assert(typeof this.#onorigin === 'function',
-           'Unexpected origin event');
     if (this.destroyed) return;
+    const inner = this.#inner;
+    assert(typeof inner.onorigin === 'function', 'Unexpected origin event');
     if (onSessionOriginChannel.hasSubscribers) {
       onSessionOriginChannel.publish({
         __proto__: null,
@@ -3666,7 +3727,7 @@ class QuicSession {
         session: this,
       });
     }
-    safeCallbackInvoke(this.#onorigin, this, origins);
+    safeCallbackInvoke(inner.onorigin, this, origins);
   }
 
   /**
@@ -3679,13 +3740,15 @@ class QuicSession {
    */
   [kHandshake](servername, protocol, cipher, cipherVersion, validationErrorReason,
                validationErrorCode, earlyDataAttempted, earlyDataAccepted) {
-    if (this.destroyed || !this.#pendingOpen.resolve) return;
+    const inner = this.#inner;
+    if (this.destroyed || !inner.pendingOpen.resolve) return;
+
 
     const addr = this.#handle.getRemoteAddress();
 
     const info = {
       __proto__: null,
-      local: this.#endpoint.address,
+      local: inner.endpoint.address,
       remote: addr !== undefined ?
         new InternalSocketAddress(addr) :
         undefined,
@@ -3700,7 +3763,7 @@ class QuicSession {
     };
 
     // Stash timing-relevant handshake info for the perf entry detail.
-    this.#handshakeInfo = {
+    inner.handshakeInfo = {
       __proto__: null,
       servername,
       protocol,
@@ -3716,19 +3779,19 @@ class QuicSession {
       });
     }
 
-    if (this.#onhandshake) {
-      safeCallbackInvoke(this.#onhandshake, this, info);
+    if (typeof inner.onhandshake === 'function') {
+      safeCallbackInvoke(inner.onhandshake, this, info);
     }
 
-    this.#pendingOpen.resolve?.(info);
-    this.#pendingOpen.resolve = undefined;
-    this.#pendingOpen.reject = undefined;
-    this.#handshakeCompleted = true;
+    inner.pendingOpen.resolve?.(info);
+    inner.pendingOpen.resolve = undefined;
+    inner.pendingOpen.reject = undefined;
+    inner.handshakeCompleted = true;
   }
 
   /** @type {boolean} */
   get [kHandshakeCompleted]() {
-    return this.#handshakeCompleted;
+    return this.#inner.handshakeCompleted;
   }
 
   /**
@@ -3736,22 +3799,25 @@ class QuicSession {
    * @param {number} direction
    */
   [kNewStream](handle, direction) {
-    const stream = new QuicStream(kPrivateConstructor, handle, this, direction);
+    const inner = this.#inner;
+    const stream = new QuicStream(kPrivateConstructor, handle, this, direction,
+                                  false /* isLocal */);
 
     // Set the default high water mark for received streams.
     stream.highWaterMark = kDefaultHighWaterMark;
 
     // A new stream was received. If we don't have an onstream callback, then
     // there's nothing we can do about it. Destroy the stream in this case.
-    if (typeof this.#onstream !== 'function') {
+    if (typeof inner.onstream !== 'function') {
       process.emitWarning('A new stream was received but no onstream callback was provided');
       stream.destroy();
       return;
     }
-    this.#streams.add(stream);
+
+    inner.streams.add(stream);
     // If the session has an onerror handler, mark the stream's closed
     // promise as handled. See the onerror setter for explanation.
-    if (typeof this.#onerror === 'function') {
+    if (typeof inner.onerror === 'function') {
       markPromiseAsHandled(stream.closed);
     }
 
@@ -3774,16 +3840,17 @@ class QuicSession {
       });
     }
 
-    safeCallbackInvoke(this.#onstream, this, stream);
+    safeCallbackInvoke(inner.onstream, this, stream);
   }
 
   [kRemoveStream](stream) {
-    this.#streams.delete(stream);
+    this.#inner.streams.delete(stream);
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
+    if (depth < 0) {
+      return 'QuicSession { }';
+    }
 
     const opts = {
       __proto__: null,
@@ -3791,106 +3858,65 @@ class QuicSession {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      isPendingClose: closing,
+      endpoint,
+      path,
+      state,
+      stats,
+      streams,
+    } = this.#inner;
+
     return `QuicSession ${inspect({
       closed: this.closed,
-      closing: this.#isPendingClose,
+      closing,
       destroyed: this.destroyed,
-      endpoint: this.endpoint,
-      path: this.path,
-      state: this.#state,
-      stats: this.stats,
-      streams: this.#streams,
+      endpoint,
+      path,
+      state,
+      stats,
+      streams,
     }, opts)}`;
   }
 
   async [SymbolAsyncDispose]() { await this.close(); }
 }
 
-let isQuicEndpoint;
-
 // The QuicEndpoint represents a local UDP port binding. It can act as both a
 // server for receiving peer sessions, or a client for initiating them. The
 // local UDP port will be lazily bound only when connect() or listen() are
 // called.
 class QuicEndpoint {
-  /**
-   * The local socket address on which the endpoint is listening (lazily created)
-   * @type {SocketAddress|undefined}
-   */
-  #address = undefined;
-  /**
-   * When true, the endpoint has been marked busy and is temporarily not accepting
-   * new sessions (only used when the Endpoint is acting as a server)
-   * @type {boolean}
-   */
-  #busy = false;
-  /**
-   * The underlying C++ handle for the endpoint. When undefined the endpoint is
-   * considered to be closed.
-   * @type {object}
-   */
   #handle;
-  /**
-   * True if endpoint.close() has been called and the [kFinishClose] method has
-   * not yet been called.
-   * @type {boolean}
-   */
-  #isPendingClose = false;
-  /**
-   * True if the endpoint is acting as a server and actively listening for connections.
-   * @type {boolean}
-   */
-  #listening = false;
-  /**
-   * A promise that is resolved when the endpoint has been closed (or rejected if
-   * the endpoint closes abruptly due to an error).
-   * @type {PromiseWithResolvers<void>}
-   */
-  #pendingClose = PromiseWithResolvers();
-  /**
-   * If destroy() is called with an error, the error is stored here and used to reject
-   * the pendingClose promise when [kFinishClose] is called.
-   * @type {any}
-   */
-  #pendingError = undefined;
-  /**
-   * The collection of active sessions.
-   * @type {Set<QuicSession>}
-   */
-  #sessions = new SafeSet();
-  /**
-   * The internal state of the endpoint. Used to efficiently track and update the
-   * state of the underlying c++ endpoint handle.
-   * @type {QuicEndpointState}
-   */
-  #state;
-  /**
-   * The collected statistics for the endpoint.
-   * @type {QuicEndpointStats}
-   */
-  #stats;
-  /**
-   * The user provided callback that is invoked when a new session is received.
-   * (used only when the endpoint is acting as a server)
-   * @type {OnSessionCallback}
-   */
-  #onsession = undefined;
-  #sessionCallbacks = undefined;
+  #inner = {
+    __proto__: null,
+    address: undefined,
+    busy: false,
+    isPendingClose: false,
+    listening: false,
+    pendingClose: PromiseWithResolvers(),
+    pendingError: undefined,
+    sessions: new SafeSet(),
+    stat: undefined,
+    stats: undefined,
+    onsession: undefined,
+    sessionCallbacks: undefined,
+  };
 
   static {
-    getQuicEndpointState = function(endpoint) {
-      assertIsQuicEndpoint(endpoint);
-      return endpoint.#state;
-    };
-
     isQuicEndpoint = function(val) {
-      return val != null && #handle in val;
+      return val != null && typeof val === 'object' && #handle in val;
     };
 
     assertIsQuicEndpoint = function(val) {
       if (!isQuicEndpoint(val)) {
         throw new ERR_INVALID_THIS('QuicEndpoint');
       }
+    };
+
+    getQuicEndpointState = function(endpoint) {
+      assertIsQuicEndpoint(endpoint);
+      return endpoint.#inner.state;
     };
 
     assertEndpointNotClosedOrClosing = function(endpoint) {
@@ -3900,7 +3926,7 @@ class QuicEndpoint {
     };
 
     assertEndpointIsNotBusy = function(endpoint) {
-      if (endpoint.#state.isBusy) {
+      if (endpoint.#inner.state.isBusy) {
         throw new ERR_INVALID_STATE('Endpoint is busy');
       }
     };
@@ -3974,7 +4000,7 @@ class QuicEndpoint {
 
   #newSession(handle) {
     const session = new QuicSession(kPrivateConstructor, handle, this);
-    this.#sessions.add(session);
+    this.#inner.sessions.add(session);
     // Set default pending datagram queue size.
     session.maxPendingDatagrams = kDefaultMaxPendingDatagrams;
     return session;
@@ -3987,8 +4013,9 @@ class QuicEndpoint {
     const options = this.#processEndpointOptions(config);
     this.#handle = new Endpoint_(options);
     this.#handle[kOwner] = this;
-    this.#stats = new QuicEndpointStats(kPrivateConstructor, this.#handle.stats);
-    this.#state = new QuicEndpointState(kPrivateConstructor, this.#handle.state);
+    const inner = this.#inner;
+    inner.stats = new QuicEndpointStats(kPrivateConstructor, this.#handle.stats);
+    inner.state = new QuicEndpointState(kPrivateConstructor, this.#handle.state);
 
     // Connection limits are stored in the shared state buffer so they
     // can be read by C++ and mutated from JS after construction.
@@ -4023,11 +4050,11 @@ class QuicEndpoint {
    */
   get stats() {
     assertIsQuicEndpoint(this);
-    return this.#stats;
+    return this.#inner.stats;
   }
 
   get #isClosedOrClosing() {
-    return this.destroyed || this.#isPendingClose;
+    return this.destroyed || this.#inner.isPendingClose;
   }
 
   /**
@@ -4037,7 +4064,7 @@ class QuicEndpoint {
    */
   get busy() {
     assertIsQuicEndpoint(this);
-    return this.#busy;
+    return this.#inner.busy;
   }
 
   /**
@@ -4048,15 +4075,16 @@ class QuicEndpoint {
     assertEndpointNotClosedOrClosing(this);
     // The val is allowed to be any truthy value
     // Non-op if there is no change
-    if (!!val !== this.#busy) {
-      debug('toggling endpoint busy status to ', !this.#busy);
-      this.#busy = !this.#busy;
-      this.#handle.markBusy(this.#busy);
+    const inner = this.#inner;
+    if (!!val !== inner.busy) {
+      debug('toggling endpoint busy status to ', !inner.busy);
+      inner.busy = !inner.busy;
+      this.#handle.markBusy(inner.busy);
       if (onEndpointBusyChangeChannel.hasSubscribers) {
         onEndpointBusyChangeChannel.publish({
           __proto__: null,
           endpoint: this,
-          busy: this.#busy,
+          busy: inner.busy,
         });
       }
     }
@@ -4069,13 +4097,13 @@ class QuicEndpoint {
    */
   get maxConnectionsPerHost() {
     assertIsQuicEndpoint(this);
-    return this.#state.maxConnectionsPerHost;
+    return this.#inner.state.maxConnectionsPerHost;
   }
 
   set maxConnectionsPerHost(val) {
     assertIsQuicEndpoint(this);
     validateInteger(val, 'maxConnectionsPerHost', 0, 0xFFFF);
-    this.#state.maxConnectionsPerHost = val;
+    this.#inner.state.maxConnectionsPerHost = val;
   }
 
   /**
@@ -4085,13 +4113,13 @@ class QuicEndpoint {
    */
   get maxConnectionsTotal() {
     assertIsQuicEndpoint(this);
-    return this.#state.maxConnectionsTotal;
+    return this.#inner.state.maxConnectionsTotal;
   }
 
   set maxConnectionsTotal(val) {
     assertIsQuicEndpoint(this);
     validateInteger(val, 'maxConnectionsTotal', 0, 0xFFFF);
-    this.#state.maxConnectionsTotal = val;
+    this.#inner.state.maxConnectionsTotal = val;
   }
 
   /**
@@ -4101,11 +4129,11 @@ class QuicEndpoint {
   get address() {
     assertIsQuicEndpoint(this);
     if (this.#isClosedOrClosing) return undefined;
-    if (this.#address === undefined) {
+    if (this.#inner.address === undefined) {
       const addr = this.#handle.address();
-      if (addr !== undefined) this.#address = new InternalSocketAddress(addr);
+      if (addr !== undefined) this.#inner.address = new InternalSocketAddress(addr);
     }
-    return this.#address;
+    return this.#inner.address;
   }
 
   /**
@@ -4116,11 +4144,13 @@ class QuicEndpoint {
   [kListen](onsession, options) {
     assertEndpointNotClosedOrClosing(this);
     assertEndpointIsNotBusy(this);
-    if (this.#listening) {
+    const inner = this.#inner;
+    if (inner.listening) {
       throw new ERR_INVALID_STATE('Endpoint is already listening');
     }
     validateObject(options, 'options');
-    this.#onsession = FunctionPrototypeBind(onsession, this);
+    validateFunction(onsession, 'onsession');
+    this.#inner.onsession = FunctionPrototypeBind(onsession, this);
 
     const {
       onerror,
@@ -4146,7 +4176,7 @@ class QuicEndpoint {
     } = options;
 
     // Store session and stream callbacks to apply to each new incoming session.
-    this.#sessionCallbacks = {
+    inner.sessionCallbacks = {
       __proto__: null,
       onerror,
       onstream,
@@ -4168,9 +4198,9 @@ class QuicEndpoint {
       onwanttrailers,
     };
 
-    debug('endpoint listening as a server');
     this.#handle.listen(rest);
-    this.#listening = true;
+    inner.listening = true;
+    debug('endpoint listening as a server');
   }
 
   /**
@@ -4212,15 +4242,16 @@ class QuicEndpoint {
     assertIsQuicEndpoint(this);
     if (!this.#isClosedOrClosing) {
       debug('gracefully closing the endpoint');
+      const inner = this.#inner;
+      inner.isPendingClose = true;
+      this.#handle.closeGracefully();
       if (onEndpointClosingChannel.hasSubscribers) {
         onEndpointClosingChannel.publish({
           __proto__: null,
           endpoint: this,
-          hasPendingError: this.#pendingError !== undefined,
+          hasPendingError: inner.pendingError !== undefined,
         });
       }
-      this.#isPendingClose = true;
-      this.#handle.closeGracefully();
     }
     return this.closed;
   }
@@ -4233,7 +4264,7 @@ class QuicEndpoint {
    */
   get closed() {
     assertIsQuicEndpoint(this);
-    return this.#pendingClose.promise;
+    return this.#inner.pendingClose.promise;
   }
 
   /**
@@ -4242,13 +4273,13 @@ class QuicEndpoint {
    */
   get closing() {
     assertIsQuicEndpoint(this);
-    return this.#isPendingClose;
+    return this.#inner.isPendingClose;
   }
 
   /** @type {boolean} */
   get listening() {
     assertIsQuicEndpoint(this);
-    return this.#listening;
+    return this.#inner.listening;
   }
 
   /** @type {boolean} */
@@ -4268,6 +4299,7 @@ class QuicEndpoint {
   destroy(error) {
     assertIsQuicEndpoint(this);
     debug('destroying the endpoint');
+    const inner = this.#inner;
     // Record the error before deciding whether to initiate a close. If
     // `close()` was already called (e.g. the user kicked off a graceful
     // shutdown and then a fatal error was reported afterwards via
@@ -4276,7 +4308,7 @@ class QuicEndpoint {
     // last in-flight session finishes draining. Only the *first* error
     // is recorded, matching how other Node subsystems handle a
     // double-error race.
-    if (error !== undefined) this.#pendingError ??= error;
+    if (error !== undefined) inner.pendingError ??= error;
     // Force all sessions to be abruptly closed *before* signalling the
     // endpoint to close gracefully. The order matters: each session's
     // `destroy(error, options)` asks the C++ side to emit a
@@ -4293,7 +4325,7 @@ class QuicEndpoint {
     // `destroy()`, which trips the `#destroying` guard and leaves the
     // C++ side asserting an inconsistent destroyed state.
     const closeOptions = errorToCloseOptions(error);
-    for (const session of this.#sessions) {
+    for (const session of inner.sessions) {
       // Mark each cascaded session's `closed` as handled before
       // destroying it. This prevents unhandled-rejection warnings when
       // the session is collateral damage from an endpoint-level destroy
@@ -4321,7 +4353,7 @@ class QuicEndpoint {
    * replace is true, the entire SNI map is replaced. Otherwise, the
    * provided entries are merged into the existing map.
    * @param {object} entries
-   * @param {{replace?: boolean}} [options]
+   * @param {SNIContextOptions} [options]
    */
   setSNIContexts(entries, options = kEmptyObject) {
     assertIsQuicEndpoint(this);
@@ -4356,38 +4388,39 @@ class QuicEndpoint {
     debug('endpoint is finishing close', context, status);
     endpointRegistry.delete(this);
     this.#handle = undefined;
-    this.#stats[kFinishClose]();
-    this.#state[kFinishClose]();
+    const inner = this.#inner;
+    inner.stats[kFinishClose]();
+    inner.state[kFinishClose]();
     if (this[kPerfEntry] && hasObserver('quic')) {
       stopPerf(this, kPerfEntry, {
         detail: { stats: this.stats },
       });
     }
-    this.#address = undefined;
-    this.#busy = false;
-    this.#listening = false;
-    this.#isPendingClose = false;
+    inner.address = undefined;
+    inner.busy = false;
+    inner.listening = false;
+    inner.isPendingClose = false;
 
     // As QuicSessions are closed they are expected to remove themselves
     // from the sessions collection. Just in case they don't, let's force
     // it by resetting the set so we don't leak memory. Let's emit a warning,
     // tho, if the set is not empty at this point as that would indicate a
     // bug in Node.js that should be fixed.
-    if (this.#sessions.size > 0) {
+    if (inner.sessions.size > 0) {
       process.emitWarning(
-        `The endpoint is closed with ${this.#sessions.size} active sessions. ` +
+        `The endpoint is closed with ${inner.sessions.size} active sessions. ` +
         'This should not happen and indicates a bug in Node.js. Please open an ' +
         'issue in the Node.js GitHub repository at https://github.com/nodejs/node ' +
         'to report the problem.',
       );
     }
-    this.#sessions.clear();
+    inner.sessions.clear();
 
     // If destroy was called with an error, then the this.#pendingError will be
     // set. Or, if context indicates an error condition that caused the endpoint
     // to be closed, the status will indicate the error code. In either case,
     // we will reject the pending close promise at this point.
-    const maybeCloseError = maybeGetCloseError(context, status, this.#pendingError);
+    const maybeCloseError = maybeGetCloseError(context, status, inner.pendingError);
     if (maybeCloseError !== undefined) {
       if (onEndpointErrorChannel.hasSubscribers) {
         onEndpointErrorChannel.publish({
@@ -4396,33 +4429,36 @@ class QuicEndpoint {
           error: maybeCloseError,
         });
       }
-      this.#pendingClose.reject(maybeCloseError);
+      inner.pendingClose.reject(maybeCloseError);
     } else {
       // Otherwise we are good to resolve the pending close promise!
-      this.#pendingClose.resolve();
+      inner.pendingClose.resolve();
     }
     if (onEndpointClosedChannel.hasSubscribers) {
       onEndpointClosedChannel.publish({
         __proto__: null,
         endpoint: this,
-        stats: this.stats,
+        stats: inner.stats,
       });
     }
 
     // Note that we are intentionally not clearing the
     // this.#pendingClose.promise here.
-    this.#pendingClose.resolve = undefined;
-    this.#pendingClose.reject = undefined;
-    this.#pendingError = undefined;
+    inner.pendingClose.resolve = undefined;
+    inner.pendingClose.reject = undefined;
+    inner.pendingError = undefined;
   }
 
   [kNewSession](handle) {
+    const inner = this.#inner;
+    assert(typeof inner.onsession === 'function',
+           'onsession callback not specified');
     const session = this.#newSession(handle);
     // Apply session callbacks stored at listen time before notifying
     // the onsession callback, to avoid missing events that fire
     // during or immediately after the handshake.
-    if (this.#sessionCallbacks) {
-      applyCallbacks(session, this.#sessionCallbacks);
+    if (inner.sessionCallbacks) {
+      applyCallbacks(session, inner.sessionCallbacks);
     }
     if (onEndpointServerSessionChannel.hasSubscribers) {
       onEndpointServerSessionChannel.publish({
@@ -4432,25 +4468,24 @@ class QuicEndpoint {
         address: session.path?.remote,
       });
     }
-    assert(typeof this.#onsession === 'function',
-           'onsession callback not specified');
     // Route through safeCallbackInvoke so that a synchronous throw or a
     // rejected promise from the user's onsession callback destroys this
     // endpoint with the error rather than surfacing as an unhandled
     // exception or unhandled rejection coming out of the C++ -> JS
     // boundary.
-    safeCallbackInvoke(this.#onsession, this, session);
+    safeCallbackInvoke(inner.onsession, this, session);
   }
 
   // Called by the QuicSession when it closes to remove itself from
   // the active sessions tracked by the QuicEndpoint.
   [kRemoveSession](session) {
-    this.#sessions.delete(session);
+    this.#inner.sessions.delete(session);
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
+    if (depth < 0) {
+      return 'QuicEndpoint { }';
+    }
 
     const opts = {
       __proto__: null,
@@ -4458,16 +4493,26 @@ class QuicEndpoint {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      address,
+      busy,
+      isPendingClose: closing,
+      listening,
+      sessions,
+      stats,
+      state,
+    } = this.#inner;
+
     return `QuicEndpoint ${inspect({
-      address: this.address,
-      busy: this.busy,
+      address,
+      busy,
       closed: this.closed,
-      closing: this.#isPendingClose,
+      closing,
       destroyed: this.destroyed,
-      listening: this.#listening,
-      sessions: this.#sessions,
-      stats: this.stats,
-      state: this.#state,
+      listening,
+      sessions,
+      stats,
+      state,
     }, opts)}`;
   }
 
@@ -4809,10 +4854,10 @@ function getPreferredAddressPolicy(policy = 'default') {
 
 /**
  * @param {SessionOptions} options
- * @param {{forServer: boolean, addressFamily: string}} [config]
+ * @param {ProcessSessionOptions} [config]
  * @returns {SessionOptions}
  */
-function processSessionOptions(options, config = { __proto__: null }) {
+function processSessionOptions(options, config = kEmptyObject) {
   validateObject(options, 'options');
   const {
     endpoint,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -1391,56 +1391,17 @@ function maybeGetCloseError(context, status, pendingError) {
 }
 
 class QuicStream {
+  // All mutable per-stream state is consolidated into a single object
+  // to minimize the number of V8 private field slots. Only #handle is
+  // kept as a private field for the brand check in #assertIsQuicStream.
   /** @type {object} */
   #handle;
-  /**
-   * Flag set at the top of `destroy()` to make the method safely
-   * re-entrant. Distinct from `#handle === undefined` (which signals
-   * "fully destroyed" and is set inside `[kFinishClose]`) so that
-   * `[kFinishClose]`'s own destroyed-guard does not bail before the
-   * cleanup work runs.
-   * @type {boolean}
-   */
-  #destroying = false;
-  /** @type {QuicSession} */
-  #session;
-  /** @type {QuicStreamStats} */
-  #stats;
-  /** @type {QuicStreamState} */
-  #state;
-  /** @type {number} */
-  #direction = undefined;
-  /** @type {Function|undefined} */
-  #onerror = undefined;
-  /** @type {OnBlockedCallback|undefined} */
-  #onblocked = undefined;
-  /** @type {OnStreamErrorCallback|undefined} */
-  #onreset = undefined;
-  /** @type {Function|undefined} */
-  #onheaders = undefined;
-  /** @type {Function|undefined} */
-  #ontrailers = undefined;
-  /** @type {Function|undefined} */
-  #oninfo = undefined;
-  /** @type {Function|undefined} */
-  #onwanttrailers = undefined;
-  /** @type {object|undefined} */
-  #headers = undefined;
-  /** @type {object|undefined} */
-  #pendingTrailers = undefined;
-  /** @type {Promise<void>} */
-  #pendingClose = PromiseWithResolvers();
-  #reader;
-  #iteratorLocked = false;
-  #writer = undefined;
-  #outboundSet = false;
-  /** @type {FileHandle|undefined} */
-  #fileHandle = undefined;
+  #inner;
 
   static {
     getQuicStreamState = function(stream) {
       QuicStream.#assertIsQuicStream(stream);
-      return stream.#state;
+      return stream.#inner.state;
     };
   }
 
@@ -1451,7 +1412,7 @@ class QuicStream {
   }
 
   #assertHeadersSupported() {
-    if (getQuicSessionState(this.#session).headersSupported === 2) {
+    if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
         'The negotiated QUIC application protocol does not support headers');
     }
@@ -1462,31 +1423,47 @@ class QuicStream {
    * @param {object} handle
    * @param {QuicSession} session
    * @param {number} direction
+   * @param {boolean} [isLocal] True for locally-initiated streams
    */
-  constructor(privateSymbol, handle, session, direction) {
+  constructor(privateSymbol, handle, session, direction, isLocal = false) {
     if (privateSymbol !== kPrivateConstructor) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
 
     this.#handle = handle;
-    this.#handle[kOwner] = this;
-    this.#session = session;
-    this.#direction = direction;
-    this.#stats = new QuicStreamStats(
-      kPrivateConstructor, this.#handle.stats, this.#handle.statsByteOffset);
-    this.#state = new QuicStreamState(
-      kPrivateConstructor, this.#handle.state, this.#handle.stateByteOffset);
-    this.#reader = this.#handle.getReader();
+    handle[kOwner] = this;
+    this.#inner = {
+      __proto__: null,
+      session,
+      direction,
+      isLocal,
+      state: new QuicStreamState(
+        kPrivateConstructor, handle.state, handle.stateByteOffset),
+      stats: undefined,
+      pendingClose: undefined,
+      reader: undefined,
+      destroying: false,
+      iteratorLocked: false,
+      outboundSet: false,
+      writer: undefined,
+      fileHandle: undefined,
+      headers: undefined,
+      pendingTrailers: undefined,
+      // Callback slots
+      onerror: undefined,
+      onblocked: undefined,
+      onreset: undefined,
+      onheaders: undefined,
+      ontrailers: undefined,
+      oninfo: undefined,
+      onwanttrailers: undefined,
+    };
 
     if (hasObserver('quic')) {
       startPerf(this, kPerfEntry, { type: 'quic', name: 'QuicStream' });
     }
 
-    if (this.pending) {
-      debug(`pending ${this.direction} stream created`);
-    } else {
-      debug(`${this.direction} stream ${this.id} created`);
-    }
+    debug('stream created');
   }
 
   get [kValidatedSource]() { return true; }
@@ -1499,15 +1476,16 @@ class QuicStream {
    */
   async *[SymbolAsyncIterator]() {
     QuicStream.#assertIsQuicStream(this);
-    if (this.#iteratorLocked) {
+    if (this.#inner.iteratorLocked) {
       throw new ERR_INVALID_STATE('Stream is already being read');
     }
-    this.#iteratorLocked = true;
+    this.#inner.iteratorLocked = true;
 
+    this.#inner.reader ??= this.#handle?.getReader();
     // Non-readable stream (outbound-only unidirectional, or closed)
-    if (!this.#reader) return;
+    if (!this.#inner.reader) return;
 
-    yield* createBlobReaderIterable(this.#reader, {
+    yield* createBlobReaderIterable(this.#inner.reader, {
       getReadError: () => {
         // The read side ends for one of three reasons:
         //   * Clean FIN received from the peer (state.finReceived
@@ -1521,8 +1499,8 @@ class QuicStream {
         //     stream.stopSending(). Both paths run EndReadable in
         //     C++, setting state.readEnded without setting
         //     state.finReceived. There is no peer code to surface.
-        if (this.#state.readEnded && !this.#state.finReceived) {
-          const peerResetCode = this.#state.resetCode;
+        if (this.#inner.state.readEnded && !this.#inner.state.finReceived) {
+          const peerResetCode = this.#inner.state.resetCode;
           if (peerResetCode !== undefined && peerResetCode > 0n) {
             return new ERR_QUIC_STREAM_RESET(Number(peerResetCode));
           }
@@ -1541,7 +1519,7 @@ class QuicStream {
    */
   get pending() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#state.pending;
+    return this.#inner.state.pending;
   }
 
   /**
@@ -1552,7 +1530,7 @@ class QuicStream {
    */
   get early() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#state.early;
+    return this.#inner.state.early;
   }
 
   /**
@@ -1563,142 +1541,144 @@ class QuicStream {
    */
   get highWaterMark() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#state.highWaterMark;
+    return this.#inner.state.highWaterMark;
   }
 
   set highWaterMark(val) {
     QuicStream.#assertIsQuicStream(this);
     validateInteger(val, 'highWaterMark', 0, 0xFFFFFFFF);
-    this.#state.highWaterMark = val;
+    this.#inner.state.highWaterMark = val;
     // If writeDesiredSize hasn't been set yet (still 0 from initialization),
     // initialize it to the highWaterMark so the first write can proceed.
-    if (this.#state.writeDesiredSize === 0 && val > 0) {
-      this.#state.writeDesiredSize = val;
+    if (this.#inner.state.writeDesiredSize === 0 && val > 0) {
+      this.#inner.state.writeDesiredSize = val;
     }
   }
 
   /** @type {Function|undefined} */
   get onerror() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#onerror;
+    return this.#inner.onerror;
   }
 
   set onerror(fn) {
     QuicStream.#assertIsQuicStream(this);
     if (fn === undefined) {
-      this.#onerror = undefined;
+      this.#inner.onerror = undefined;
     } else {
       validateFunction(fn, 'onerror');
-      this.#onerror = FunctionPrototypeBind(fn, this);
-      markPromiseAsHandled(this.#pendingClose.promise);
+      this.#inner.onerror = FunctionPrototypeBind(fn, this);
+      // Lazily create the close promise so it can be marked handled.
+      this.#inner.pendingClose ??= PromiseWithResolvers();
+      markPromiseAsHandled(this.#inner.pendingClose.promise);
     }
   }
 
   /** @type {OnBlockedCallback} */
   get onblocked() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#onblocked;
+    return this.#inner.onblocked;
   }
 
   set onblocked(fn) {
     QuicStream.#assertIsQuicStream(this);
     if (fn === undefined) {
-      this.#onblocked = undefined;
-      this.#state.wantsBlock = false;
+      this.#inner.onblocked = undefined;
+      this.#inner.state.wantsBlock = false;
     } else {
       validateFunction(fn, 'onblocked');
-      this.#onblocked = FunctionPrototypeBind(fn, this);
-      this.#state.wantsBlock = true;
+      this.#inner.onblocked = FunctionPrototypeBind(fn, this);
+      this.#inner.state.wantsBlock = true;
     }
   }
 
   /** @type {OnStreamErrorCallback} */
   get onreset() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#onreset;
+    return this.#inner.onreset;
   }
 
   set onreset(fn) {
     QuicStream.#assertIsQuicStream(this);
     if (fn === undefined) {
-      this.#onreset = undefined;
-      this.#state.wantsReset = false;
+      this.#inner.onreset = undefined;
+      this.#inner.state.wantsReset = false;
     } else {
       validateFunction(fn, 'onreset');
-      this.#onreset = FunctionPrototypeBind(fn, this);
-      this.#state.wantsReset = true;
+      this.#inner.onreset = FunctionPrototypeBind(fn, this);
+      this.#inner.state.wantsReset = true;
     }
   }
 
   /** @type {OnHeadersCallback} */
   get onheaders() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#onheaders;
+    return this.#inner.onheaders;
   }
 
   set onheaders(fn) {
     QuicStream.#assertIsQuicStream(this);
     if (fn === undefined) {
-      this.#onheaders = undefined;
-      this.#state[kWantsHeaders] = false;
+      this.#inner.onheaders = undefined;
+      this.#inner.state[kWantsHeaders] = false;
     } else {
       this.#assertHeadersSupported();
       validateFunction(fn, 'onheaders');
-      this.#onheaders = FunctionPrototypeBind(fn, this);
-      this.#state[kWantsHeaders] = true;
+      this.#inner.onheaders = FunctionPrototypeBind(fn, this);
+      this.#inner.state[kWantsHeaders] = true;
     }
   }
 
   /** @type {Function|undefined} */
   get oninfo() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#oninfo;
+    return this.#inner.oninfo;
   }
 
   set oninfo(fn) {
     QuicStream.#assertIsQuicStream(this);
     if (fn === undefined) {
-      this.#oninfo = undefined;
+      this.#inner.oninfo = undefined;
     } else {
       this.#assertHeadersSupported();
       validateFunction(fn, 'oninfo');
-      this.#oninfo = FunctionPrototypeBind(fn, this);
+      this.#inner.oninfo = FunctionPrototypeBind(fn, this);
     }
   }
 
   /** @type {Function|undefined} */
   get ontrailers() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#ontrailers;
+    return this.#inner.ontrailers;
   }
 
   set ontrailers(fn) {
     QuicStream.#assertIsQuicStream(this);
     if (fn === undefined) {
-      this.#ontrailers = undefined;
+      this.#inner.ontrailers = undefined;
     } else {
       this.#assertHeadersSupported();
       validateFunction(fn, 'ontrailers');
-      this.#ontrailers = FunctionPrototypeBind(fn, this);
+      this.#inner.ontrailers = FunctionPrototypeBind(fn, this);
     }
   }
 
   /** @type {Function|undefined} */
   get onwanttrailers() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#onwanttrailers;
+    return this.#inner.onwanttrailers;
   }
 
   set onwanttrailers(fn) {
     QuicStream.#assertIsQuicStream(this);
     if (fn === undefined) {
-      this.#onwanttrailers = undefined;
-      this.#state[kWantsTrailers] = false;
+      this.#inner.onwanttrailers = undefined;
+      this.#inner.state[kWantsTrailers] = false;
     } else {
       this.#assertHeadersSupported();
       validateFunction(fn, 'onwanttrailers');
-      this.#onwanttrailers = FunctionPrototypeBind(fn, this);
-      this.#state[kWantsTrailers] = true;
+      this.#inner.onwanttrailers = FunctionPrototypeBind(fn, this);
+      this.#inner.state[kWantsTrailers] = true;
     }
   }
 
@@ -1710,7 +1690,7 @@ class QuicStream {
    */
   get headers() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#headers;
+    return this.#inner.headers;
   }
 
   /**
@@ -1719,21 +1699,21 @@ class QuicStream {
    */
   get pendingTrailers() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#pendingTrailers;
+    return this.#inner.pendingTrailers;
   }
 
   set pendingTrailers(headers) {
     QuicStream.#assertIsQuicStream(this);
     if (headers === undefined) {
-      this.#pendingTrailers = undefined;
+      this.#inner.pendingTrailers = undefined;
       return;
     }
-    if (getQuicSessionState(this.#session).headersSupported === 2) {
+    if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
         'The negotiated QUIC application protocol does not support headers');
     }
     validateObject(headers, 'headers');
-    this.#pendingTrailers = headers;
+    this.#inner.pendingTrailers = headers;
   }
 
   /**
@@ -1742,7 +1722,11 @@ class QuicStream {
    */
   get stats() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#stats;
+    if (this.#inner.stats === undefined) {
+      this.#inner.stats = new QuicStreamStats(
+        kPrivateConstructor, this.#handle.stats, this.#handle.statsByteOffset);
+    }
+    return this.#inner.stats;
   }
 
   /**
@@ -1753,7 +1737,7 @@ class QuicStream {
   get session() {
     QuicStream.#assertIsQuicStream(this);
     if (this.destroyed) return null;
-    return this.#session;
+    return this.#inner.session;
   }
 
   /**
@@ -1764,7 +1748,7 @@ class QuicStream {
   get id() {
     QuicStream.#assertIsQuicStream(this);
     if (this.destroyed || this.pending) return null;
-    return this.#state.id;
+    return this.#inner.state.id;
   }
 
   /**
@@ -1775,7 +1759,7 @@ class QuicStream {
   get direction() {
     QuicStream.#assertIsQuicStream(this);
     if (this.destroyed || this.pending) return null;
-    return this.#direction === kStreamDirectionBidirectional ? 'bidi' : 'uni';
+    return this.#inner.direction === kStreamDirectionBidirectional ? 'bidi' : 'uni';
   }
 
   /**
@@ -1793,7 +1777,10 @@ class QuicStream {
    */
   get closed() {
     QuicStream.#assertIsQuicStream(this);
-    return this.#pendingClose.promise;
+    if (this.#inner.pendingClose === undefined) {
+      this.#inner.pendingClose = PromiseWithResolvers();
+    }
+    return this.#inner.pendingClose.promise;
   }
 
   /**
@@ -1829,7 +1816,7 @@ class QuicStream {
     //     `onStreamClose -> [kFinishClose]` path - which does NOT go
     //     through `destroy()` and therefore never sets `#destroying`.
     //     `[kFinishClose]` clears `#handle` at the end of its work.
-    if (this.#destroying || this.destroyed) return;
+    if (this.#inner.destroying || this.destroyed) return;
     // Validate options up front so a malformed `options` argument
     // throws before any side effects (mutating `#destroying`,
     // emitting wire frames, invoking `onerror`, settling the closed
@@ -1845,7 +1832,7 @@ class QuicStream {
     if (reason !== undefined) {
       validateString(reason, 'options.reason');
     }
-    this.#destroying = true;
+    this.#inner.destroying = true;
     // Resolve the wire error code for any RESET_STREAM / STOP_SENDING
     // frames emitted below.
     let abortCode;
@@ -1854,21 +1841,16 @@ class QuicStream {
     } else if (error !== undefined) {
       abortCode = error instanceof QuicError ?
         error.errorCode :
-        getQuicSessionState(this.#session).internalErrorCode;
+        getQuicSessionState(this.#inner.session).internalErrorCode;
     }
     // When destroying with an error, ensure the peer stops sending
     // data we are about to discard by emitting STOP_SENDING. The
     // condition gates the emission to error-path destroys with a
-    // still-open readable side. Direction model for the readable
-    // side:
-    //   * bidi: always has a readable side.
-    //   * uni + #reader !== undefined: remote-initiated, read-only.
-    //   * uni + #reader === undefined: locally-initiated, write-only;
-    //     no readable side to stop.
+    // still-open readable side. The C++ state.readEnded flag is
+    // authoritative -- it is set for locally-initiated uni streams
+    // (which have no readable side) and when reading completes.
     if (abortCode !== undefined &&
-        !this.#state.readEnded &&
-        (this.#direction === kStreamDirectionBidirectional ||
-         this.#reader !== undefined)) {
+        !this.#inner.state.readEnded) {
       this.#handle.stopSending(abortCode);
     }
     // When destroying with an error, ensure the peer learns about
@@ -1877,22 +1859,14 @@ class QuicStream {
     // streams that destroy without ever accessing stream.writer
     // (e.g. used setBody or never wrote at all) need an explicit
     // RESET_STREAM here so the write side does not dangle on the
-    // wire. The condition gates the emission to error-path destroys
-    // with a still-open writable side.
-    // Direction model for the writable side:
-    //   * bidi: always has a writable side.
-    //   * uni + #reader === undefined: locally-initiated, write-only.
-    //   * uni + #reader !== undefined: remote-initiated, read-only;
-    //     no writable side to reset.
+    // wire. The C++ state.writeEnded flag is authoritative.
     if (abortCode !== undefined &&
-        this.#writer === undefined &&
-        !this.#state.writeEnded &&
-        (this.#direction === kStreamDirectionBidirectional ||
-         this.#reader === undefined)) {
+        this.#inner.writer === undefined &&
+        !this.#inner.state.writeEnded) {
       this.#handle.resetStream(abortCode);
     }
-    if (error !== undefined && typeof this.#onerror === 'function') {
-      invokeOnerror(this.#onerror, error);
+    if (error !== undefined && typeof this.#inner.onerror === 'function') {
+      invokeOnerror(this.#inner.onerror, error);
     }
     const handle = this.#handle;
     this[kFinishClose](error);
@@ -1912,7 +1886,7 @@ class QuicStream {
     if (this.destroyed) {
       throw new ERR_INVALID_STATE('Stream is destroyed');
     }
-    if (this.#state.hasOutbound) {
+    if (this.#inner.state.hasOutbound) {
       throw new ERR_INVALID_STATE('Stream already has an outbound data source');
     }
     this.#handle.attachSource(validateBody(outbound));
@@ -1928,7 +1902,7 @@ class QuicStream {
   sendHeaders(headers, options = kEmptyObject) {
     QuicStream.#assertIsQuicStream(this);
     if (this.destroyed) return false;
-    if (getQuicSessionState(this.#session).headersSupported === 2) {
+    if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
         'The negotiated QUIC application protocol does not support headers');
     }
@@ -1949,7 +1923,7 @@ class QuicStream {
   sendInformationalHeaders(headers) {
     QuicStream.#assertIsQuicStream(this);
     if (this.destroyed) return false;
-    if (getQuicSessionState(this.#session).headersSupported === 2) {
+    if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
         'The negotiated QUIC application protocol does not support headers');
     }
@@ -1970,7 +1944,7 @@ class QuicStream {
   sendTrailers(headers) {
     QuicStream.#assertIsQuicStream(this);
     if (this.destroyed) return false;
-    if (getQuicSessionState(this.#session).headersSupported === 2) {
+    if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
         'The negotiated QUIC application protocol does not support headers');
     }
@@ -1988,8 +1962,8 @@ class QuicStream {
    */
   get writer() {
     QuicStream.#assertIsQuicStream(this);
-    if (this.#writer !== undefined) return this.#writer;
-    if (this.#outboundSet) {
+    if (this.#inner.writer !== undefined) return this.#inner.writer;
+    if (this.#inner.outboundSet) {
       throw new ERR_INVALID_STATE(
         'Stream outbound already configured with a body source');
     }
@@ -2020,7 +1994,7 @@ class QuicStream {
       // more data. Refuse the sync write.
       // If a drain is already pending, another operation is waiting
       // for capacity. Refuse the sync write.
-      if (closed || errored || stream.#state.writeEnded || drainWakeup != null) {
+      if (closed || errored || stream.#inner.state.writeEnded || drainWakeup != null) {
         return false;
       }
       chunk = toUint8Array(chunk);
@@ -2034,7 +2008,7 @@ class QuicStream {
       // at which point the standard drain mechanism takes over.
       // This follows the Web Streams model where writes beyond the HWM
       // succeed and backpressure applies to *subsequent* writes.
-      if (stream.#state.writeDesiredSize === 0) return false;
+      if (stream.#inner.state.writeDesiredSize === 0) return false;
       const result = handle.write([chunk]);
       if (result === undefined) return false;
       totalBytesWritten += len;
@@ -2049,7 +2023,7 @@ class QuicStream {
         signal.throwIfAborted();
       }
       if (errored) throw error;
-      if (closed || stream.#state.writeEnded) {
+      if (closed || stream.#inner.state.writeEnded) {
         throw new ERR_INVALID_STATE('Writer is closed');
       }
       // If a drain is already pending, another operation is waiting
@@ -2066,14 +2040,14 @@ class QuicStream {
     }
 
     function writevSync(chunks) {
-      if (closed || errored || stream.#state.writeEnded || drainWakeup != null) {
+      if (closed || errored || stream.#inner.state.writeEnded || drainWakeup != null) {
         return false;
       }
       chunks = convertChunks(chunks);
       let len = 0;
       for (const c of chunks) len += TypedArrayPrototypeGetByteLength(c);
       if (len === 0) return true;
-      if (stream.#state.writeDesiredSize === 0) return false;
+      if (stream.#inner.state.writeDesiredSize === 0) return false;
       const result = handle.write(chunks);
       if (result === undefined) return false;
       totalBytesWritten += len;
@@ -2089,7 +2063,7 @@ class QuicStream {
       }
 
       if (errored) throw error;
-      if (closed || stream.#state.writeEnded) {
+      if (closed || stream.#inner.state.writeEnded) {
         throw new ERR_INVALID_STATE('Writer is closed');
       }
 
@@ -2182,7 +2156,7 @@ class QuicStream {
       //      `INTERNAL_ERROR` (0x1).
       const code = error instanceof QuicError ?
         error.errorCode :
-        getQuicSessionState(stream.#session).internalErrorCode;
+        getQuicSessionState(stream.#inner.session).internalErrorCode;
       handle.resetStream(code);
       if (drainWakeup != null) {
         drainWakeup.reject(error);
@@ -2193,8 +2167,8 @@ class QuicStream {
     const writer = {
       __proto__: null,
       get desiredSize() {
-        if (closed || errored || stream.#state.writeEnded) return null;
-        return stream.#state.writeDesiredSize;
+        if (closed || errored || stream.#inner.state.writeEnded) return null;
+        return stream.#inner.state.writeDesiredSize;
       },
       writeSync,
       write,
@@ -2207,7 +2181,7 @@ class QuicStream {
         if (closed || errored) return null;
         // If a drain is already pending, return the existing promise.
         if (drainWakeup != null) return drainWakeup.promise;
-        if (stream.#state.writeDesiredSize > 0) return null;
+        if (stream.#inner.state.writeDesiredSize > 0) return null;
         drainWakeup = PromiseWithResolvers();
         return drainWakeup.promise;
       },
@@ -2221,21 +2195,23 @@ class QuicStream {
     };
 
     // Non-writable stream - return a pre-closed writer.
-    // A readable unidirectional stream is a remote uni (read-only).
-    if (!handle || this.destroyed || this.#state.writeEnded ||
-        (this.#direction === kStreamDirectionUnidirectional &&
-         this.#reader !== undefined)) {
+    // A remote unidirectional stream is read-only and has no writable
+    // side. isLocal distinguishes locally-initiated (writable) from
+    // remotely-initiated (read-only) uni streams.
+    if (!handle || this.destroyed || this.#inner.state.writeEnded ||
+        (this.#inner.direction === kStreamDirectionUnidirectional &&
+         !this.#inner.isLocal)) {
       closed = true;
-      this.#writer = writer;
-      return this.#writer;
+      this.#inner.writer = writer;
+      return this.#inner.writer;
     }
 
     // Initialize the outbound DataQueue for streaming writes
     handle.initStreamingSource();
     initStreamingBackpressure(this);
 
-    this.#writer = writer;
-    return this.#writer;
+    this.#inner.writer = writer;
+    return this.#inner.writer;
   }
 
   /**
@@ -2249,17 +2225,17 @@ class QuicStream {
     if (this.destroyed) {
       throw new ERR_INVALID_STATE('Stream is destroyed');
     }
-    if (this.#outboundSet) {
+    if (this.#inner.outboundSet) {
       throw new ERR_INVALID_STATE('Stream outbound already configured');
     }
-    if (this.#writer !== undefined) {
+    if (this.#inner.writer !== undefined) {
       throw new ERR_INVALID_STATE('Stream writer already accessed');
     }
-    this.#outboundSet = true;
+    this.#inner.outboundSet = true;
     // If the body is a FileHandle, store it so it is closed
     // automatically when the stream finishes.
     if (body instanceof FileHandle) {
-      this.#fileHandle = body;
+      this.#inner.fileHandle = body;
     }
     configureOutbound(this.#handle, this, body);
   }
@@ -2271,7 +2247,7 @@ class QuicStream {
    * @param {FileHandle} fh
    */
   [kAttachFileHandle](fh) {
-    this.#fileHandle = fh;
+    this.#inner.fileHandle = fh;
   }
 
   /**
@@ -2309,7 +2285,7 @@ class QuicStream {
   get priority() {
     QuicStream.#assertIsQuicStream(this);
     if (this.destroyed ||
-        !getQuicSessionState(this.#session).isPrioritySupported) return null;
+        !getQuicSessionState(this.#inner.session).isPrioritySupported) return null;
     const packed = this.#handle.getPriority();
     const urgency = packed >> 1;
     const incremental = !!(packed & 1);
@@ -2327,7 +2303,7 @@ class QuicStream {
   setPriority(options = kEmptyObject) {
     QuicStream.#assertIsQuicStream(this);
     if (this.destroyed) return;
-    if (!getQuicSessionState(this.#session).isPrioritySupported) {
+    if (!getQuicSessionState(this.#inner.session).isPrioritySupported) {
       throw new ERR_INVALID_STATE(
         'The session does not support stream priority');
     }
@@ -2357,7 +2333,7 @@ class QuicStream {
   [kSendHeaders](headers, kind = kHeadersKindInitial,
                  flags = kHeadersFlagsTerminal) {
     validateObject(headers, 'headers');
-    if (getQuicSessionState(this.#session).headersSupported === 2) {
+    if (getQuicSessionState(this.#inner.session).headersSupported === 2) {
       throw new ERR_INVALID_STATE(
         'The negotiated QUIC application protocol does not support headers');
     }
@@ -2375,27 +2351,21 @@ class QuicStream {
   }
 
   [kFinishClose](error) {
-    if (this.destroyed) return this.#pendingClose.promise;
-    if (error !== undefined) {
-      if (this.pending) {
-        debug(`destroying pending stream with error: ${error}`);
-      } else {
-        debug(`destroying stream ${this.id} with error: ${error}`);
-      }
-      this.#pendingClose.reject(error);
-    } else {
-      if (this.pending) {
-        debug('destroying pending stream with no error');
-      } else {
-        debug(`destroying stream ${this.id} with no error`);
-      }
-      this.#pendingClose.resolve();
+    this.#inner.pendingClose ??= PromiseWithResolvers();
+    if (this.destroyed) {
+      return this.#inner.pendingClose.promise;
     }
+    if (error !== undefined) {
+      this.#inner.pendingClose.reject(error);
+    } else {
+      this.#inner.pendingClose.resolve();
+    }
+    debug('stream closed');
     if (onStreamClosedChannel.hasSubscribers) {
       onStreamClosedChannel.publish({
         __proto__: null,
         stream: this,
-        session: this.#session,
+        session: this.#inner.session,
         error,
         stats: this.stats,
       });
@@ -2408,46 +2378,44 @@ class QuicStream {
         },
       });
     }
-    this.#stats[kFinishClose]();
-    this.#state[kFinishClose]();
-    this.#session[kRemoveStream](this);
-    if (this.#writer !== undefined) {
-      this.#writer.fail(error);
-    }
-    this.#session = undefined;
-    this.#pendingClose.reject = undefined;
-    this.#pendingClose.resolve = undefined;
-    this.#onblocked = undefined;
-    this.#onreset = undefined;
-    this.#onheaders = undefined;
-    this.#onerror = undefined;
-    this.#ontrailers = undefined;
-    this.#oninfo = undefined;
-    this.#onwanttrailers = undefined;
-    this.#headers = undefined;
-    this.#pendingTrailers = undefined;
+    this.#inner.stats?.[kFinishClose]();
+    this.#inner.state?.[kFinishClose]();
+    this.#inner.session[kRemoveStream](this);
+    this.#inner.writer?.fail(error);
+    this.#inner.session = undefined;
+    this.#inner.pendingClose.reject = undefined;
+    this.#inner.pendingClose.resolve = undefined;
+    this.#inner.onblocked = undefined;
+    this.#inner.onreset = undefined;
+    this.#inner.onheaders = undefined;
+    this.#inner.onerror = undefined;
+    this.#inner.ontrailers = undefined;
+    this.#inner.oninfo = undefined;
+    this.#inner.onwanttrailers = undefined;
+    this.#inner.headers = undefined;
+    this.#inner.pendingTrailers = undefined;
     this.#handle = undefined;
-    if (this.#fileHandle !== undefined) {
+    if (this.#inner.fileHandle !== undefined) {
       // Close the FileHandle that was used as a body source. The close
       // may fail if the user already closed it -- that's expected and
       // harmless, so mark the promise as handled.
-      markPromiseAsHandled(this.#fileHandle.close());
-      this.#fileHandle = undefined;
+      markPromiseAsHandled(this.#inner.fileHandle.close());
+      this.#inner.fileHandle = undefined;
     }
   }
 
   [kBlocked]() {
     // The blocked event should only be called if the stream was created with
     // an onblocked callback. The callback should always exist here.
-    assert(this.#onblocked, 'Unexpected stream blocked event');
+    assert(this.#inner.onblocked, 'Unexpected stream blocked event');
     if (onStreamBlockedChannel.hasSubscribers) {
       onStreamBlockedChannel.publish({
         __proto__: null,
         stream: this,
-        session: this.#session,
+        session: this.#inner.session,
       });
     }
-    safeCallbackInvoke(this.#onblocked, this);
+    safeCallbackInvoke(this.#inner.onblocked, this);
   }
 
   [kDrain]() {
@@ -2458,16 +2426,16 @@ class QuicStream {
   [kReset](error) {
     // The reset event should only be called if the stream was created with
     // an onreset callback. The callback should always exist here.
-    assert(this.#onreset, 'Unexpected stream reset event');
+    assert(this.#inner.onreset, 'Unexpected stream reset event');
     if (onStreamResetChannel.hasSubscribers) {
       onStreamResetChannel.publish({
         __proto__: null,
         stream: this,
-        session: this.#session,
+        session: this.#inner.session,
         error,
       });
     }
-    safeCallbackInvoke(this.#onreset, this, error);
+    safeCallbackInvoke(this.#inner.onreset, this, error);
   }
 
   [kHeaders](headers, kind) {
@@ -2476,41 +2444,41 @@ class QuicStream {
 
     switch (kindName) {
       case 'initial':
-        assert(this.#onheaders, 'Unexpected stream headers event');
-        if (this.#headers === undefined) this.#headers = block;
+        assert(this.#inner.onheaders, 'Unexpected stream headers event');
+        this.#inner.headers ??= block;
         if (onStreamHeadersChannel.hasSubscribers) {
           onStreamHeadersChannel.publish({
             __proto__: null,
             stream: this,
-            session: this.#session,
+            session: this.#inner.session,
             headers: block,
           });
         }
-        safeCallbackInvoke(this.#onheaders, this, block);
+        safeCallbackInvoke(this.#inner.onheaders, this, block);
         break;
       case 'trailing':
         if (onStreamTrailersChannel.hasSubscribers) {
           onStreamTrailersChannel.publish({
             __proto__: null,
             stream: this,
-            session: this.#session,
+            session: this.#inner.session,
             trailers: block,
           });
         }
-        if (this.#ontrailers)
-          safeCallbackInvoke(this.#ontrailers, this, block);
+        if (this.#inner.ontrailers)
+          safeCallbackInvoke(this.#inner.ontrailers, this, block);
         break;
       case 'hints':
         if (onStreamInfoChannel.hasSubscribers) {
           onStreamInfoChannel.publish({
             __proto__: null,
             stream: this,
-            session: this.#session,
+            session: this.#inner.session,
             headers: block,
           });
         }
-        if (this.#oninfo)
-          safeCallbackInvoke(this.#oninfo, this, block);
+        if (this.#inner.oninfo)
+          safeCallbackInvoke(this.#inner.oninfo, this, block);
         break;
     }
   }
@@ -2520,11 +2488,11 @@ class QuicStream {
 
     // nghttp3 is asking us to provide trailers to send.
     // Check for pre-set pendingTrailers first, then the callback.
-    if (this.#pendingTrailers) {
-      this.sendTrailers(this.#pendingTrailers);
-      this.#pendingTrailers = undefined;
-    } else if (this.#onwanttrailers) {
-      safeCallbackInvoke(this.#onwanttrailers, this);
+    if (this.#inner.pendingTrailers) {
+      this.sendTrailers(this.#inner.pendingTrailers);
+      this.#inner.pendingTrailers = undefined;
+    } else if (this.#inner.onwanttrailers) {
+      safeCallbackInvoke(this.#inner.onwanttrailers, this);
     }
   }
 
@@ -2544,7 +2512,7 @@ class QuicStream {
       direction: this.direction,
       pending: this.pending,
       stats: this.stats,
-      state: this.#state,
+      state: this.#inner.state,
       session: this.session,
     }, opts)}`;
   }
@@ -3071,7 +3039,8 @@ class QuicSession {
       handle.setPriority((urgency << 1) | (incremental ? 1 : 0));
     }
 
-    const stream = new QuicStream(kPrivateConstructor, handle, this, direction);
+    const stream = new QuicStream(
+      kPrivateConstructor, handle, this, direction, true /* isLocal */);
     this.#streams.add(stream);
     if (typeof this.#onerror === 'function') {
       markPromiseAsHandled(stream.closed);

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -304,6 +304,7 @@ const endpointRegistry = new SafeSet();
  * @property {boolean} [disableStatelessReset] When true, the endpoint will not send stateless resets
  * @property {bigint|number} [idleTimeout] The default idle timeout for sessions on this endpoint
  * @property {boolean} [ipv6Only] Use IPv6 only
+ * @property {boolean} [reusePort] Enable SO_REUSEPORT for multi-process load balancing
  * @property {bigint|number} [maxConnectionsPerHost] The maximum number of connections per host
  * @property {bigint|number} [maxConnectionsTotal] The maximum number of total connections
  * @property {bigint|number} [maxRetries] The maximum number of retries
@@ -3956,6 +3957,7 @@ class QuicEndpoint {
       idleTimeout,
       validateAddress,
       ipv6Only,
+      reusePort,
       cc,
       resetTokenSecret,
       tokenSecret,
@@ -3992,6 +3994,7 @@ class QuicEndpoint {
       idleTimeout,
       validateAddress,
       ipv6Only,
+      reusePort,
       cc,
       resetTokenSecret,
       tokenSecret,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -1472,8 +1472,10 @@ class QuicStream {
     this.#handle[kOwner] = this;
     this.#session = session;
     this.#direction = direction;
-    this.#stats = new QuicStreamStats(kPrivateConstructor, this.#handle.stats);
-    this.#state = new QuicStreamState(kPrivateConstructor, this.#handle.state);
+    this.#stats = new QuicStreamStats(
+      kPrivateConstructor, this.#handle.stats, this.#handle.statsByteOffset);
+    this.#state = new QuicStreamState(
+      kPrivateConstructor, this.#handle.state, this.#handle.stateByteOffset);
     this.#reader = this.#handle.getReader();
 
     if (hasObserver('quic')) {
@@ -2656,8 +2658,10 @@ class QuicSession {
       this.#pendingQlog = handle._pendingQlog;
       handle._pendingQlog = undefined;
     }
-    this.#stats = new QuicSessionStats(kPrivateConstructor, handle.stats);
-    this.#state = new QuicSessionState(kPrivateConstructor, handle.state);
+    this.#stats = new QuicSessionStats(
+      kPrivateConstructor, handle.stats, handle.statsByteOffset);
+    this.#state = new QuicSessionState(
+      kPrivateConstructor, handle.state, handle.stateByteOffset);
 
     if (hasObserver('quic')) {
       startPerf(this, kPerfEntry, { type: 'quic', name: 'QuicSession' });

--- a/lib/internal/quic/state.js
+++ b/lib/internal/quic/state.js
@@ -5,7 +5,6 @@
 /* c8 ignore start */
 
 const {
-  ArrayBuffer,
   DataView,
   DataViewPrototypeGetBigInt64,
   DataViewPrototypeGetBigUint64,
@@ -16,21 +15,15 @@ const {
   DataViewPrototypeSetUint16,
   DataViewPrototypeSetUint32,
   DataViewPrototypeSetUint8,
-  Float32Array,
   JSONStringify,
-  Uint8Array,
+  Number,
 } = primordials;
 
-// Determine native byte order. The shared state buffer is written by
-// C++ in native byte order, so DataView reads must match.
-const kIsLittleEndian = (() => {
-  // -1 as float32 is 0xBF800000. On little-endian, the bytes are
-  // [0x00, 0x00, 0x80, 0xBF], so byte[3] is 0xBF (non-zero).
-  // On big-endian, the bytes are [0xBF, 0x80, 0x00, 0x00], so byte[3] is 0.
-  const buf = new Float32Array(1);
-  buf[0] = -1;
-  return new Uint8Array(buf.buffer)[3] !== 0;
-})();
+const {
+  isBigEndian,
+} = internalBinding('os');
+
+const kIsLittleEndian = !isBigEndian;
 
 const {
   getOptionValue,
@@ -58,8 +51,6 @@ const {
   kFinishClose,
   kInspect,
   kPrivateConstructor,
-  kWantsHeaders,
-  kWantsTrailers,
 } = require('internal/quic/symbols');
 
 // This file defines the helper objects for accessing state for
@@ -155,6 +146,11 @@ assert(IDX_STATE_STREAM_WANTS_TRAILERS !== undefined);
 assert(IDX_STATE_STREAM_WRITE_DESIRED_SIZE !== undefined);
 assert(IDX_STATE_STREAM_RESET_CODE !== undefined);
 
+const kEmptyObject = { __proto__: null };
+
+// The internal state objects for endpoints, sessions, and streams.
+// These are not exposed directly to users.
+
 class QuicEndpointState {
   /** @type {DataView} */
   #handle;
@@ -175,58 +171,67 @@ class QuicEndpointState {
 
   /** @type {boolean} */
   get isBound() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_ENDPOINT_BOUND);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, IDX_STATE_ENDPOINT_BOUND) !== 0;
   }
 
   /** @type {boolean} */
   get isReceiving() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_ENDPOINT_RECEIVING);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, IDX_STATE_ENDPOINT_RECEIVING) !== 0;
   }
 
   /** @type {boolean} */
   get isListening() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_ENDPOINT_LISTENING);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, IDX_STATE_ENDPOINT_LISTENING) !== 0;
   }
 
   /** @type {boolean} */
   get isClosing() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_ENDPOINT_CLOSING);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, IDX_STATE_ENDPOINT_CLOSING) !== 0;
   }
 
   /** @type {boolean} */
   get isBusy() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_ENDPOINT_BUSY);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, IDX_STATE_ENDPOINT_BUSY) !== 0;
   }
 
   /** @type {number} */
   get maxConnectionsPerHost() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetUint16(
-      this.#handle, IDX_STATE_ENDPOINT_MAX_CONNECTIONS_PER_HOST, kIsLittleEndian);
+      handle, IDX_STATE_ENDPOINT_MAX_CONNECTIONS_PER_HOST, kIsLittleEndian);
   }
 
   set maxConnectionsPerHost(val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
+    const handle = this.#handle;
+    if (handle === undefined) return;
     DataViewPrototypeSetUint16(
-      this.#handle, IDX_STATE_ENDPOINT_MAX_CONNECTIONS_PER_HOST, val, kIsLittleEndian);
+      handle, IDX_STATE_ENDPOINT_MAX_CONNECTIONS_PER_HOST, val, kIsLittleEndian);
   }
 
   /** @type {number} */
   get maxConnectionsTotal() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetUint16(
-      this.#handle, IDX_STATE_ENDPOINT_MAX_CONNECTIONS_TOTAL, kIsLittleEndian);
+      handle, IDX_STATE_ENDPOINT_MAX_CONNECTIONS_TOTAL, kIsLittleEndian);
   }
 
   set maxConnectionsTotal(val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
+    const handle = this.#handle;
+    if (handle === undefined) return;
     DataViewPrototypeSetUint16(
-      this.#handle, IDX_STATE_ENDPOINT_MAX_CONNECTIONS_TOTAL, val, kIsLittleEndian);
+      handle, IDX_STATE_ENDPOINT_MAX_CONNECTIONS_TOTAL, val, kIsLittleEndian);
   }
 
   /**
@@ -236,8 +241,9 @@ class QuicEndpointState {
    * @type {bigint}
    */
   get pendingCallbacks() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetBigUint64(this.#handle, IDX_STATE_ENDPOINT_PENDING_CALLBACKS, kIsLittleEndian);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetBigUint64(handle, IDX_STATE_ENDPOINT_PENDING_CALLBACKS, kIsLittleEndian);
   }
 
   toString() {
@@ -245,26 +251,37 @@ class QuicEndpointState {
   }
 
   toJSON() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return {};
+    if (this.#handle === undefined) return kEmptyObject;
+    const {
+      isBound,
+      isReceiving,
+      isListening,
+      isClosing,
+      isBusy,
+      maxConnectionsPerHost,
+      maxConnectionsTotal,
+      pendingCallbacks,
+    } = this;
     return {
       __proto__: null,
-      isBound: this.isBound,
-      isReceiving: this.isReceiving,
-      isListening: this.isListening,
-      isClosing: this.isClosing,
-      isBusy: this.isBusy,
-      maxConnectionsPerHost: this.maxConnectionsPerHost,
-      maxConnectionsTotal: this.maxConnectionsTotal,
-      pendingCallbacks: `${this.pendingCallbacks}`,
+      isBound,
+      isReceiving,
+      isListening,
+      isClosing,
+      isBusy,
+      maxConnectionsPerHost,
+      maxConnectionsTotal,
+      pendingCallbacks: Number(pendingCallbacks),
     };
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
-
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) {
+    if (this.#handle === undefined) {
       return 'QuicEndpointState { <Closed> }';
+    }
+
+    if (depth < 0) {
+      return 'QuicEndpointState { }';
     }
 
     const opts = {
@@ -273,21 +290,31 @@ class QuicEndpointState {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      isBound,
+      isReceiving,
+      isListening,
+      isClosing,
+      isBusy,
+      maxConnectionsPerHost,
+      maxConnectionsTotal,
+      pendingCallbacks,
+    } = this;
+
     return `QuicEndpointState ${inspect({
-      isBound: this.isBound,
-      isReceiving: this.isReceiving,
-      isListening: this.isListening,
-      isClosing: this.isClosing,
-      isBusy: this.isBusy,
-      pendingCallbacks: this.pendingCallbacks,
+      isBound,
+      isReceiving,
+      isListening,
+      isClosing,
+      isBusy,
+      maxConnectionsPerHost,
+      maxConnectionsTotal,
+      pendingCallbacks,
     }, opts)}`;
   }
 
   [kFinishClose]() {
-    // Snapshot the state into a new DataView since the underlying
-    // buffer will be destroyed.
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    this.#handle = new DataView(new ArrayBuffer(0));
+    this.#handle = undefined;
   }
 }
 
@@ -324,17 +351,19 @@ class QuicSessionState {
   static #LISTENER_ORIGIN = 1 << 5;
 
   #getListenerFlag(flag) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!(DataViewPrototypeGetUint32(
-      this.#handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS, kIsLittleEndian) & flag);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return (DataViewPrototypeGetUint32(
+      handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS, kIsLittleEndian) & flag) !== 0;
   }
 
   #setListenerFlag(flag, val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
+    const handle = this.#handle;
+    if (handle === undefined) return;
     const current = DataViewPrototypeGetUint32(
-      this.#handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS, kIsLittleEndian);
     DataViewPrototypeSetUint32(
-      this.#handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS,
+      handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS,
       val ? (current | flag) : (current & ~flag), kIsLittleEndian);
   }
 
@@ -388,50 +417,58 @@ class QuicSessionState {
 
   /** @type {boolean} */
   get isClosing() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_CLOSING);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_CLOSING) !== 0;
   }
 
   /** @type {boolean} */
   get isGracefulClose() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_GRACEFUL_CLOSE);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_GRACEFUL_CLOSE) !== 0;
   }
 
   /** @type {boolean} */
   get isSilentClose() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_SILENT_CLOSE);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_SILENT_CLOSE) !== 0;
   }
 
   /** @type {boolean} */
   get isStatelessReset() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_STATELESS_RESET);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_STATELESS_RESET) !== 0;
   }
 
   /** @type {boolean} */
   get isHandshakeCompleted() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_HANDSHAKE_COMPLETED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_HANDSHAKE_COMPLETED) !== 0;
   }
 
   /** @type {boolean} */
   get isHandshakeConfirmed() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_HANDSHAKE_CONFIRMED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_HANDSHAKE_CONFIRMED) !== 0;
   }
 
   /** @type {boolean} */
   get isStreamOpenAllowed() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_STREAM_OPEN_ALLOWED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_STREAM_OPEN_ALLOWED) !== 0;
   }
 
   /** @type {boolean} */
   get isPrioritySupported() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_PRIORITY_SUPPORTED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_PRIORITY_SUPPORTED) !== 0;
   }
 
   /**
@@ -440,20 +477,23 @@ class QuicSessionState {
    * @type {number}
    */
   get headersSupported() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_HEADERS_SUPPORTED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_HEADERS_SUPPORTED);
   }
 
   /** @type {boolean} */
   get isWrapped() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_WRAPPED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_WRAPPED) !== 0;
   }
 
   /** @type {number} */
   get applicationType() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_APPLICATION_TYPE);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_SESSION_APPLICATION_TYPE);
   }
 
   /**
@@ -464,9 +504,10 @@ class QuicSessionState {
    * @type {bigint}
    */
   get noErrorCode() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetBigUint64(
-      this.#handle, this.#offset + IDX_STATE_SESSION_NO_ERROR_CODE, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_SESSION_NO_ERROR_CODE, kIsLittleEndian);
   }
 
   /**
@@ -479,38 +520,43 @@ class QuicSessionState {
    * @type {bigint}
    */
   get internalErrorCode() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetBigUint64(
-      this.#handle, this.#offset + IDX_STATE_SESSION_INTERNAL_ERROR_CODE, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_SESSION_INTERNAL_ERROR_CODE, kIsLittleEndian);
   }
 
   /** @type {number} */
   get maxDatagramSize() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetUint16(
-      this.#handle, this.#offset + IDX_STATE_SESSION_MAX_DATAGRAM_SIZE,
+      handle, this.#offset + IDX_STATE_SESSION_MAX_DATAGRAM_SIZE,
       kIsLittleEndian);
   }
 
   /** @type {bigint} */
   get lastDatagramId() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetBigUint64(
-      this.#handle, this.#offset + IDX_STATE_SESSION_LAST_DATAGRAM_ID,
+      handle, this.#offset + IDX_STATE_SESSION_LAST_DATAGRAM_ID,
       kIsLittleEndian);
   }
 
   /** @type {number} */
   get maxPendingDatagrams() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetUint16(
-      this.#handle, this.#offset + IDX_STATE_SESSION_MAX_PENDING_DATAGRAMS, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_SESSION_MAX_PENDING_DATAGRAMS, kIsLittleEndian);
   }
 
   set maxPendingDatagrams(val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
+    const handle = this.#handle;
+    if (handle === undefined) return;
     DataViewPrototypeSetUint16(
-      this.#handle, this.#offset + IDX_STATE_SESSION_MAX_PENDING_DATAGRAMS, val, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_SESSION_MAX_PENDING_DATAGRAMS, val, kIsLittleEndian);
   }
 
   toString() {
@@ -518,40 +564,65 @@ class QuicSessionState {
   }
 
   toJSON() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return {};
+    if (this.#handle === undefined) return kEmptyObject;
+    const {
+      hasPathValidationListener,
+      hasDatagramListener,
+      hasDatagramStatusListener,
+      hasSessionTicketListener,
+      hasNewTokenListener,
+      hasOriginListener,
+      isClosing,
+      isGracefulClose,
+      isSilentClose,
+      isStatelessReset,
+      isHandshakeCompleted,
+      isHandshakeConfirmed,
+      isStreamOpenAllowed,
+      isPrioritySupported,
+      headersSupported,
+      isWrapped,
+      applicationType,
+      noErrorCode,
+      internalErrorCode,
+      maxDatagramSize,
+      lastDatagramId,
+      maxPendingDatagrams,
+    } = this;
     return {
       __proto__: null,
-      hasPathValidationListener: this.hasPathValidationListener,
-      hasDatagramListener: this.hasDatagramListener,
-      hasDatagramStatusListener: this.hasDatagramStatusListener,
-      hasSessionTicketListener: this.hasSessionTicketListener,
-      hasNewTokenListener: this.hasNewTokenListener,
-      hasOriginListener: this.hasOriginListener,
-      isClosing: this.isClosing,
-      isGracefulClose: this.isGracefulClose,
-      isSilentClose: this.isSilentClose,
-      isStatelessReset: this.isStatelessReset,
-      isHandshakeCompleted: this.isHandshakeCompleted,
-      isHandshakeConfirmed: this.isHandshakeConfirmed,
-      isStreamOpenAllowed: this.isStreamOpenAllowed,
-      isPrioritySupported: this.isPrioritySupported,
-      headersSupported: this.headersSupported,
-      isWrapped: this.isWrapped,
-      applicationType: this.applicationType,
-      noErrorCode: `${this.noErrorCode}`,
-      internalErrorCode: `${this.internalErrorCode}`,
-      maxDatagramSize: `${this.maxDatagramSize}`,
-      lastDatagramId: `${this.lastDatagramId}`,
-      maxPendingDatagrams: this.maxPendingDatagrams,
+      hasPathValidationListener,
+      hasDatagramListener,
+      hasDatagramStatusListener,
+      hasSessionTicketListener,
+      hasNewTokenListener,
+      hasOriginListener,
+      isClosing,
+      isGracefulClose,
+      isSilentClose,
+      isStatelessReset,
+      isHandshakeCompleted,
+      isHandshakeConfirmed,
+      isStreamOpenAllowed,
+      isPrioritySupported,
+      headersSupported,
+      isWrapped,
+      applicationType,
+      noErrorCode: `${noErrorCode}`,
+      internalErrorCode: `${internalErrorCode}`,
+      maxDatagramSize: `${maxDatagramSize}`,
+      lastDatagramId: `${lastDatagramId}`,
+      maxPendingDatagrams,
     };
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
-
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) {
+    if (this.#handle === undefined) {
       return 'QuicSessionState { <Closed> }';
+    }
+
+    if (depth < 0) {
+      return 'QuicSessionState { }';
     }
 
     const opts = {
@@ -560,36 +631,59 @@ class QuicSessionState {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      hasPathValidationListener,
+      hasDatagramListener,
+      hasDatagramStatusListener,
+      hasSessionTicketListener,
+      hasNewTokenListener,
+      hasOriginListener,
+      isClosing,
+      isGracefulClose,
+      isSilentClose,
+      isStatelessReset,
+      isHandshakeCompleted,
+      isHandshakeConfirmed,
+      isStreamOpenAllowed,
+      isPrioritySupported,
+      headersSupported,
+      isWrapped,
+      applicationType,
+      noErrorCode,
+      internalErrorCode,
+      maxDatagramSize,
+      lastDatagramId,
+      maxPendingDatagrams,
+    } = this;
+
     return `QuicSessionState ${inspect({
-      hasPathValidationListener: this.hasPathValidationListener,
-      hasDatagramListener: this.hasDatagramListener,
-      hasDatagramStatusListener: this.hasDatagramStatusListener,
-      hasSessionTicketListener: this.hasSessionTicketListener,
-      hasNewTokenListener: this.hasNewTokenListener,
-      hasOriginListener: this.hasOriginListener,
-      isClosing: this.isClosing,
-      isGracefulClose: this.isGracefulClose,
-      isSilentClose: this.isSilentClose,
-      isStatelessReset: this.isStatelessReset,
-      isHandshakeCompleted: this.isHandshakeCompleted,
-      isHandshakeConfirmed: this.isHandshakeConfirmed,
-      isStreamOpenAllowed: this.isStreamOpenAllowed,
-      isPrioritySupported: this.isPrioritySupported,
-      headersSupported: this.headersSupported,
-      isWrapped: this.isWrapped,
-      applicationType: this.applicationType,
-      noErrorCode: this.noErrorCode,
-      internalErrorCode: this.internalErrorCode,
-      maxDatagramSize: this.maxDatagramSize,
-      lastDatagramId: this.lastDatagramId,
+      hasPathValidationListener,
+      hasDatagramListener,
+      hasDatagramStatusListener,
+      hasSessionTicketListener,
+      hasNewTokenListener,
+      hasOriginListener,
+      isClosing,
+      isGracefulClose,
+      isSilentClose,
+      isStatelessReset,
+      isHandshakeCompleted,
+      isHandshakeConfirmed,
+      isStreamOpenAllowed,
+      isPrioritySupported,
+      headersSupported,
+      isWrapped,
+      applicationType,
+      noErrorCode,
+      internalErrorCode,
+      maxDatagramSize,
+      lastDatagramId,
+      maxPendingDatagrams,
     }, opts)}`;
   }
 
   [kFinishClose]() {
-    // Snapshot the state into a new DataView since the underlying
-    // buffer will be destroyed.
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    this.#handle = new DataView(new ArrayBuffer(0));
+    this.#handle = undefined;
   }
 }
 
@@ -598,6 +692,8 @@ class QuicStreamState {
   #handle;
   /** @type {number} */
   #offset = 0;
+  /** @type {bigint|undefined} */
+  #id = undefined;
 
   /**
    * @param {symbol} privateSymbol
@@ -618,144 +714,166 @@ class QuicStreamState {
 
   /** @type {bigint} */
   get id() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetBigInt64(this.#handle, this.#offset + IDX_STATE_STREAM_ID, kIsLittleEndian);
+    const handle = this.#handle;
+    if (handle === undefined) return this.#id;
+    return DataViewPrototypeGetBigInt64(handle, this.#offset + IDX_STATE_STREAM_ID, kIsLittleEndian);
   }
 
   /** @type {boolean} */
   get pending() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_PENDING);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_PENDING) !== 0;
   }
 
   /** @type {boolean} */
   get finSent() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_FIN_SENT);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_FIN_SENT) !== 0;
   }
 
   /** @type {boolean} */
   get finReceived() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_FIN_RECEIVED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_FIN_RECEIVED) !== 0;
   }
 
   /** @type {boolean} */
   get readEnded() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_READ_ENDED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_READ_ENDED) !== 0;
   }
 
   /** @type {boolean} */
   get writeEnded() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WRITE_ENDED);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_WRITE_ENDED) !== 0;
   }
-
 
   /** @type {boolean} */
   get reset() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_RESET);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_RESET) !== 0;
   }
 
   /** @type {boolean} */
   get hasOutbound() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_HAS_OUTBOUND);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_HAS_OUTBOUND) !== 0;
   }
 
   /** @type {boolean} */
   get hasReader() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_HAS_READER);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_HAS_READER) !== 0;
   }
 
   /** @type {boolean} */
   get wantsBlock() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_BLOCK);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_WANTS_BLOCK) !== 0;
   }
 
   /** @type {boolean} */
   set wantsBlock(val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    DataViewPrototypeSetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_BLOCK, val ? 1 : 0);
+    const handle = this.#handle;
+    if (handle === undefined) return;
+    DataViewPrototypeSetUint8(handle, this.#offset + IDX_STATE_STREAM_WANTS_BLOCK, val ? 1 : 0);
   }
 
   /** @type {boolean} */
-  get [kWantsHeaders]() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_HEADERS);
+  get wantsHeaders() {
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_WANTS_HEADERS) !== 0;
   }
 
   /** @type {boolean} */
-  set [kWantsHeaders](val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    DataViewPrototypeSetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_HEADERS, val ? 1 : 0);
+  set wantsHeaders(val) {
+    const handle = this.#handle;
+    if (handle === undefined) return;
+    DataViewPrototypeSetUint8(handle, this.#offset + IDX_STATE_STREAM_WANTS_HEADERS, val ? 1 : 0);
   }
 
   /** @type {boolean} */
   get wantsReset() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_RESET);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_WANTS_RESET) !== 0;
   }
 
   /** @type {boolean} */
   set wantsReset(val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    DataViewPrototypeSetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_RESET, val ? 1 : 0);
+    const handle = this.#handle;
+    if (handle === undefined) return;
+    DataViewPrototypeSetUint8(handle, this.#offset + IDX_STATE_STREAM_WANTS_RESET, val ? 1 : 0);
   }
 
   /** @type {boolean} */
-  get [kWantsTrailers]() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_TRAILERS);
+  get wantsTrailers() {
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_WANTS_TRAILERS) !== 0;
   }
 
   /** @type {boolean} */
-  set [kWantsTrailers](val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    DataViewPrototypeSetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_TRAILERS, val ? 1 : 0);
+  set wantsTrailers(val) {
+    const handle = this.#handle;
+    if (handle === undefined) return;
+    DataViewPrototypeSetUint8(handle, this.#offset + IDX_STATE_STREAM_WANTS_TRAILERS, val ? 1 : 0);
   }
 
   /** @type {boolean} */
   get early() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_RECEIVED_EARLY_DATA);
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
+    return DataViewPrototypeGetUint8(handle, this.#offset + IDX_STATE_STREAM_RECEIVED_EARLY_DATA) !== 0;
   }
 
   /** @type {bigint} */
   get resetCode() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetBigUint64(
-      this.#handle, this.#offset + IDX_STATE_STREAM_RESET_CODE, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_STREAM_RESET_CODE, kIsLittleEndian);
   }
 
   /** @type {bigint} */
   get writeDesiredSize() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetUint32(
-      this.#handle, this.#offset + IDX_STATE_STREAM_WRITE_DESIRED_SIZE, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_STREAM_WRITE_DESIRED_SIZE, kIsLittleEndian);
   }
 
   set writeDesiredSize(val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
+    const handle = this.#handle;
+    if (handle === undefined) return;
     DataViewPrototypeSetUint32(
-      this.#handle, this.#offset + IDX_STATE_STREAM_WRITE_DESIRED_SIZE, val, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_STREAM_WRITE_DESIRED_SIZE, val, kIsLittleEndian);
   }
 
   /** @type {number} */
   get highWaterMark() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
+    const handle = this.#handle;
+    if (handle === undefined) return undefined;
     return DataViewPrototypeGetUint32(
-      this.#handle, this.#offset + IDX_STATE_STREAM_HIGH_WATER_MARK, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_STREAM_HIGH_WATER_MARK, kIsLittleEndian);
   }
 
   set highWaterMark(val) {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
+    const handle = this.#handle;
+    if (handle === undefined) return;
     DataViewPrototypeSetUint32(
-      this.#handle, this.#offset + IDX_STATE_STREAM_HIGH_WATER_MARK, val, kIsLittleEndian);
+      handle, this.#offset + IDX_STATE_STREAM_HIGH_WATER_MARK, val, kIsLittleEndian);
   }
 
   toString() {
@@ -763,30 +881,55 @@ class QuicStreamState {
   }
 
   toJSON() {
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return {};
+    if (this.#handle === undefined) return kEmptyObject;
+    const {
+      id,
+      pending,
+      finSent,
+      finReceived,
+      readEnded,
+      writeEnded,
+      reset,
+      hasOutbound,
+      hasReader,
+      wantsBlock,
+      wantsReset,
+      wantsHeaders,
+      wantsTrailers,
+      early,
+      resetCode,
+      writeDesiredSize,
+      highWaterMark,
+    } = this;
     return {
       __proto__: null,
-      id: `${this.id}`,
-      pending: this.pending,
-      finSent: this.finSent,
-      finReceived: this.finReceived,
-      readEnded: this.readEnded,
-      writeEnded: this.writeEnded,
-      reset: this.reset,
-      hasOutbound: this.hasOutbound,
-      hasReader: this.hasReader,
-      wantsBlock: this.wantsBlock,
-      wantsReset: this.wantsReset,
-      early: this.early,
+      id: `${id}`,
+      pending,
+      finSent,
+      finReceived,
+      readEnded,
+      writeEnded,
+      reset,
+      hasOutbound,
+      hasReader,
+      wantsBlock,
+      wantsReset,
+      wantsHeaders,
+      wantsTrailers,
+      early,
+      resetCode,
+      writeDesiredSize,
+      highWaterMark,
     };
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
-
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) {
       return 'QuicStreamState { <Closed> }';
+    }
+
+    if (depth < 0) {
+      return 'QuicStreamState { }';
     }
 
     const opts = {
@@ -795,27 +938,51 @@ class QuicStreamState {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      id,
+      pending,
+      finSent,
+      finReceived,
+      readEnded,
+      writeEnded,
+      reset,
+      hasOutbound,
+      hasReader,
+      wantsBlock,
+      wantsReset,
+      wantsHeaders,
+      wantsTrailers,
+      early,
+      resetCode,
+      writeDesiredSize,
+      highWaterMark,
+    } = this;
+
     return `QuicStreamState ${inspect({
-      id: this.id,
-      pending: this.pending,
-      finSent: this.finSent,
-      finReceived: this.finReceived,
-      readEnded: this.readEnded,
-      writeEnded: this.writeEnded,
-      reset: this.reset,
-      hasOutbound: this.hasOutbound,
-      hasReader: this.hasReader,
-      wantsBlock: this.wantsBlock,
-      wantsReset: this.wantsReset,
-      early: this.early,
+      id,
+      pending,
+      finSent,
+      finReceived,
+      readEnded,
+      writeEnded,
+      reset,
+      hasOutbound,
+      hasReader,
+      wantsBlock,
+      wantsReset,
+      wantsHeaders,
+      wantsTrailers,
+      early,
+      resetCode,
+      writeDesiredSize,
+      highWaterMark,
     }, opts)}`;
   }
 
   [kFinishClose]() {
-    // Snapshot the state into a new DataView since the underlying
-    // buffer will be destroyed.
-    if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    this.#handle = new DataView(new ArrayBuffer(0));
+    // Cache the stream ID since the buffer will be zeroed out and the ID will be lost.
+    this.#id = this.id;
+    this.#handle = undefined;
   }
 }
 

--- a/lib/internal/quic/state.js
+++ b/lib/internal/quic/state.js
@@ -294,19 +294,24 @@ class QuicEndpointState {
 class QuicSessionState {
   /** @type {DataView} */
   #handle;
+  /** @type {number} */
+  #offset = 0;
 
   /**
    * @param {symbol} privateSymbol
-   * @param {ArrayBuffer} buffer
+   * @param {DataView|ArrayBuffer} view
+   * @param {number} [byteOffset]
    */
-  constructor(privateSymbol, buffer) {
+  constructor(privateSymbol, view, byteOffset = 0) {
     if (privateSymbol !== kPrivateConstructor) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
-    if (!isArrayBuffer(buffer)) {
-      throw new ERR_INVALID_ARG_TYPE('buffer', ['ArrayBuffer'], buffer);
+    if (isArrayBuffer(view)) {
+      this.#handle = new DataView(view);
+    } else {
+      this.#handle = view;
     }
-    this.#handle = new DataView(buffer);
+    this.#offset = byteOffset;
   }
 
   // Listener flags are packed into a single uint32_t bitfield. The bit
@@ -321,15 +326,15 @@ class QuicSessionState {
   #getListenerFlag(flag) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
     return !!(DataViewPrototypeGetUint32(
-      this.#handle, IDX_STATE_SESSION_LISTENER_FLAGS, kIsLittleEndian) & flag);
+      this.#handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS, kIsLittleEndian) & flag);
   }
 
   #setListenerFlag(flag, val) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
     const current = DataViewPrototypeGetUint32(
-      this.#handle, IDX_STATE_SESSION_LISTENER_FLAGS, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS, kIsLittleEndian);
     DataViewPrototypeSetUint32(
-      this.#handle, IDX_STATE_SESSION_LISTENER_FLAGS,
+      this.#handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS,
       val ? (current | flag) : (current & ~flag), kIsLittleEndian);
   }
 
@@ -384,49 +389,49 @@ class QuicSessionState {
   /** @type {boolean} */
   get isClosing() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_CLOSING);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_CLOSING);
   }
 
   /** @type {boolean} */
   get isGracefulClose() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_GRACEFUL_CLOSE);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_GRACEFUL_CLOSE);
   }
 
   /** @type {boolean} */
   get isSilentClose() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_SILENT_CLOSE);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_SILENT_CLOSE);
   }
 
   /** @type {boolean} */
   get isStatelessReset() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_STATELESS_RESET);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_STATELESS_RESET);
   }
 
   /** @type {boolean} */
   get isHandshakeCompleted() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_HANDSHAKE_COMPLETED);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_HANDSHAKE_COMPLETED);
   }
 
   /** @type {boolean} */
   get isHandshakeConfirmed() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_HANDSHAKE_CONFIRMED);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_HANDSHAKE_CONFIRMED);
   }
 
   /** @type {boolean} */
   get isStreamOpenAllowed() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_STREAM_OPEN_ALLOWED);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_STREAM_OPEN_ALLOWED);
   }
 
   /** @type {boolean} */
   get isPrioritySupported() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_PRIORITY_SUPPORTED);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_PRIORITY_SUPPORTED);
   }
 
   /**
@@ -436,19 +441,19 @@ class QuicSessionState {
    */
   get headersSupported() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_HEADERS_SUPPORTED);
+    return DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_HEADERS_SUPPORTED);
   }
 
   /** @type {boolean} */
   get isWrapped() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_WRAPPED);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_WRAPPED);
   }
 
   /** @type {number} */
   get applicationType() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetUint8(this.#handle, IDX_STATE_SESSION_APPLICATION_TYPE);
+    return DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_SESSION_APPLICATION_TYPE);
   }
 
   /**
@@ -461,7 +466,7 @@ class QuicSessionState {
   get noErrorCode() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
     return DataViewPrototypeGetBigUint64(
-      this.#handle, IDX_STATE_SESSION_NO_ERROR_CODE, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_SESSION_NO_ERROR_CODE, kIsLittleEndian);
   }
 
   /**
@@ -476,32 +481,36 @@ class QuicSessionState {
   get internalErrorCode() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
     return DataViewPrototypeGetBigUint64(
-      this.#handle, IDX_STATE_SESSION_INTERNAL_ERROR_CODE, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_SESSION_INTERNAL_ERROR_CODE, kIsLittleEndian);
   }
 
   /** @type {number} */
   get maxDatagramSize() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetUint16(this.#handle, IDX_STATE_SESSION_MAX_DATAGRAM_SIZE, kIsLittleEndian);
+    return DataViewPrototypeGetUint16(
+      this.#handle, this.#offset + IDX_STATE_SESSION_MAX_DATAGRAM_SIZE,
+      kIsLittleEndian);
   }
 
   /** @type {bigint} */
   get lastDatagramId() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetBigUint64(this.#handle, IDX_STATE_SESSION_LAST_DATAGRAM_ID, kIsLittleEndian);
+    return DataViewPrototypeGetBigUint64(
+      this.#handle, this.#offset + IDX_STATE_SESSION_LAST_DATAGRAM_ID,
+      kIsLittleEndian);
   }
 
   /** @type {number} */
   get maxPendingDatagrams() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
     return DataViewPrototypeGetUint16(
-      this.#handle, IDX_STATE_SESSION_MAX_PENDING_DATAGRAMS, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_SESSION_MAX_PENDING_DATAGRAMS, kIsLittleEndian);
   }
 
   set maxPendingDatagrams(val) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
     DataViewPrototypeSetUint16(
-      this.#handle, IDX_STATE_SESSION_MAX_PENDING_DATAGRAMS, val, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_SESSION_MAX_PENDING_DATAGRAMS, val, kIsLittleEndian);
   }
 
   toString() {
@@ -587,161 +596,166 @@ class QuicSessionState {
 class QuicStreamState {
   /** @type {DataView} */
   #handle;
+  /** @type {number} */
+  #offset = 0;
 
   /**
    * @param {symbol} privateSymbol
-   * @param {ArrayBuffer} buffer
+   * @param {DataView|ArrayBuffer} view
+   * @param {number} [byteOffset]
    */
-  constructor(privateSymbol, buffer) {
+  constructor(privateSymbol, view, byteOffset = 0) {
     if (privateSymbol !== kPrivateConstructor) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
-    if (!isArrayBuffer(buffer)) {
-      throw new ERR_INVALID_ARG_TYPE('buffer', ['ArrayBuffer'], buffer);
+    if (isArrayBuffer(view)) {
+      this.#handle = new DataView(view);
+    } else {
+      this.#handle = view;
     }
-    this.#handle = new DataView(buffer);
+    this.#offset = byteOffset;
   }
 
   /** @type {bigint} */
   get id() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return DataViewPrototypeGetBigInt64(this.#handle, IDX_STATE_STREAM_ID, kIsLittleEndian);
+    return DataViewPrototypeGetBigInt64(this.#handle, this.#offset + IDX_STATE_STREAM_ID, kIsLittleEndian);
   }
 
   /** @type {boolean} */
   get pending() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_PENDING);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_PENDING);
   }
 
   /** @type {boolean} */
   get finSent() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_FIN_SENT);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_FIN_SENT);
   }
 
   /** @type {boolean} */
   get finReceived() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_FIN_RECEIVED);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_FIN_RECEIVED);
   }
 
   /** @type {boolean} */
   get readEnded() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_READ_ENDED);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_READ_ENDED);
   }
 
   /** @type {boolean} */
   get writeEnded() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_WRITE_ENDED);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WRITE_ENDED);
   }
 
 
   /** @type {boolean} */
   get reset() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_RESET);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_RESET);
   }
 
   /** @type {boolean} */
   get hasOutbound() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_HAS_OUTBOUND);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_HAS_OUTBOUND);
   }
 
   /** @type {boolean} */
   get hasReader() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_HAS_READER);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_HAS_READER);
   }
 
   /** @type {boolean} */
   get wantsBlock() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_WANTS_BLOCK);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_BLOCK);
   }
 
   /** @type {boolean} */
   set wantsBlock(val) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    DataViewPrototypeSetUint8(this.#handle, IDX_STATE_STREAM_WANTS_BLOCK, val ? 1 : 0);
+    DataViewPrototypeSetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_BLOCK, val ? 1 : 0);
   }
 
   /** @type {boolean} */
   get [kWantsHeaders]() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_WANTS_HEADERS);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_HEADERS);
   }
 
   /** @type {boolean} */
   set [kWantsHeaders](val) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    DataViewPrototypeSetUint8(this.#handle, IDX_STATE_STREAM_WANTS_HEADERS, val ? 1 : 0);
+    DataViewPrototypeSetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_HEADERS, val ? 1 : 0);
   }
 
   /** @type {boolean} */
   get wantsReset() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_WANTS_RESET);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_RESET);
   }
 
   /** @type {boolean} */
   set wantsReset(val) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    DataViewPrototypeSetUint8(this.#handle, IDX_STATE_STREAM_WANTS_RESET, val ? 1 : 0);
+    DataViewPrototypeSetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_RESET, val ? 1 : 0);
   }
 
   /** @type {boolean} */
   get [kWantsTrailers]() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_WANTS_TRAILERS);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_TRAILERS);
   }
 
   /** @type {boolean} */
   set [kWantsTrailers](val) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
-    DataViewPrototypeSetUint8(this.#handle, IDX_STATE_STREAM_WANTS_TRAILERS, val ? 1 : 0);
+    DataViewPrototypeSetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_WANTS_TRAILERS, val ? 1 : 0);
   }
 
   /** @type {boolean} */
   get early() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
-    return !!DataViewPrototypeGetUint8(this.#handle, IDX_STATE_STREAM_RECEIVED_EARLY_DATA);
+    return !!DataViewPrototypeGetUint8(this.#handle, this.#offset + IDX_STATE_STREAM_RECEIVED_EARLY_DATA);
   }
 
   /** @type {bigint} */
   get resetCode() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
     return DataViewPrototypeGetBigUint64(
-      this.#handle, IDX_STATE_STREAM_RESET_CODE, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_STREAM_RESET_CODE, kIsLittleEndian);
   }
 
   /** @type {bigint} */
   get writeDesiredSize() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
     return DataViewPrototypeGetUint32(
-      this.#handle, IDX_STATE_STREAM_WRITE_DESIRED_SIZE, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_STREAM_WRITE_DESIRED_SIZE, kIsLittleEndian);
   }
 
   set writeDesiredSize(val) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
     DataViewPrototypeSetUint32(
-      this.#handle, IDX_STATE_STREAM_WRITE_DESIRED_SIZE, val, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_STREAM_WRITE_DESIRED_SIZE, val, kIsLittleEndian);
   }
 
   /** @type {number} */
   get highWaterMark() {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return undefined;
     return DataViewPrototypeGetUint32(
-      this.#handle, IDX_STATE_STREAM_HIGH_WATER_MARK, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_STREAM_HIGH_WATER_MARK, kIsLittleEndian);
   }
 
   set highWaterMark(val) {
     if (DataViewPrototypeGetByteLength(this.#handle) === 0) return;
     DataViewPrototypeSetUint32(
-      this.#handle, IDX_STATE_STREAM_HIGH_WATER_MARK, val, kIsLittleEndian);
+      this.#handle, this.#offset + IDX_STATE_STREAM_HIGH_WATER_MARK, val, kIsLittleEndian);
   }
 
   toString() {

--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -332,163 +332,168 @@ class QuicSessionStats {
    * @param {symbol} privateSymbol
    * @param {ArrayBuffer} buffer
    */
-  constructor(privateSymbol, buffer) {
+  /** @type {number} */
+  #offset = 0;
+
+  constructor(privateSymbol, view, byteOffset = 0) {
     // We use the kPrivateConstructor symbol to restrict the ability to
     // create new instances of QuicSessionStats to internal code.
     if (privateSymbol !== kPrivateConstructor) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
-    if (!isArrayBuffer(buffer)) {
-      throw new ERR_INVALID_ARG_TYPE('buffer', ['ArrayBuffer'], buffer);
+    if (isArrayBuffer(view)) {
+      this.#handle = new BigUint64Array(view);
+    } else {
+      this.#handle = view;
     }
-    this.#handle = new BigUint64Array(buffer);
+    this.#offset = byteOffset / 8;
   }
 
   /** @type {bigint} */
   get createdAt() {
-    return this.#handle[IDX_STATS_SESSION_CREATED_AT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_CREATED_AT];
   }
 
   /** @type {bigint} */
   get destroyedAt() {
-    return this.#handle[IDX_STATS_SESSION_DESTROYED_AT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_DESTROYED_AT];
   }
 
   /** @type {bigint} */
   get closingAt() {
-    return this.#handle[IDX_STATS_SESSION_CLOSING_AT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_CLOSING_AT];
   }
 
   /** @type {bigint} */
   get handshakeCompletedAt() {
-    return this.#handle[IDX_STATS_SESSION_HANDSHAKE_COMPLETED_AT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_HANDSHAKE_COMPLETED_AT];
   }
 
   /** @type {bigint} */
   get handshakeConfirmedAt() {
-    return this.#handle[IDX_STATS_SESSION_HANDSHAKE_CONFIRMED_AT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_HANDSHAKE_CONFIRMED_AT];
   }
 
   /** @type {bigint} */
   get bytesReceived() {
-    return this.#handle[IDX_STATS_SESSION_BYTES_RECEIVED];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_RECEIVED];
   }
 
   /** @type {bigint} */
   get bidiInStreamCount() {
-    return this.#handle[IDX_STATS_SESSION_BIDI_IN_STREAM_COUNT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_BIDI_IN_STREAM_COUNT];
   }
 
   /** @type {bigint} */
   get bidiOutStreamCount() {
-    return this.#handle[IDX_STATS_SESSION_BIDI_OUT_STREAM_COUNT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_BIDI_OUT_STREAM_COUNT];
   }
 
   /** @type {bigint} */
   get uniInStreamCount() {
-    return this.#handle[IDX_STATS_SESSION_UNI_IN_STREAM_COUNT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_UNI_IN_STREAM_COUNT];
   }
 
   /** @type {bigint} */
   get uniOutStreamCount() {
-    return this.#handle[IDX_STATS_SESSION_UNI_OUT_STREAM_COUNT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_UNI_OUT_STREAM_COUNT];
   }
 
   /** @type {bigint} */
   get maxBytesInFlight() {
-    return this.#handle[IDX_STATS_SESSION_MAX_BYTES_IN_FLIGHT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_MAX_BYTES_IN_FLIGHT];
   }
 
   /** @type {bigint} */
   get bytesInFlight() {
-    return this.#handle[IDX_STATS_SESSION_BYTES_IN_FLIGHT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_IN_FLIGHT];
   }
 
   /** @type {bigint} */
   get blockCount() {
-    return this.#handle[IDX_STATS_SESSION_BLOCK_COUNT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_BLOCK_COUNT];
   }
 
   /** @type {bigint} */
   get cwnd() {
-    return this.#handle[IDX_STATS_SESSION_CWND];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_CWND];
   }
 
   /** @type {bigint} */
   get latestRtt() {
-    return this.#handle[IDX_STATS_SESSION_LATEST_RTT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_LATEST_RTT];
   }
 
   /** @type {bigint} */
   get minRtt() {
-    return this.#handle[IDX_STATS_SESSION_MIN_RTT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_MIN_RTT];
   }
 
   /** @type {bigint} */
   get rttVar() {
-    return this.#handle[IDX_STATS_SESSION_RTTVAR];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_RTTVAR];
   }
 
   /** @type {bigint} */
   get smoothedRtt() {
-    return this.#handle[IDX_STATS_SESSION_SMOOTHED_RTT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_SMOOTHED_RTT];
   }
 
   /** @type {bigint} */
   get ssthresh() {
-    return this.#handle[IDX_STATS_SESSION_SSTHRESH];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_SSTHRESH];
   }
 
   get pktSent() {
-    return this.#handle[IDX_STATS_SESSION_PKT_SENT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_PKT_SENT];
   }
 
   get bytesSent() {
-    return this.#handle[IDX_STATS_SESSION_BYTES_SENT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_SENT];
   }
 
   get pktRecv() {
-    return this.#handle[IDX_STATS_SESSION_PKT_RECV];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_PKT_RECV];
   }
 
   get bytesRecv() {
-    return this.#handle[IDX_STATS_SESSION_BYTES_RECV];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_RECV];
   }
 
   get pktLost() {
-    return this.#handle[IDX_STATS_SESSION_PKT_LOST];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_PKT_LOST];
   }
 
   get bytesLost() {
-    return this.#handle[IDX_STATS_SESSION_BYTES_LOST];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_LOST];
   }
 
   get pingRecv() {
-    return this.#handle[IDX_STATS_SESSION_PING_RECV];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_PING_RECV];
   }
 
   get pktDiscarded() {
-    return this.#handle[IDX_STATS_SESSION_PKT_DISCARDED];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_PKT_DISCARDED];
   }
 
   /** @type {bigint} */
   get datagramsReceived() {
-    return this.#handle[IDX_STATS_SESSION_DATAGRAMS_RECEIVED];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_RECEIVED];
   }
 
   /** @type {bigint} */
   get datagramsSent() {
-    return this.#handle[IDX_STATS_SESSION_DATAGRAMS_SENT];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_SENT];
   }
 
   /** @type {bigint} */
   get datagramsAcknowledged() {
-    return this.#handle[IDX_STATS_SESSION_DATAGRAMS_ACKNOWLEDGED];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_ACKNOWLEDGED];
   }
 
   /** @type {bigint} */
   get datagramsLost() {
-    return this.#handle[IDX_STATS_SESSION_DATAGRAMS_LOST];
+    return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_LOST];
   }
 
   toString() {
@@ -590,9 +595,14 @@ class QuicSessionStats {
   }
 
   [kFinishClose]() {
-    // Snapshot the stats into a new BigUint64Array since the underlying
-    // buffer will be destroyed.
-    this.#handle = new BigUint64Array(this.#handle);
+    // Snapshot this session's stats slice into a standalone BigUint64Array.
+    const count = IDX_STATS_SESSION_DATAGRAMS_LOST + 1;
+    const snapshot = new BigUint64Array(count);
+    for (let i = 0; i < count; i++) {
+      snapshot[i] = this.#handle[this.#offset + i];
+    }
+    this.#handle = snapshot;
+    this.#offset = 0;
     this.#disconnected = true;
   }
 }
@@ -600,78 +610,84 @@ class QuicSessionStats {
 class QuicStreamStats {
   /** @type {BigUint64Array} */
   #handle;
+  /** @type {number} */
+  #offset = 0;
   /** type {boolean} */
   #disconnected = false;
 
   /**
    * @param {symbol} privateSymbol
-   * @param {ArrayBuffer} buffer
+   * @param {BigUint64Array|ArrayBuffer} view
+   * @param {number} [byteOffset] - byte offset into the shared page view
    */
-  constructor(privateSymbol, buffer) {
+  constructor(privateSymbol, view, byteOffset = 0) {
     // We use the kPrivateConstructor symbol to restrict the ability to
     // create new instances of QuicStreamStats to internal code.
     if (privateSymbol !== kPrivateConstructor) {
       throw new ERR_ILLEGAL_CONSTRUCTOR();
     }
-    if (!isArrayBuffer(buffer)) {
-      throw new ERR_INVALID_ARG_TYPE('buffer', ['ArrayBuffer'], buffer);
+    if (isArrayBuffer(view)) {
+      this.#handle = new BigUint64Array(view);
+    } else {
+      this.#handle = view;
     }
-    this.#handle = new BigUint64Array(buffer);
+    // Convert byte offset to element offset (8 bytes per uint64).
+    this.#offset = byteOffset / 8;
   }
 
   /** @type {bigint} */
   get createdAt() {
-    return this.#handle[IDX_STATS_STREAM_CREATED_AT];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_CREATED_AT];
   }
 
   /** @type {bigint} */
   get openedAt() {
-    return this.#handle[IDX_STATS_STREAM_OPENED_AT];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_OPENED_AT];
   }
 
   /** @type {bigint} */
   get receivedAt() {
-    return this.#handle[IDX_STATS_STREAM_RECEIVED_AT];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_RECEIVED_AT];
   }
 
   /** @type {bigint} */
   get ackedAt() {
-    return this.#handle[IDX_STATS_STREAM_ACKED_AT];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_ACKED_AT];
   }
 
   /** @type {bigint} */
   get destroyedAt() {
-    return this.#handle[IDX_STATS_STREAM_DESTROYED_AT];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_DESTROYED_AT];
   }
 
   /** @type {bigint} */
   get bytesReceived() {
-    return this.#handle[IDX_STATS_STREAM_BYTES_RECEIVED];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_BYTES_RECEIVED];
   }
 
   /** @type {bigint} */
   get bytesSent() {
-    return this.#handle[IDX_STATS_STREAM_BYTES_SENT];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_BYTES_SENT];
   }
 
   /** @type {bigint} */
   get maxOffset() {
-    return this.#handle[IDX_STATS_STREAM_MAX_OFFSET];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_MAX_OFFSET];
   }
 
   /** @type {bigint} */
   get maxOffsetAcknowledged() {
-    return this.#handle[IDX_STATS_STREAM_MAX_OFFSET_ACK];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_MAX_OFFSET_ACK];
   }
 
   /** @type {bigint} */
   get maxOffsetReceived() {
-    return this.#handle[IDX_STATS_STREAM_MAX_OFFSET_RECV];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_MAX_OFFSET_RECV];
   }
 
   /** @type {bigint} */
   get finalSize() {
-    return this.#handle[IDX_STATS_STREAM_FINAL_SIZE];
+    return this.#handle[this.#offset + IDX_STATS_STREAM_FINAL_SIZE];
   }
 
   toString() {
@@ -735,9 +751,14 @@ class QuicStreamStats {
   }
 
   [kFinishClose]() {
-    // Snapshot the stats into a new BigUint64Array since the underlying
-    // buffer will be destroyed.
-    this.#handle = new BigUint64Array(this.#handle);
+    // Snapshot this stream's stats slice into a standalone BigUint64Array.
+    const count = IDX_STATS_STREAM_FINAL_SIZE + 1;
+    const snapshot = new BigUint64Array(count);
+    for (let i = 0; i < count; i++) {
+      snapshot[i] = this.#handle[this.#offset + i];
+    }
+    this.#handle = snapshot;
+    this.#offset = 0;
     this.#disconnected = true;
   }
 }

--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -7,6 +7,8 @@
 const {
   BigUint64Array,
   JSONStringify,
+  Symbol,
+  TypedArrayPrototypeSubarray,
 } = primordials;
 
 const {
@@ -25,6 +27,7 @@ const {
   codes: {
     ERR_ILLEGAL_CONSTRUCTOR,
     ERR_INVALID_ARG_TYPE,
+    ERR_INVALID_THIS,
   },
 } = require('internal/errors');
 
@@ -88,11 +91,11 @@ const {
   IDX_STATS_SESSION_BYTES_LOST,
   IDX_STATS_SESSION_PING_RECV,
   IDX_STATS_SESSION_PKT_DISCARDED,
-
   IDX_STATS_SESSION_DATAGRAMS_RECEIVED,
   IDX_STATS_SESSION_DATAGRAMS_SENT,
   IDX_STATS_SESSION_DATAGRAMS_ACKNOWLEDGED,
   IDX_STATS_SESSION_DATAGRAMS_LOST,
+  IDX_STATS_SESSION_COUNT,
 
   IDX_STATS_STREAM_CREATED_AT,
   IDX_STATS_STREAM_OPENED_AT,
@@ -105,6 +108,7 @@ const {
   IDX_STATS_STREAM_MAX_OFFSET_ACK,
   IDX_STATS_STREAM_MAX_OFFSET_RECV,
   IDX_STATS_STREAM_FINAL_SIZE,
+  IDX_STATS_STREAM_COUNT,
 } = internalBinding('quic');
 
 assert(IDX_STATS_ENDPOINT_CREATED_AT !== undefined);
@@ -162,12 +166,41 @@ assert(IDX_STATS_STREAM_MAX_OFFSET !== undefined);
 assert(IDX_STATS_STREAM_MAX_OFFSET_ACK !== undefined);
 assert(IDX_STATS_STREAM_MAX_OFFSET_RECV !== undefined);
 assert(IDX_STATS_STREAM_FINAL_SIZE !== undefined);
+assert(IDX_STATS_STREAM_COUNT !== undefined);
+assert(IDX_STATS_SESSION_COUNT !== undefined);
+
+const kCreateDisconnected = Symbol('kCreateDisconnected');
+
+let assertIsQuicEndpointStats;
+let assertIsQuicSessionStats;
+let assertIsQuicStreamStats;
+let isQuicEndpointStats;
+let isQuicSessionStats;
+let isQuicStreamStats;
+
+function assertIsPrivateConstructor(privateSymbol) {
+  if (privateSymbol !== kPrivateConstructor) {
+    throw new ERR_ILLEGAL_CONSTRUCTOR();
+  }
+}
 
 class QuicEndpointStats {
   /** @type {BigUint64Array} */
   #handle;
   /** @type {boolean} */
   #disconnected = false;
+
+  static {
+    isQuicEndpointStats = function(val) {
+      return val != null && typeof val === 'object' && #handle in val;
+    };
+
+    assertIsQuicEndpointStats = function(val) {
+      if (!isQuicEndpointStats(val)) {
+        throw new ERR_INVALID_THIS('QuicEndpointStats');
+      }
+    };
+  }
 
   /**
    * @param {symbol} privateSymbol
@@ -176,9 +209,7 @@ class QuicEndpointStats {
   constructor(privateSymbol, buffer) {
     // We use the kPrivateConstructor symbol to restrict the ability to
     // create new instances of QuicEndpointStats to internal code.
-    if (privateSymbol !== kPrivateConstructor) {
-      throw new ERR_ILLEGAL_CONSTRUCTOR();
-    }
+    assertIsPrivateConstructor(privateSymbol);
     if (!isArrayBuffer(buffer)) {
       throw new ERR_INVALID_ARG_TYPE('buffer', ['ArrayBuffer'], buffer);
     }
@@ -187,66 +218,79 @@ class QuicEndpointStats {
 
   /** @type {bigint} */
   get createdAt() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_CREATED_AT];
   }
 
   /** @type {bigint} */
   get destroyedAt() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_DESTROYED_AT];
   }
 
   /** @type {bigint} */
   get bytesReceived() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_BYTES_RECEIVED];
   }
 
   /** @type {bigint} */
   get bytesSent() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_BYTES_SENT];
   }
 
   /** @type {bigint} */
   get packetsReceived() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_PACKETS_RECEIVED];
   }
 
   /** @type {bigint} */
   get packetsSent() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_PACKETS_SENT];
   }
 
   /** @type {bigint} */
   get serverSessions() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_SERVER_SESSIONS];
   }
 
   /** @type {bigint} */
   get clientSessions() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_CLIENT_SESSIONS];
   }
 
   /** @type {bigint} */
   get serverBusyCount() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_SERVER_BUSY_COUNT];
   }
 
   /** @type {bigint} */
   get retryCount() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_RETRY_COUNT];
   }
 
   /** @type {bigint} */
   get versionNegotiationCount() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_VERSION_NEGOTIATION_COUNT];
   }
 
   /** @type {bigint} */
   get statelessResetCount() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_STATELESS_RESET_COUNT];
   }
 
   /** @type {bigint} */
   get immediateCloseCount() {
+    assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_COUNT];
   }
 
@@ -255,30 +299,48 @@ class QuicEndpointStats {
   }
 
   toJSON() {
+    assertIsQuicEndpointStats(this);
+    const {
+      createdAt,
+      destroyedAt,
+      bytesReceived,
+      bytesSent,
+      packetsReceived,
+      packetsSent,
+      serverSessions,
+      clientSessions,
+      serverBusyCount,
+      retryCount,
+      versionNegotiationCount,
+      statelessResetCount,
+      immediateCloseCount,
+    } = this;
     return {
       __proto__: null,
       connected: this.isConnected,
       // We need to convert the values to strings because JSON does not
       // support BigInts.
-      createdAt: `${this.createdAt}`,
-      destroyedAt: `${this.destroyedAt}`,
-      bytesReceived: `${this.bytesReceived}`,
-      bytesSent: `${this.bytesSent}`,
-      packetsReceived: `${this.packetsReceived}`,
-      packetsSent: `${this.packetsSent}`,
-      serverSessions: `${this.serverSessions}`,
-      clientSessions: `${this.clientSessions}`,
-      serverBusyCount: `${this.serverBusyCount}`,
-      retryCount: `${this.retryCount}`,
-      versionNegotiationCount: `${this.versionNegotiationCount}`,
-      statelessResetCount: `${this.statelessResetCount}`,
-      immediateCloseCount: `${this.immediateCloseCount}`,
+      createdAt: `${createdAt}`,
+      destroyedAt: `${destroyedAt}`,
+      bytesReceived: `${bytesReceived}`,
+      bytesSent: `${bytesSent}`,
+      packetsReceived: `${packetsReceived}`,
+      packetsSent: `${packetsSent}`,
+      serverSessions: `${serverSessions}`,
+      clientSessions: `${clientSessions}`,
+      serverBusyCount: `${serverBusyCount}`,
+      retryCount: `${retryCount}`,
+      versionNegotiationCount: `${versionNegotiationCount}`,
+      statelessResetCount: `${statelessResetCount}`,
+      immediateCloseCount: `${immediateCloseCount}`,
     };
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
+    assertIsQuicEndpointStats(this);
+    if (depth < 0) {
+      return 'QuicEndpointStats { }';
+    }
 
     const opts = {
       __proto__: null,
@@ -286,21 +348,37 @@ class QuicEndpointStats {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      createdAt,
+      destroyedAt,
+      bytesReceived,
+      bytesSent,
+      packetsReceived,
+      packetsSent,
+      serverSessions,
+      clientSessions,
+      serverBusyCount,
+      retryCount,
+      versionNegotiationCount,
+      statelessResetCount,
+      immediateCloseCount,
+    } = this;
+
     return `QuicEndpointStats ${inspect({
       connected: this.isConnected,
-      createdAt: this.createdAt,
-      destroyedAt: this.destroyedAt,
-      bytesReceived: this.bytesReceived,
-      bytesSent: this.bytesSent,
-      packetsReceived: this.packetsReceived,
-      packetsSent: this.packetsSent,
-      serverSessions: this.serverSessions,
-      clientSessions: this.clientSessions,
-      serverBusyCount: this.serverBusyCount,
-      retryCount: this.retryCount,
-      versionNegotiationCount: this.versionNegotiationCount,
-      statelessResetCount: this.statelessResetCount,
-      immediateCloseCount: this.immediateCloseCount,
+      createdAt,
+      destroyedAt,
+      bytesReceived,
+      bytesSent,
+      packetsReceived,
+      packetsSent,
+      serverSessions,
+      clientSessions,
+      serverBusyCount,
+      retryCount,
+      versionNegotiationCount,
+      statelessResetCount,
+      immediateCloseCount,
     }, opts)}`;
   }
 
@@ -311,12 +389,11 @@ class QuicEndpointStats {
    * @type {boolean}
    */
   get isConnected() {
+    assertIsQuicEndpointStats(this);
     return !this.#disconnected;
   }
 
   [kFinishClose]() {
-    // Snapshot the stats into a new BigUint64Array since the underlying
-    // buffer will be destroyed.
     this.#handle = new BigUint64Array(this.#handle);
     this.#disconnected = true;
   }
@@ -325,22 +402,31 @@ class QuicEndpointStats {
 class QuicSessionStats {
   /** @type {BigUint64Array} */
   #handle;
-  /** @type {boolean} */
   #disconnected = false;
+  #offset = 0;
+
+  static {
+    isQuicSessionStats = function(val) {
+      return val != null && typeof val === 'object' && #handle in val;
+    };
+
+    assertIsQuicSessionStats = function(val) {
+      if (!isQuicSessionStats(val)) {
+        throw new ERR_INVALID_THIS('QuicSessionStats');
+      }
+    };
+  }
+
 
   /**
    * @param {symbol} privateSymbol
-   * @param {ArrayBuffer} buffer
+   * @param {ArrayBuffer} view
+   * @param {number} [byteOffset]
    */
-  /** @type {number} */
-  #offset = 0;
-
   constructor(privateSymbol, view, byteOffset = 0) {
     // We use the kPrivateConstructor symbol to restrict the ability to
     // create new instances of QuicSessionStats to internal code.
-    if (privateSymbol !== kPrivateConstructor) {
-      throw new ERR_ILLEGAL_CONSTRUCTOR();
-    }
+    assertIsPrivateConstructor(privateSymbol);
     if (isArrayBuffer(view)) {
       this.#handle = new BigUint64Array(view);
     } else {
@@ -351,148 +437,179 @@ class QuicSessionStats {
 
   /** @type {bigint} */
   get createdAt() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_CREATED_AT];
   }
 
   /** @type {bigint} */
   get destroyedAt() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_DESTROYED_AT];
   }
 
   /** @type {bigint} */
   get closingAt() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_CLOSING_AT];
   }
 
   /** @type {bigint} */
   get handshakeCompletedAt() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_HANDSHAKE_COMPLETED_AT];
   }
 
   /** @type {bigint} */
   get handshakeConfirmedAt() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_HANDSHAKE_CONFIRMED_AT];
   }
 
   /** @type {bigint} */
   get bytesReceived() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_RECEIVED];
   }
 
   /** @type {bigint} */
   get bidiInStreamCount() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_BIDI_IN_STREAM_COUNT];
   }
 
   /** @type {bigint} */
   get bidiOutStreamCount() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_BIDI_OUT_STREAM_COUNT];
   }
 
   /** @type {bigint} */
   get uniInStreamCount() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_UNI_IN_STREAM_COUNT];
   }
 
   /** @type {bigint} */
   get uniOutStreamCount() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_UNI_OUT_STREAM_COUNT];
   }
 
   /** @type {bigint} */
   get maxBytesInFlight() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_MAX_BYTES_IN_FLIGHT];
   }
 
   /** @type {bigint} */
   get bytesInFlight() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_IN_FLIGHT];
   }
 
   /** @type {bigint} */
   get blockCount() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_BLOCK_COUNT];
   }
 
   /** @type {bigint} */
   get cwnd() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_CWND];
   }
 
   /** @type {bigint} */
   get latestRtt() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_LATEST_RTT];
   }
 
   /** @type {bigint} */
   get minRtt() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_MIN_RTT];
   }
 
   /** @type {bigint} */
   get rttVar() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_RTTVAR];
   }
 
   /** @type {bigint} */
   get smoothedRtt() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_SMOOTHED_RTT];
   }
 
   /** @type {bigint} */
   get ssthresh() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_SSTHRESH];
   }
 
   get pktSent() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_PKT_SENT];
   }
 
   get bytesSent() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_SENT];
   }
 
   get pktRecv() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_PKT_RECV];
   }
 
   get bytesRecv() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_RECV];
   }
 
   get pktLost() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_PKT_LOST];
   }
 
   get bytesLost() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_BYTES_LOST];
   }
 
   get pingRecv() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_PING_RECV];
   }
 
   get pktDiscarded() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_PKT_DISCARDED];
   }
 
   /** @type {bigint} */
   get datagramsReceived() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_RECEIVED];
   }
 
   /** @type {bigint} */
   get datagramsSent() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_SENT];
   }
 
   /** @type {bigint} */
   get datagramsAcknowledged() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_ACKNOWLEDGED];
   }
 
   /** @type {bigint} */
   get datagramsLost() {
+    assertIsQuicSessionStats(this);
     return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_LOST];
   }
 
@@ -501,47 +618,81 @@ class QuicSessionStats {
   }
 
   toJSON() {
+    assertIsQuicSessionStats(this);
+    const {
+      createdAt,
+      closingAt,
+      handshakeCompletedAt,
+      handshakeConfirmedAt,
+      bytesReceived,
+      bidiInStreamCount,
+      bidiOutStreamCount,
+      uniInStreamCount,
+      uniOutStreamCount,
+      maxBytesInFlight,
+      bytesInFlight,
+      blockCount,
+      cwnd,
+      latestRtt,
+      minRtt,
+      rttVar,
+      smoothedRtt,
+      ssthresh,
+      pktSent,
+      bytesSent,
+      pktRecv,
+      bytesRecv,
+      pktLost,
+      bytesLost,
+      pingRecv,
+      pktDiscarded,
+      datagramsReceived,
+      datagramsSent,
+      datagramsAcknowledged,
+      datagramsLost,
+    } = this;
     return {
       __proto__: null,
       connected: this.isConnected,
       // We need to convert the values to strings because JSON does not
       // support BigInts.
-      createdAt: `${this.createdAt}`,
-      closingAt: `${this.closingAt}`,
-      handshakeCompletedAt: `${this.handshakeCompletedAt}`,
-      handshakeConfirmedAt: `${this.handshakeConfirmedAt}`,
-      bytesReceived: `${this.bytesReceived}`,
-      bidiInStreamCount: `${this.bidiInStreamCount}`,
-      bidiOutStreamCount: `${this.bidiOutStreamCount}`,
-      uniInStreamCount: `${this.uniInStreamCount}`,
-      uniOutStreamCount: `${this.uniOutStreamCount}`,
-      maxBytesInFlight: `${this.maxBytesInFlight}`,
-      bytesInFlight: `${this.bytesInFlight}`,
-      blockCount: `${this.blockCount}`,
-      cwnd: `${this.cwnd}`,
-      latestRtt: `${this.latestRtt}`,
-      minRtt: `${this.minRtt}`,
-      rttVar: `${this.rttVar}`,
-      smoothedRtt: `${this.smoothedRtt}`,
-      ssthresh: `${this.ssthresh}`,
-      pktSent: `${this.pktSent}`,
-      bytesSent: `${this.bytesSent}`,
-      pktRecv: `${this.pktRecv}`,
-      bytesRecv: `${this.bytesRecv}`,
-      pktLost: `${this.pktLost}`,
-      bytesLost: `${this.bytesLost}`,
-      pingRecv: `${this.pingRecv}`,
-      pktDiscarded: `${this.pktDiscarded}`,
-      datagramsReceived: `${this.datagramsReceived}`,
-      datagramsSent: `${this.datagramsSent}`,
-      datagramsAcknowledged: `${this.datagramsAcknowledged}`,
-      datagramsLost: `${this.datagramsLost}`,
+      createdAt: `${createdAt}`,
+      closingAt: `${closingAt}`,
+      handshakeCompletedAt: `${handshakeCompletedAt}`,
+      handshakeConfirmedAt: `${handshakeConfirmedAt}`,
+      bytesReceived: `${bytesReceived}`,
+      bidiInStreamCount: `${bidiInStreamCount}`,
+      bidiOutStreamCount: `${bidiOutStreamCount}`,
+      uniInStreamCount: `${uniInStreamCount}`,
+      uniOutStreamCount: `${uniOutStreamCount}`,
+      maxBytesInFlight: `${maxBytesInFlight}`,
+      bytesInFlight: `${bytesInFlight}`,
+      blockCount: `${blockCount}`,
+      cwnd: `${cwnd}`,
+      latestRtt: `${latestRtt}`,
+      minRtt: `${minRtt}`,
+      rttVar: `${rttVar}`,
+      smoothedRtt: `${smoothedRtt}`,
+      ssthresh: `${ssthresh}`,
+      pktSent: `${pktSent}`,
+      bytesSent: `${bytesSent}`,
+      pktRecv: `${pktRecv}`,
+      bytesRecv: `${bytesRecv}`,
+      pktLost: `${pktLost}`,
+      bytesLost: `${bytesLost}`,
+      pingRecv: `${pingRecv}`,
+      pktDiscarded: `${pktDiscarded}`,
+      datagramsReceived: `${datagramsReceived}`,
+      datagramsSent: `${datagramsSent}`,
+      datagramsAcknowledged: `${datagramsAcknowledged}`,
+      datagramsLost: `${datagramsLost}`,
     };
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
+    if (depth < 0) {
+      return 'QuicSessionStats { }';
+    }
 
     const opts = {
       __proto__: null,
@@ -549,38 +700,71 @@ class QuicSessionStats {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      createdAt,
+      closingAt,
+      handshakeCompletedAt,
+      handshakeConfirmedAt,
+      bytesReceived,
+      bidiInStreamCount,
+      bidiOutStreamCount,
+      uniInStreamCount,
+      uniOutStreamCount,
+      maxBytesInFlight,
+      bytesInFlight,
+      blockCount,
+      cwnd,
+      latestRtt,
+      minRtt,
+      rttVar,
+      smoothedRtt,
+      ssthresh,
+      pktSent,
+      bytesSent,
+      pktRecv,
+      bytesRecv,
+      pktLost,
+      bytesLost,
+      pingRecv,
+      pktDiscarded,
+      datagramsReceived,
+      datagramsSent,
+      datagramsAcknowledged,
+      datagramsLost,
+    } = this;
+
     return `QuicSessionStats ${inspect({
       connected: this.isConnected,
-      createdAt: this.createdAt,
-      closingAt: this.closingAt,
-      handshakeCompletedAt: this.handshakeCompletedAt,
-      handshakeConfirmedAt: this.handshakeConfirmedAt,
-      bytesReceived: this.bytesReceived,
-      bidiInStreamCount: this.bidiInStreamCount,
-      bidiOutStreamCount: this.bidiOutStreamCount,
-      uniInStreamCount: this.uniInStreamCount,
-      uniOutStreamCount: this.uniOutStreamCount,
-      maxBytesInFlight: this.maxBytesInFlight,
-      bytesInFlight: this.bytesInFlight,
-      blockCount: this.blockCount,
-      cwnd: this.cwnd,
-      latestRtt: this.latestRtt,
-      minRtt: this.minRtt,
-      rttVar: this.rttVar,
-      smoothedRtt: this.smoothedRtt,
-      ssthresh: this.ssthresh,
-      pktSent: this.pktSent,
-      bytesSent: this.bytesSent,
-      pktRecv: this.pktRecv,
-      bytesRecv: this.bytesRecv,
-      pktLost: this.pktLost,
-      bytesLost: this.bytesLost,
-      pingRecv: this.pingRecv,
-      pktDiscarded: this.pktDiscarded,
-      datagramsReceived: this.datagramsReceived,
-      datagramsSent: this.datagramsSent,
-      datagramsAcknowledged: this.datagramsAcknowledged,
-      datagramsLost: this.datagramsLost,
+      createdAt,
+      closingAt,
+      handshakeCompletedAt,
+      handshakeConfirmedAt,
+      bytesReceived,
+      bidiInStreamCount,
+      bidiOutStreamCount,
+      uniInStreamCount,
+      uniOutStreamCount,
+      maxBytesInFlight,
+      bytesInFlight,
+      blockCount,
+      cwnd,
+      latestRtt,
+      minRtt,
+      rttVar,
+      smoothedRtt,
+      ssthresh,
+      pktSent,
+      bytesSent,
+      pktRecv,
+      bytesRecv,
+      pktLost,
+      bytesLost,
+      pingRecv,
+      pktDiscarded,
+      datagramsReceived,
+      datagramsSent,
+      datagramsAcknowledged,
+      datagramsLost,
     }, opts)}`;
   }
 
@@ -595,13 +779,10 @@ class QuicSessionStats {
   }
 
   [kFinishClose]() {
-    // Snapshot this session's stats slice into a standalone BigUint64Array.
-    const count = IDX_STATS_SESSION_DATAGRAMS_LOST + 1;
-    const snapshot = new BigUint64Array(count);
-    for (let i = 0; i < count; i++) {
-      snapshot[i] = this.#handle[this.#offset + i];
-    }
-    this.#handle = snapshot;
+    const view = TypedArrayPrototypeSubarray(this.#handle,
+                                             this.#offset,
+                                             this.#offset + IDX_STATS_STREAM_COUNT);
+    this.#handle = new BigUint64Array(view);
     this.#offset = 0;
     this.#disconnected = true;
   }
@@ -610,10 +791,20 @@ class QuicSessionStats {
 class QuicStreamStats {
   /** @type {BigUint64Array} */
   #handle;
-  /** @type {number} */
   #offset = 0;
-  /** type {boolean} */
   #disconnected = false;
+
+  static {
+    isQuicStreamStats = function(val) {
+      return val != null && typeof val === 'object' && #handle in val;
+    };
+
+    assertIsQuicStreamStats = function(val) {
+      if (!isQuicStreamStats(val)) {
+        throw new ERR_INVALID_THIS('QuicStreamStats');
+      }
+    };
+  }
 
   /**
    * @param {symbol} privateSymbol
@@ -623,70 +814,78 @@ class QuicStreamStats {
   constructor(privateSymbol, view, byteOffset = 0) {
     // We use the kPrivateConstructor symbol to restrict the ability to
     // create new instances of QuicStreamStats to internal code.
-    if (privateSymbol !== kPrivateConstructor) {
-      throw new ERR_ILLEGAL_CONSTRUCTOR();
-    }
+    assertIsPrivateConstructor(privateSymbol);
     if (isArrayBuffer(view)) {
       this.#handle = new BigUint64Array(view);
     } else {
       this.#handle = view;
     }
-    // Convert byte offset to element offset (8 bytes per uint64).
     this.#offset = byteOffset / 8;
   }
 
   /** @type {bigint} */
   get createdAt() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_CREATED_AT];
   }
 
   /** @type {bigint} */
   get openedAt() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_OPENED_AT];
   }
 
   /** @type {bigint} */
   get receivedAt() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_RECEIVED_AT];
   }
 
   /** @type {bigint} */
   get ackedAt() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_ACKED_AT];
   }
 
   /** @type {bigint} */
   get destroyedAt() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_DESTROYED_AT];
   }
 
   /** @type {bigint} */
   get bytesReceived() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_BYTES_RECEIVED];
   }
 
   /** @type {bigint} */
   get bytesSent() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_BYTES_SENT];
   }
 
   /** @type {bigint} */
   get maxOffset() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_MAX_OFFSET];
   }
 
   /** @type {bigint} */
   get maxOffsetAcknowledged() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_MAX_OFFSET_ACK];
   }
 
   /** @type {bigint} */
   get maxOffsetReceived() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_MAX_OFFSET_RECV];
   }
 
   /** @type {bigint} */
   get finalSize() {
+    assertIsQuicStreamStats(this);
     return this.#handle[this.#offset + IDX_STATS_STREAM_FINAL_SIZE];
   }
 
@@ -695,28 +894,43 @@ class QuicStreamStats {
   }
 
   toJSON() {
+    assertIsQuicStreamStats(this);
+    const {
+      createdAt,
+      openedAt,
+      receivedAt,
+      ackedAt,
+      destroyedAt,
+      bytesReceived,
+      bytesSent,
+      maxOffset,
+      maxOffsetAcknowledged,
+      maxOffsetReceived,
+      finalSize,
+    } = this;
     return {
       __proto__: null,
       connected: this.isConnected,
       // We need to convert the values to strings because JSON does not
       // support BigInts.
-      createdAt: `${this.createdAt}`,
-      openedAt: `${this.openedAt}`,
-      receivedAt: `${this.receivedAt}`,
-      ackedAt: `${this.ackedAt}`,
-      destroyedAt: `${this.destroyedAt}`,
-      bytesReceived: `${this.bytesReceived}`,
-      bytesSent: `${this.bytesSent}`,
-      maxOffset: `${this.maxOffset}`,
-      maxOffsetAcknowledged: `${this.maxOffsetAcknowledged}`,
-      maxOffsetReceived: `${this.maxOffsetReceived}`,
-      finalSize: `${this.finalSize}`,
+      createdAt: `${createdAt}`,
+      openedAt: `${openedAt}`,
+      receivedAt: `${receivedAt}`,
+      ackedAt: `${ackedAt}`,
+      destroyedAt: `${destroyedAt}`,
+      bytesReceived: `${bytesReceived}`,
+      bytesSent: `${bytesSent}`,
+      maxOffset: `${maxOffset}`,
+      maxOffsetAcknowledged: `${maxOffsetAcknowledged}`,
+      maxOffsetReceived: `${maxOffsetReceived}`,
+      finalSize: `${finalSize}`,
     };
   }
 
   [kInspect](depth, options) {
-    if (depth < 0)
-      return this;
+    if (depth < 0) {
+      return 'QuicStreamStats { }';
+    }
 
     const opts = {
       __proto__: null,
@@ -724,19 +938,33 @@ class QuicStreamStats {
       depth: options.depth == null ? null : options.depth - 1,
     };
 
+    const {
+      createdAt,
+      openedAt,
+      receivedAt,
+      ackedAt,
+      destroyedAt,
+      bytesReceived,
+      bytesSent,
+      maxOffset,
+      maxOffsetAcknowledged,
+      maxOffsetReceived,
+      finalSize,
+    } = this;
+
     return `QuicStreamStats ${inspect({
       connected: this.isConnected,
-      createdAt: this.createdAt,
-      openedAt: this.openedAt,
-      receivedAt: this.receivedAt,
-      ackedAt: this.ackedAt,
-      destroyedAt: this.destroyedAt,
-      bytesReceived: this.bytesReceived,
-      bytesSent: this.bytesSent,
-      maxOffset: this.maxOffset,
-      maxOffsetAcknowledged: this.maxOffsetAcknowledged,
-      maxOffsetReceived: this.maxOffsetReceived,
-      finalSize: this.finalSize,
+      createdAt,
+      openedAt,
+      receivedAt,
+      ackedAt,
+      destroyedAt,
+      bytesReceived,
+      bytesSent,
+      maxOffset,
+      maxOffsetAcknowledged,
+      maxOffsetReceived,
+      finalSize,
     }, opts)}`;
   }
 
@@ -751,15 +979,21 @@ class QuicStreamStats {
   }
 
   [kFinishClose]() {
-    // Snapshot this stream's stats slice into a standalone BigUint64Array.
-    const count = IDX_STATS_STREAM_FINAL_SIZE + 1;
-    const snapshot = new BigUint64Array(count);
-    for (let i = 0; i < count; i++) {
-      snapshot[i] = this.#handle[this.#offset + i];
-    }
-    this.#handle = snapshot;
+    const view = TypedArrayPrototypeSubarray(this.#handle,
+                                             this.#offset,
+                                             this.#offset + IDX_STATS_STREAM_COUNT);
+    this.#handle = new BigUint64Array(view);
     this.#offset = 0;
     this.#disconnected = true;
+  }
+
+  // Creates an immediately disconnected QuicStreamStats object. Used when
+  // lazily creating stats for a stream that has already been destroyed.
+  static [kCreateDisconnected]() {
+    const count = IDX_STATS_STREAM_FINAL_SIZE + 1;
+    const stats = new QuicStreamStats(kPrivateConstructor, new BigUint64Array(count), 0);
+    stats.#disconnected = true;
+    return stats;
   }
 }
 
@@ -767,6 +1001,7 @@ module.exports = {
   QuicEndpointStats,
   QuicSessionStats,
   QuicStreamStats,
+  kCreateDisconnected,
 };
 
 /* c8 ignore stop */

--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -108,6 +108,8 @@ const {
   IDX_STATS_STREAM_MAX_OFFSET_ACK,
   IDX_STATS_STREAM_MAX_OFFSET_RECV,
   IDX_STATS_STREAM_FINAL_SIZE,
+  IDX_STATS_STREAM_BYTES_ACCUMULATED,
+  IDX_STATS_STREAM_MAX_BYTES_ACCUMULATED,
   IDX_STATS_STREAM_COUNT,
 } = internalBinding('quic');
 
@@ -166,6 +168,8 @@ assert(IDX_STATS_STREAM_MAX_OFFSET !== undefined);
 assert(IDX_STATS_STREAM_MAX_OFFSET_ACK !== undefined);
 assert(IDX_STATS_STREAM_MAX_OFFSET_RECV !== undefined);
 assert(IDX_STATS_STREAM_FINAL_SIZE !== undefined);
+assert(IDX_STATS_STREAM_BYTES_ACCUMULATED !== undefined);
+assert(IDX_STATS_STREAM_MAX_BYTES_ACCUMULATED !== undefined);
 assert(IDX_STATS_STREAM_COUNT !== undefined);
 assert(IDX_STATS_SESSION_COUNT !== undefined);
 
@@ -889,6 +893,18 @@ class QuicStreamStats {
     return this.#handle[this.#offset + IDX_STATS_STREAM_FINAL_SIZE];
   }
 
+  /** @type {bigint} Current bytes in the receive accumulation buffer. */
+  get bytesAccumulated() {
+    assertIsQuicStreamStats(this);
+    return this.#handle[this.#offset + IDX_STATS_STREAM_BYTES_ACCUMULATED];
+  }
+
+  /** @type {bigint} Peak bytes accumulated over the stream's lifetime. */
+  get maxBytesAccumulated() {
+    assertIsQuicStreamStats(this);
+    return this.#handle[this.#offset + IDX_STATS_STREAM_MAX_BYTES_ACCUMULATED];
+  }
+
   toString() {
     return JSONStringify(this.toJSON());
   }
@@ -907,6 +923,8 @@ class QuicStreamStats {
       maxOffsetAcknowledged,
       maxOffsetReceived,
       finalSize,
+      bytesAccumulated,
+      maxBytesAccumulated,
     } = this;
     return {
       __proto__: null,
@@ -924,6 +942,8 @@ class QuicStreamStats {
       maxOffsetAcknowledged: `${maxOffsetAcknowledged}`,
       maxOffsetReceived: `${maxOffsetReceived}`,
       finalSize: `${finalSize}`,
+      bytesAccumulated: `${bytesAccumulated}`,
+      maxBytesAccumulated: `${maxBytesAccumulated}`,
     };
   }
 
@@ -950,6 +970,8 @@ class QuicStreamStats {
       maxOffsetAcknowledged,
       maxOffsetReceived,
       finalSize,
+      bytesAccumulated,
+      maxBytesAccumulated,
     } = this;
 
     return `QuicStreamStats ${inspect({
@@ -965,6 +987,8 @@ class QuicStreamStats {
       maxOffsetAcknowledged,
       maxOffsetReceived,
       finalSize,
+      bytesAccumulated,
+      maxBytesAccumulated,
     }, opts)}`;
   }
 
@@ -990,7 +1014,7 @@ class QuicStreamStats {
   // Creates an immediately disconnected QuicStreamStats object. Used when
   // lazily creating stats for a stream that has already been destroyed.
   static [kCreateDisconnected]() {
-    const count = IDX_STATS_STREAM_FINAL_SIZE + 1;
+    const count = IDX_STATS_STREAM_COUNT;
     const stats = new QuicStreamStats(kPrivateConstructor, new BigUint64Array(count), 0);
     stats.#disconnected = true;
     return stats;

--- a/lib/internal/quic/symbols.js
+++ b/lib/internal/quic/symbols.js
@@ -57,8 +57,6 @@ const kSendHeaders = Symbol('kSendHeaders');
 const kSessionTicket = Symbol('kSessionTicket');
 const kTrailers = Symbol('kTrailers');
 const kVersionNegotiation = Symbol('kVersionNegotiation');
-const kWantsHeaders = Symbol('kWantsHeaders');
-const kWantsTrailers = Symbol('kWantsTrailers');
 
 module.exports = {
   kAttachFileHandle,
@@ -93,8 +91,6 @@ module.exports = {
   kSessionTicket,
   kTrailers,
   kVersionNegotiation,
-  kWantsHeaders,
-  kWantsTrailers,
 };
 
 /* c8 ignore stop */

--- a/src/aliased_struct-inl.h
+++ b/src/aliased_struct-inl.h
@@ -47,6 +47,95 @@ AliasedStruct<T>::~AliasedStruct() {
   if (ptr_ != nullptr) ptr_->~T();
 }
 
+// ---------------------------------------------------------------------------
+// AliasedStructArena implementation
+// ---------------------------------------------------------------------------
+
+template <typename T, size_t kPageBytes>
+typename AliasedStructArena<T, kPageBytes>::Page*
+AliasedStructArena<T, kPageBytes>::FindOrCreatePage(v8::Isolate* isolate) {
+  for (auto& p : pages_) {
+    if (p->HasFreeSlots()) return p.get();
+  }
+  auto p = std::make_unique<Page>();
+  p->Init(isolate);
+  Page* raw = p.get();
+  pages_.push_back(std::move(p));
+  return raw;
+}
+
+template <typename T, size_t kPageBytes>
+template <typename... Args>
+typename AliasedStructArena<T, kPageBytes>::Slot
+AliasedStructArena<T, kPageBytes>::Allocate(v8::Isolate* isolate,
+                                            Args&&... args) {
+  Page* page = FindOrCreatePage(isolate);
+  DCHECK(page->HasFreeSlots());
+
+  uint32_t idx = page->free_head;
+  T* raw = &page->base[idx];
+
+  // Advance freelist before placement new overwrites the linkage.
+  page->free_head = *reinterpret_cast<uint32_t*>(raw);
+  page->used_count++;
+
+  // Placement-construct T in the slot.
+  T* ptr = new (raw) T(std::forward<Args>(args)...);
+
+  Slot slot;
+  slot.page = static_cast<void*>(page);
+  slot.ptr = static_cast<void*>(ptr);
+  slot.index = idx;
+  slot.byte_offset = reinterpret_cast<const uint8_t*>(ptr) -
+                     static_cast<const uint8_t*>(page->store->Data());
+  return slot;
+}
+
+template <typename T, size_t kPageBytes>
+void AliasedStructArena<T, kPageBytes>::Release(
+    typename AliasedStructArena<T, kPageBytes>::Slot&& slot) {
+  if (!slot) return;
+  auto* page = static_cast<Page*>(slot.page);
+  auto* ptr = static_cast<T*>(slot.ptr);
+  uint32_t idx = slot.index;
+
+  // Destruct and zero so JS views see clean data.
+  ptr->~T();
+  memset(ptr, 0, sizeof(T));
+
+  // Push onto page freelist.
+  *reinterpret_cast<uint32_t*>(ptr) = page->free_head;
+  page->free_head = idx;
+  page->used_count--;
+
+  slot.page = nullptr;
+  slot.ptr = nullptr;
+
+  // Drop empty pages. The shared_ptr<BackingStore> ensures the
+  // underlying memory stays alive until V8 GCs any remaining JS
+  // references to the page's ArrayBuffer/views.
+  if (page->used_count == 0) {
+    for (auto it = pages_.begin(); it != pages_.end(); ++it) {
+      if (it->get() == page) {
+        pages_.erase(it);
+        break;
+      }
+    }
+  }
+}
+
+template <typename T, size_t kPageBytes>
+void AliasedStructArena<T, kPageBytes>::ReleaseSlot(ArenaSlotBase& base) {
+  Slot slot;
+  slot.page = base.page;
+  slot.ptr = base.ptr;
+  slot.index = base.index;
+  slot.byte_offset = base.byte_offset;
+  Release(std::move(slot));
+  base.page = nullptr;
+  base.ptr = nullptr;
+}
+
 }  // namespace node
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS

--- a/src/aliased_struct.h
+++ b/src/aliased_struct.h
@@ -3,9 +3,10 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include <memory>
+#include <vector>
 #include "node_internals.h"
 #include "v8.h"
-#include <memory>
 
 namespace node {
 
@@ -55,6 +56,190 @@ class AliasedStruct final {
   T* ptr_;
   v8::Global<v8::ArrayBuffer> buffer_;
 };
+
+// ---------------------------------------------------------------------------
+// ArenaSlot — type-erased handle to a slot in an AliasedStructArena page.
+// This can be stored in headers where T is incomplete. The typed accessors
+// are provided via a thin typed wrapper (AliasedStructArena<T>::Slot).
+struct ArenaSlotBase {
+  // Opaque page pointer — only the arena knows the concrete type.
+  void* page = nullptr;
+  void* ptr = nullptr;
+  uint32_t index = 0;
+  size_t byte_offset = 0;
+
+  explicit operator bool() const { return ptr != nullptr; }
+
+  // Returns the page's ArrayBuffer. Implemented below after ArenaPageHeader.
+  v8::Local<v8::ArrayBuffer> GetArrayBuffer(v8::Isolate* isolate) const;
+
+  size_t GetByteOffset() const { return byte_offset; }
+
+  // Returns the page's cached DataView over the full page.
+  // Callers use byte_offset to index into the correct slot region.
+  v8::Local<v8::DataView> GetPageDataView(v8::Isolate* isolate) const;
+
+  // Returns the page's cached BigUint64Array over the full page.
+  // Callers use byte_offset / sizeof(uint64_t) to index into the
+  // correct slot region.
+  v8::Local<v8::BigUint64Array> GetPageBigUint64Array(
+      v8::Isolate* isolate) const;
+};
+
+// ---------------------------------------------------------------------------
+// AliasedStructArena<T> — pool allocator for AliasedStruct-style shared
+// memory.  Instead of creating a separate ArrayBuffer + BackingStore per
+// instance, the arena pre-allocates pages of N slots backed by a single
+// ArrayBuffer each.  Callers receive a Slot handle that provides the same
+// T*/operator-> interface as AliasedStruct, plus the ability to create a
+// JS typed-array view over just that slot's region of the page buffer.
+//
+// Pages target kPageBytes (default 16 KB) for L1 cache residency during
+// sequential access patterns.  Slots are recycled via an intrusive
+// freelist, and empty pages are dropped when their last slot is released.
+//
+// Usage:
+//   AliasedStructArena<MyState> arena;
+//   auto slot = arena.Allocate(isolate);
+//   slot->some_field = 42;
+//   auto view = slot.GetArrayBuffer(isolate);  // JS-visible view
+//   ...
+//   arena.Release(std::move(slot));             // return to freelist
+//
+template <typename T, size_t kPageBytes = 16384>
+class AliasedStructArena final {
+ public:
+  static constexpr size_t kSlotsPerPage = kPageBytes / sizeof(T);
+  static_assert(kSlotsPerPage >= 4, "Page too small for type T");
+  static_assert(sizeof(T) >= sizeof(uint32_t),
+                "T must be at least 4 bytes for freelist linkage");
+
+  AliasedStructArena() = default;
+  ~AliasedStructArena() = default;
+
+  AliasedStructArena(const AliasedStructArena&) = delete;
+  AliasedStructArena& operator=(const AliasedStructArena&) = delete;
+
+  struct Page {
+    std::shared_ptr<v8::BackingStore> store;
+    v8::Global<v8::ArrayBuffer> buffer;
+    // Lazily created full-page views shared by all slots in
+    // this page. Typically only one is used per arena.
+    v8::Global<v8::DataView> data_view;
+    v8::Global<v8::BigUint64Array> big_uint64_array;
+    size_t page_byte_length = 0;
+    T* base = nullptr;
+    uint32_t free_head = 0;
+    uint32_t used_count = 0;
+    static constexpr uint32_t kNoFreeSlot = UINT32_MAX;
+
+    void Init(v8::Isolate* isolate) {
+      const v8::HandleScope handle_scope(isolate);
+      const size_t total_bytes = kSlotsPerPage * sizeof(T);
+      store = v8::ArrayBuffer::NewBackingStore(isolate, total_bytes);
+      memset(store->Data(), 0, total_bytes);
+      base = static_cast<T*>(store->Data());
+      page_byte_length = total_bytes;
+      v8::Local<v8::ArrayBuffer> ab = v8::ArrayBuffer::New(isolate, store);
+      buffer = v8::Global<v8::ArrayBuffer>(isolate, ab);
+
+      // Build freelist: each slot points to the next.
+      for (uint32_t i = 0; i < kSlotsPerPage - 1; i++) {
+        *reinterpret_cast<uint32_t*>(&base[i]) = i + 1;
+      }
+      *reinterpret_cast<uint32_t*>(&base[kSlotsPerPage - 1]) = kNoFreeSlot;
+      free_head = 0;
+      used_count = 0;
+    }
+
+    bool HasFreeSlots() const { return free_head != kNoFreeSlot; }
+  };
+
+  // Typed slot handle — wraps ArenaSlotBase with T* accessors.
+  class Slot : public ArenaSlotBase {
+   public:
+    Slot() = default;
+
+    const T& operator*() const { return *static_cast<T*>(ptr); }
+    T& operator*() { return *static_cast<T*>(ptr); }
+    const T* operator->() const { return static_cast<T*>(ptr); }
+    T* operator->() { return static_cast<T*>(ptr); }
+    T* Data() { return static_cast<T*>(ptr); }
+    const T* Data() const { return static_cast<T*>(ptr); }
+  };
+
+  // Allocate a slot, placement-constructing T with the given args.
+  // Creates a new page if all existing pages are full.
+  template <typename... Args>
+  Slot Allocate(v8::Isolate* isolate, Args&&... args);
+
+  // Release a slot back to the arena freelist.  Calls ~T() and zeros
+  // the memory so that any JS views see clean data.
+  void Release(Slot&& slot);
+
+  // Release a slot given a type-erased ArenaSlotBase reference.
+  // Convenience for callers that store ArenaSlotBase in headers where
+  // T is incomplete.
+  void ReleaseSlot(ArenaSlotBase& base);
+
+ private:
+  Page* FindOrCreatePage(v8::Isolate* isolate);
+
+  std::vector<std::unique_ptr<Page>> pages_;
+};
+
+// ArenaSlotBase accessors need to reach the v8::Globals inside a Page.
+// All AliasedStructArena<T>::Page types share the same leading layout.
+// The page_byte_length field allows lazy view creation without knowing T.
+namespace detail {
+struct ArenaPageHeader {
+  std::shared_ptr<v8::BackingStore> store;
+  v8::Global<v8::ArrayBuffer> buffer;
+  v8::Global<v8::DataView> data_view;
+  v8::Global<v8::BigUint64Array> big_uint64_array;
+  size_t page_byte_length = 0;
+
+  v8::Local<v8::DataView> GetDataView(v8::Isolate* isolate) {
+    if (data_view.IsEmpty()) {
+      const v8::HandleScope handle_scope(isolate);
+      auto dv = v8::DataView::New(buffer.Get(isolate), 0, page_byte_length);
+      data_view = v8::Global<v8::DataView>(isolate, dv);
+    }
+    return data_view.Get(isolate);
+  }
+
+  v8::Local<v8::BigUint64Array> GetBigUint64Array(v8::Isolate* isolate) {
+    if (big_uint64_array.IsEmpty()) {
+      const v8::HandleScope handle_scope(isolate);
+      auto bu = v8::BigUint64Array::New(
+          buffer.Get(isolate), 0, page_byte_length / sizeof(uint64_t));
+      big_uint64_array = v8::Global<v8::BigUint64Array>(isolate, bu);
+    }
+    return big_uint64_array.Get(isolate);
+  }
+};
+}  // namespace detail
+
+inline v8::Local<v8::ArrayBuffer> ArenaSlotBase::GetArrayBuffer(
+    v8::Isolate* isolate) const {
+  DCHECK_NOT_NULL(page);
+  auto* header = static_cast<detail::ArenaPageHeader*>(page);
+  return header->buffer.Get(isolate);
+}
+
+inline v8::Local<v8::DataView> ArenaSlotBase::GetPageDataView(
+    v8::Isolate* isolate) const {
+  DCHECK_NOT_NULL(page);
+  auto* header = static_cast<detail::ArenaPageHeader*>(page);
+  return header->GetDataView(isolate);
+}
+
+inline v8::Local<v8::BigUint64Array> ArenaSlotBase::GetPageBigUint64Array(
+    v8::Isolate* isolate) const {
+  DCHECK_NOT_NULL(page);
+  auto* header = static_cast<detail::ArenaPageHeader*>(page);
+  return header->GetBigUint64Array(isolate);
+}
 
 }  // namespace node
 

--- a/src/dataqueue/queue.cc
+++ b/src/dataqueue/queue.cc
@@ -179,6 +179,11 @@ class DataQueueImpl final : public DataQueue,
     for (auto& listener : backpressure_listeners_) listener->EntryRead(amount);
   }
 
+  void NotifyBeforePull() {
+    if (idempotent_) return;
+    for (auto& listener : backpressure_listeners_) listener->BeforePull();
+  }
+
   bool HasBackpressureListeners() const noexcept {
     return !backpressure_listeners_.empty();
   }
@@ -380,6 +385,11 @@ class NonIdempotentDataQueueReader final
            size_t count,
            size_t max_count_hint = bob::kMaxCountHint) override {
     std::shared_ptr<DataQueue::Reader> self = shared_from_this();
+
+    // Let listeners flush pending data before we check the entries list.
+    // This allows, for example, the QUIC Stream to flush its receive
+    // accumulation buffer into the queue before the pull proceeds.
+    data_queue_->NotifyBeforePull();
 
     // If ended is true, this reader has already reached the end and cannot
     // provide any more data.

--- a/src/dataqueue/queue.h
+++ b/src/dataqueue/queue.h
@@ -147,6 +147,11 @@ class DataQueue : public MemoryRetainer {
   class BackpressureListener {
    public:
     virtual void EntryRead(size_t amount) = 0;
+
+    // Called before the reader pulls from the DataQueue. Gives
+    // the listener a chance to flush pending data into the queue
+    // before the pull checks the entries list.
+    virtual void BeforePull() {}
   };
 
   // A DataQueue::Entry represents a logical chunk of data in the queue.

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -239,7 +239,8 @@ void Session::Application::ReceiveStreamReset(Stream* stream,
 //   < 0 (other): fatal error, session already closed
 ssize_t Session::Application::TryWritePendingDatagram(PathStorage* path,
                                                       uint8_t* dest,
-                                                      size_t destlen) {
+                                                      size_t destlen,
+                                                      uint64_t ts) {
   CHECK(session_->HasPendingDatagrams());
   auto max_attempts = session_->config().options.max_datagram_send_attempts;
 
@@ -275,7 +276,7 @@ ssize_t Session::Application::TryWritePendingDatagram(PathStorage* path,
                                                   dg.id,
                                                   &dgvec,
                                                   1,
-                                                  uv_hrtime());
+                                                  ts);
 
   if (accepted) {
     // Nice, the datagram was accepted!
@@ -338,6 +339,13 @@ void Session::Application::SendPendingData() {
   // call is dynamically capped by ngtcp2_conn_get_send_quantum().
   static constexpr size_t kMaxPackets = 64;
   Debug(session_, "Application sending pending data");
+  // Cache the timestamp once for the entire send loop. ngtcp2 does not
+  // require nanosecond-accurate monotonicity within a single burst —
+  // a single timestamp per SendPendingData call is what other QUIC
+  // implementations use (e.g., quiche, msquic). When kernel-level
+  // packet pacing becomes available via libuv, this timestamp becomes
+  // the base for computing per-packet transmit timestamps.
+  const uint64_t ts = uv_hrtime();
   PathStorage path;
   StreamData stream_data;
 
@@ -441,7 +449,8 @@ void Session::Application::SendPendingData() {
     // Awesome, let's write our packet!
     PacketInfo pi;
     ssize_t nwrite = WriteVStream(
-        &path, &pi, packet->data(), &ndatalen, packet->length(), stream_data);
+        &path, &pi, packet->data(), &ndatalen, packet->length(),
+        stream_data, ts);
 
     // When ndatalen is > 0, that's our indication that stream data was accepted
     // in to the packet. Yay!
@@ -528,7 +537,7 @@ void Session::Application::SendPendingData() {
           // if there is one. Otherwise just loop around and keep going.
           if (session_->HasPendingDatagrams()) {
             auto result = TryWritePendingDatagram(
-                &path, packet->data(), packet->length());
+                &path, packet->data(), packet->length(), ts);
             // When result is 0, either the datagram was congestion controlled,
             // didn't fit in the packet, or was abandoned. Skip and continue.
 
@@ -590,7 +599,7 @@ void Session::Application::SendPendingData() {
         return session_->Close(CloseMethod::SILENT);
       }
       auto result =
-          TryWritePendingDatagram(&path, packet->data(), packet->length());
+          TryWritePendingDatagram(&path, packet->data(), packet->length(), ts);
       if (result > 0) {
         Debug(session_, "Sending datagram packet with %zd bytes", result);
         enqueue_packet(packet, static_cast<size_t>(result), PacketInfo());
@@ -610,7 +619,8 @@ ssize_t Session::Application::WriteVStream(PathStorage* path,
                                            uint8_t* dest,
                                            ssize_t* ndatalen,
                                            size_t max_packet_size,
-                                           const StreamData& stream_data) {
+                                           const StreamData& stream_data,
+                                           uint64_t ts) {
   DCHECK_LE(stream_data.count, kMaxVectorCount);
   uint32_t flags = NGTCP2_WRITE_STREAM_FLAG_MORE;
   if (stream_data.fin) flags |= NGTCP2_WRITE_STREAM_FLAG_FIN;
@@ -627,7 +637,7 @@ ssize_t Session::Application::WriteVStream(PathStorage* path,
                                    stream_data.id,
                                    stream_data,
                                    stream_data.count,
-                                   uv_hrtime());
+                                   ts);
 }
 
 // ============================================================================

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -448,9 +448,13 @@ void Session::Application::SendPendingData() {
 
     // Awesome, let's write our packet!
     PacketInfo pi;
-    ssize_t nwrite = WriteVStream(
-        &path, &pi, packet->data(), &ndatalen, packet->length(),
-        stream_data, ts);
+    ssize_t nwrite = WriteVStream(&path,
+                                  &pi,
+                                  packet->data(),
+                                  &ndatalen,
+                                  packet->length(),
+                                  stream_data,
+                                  ts);
 
     // When ndatalen is > 0, that's our indication that stream data was accepted
     // in to the packet. Yay!

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -369,7 +369,8 @@ void Session::Application::SendPendingData() {
     if (closed) return;
     // Flush any remaining accumulated packets before updating stats.
     flush_batch();
-    if (session().is_destroyed()) [[unlikely]] return;
+    if (session().is_destroyed()) [[unlikely]]
+      return;
 
     // Get a strong pointer to protect against potential destruction during
     // updating the time and data stats.

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -369,12 +369,14 @@ void Session::Application::SendPendingData() {
     if (closed) return;
     // Flush any remaining accumulated packets before updating stats.
     flush_batch();
-    auto& s = session();
-    if (!s.is_destroyed()) [[likely]] {
-      s.UpdatePacketTxTime();
-      s.UpdateTimer();
-      s.UpdateDataStats();
-    }
+    if (session().is_destroyed()) [[unlikely]] return;
+
+    // Get a strong pointer to protect against potential destruction during
+    // updating the time and data stats.
+    BaseObjectPtr<Session> s(session_);
+    s->UpdatePacketTxTime();
+    s->UpdateTimer();
+    s->UpdateDataStats();
   });
 
   // The maximum size of packet to create.

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -19,9 +19,13 @@
 
 namespace node {
 
+using v8::BigInt;
+using v8::Boolean;
+using v8::DictionaryTemplate;
 using v8::Just;
 using v8::Local;
 using v8::Maybe;
+using v8::MaybeLocal;
 using v8::Nothing;
 using v8::Object;
 using v8::Value;
@@ -112,6 +116,44 @@ Maybe<Session::Application_Options> Session::Application_Options::From(
 #undef SET
 
   return Just<Application_Options>(options);
+}
+
+MaybeLocal<Object> Session::Application_Options::ToObject(
+    Environment* env) const {
+  auto& binding_data = BindingData::Get(env);
+  auto tmpl = binding_data.application_options_template();
+  static constexpr std::string_view names[] = {
+      "maxHeaderPairs",
+      "maxHeaderLength",
+      "maxFieldSectionSize",
+      "qpackMaxDtableCapacity",
+      "qpackEncoderMaxDtableCapacity",
+      "qpackBlockedStreams",
+      "enableConnectProtocol",
+      "enableDatagrams",
+  };
+  if (tmpl.IsEmpty()) {
+    tmpl = DictionaryTemplate::New(env->isolate(), names);
+    binding_data.set_application_options_template(tmpl);
+  }
+  MaybeLocal<Value> values[] = {
+      BigInt::NewFromUnsigned(env->isolate(), max_header_pairs),
+      BigInt::NewFromUnsigned(env->isolate(), max_header_length),
+      BigInt::NewFromUnsigned(env->isolate(), max_field_section_size),
+      BigInt::NewFromUnsigned(env->isolate(), qpack_max_dtable_capacity),
+      BigInt::NewFromUnsigned(env->isolate(),
+                              qpack_encoder_max_dtable_capacity),
+      BigInt::NewFromUnsigned(env->isolate(), qpack_blocked_streams),
+      Boolean::New(env->isolate(), enable_connect_protocol),
+      Boolean::New(env->isolate(), enable_datagrams),
+  };
+  static_assert(std::size(values) == std::size(names));
+
+  auto obj = tmpl->NewInstance(env->context(), values);
+  if (obj->SetPrototypeV2(env->context(), Null(env->isolate())).IsNothing()) {
+    return {};
+  }
+  return obj;
 }
 
 // ============================================================================
@@ -655,7 +697,10 @@ class DefaultApplication final : public Session::Application {
   // Marked NOLINT because the cpp linter gets confused about this using
   // statement not being sorted with the using v8 statements at the top
   // of the namespace.
-  using Application::Application;  // NOLINT
+  DefaultApplication(Session* session, const Options& options)
+      : Session::Application(session, options), options_(options) {}
+
+  const Options& options() const override { return options_; }
 
   Session::Application::Type type() const override {
     return Session::Application::Type::DEFAULT;
@@ -826,6 +871,8 @@ class DefaultApplication final : public Session::Application {
       stream->Schedule(&stream_queue_);
     }
   }
+
+  Options options_;
 
   Stream::Queue stream_queue_;
 };

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -329,14 +329,35 @@ void Session::Application::SendPendingData() {
   if (!session().can_send_packets()) [[unlikely]] {
     return;
   }
-  static constexpr size_t kMaxPackets = 32;
+  // Upper bound on packets per SendPendingData call. ngtcp2's send quantum
+  // is typically 64 KB, which at 1200-byte minimum packet size is ~53
+  // packets. 64 covers the worst case with headroom. The actual count per
+  // call is dynamically capped by ngtcp2_conn_get_send_quantum().
+  static constexpr size_t kMaxPackets = 64;
   Debug(session_, "Application sending pending data");
   PathStorage path;
   StreamData stream_data;
 
   bool closed = false;
+
+  // Batch accumulation: packets are collected here and flushed via
+  // Session::SendBatch when the loop exits, the batch is full, or
+  // on early return. This enables synchronous batched delivery via
+  // uv_udp_try_send2 (sendmmsg) from the deferred flush path.
+  Packet::Ptr batch[kMaxPackets];
+  PathStorage batch_paths[kMaxPackets];
+  size_t batch_count = 0;
+
+  auto flush_batch = [&] {
+    if (batch_count == 0) return;
+    session_->SendBatch(batch, batch_paths, batch_count);
+    batch_count = 0;
+  };
+
   auto update_stats = OnScopeLeave([&] {
     if (closed) return;
+    // Flush any remaining accumulated packets before updating stats.
+    flush_batch();
     auto& s = session();
     if (!s.is_destroyed()) [[likely]] {
       s.UpdatePacketTxTime();
@@ -353,7 +374,7 @@ void Session::Application::SendPendingData() {
       kMaxPackets, ngtcp2_conn_get_send_quantum(*session_) / max_packet_size);
   if (max_packet_count == 0) return;
 
-  // The number of packets that have been sent in this call to SendPendingData.
+  // The number of packets that have been prepared in this call.
   size_t packet_send_count = 0;
 
   Packet::Ptr packet;
@@ -366,6 +387,14 @@ void Session::Application::SendPendingData() {
     }
     DCHECK(packet);
     return true;
+  };
+
+  // Accumulate a completed packet into the batch.
+  auto enqueue_packet = [&](Packet::Ptr& pkt, size_t len) {
+    Debug(session_, "Enqueuing packet with %zu bytes into batch", len);
+    pkt->Truncate(len);
+    path.CopyTo(&batch_paths[batch_count]);
+    batch[batch_count++] = std::move(pkt);
   };
 
   // We're going to enter a loop here to prepare and send no more than
@@ -502,8 +531,7 @@ void Session::Application::SendPendingData() {
             if (result > 0) {
               size_t len = result;
               Debug(session_, "Sending packet with %zu bytes", len);
-              packet->Truncate(len);
-              session_->Send(std::move(packet), path);
+              enqueue_packet(packet, len);
               if (++packet_send_count == max_packet_count) return;
             } else if (result < 0) {
               // Any negative result other than NGTCP2_ERR_WRITE_MORE
@@ -540,8 +568,7 @@ void Session::Application::SendPendingData() {
     // is the size of the packet we are sending.
     size_t len = nwrite;
     Debug(session_, "Sending packet with %zu bytes", len);
-    packet->Truncate(len);
-    session_->Send(std::move(packet), path);
+    enqueue_packet(packet, len);
     if (++packet_send_count == max_packet_count) return;
 
     // If there are pending datagrams, try sending them in a fresh packet.
@@ -560,8 +587,7 @@ void Session::Application::SendPendingData() {
           TryWritePendingDatagram(&path, packet->data(), packet->length());
       if (result > 0) {
         Debug(session_, "Sending datagram packet with %zd bytes", result);
-        packet->Truncate(static_cast<size_t>(result));
-        session_->Send(std::move(packet), path);
+        enqueue_packet(packet, static_cast<size_t>(result));
         if (++packet_send_count == max_packet_count) return;
       } else if (result < 0 && result != NGTCP2_ERR_WRITE_MORE) {
         // Fatal error — session already closed by TryWritePendingDatagram.

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -262,9 +262,12 @@ ssize_t Session::Application::TryWritePendingDatagram(PathStorage* path,
   int accepted = 0;
   int dg_flags = NGTCP2_WRITE_DATAGRAM_FLAG_MORE;
 
+  // PacketInfo for the datagram path. When libuv gains per-socket ECN
+  // marking, the value from ngtcp2 should be forwarded to the send path.
+  PacketInfo dg_pi;
   ssize_t dg_nwrite = ngtcp2_conn_writev_datagram(*session_,
                                                   &path->path,
-                                                  nullptr,
+                                                  dg_pi,
                                                   dest,
                                                   destlen,
                                                   &accepted,
@@ -390,12 +393,14 @@ void Session::Application::SendPendingData() {
   };
 
   // Accumulate a completed packet into the batch.
-  auto enqueue_packet = [&](Packet::Ptr& pkt, size_t len) {
-    Debug(session_, "Enqueuing packet with %zu bytes into batch", len);
-    pkt->Truncate(len);
-    path.CopyTo(&batch_paths[batch_count]);
-    batch[batch_count++] = std::move(pkt);
-  };
+  auto enqueue_packet =
+      [&](Packet::Ptr& pkt, size_t len, const PacketInfo& pi) {
+        Debug(session_, "Enqueuing packet with %zu bytes into batch", len);
+        pkt->Truncate(len);
+        pkt->set_pkt_info(pi);
+        path.CopyTo(&batch_paths[batch_count]);
+        batch[batch_count++] = std::move(pkt);
+      };
 
   // We're going to enter a loop here to prepare and send no more than
   // max_packet_count packets.
@@ -434,8 +439,9 @@ void Session::Application::SendPendingData() {
     }
 
     // Awesome, let's write our packet!
+    PacketInfo pi;
     ssize_t nwrite = WriteVStream(
-        &path, packet->data(), &ndatalen, packet->length(), stream_data);
+        &path, &pi, packet->data(), &ndatalen, packet->length(), stream_data);
 
     // When ndatalen is > 0, that's our indication that stream data was accepted
     // in to the packet. Yay!
@@ -531,7 +537,7 @@ void Session::Application::SendPendingData() {
             if (result > 0) {
               size_t len = result;
               Debug(session_, "Sending packet with %zu bytes", len);
-              enqueue_packet(packet, len);
+              enqueue_packet(packet, len, pi);
               if (++packet_send_count == max_packet_count) return;
             } else if (result < 0) {
               // Any negative result other than NGTCP2_ERR_WRITE_MORE
@@ -568,7 +574,7 @@ void Session::Application::SendPendingData() {
     // is the size of the packet we are sending.
     size_t len = nwrite;
     Debug(session_, "Sending packet with %zu bytes", len);
-    enqueue_packet(packet, len);
+    enqueue_packet(packet, len, pi);
     if (++packet_send_count == max_packet_count) return;
 
     // If there are pending datagrams, try sending them in a fresh packet.
@@ -587,7 +593,7 @@ void Session::Application::SendPendingData() {
           TryWritePendingDatagram(&path, packet->data(), packet->length());
       if (result > 0) {
         Debug(session_, "Sending datagram packet with %zd bytes", result);
-        enqueue_packet(packet, static_cast<size_t>(result));
+        enqueue_packet(packet, static_cast<size_t>(result), PacketInfo());
         if (++packet_send_count == max_packet_count) return;
       } else if (result < 0 && result != NGTCP2_ERR_WRITE_MORE) {
         // Fatal error — session already closed by TryWritePendingDatagram.
@@ -600,6 +606,7 @@ void Session::Application::SendPendingData() {
 }
 
 ssize_t Session::Application::WriteVStream(PathStorage* path,
+                                           PacketInfo* pi,
                                            uint8_t* dest,
                                            ssize_t* ndatalen,
                                            size_t max_packet_size,
@@ -607,10 +614,12 @@ ssize_t Session::Application::WriteVStream(PathStorage* path,
   DCHECK_LE(stream_data.count, kMaxVectorCount);
   uint32_t flags = NGTCP2_WRITE_STREAM_FLAG_MORE;
   if (stream_data.fin) flags |= NGTCP2_WRITE_STREAM_FLAG_FIN;
+  // The PacketInfo out-param is populated by ngtcp2 with the ECN codepoint
+  // to apply when sending this packet. When libuv gains per-socket ECN
+  // marking, the value should be forwarded to the send path.
   return ngtcp2_conn_writev_stream(*session_,
                                    &path->path,
-                                   // TODO(@jasnell): ECN blocked on libuv
-                                   nullptr,
+                                   *pi,
                                    dest,
                                    max_packet_size,
                                    ndatalen,

--- a/src/quic/application.h
+++ b/src/quic/application.h
@@ -269,8 +269,11 @@ class Session::Application : public MemoryRetainer {
                                   uint8_t* dest,
                                   size_t destlen);
 
-  // Write the given stream_data into the buffer.
+  // Write the given stream_data into the buffer. The PacketInfo out-param
+  // is populated by ngtcp2 with per-packet metadata (e.g., ECN codepoint)
+  // that should be applied when sending the packet.
   ssize_t WriteVStream(PathStorage* path,
+                       PacketInfo* pi,
                        uint8_t* buf,
                        ssize_t* ndatalen,
                        size_t max_packet_size,

--- a/src/quic/application.h
+++ b/src/quic/application.h
@@ -267,7 +267,8 @@ class Session::Application : public MemoryRetainer {
   // the datagram is either congestion limited or was abandoned
   ssize_t TryWritePendingDatagram(PathStorage* path,
                                   uint8_t* dest,
-                                  size_t destlen);
+                                  size_t destlen,
+                                  uint64_t ts);
 
   // Write the given stream_data into the buffer. The PacketInfo out-param
   // is populated by ngtcp2 with per-packet metadata (e.g., ECN codepoint)
@@ -277,7 +278,8 @@ class Session::Application : public MemoryRetainer {
                        uint8_t* buf,
                        ssize_t* ndatalen,
                        size_t max_packet_size,
-                       const StreamData& stream_data);
+                       const StreamData& stream_data,
+                       uint64_t ts);
 
   Session* session_ = nullptr;
 };

--- a/src/quic/application.h
+++ b/src/quic/application.h
@@ -38,6 +38,10 @@ class Session::Application : public MemoryRetainer {
   Application(Session* session, const Options& options);
   DISALLOW_COPY_AND_MOVE(Application)
 
+  // Get the active options for this application. These may differ from the
+  // options passed at construction time since some options can be negotiated.
+  virtual const Options& options() const = 0;
+
   // The type of Application, exposed via the session state so JS
   // can observe which Application was selected after ALPN negotiation.
   // This is used primarily for testing/debugging.

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -335,7 +335,7 @@ void BindingData::OnFlushCheck() {
   // pending_flush_sessions_ and are picked up on the next check tick.
   auto sessions = std::move(pending_flush_sessions_);
   for (auto& session : sessions) {
-    session->pending_flush_ = false;
+    session->flags_.pending_flush = false;
     if (!session->is_destroyed()) {
       session->FlushPendingData();
     }
@@ -437,28 +437,28 @@ JS_METHOD_IMPL(BindingData::SetCallbacks) {
 }
 
 NgTcp2CallbackScope::NgTcp2CallbackScope(Session* session) : session(session) {
-  CHECK(!session->in_ngtcp2_callback_scope_);
-  session->in_ngtcp2_callback_scope_ = true;
+  CHECK(!session->flags_.in_ngtcp2_callback_scope);
+  session->flags_.in_ngtcp2_callback_scope = true;
 }
 
 NgTcp2CallbackScope::~NgTcp2CallbackScope() {
-  session->in_ngtcp2_callback_scope_ = false;
-  if (session->destroy_deferred_) {
-    session->destroy_deferred_ = false;
+  session->flags_.in_ngtcp2_callback_scope = false;
+  if (session->flags_.destroy_deferred) {
+    session->flags_.destroy_deferred = false;
     session->Destroy();
   }
 }
 
 NgHttp3CallbackScope::NgHttp3CallbackScope(Session* session)
     : session(session) {
-  CHECK(!session->in_nghttp3_callback_scope_);
-  session->in_nghttp3_callback_scope_ = true;
+  CHECK(!session->flags_.in_nghttp3_callback_scope);
+  session->flags_.in_nghttp3_callback_scope = true;
 }
 
 NgHttp3CallbackScope::~NgHttp3CallbackScope() {
-  session->in_nghttp3_callback_scope_ = false;
-  if (session->destroy_deferred_) {
-    session->destroy_deferred_ = false;
+  session->flags_.in_nghttp3_callback_scope = false;
+  if (session->flags_.destroy_deferred) {
+    session->flags_.destroy_deferred = false;
     session->Destroy();
   }
 }

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -23,6 +23,7 @@ using mem::kReserveSizeAndAlign;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::HandleScope;
+using v8::Isolate;
 using v8::Local;
 using v8::Object;
 using v8::String;
@@ -274,7 +275,7 @@ void BindingData::DecreaseAllocatedSize(size_t size) {
 // Forwards detailed(verbose) debugging information from nghttp3. Enabled using
 // the NODE_DEBUG_NATIVE=NGHTTP3 category.
 void nghttp3_debug_log(const char* fmt, va_list args) {
-  auto isolate = v8::Isolate::GetCurrent();
+  auto isolate = Isolate::GetCurrent();
   if (isolate == nullptr) return;
   auto env = Environment::GetCurrent(isolate);
   if (env->enabled_debug_list()->enabled(DebugCategory::NGHTTP3)) {

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -20,6 +20,7 @@
 namespace node {
 
 using mem::kReserveSizeAndAlign;
+using v8::DictionaryTemplate;
 using v8::Function;
 using v8::FunctionTemplate;
 using v8::HandleScope;
@@ -376,6 +377,16 @@ void BindingData::MemoryInfo(MemoryTracker* tracker) const {
 QUIC_CONSTRUCTORS(V)
 
 #undef V
+
+void BindingData::set_transport_params_template(
+    Local<DictionaryTemplate> tmpl) {
+  transport_params_template_.Reset(env()->isolate(), tmpl);
+}
+
+Local<DictionaryTemplate> BindingData::transport_params_template() const {
+  return PersistentToLocal::Default(env()->isolate(),
+    transport_params_template_);
+}
 
 #define V(name, _)                                                             \
   void BindingData::set_##name##_callback(Local<Function> fn) {                \

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -385,7 +385,17 @@ void BindingData::set_transport_params_template(
 
 Local<DictionaryTemplate> BindingData::transport_params_template() const {
   return PersistentToLocal::Default(env()->isolate(),
-    transport_params_template_);
+                                    transport_params_template_);
+}
+
+void BindingData::set_application_options_template(
+    Local<DictionaryTemplate> tmpl) {
+  application_options_template_.Reset(env()->isolate(), tmpl);
+}
+
+Local<DictionaryTemplate> BindingData::application_options_template() const {
+  return PersistentToLocal::Default(env()->isolate(),
+                                    application_options_template_);
 }
 
 #define V(name, _)                                                             \

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -22,6 +22,7 @@ namespace node {
 using mem::kReserveSizeAndAlign;
 using v8::Function;
 using v8::FunctionTemplate;
+using v8::HandleScope;
 using v8::Local;
 using v8::Object;
 using v8::String;
@@ -154,6 +155,16 @@ BindingData& BindingData::Get(Environment* env) {
 
 BindingData::~BindingData() {
   quic_alloc_state.binding = nullptr;
+  if (flush_check_initialized_) {
+    uv_check_stop(&flush_check_);
+    flush_check_started_ = false;
+    // The check handle is closed inline here. Because BindingData destruction
+    // happens during Environment cleanup, the handle will be finalized by
+    // libuv's close phase.
+    uv_close(reinterpret_cast<uv_handle_t*>(&flush_check_), nullptr);
+    flush_check_initialized_ = false;
+  }
+  pending_flush_sessions_.clear();
 }
 
 ngtcp2_mem* BindingData::ngtcp2_allocator() {
@@ -221,6 +232,11 @@ void BindingData::RegisterExternalReferences(
 BindingData::BindingData(Realm* realm, Local<Object> object)
     : BaseObject(realm, object) {
   MakeWeak();
+  CHECK_EQ(uv_check_init(env()->event_loop(), &flush_check_), 0);
+  flush_check_.data = this;
+  // Unref so the check handle doesn't keep the event loop alive on its own.
+  uv_unref(reinterpret_cast<uv_handle_t*>(&flush_check_));
+  flush_check_initialized_ = true;
 }
 
 SessionManager& BindingData::session_manager() {
@@ -228,6 +244,45 @@ SessionManager& BindingData::session_manager() {
     session_manager_ = std::make_unique<SessionManager>();
   }
   return *session_manager_;
+}
+
+void BindingData::ScheduleSessionFlush(const BaseObjectPtr<Session>& session) {
+  pending_flush_sessions_.push_back(session);
+  if (!flush_check_started_) {
+    uv_check_start(&flush_check_, OnFlushCheck);
+    flush_check_started_ = true;
+  }
+}
+
+void BindingData::OnFlushCheck(uv_check_t* handle) {
+  auto* binding = static_cast<BindingData*>(handle->data);
+  if (binding->pending_flush_sessions_.empty()) {
+    uv_check_stop(&binding->flush_check_);
+    binding->flush_check_started_ = false;
+    return;
+  }
+
+  HandleScope scope(binding->env()->isolate());
+
+  // Swap to a local vector before iterating. SendPendingData may trigger
+  // MakeCallback which runs JS that could cause more packet receives via
+  // re-entry (e.g., a stream data callback that synchronously writes to
+  // another session). Any sessions added during the flush remain in
+  // pending_flush_sessions_ and are picked up on the next check tick.
+  auto sessions = std::move(binding->pending_flush_sessions_);
+  for (auto& session : sessions) {
+    session->pending_flush_ = false;
+    if (!session->is_destroyed()) {
+      session->FlushPendingData();
+    }
+  }
+
+  // If no new sessions were added during the flush, stop the check
+  // to avoid per-tick callback overhead when idle.
+  if (binding->pending_flush_sessions_.empty()) {
+    uv_check_stop(&binding->flush_check_);
+    binding->flush_check_started_ = false;
+  }
 }
 
 void BindingData::MemoryInfo(MemoryTracker* tracker) const {

--- a/src/quic/bindingdata.cc
+++ b/src/quic/bindingdata.cc
@@ -149,21 +149,87 @@ void* Nghttp3Realloc(void* ptr, size_t size, void* ud) {
 }
 }  // namespace
 
+// ============================================================================
+// CheckWrap / CheckWrapHandle
+
+void CheckWrap::Start() {
+  if (check_.data == nullptr) return;
+  uv_check_start(&check_, OnCheck);
+}
+
+void CheckWrap::Stop() {
+  if (check_.data == nullptr) return;
+  uv_check_stop(&check_);
+}
+
+void CheckWrap::Close() {
+  check_.data = nullptr;
+  env_->CloseHandle(reinterpret_cast<uv_handle_t*>(&check_), CheckClosedCb);
+}
+
+void CheckWrap::Ref() {
+  if (check_.data == nullptr) return;
+  uv_ref(reinterpret_cast<uv_handle_t*>(&check_));
+}
+
+void CheckWrap::Unref() {
+  if (check_.data == nullptr) return;
+  uv_unref(reinterpret_cast<uv_handle_t*>(&check_));
+}
+
+void CheckWrap::OnCheck(uv_check_t* check) {
+  CheckWrap* wrap = ContainerOf(&CheckWrap::check_, check);
+  wrap->fn_();
+}
+
+void CheckWrap::CheckClosedCb(uv_handle_t* handle) {
+  std::unique_ptr<CheckWrap> ptr(
+      ContainerOf(&CheckWrap::check_, reinterpret_cast<uv_check_t*>(handle)));
+}
+
+void CheckWrapHandle::Start() {
+  if (check_ != nullptr) check_->Start();
+}
+
+void CheckWrapHandle::Stop() {
+  if (check_ != nullptr) check_->Stop();
+}
+
+void CheckWrapHandle::Close() {
+  if (check_ != nullptr) {
+    check_->env()->RemoveCleanupHook(CleanupHook, this);
+    check_->Close();
+  }
+  check_ = nullptr;
+}
+
+void CheckWrapHandle::Ref() {
+  if (check_ != nullptr) check_->Ref();
+}
+
+void CheckWrapHandle::Unref() {
+  if (check_ != nullptr) check_->Unref();
+}
+
+void CheckWrapHandle::MemoryInfo(MemoryTracker* tracker) const {
+  if (check_ != nullptr) tracker->TrackField("check", *check_);
+}
+
+void CheckWrapHandle::CleanupHook(void* data) {
+  static_cast<CheckWrapHandle*>(data)->Close();
+}
+
+// ============================================================================
+
 BindingData& BindingData::Get(Environment* env) {
   return *(env->principal_realm()->GetBindingData<BindingData>());
 }
 
 BindingData::~BindingData() {
   quic_alloc_state.binding = nullptr;
-  if (flush_check_initialized_) {
-    uv_check_stop(&flush_check_);
-    flush_check_started_ = false;
-    // The check handle is closed inline here. Because BindingData destruction
-    // happens during Environment cleanup, the handle will be finalized by
-    // libuv's close phase.
-    uv_close(reinterpret_cast<uv_handle_t*>(&flush_check_), nullptr);
-    flush_check_initialized_ = false;
-  }
+  // flush_check_ is cleaned up by ~CheckWrapHandle() after the destructor
+  // body completes. The inner CheckWrap (and its uv_check_t) will be freed
+  // later by the uv_close callback, after CleanupHandles() runs uv_run().
   pending_flush_sessions_.clear();
 }
 
@@ -230,13 +296,11 @@ void BindingData::RegisterExternalReferences(
 }
 
 BindingData::BindingData(Realm* realm, Local<Object> object)
-    : BaseObject(realm, object) {
+    : BaseObject(realm, object),
+      flush_check_(env(), [this]() { OnFlushCheck(); }) {
   MakeWeak();
-  CHECK_EQ(uv_check_init(env()->event_loop(), &flush_check_), 0);
-  flush_check_.data = this;
   // Unref so the check handle doesn't keep the event loop alive on its own.
-  uv_unref(reinterpret_cast<uv_handle_t*>(&flush_check_));
-  flush_check_initialized_ = true;
+  flush_check_.Unref();
 }
 
 SessionManager& BindingData::session_manager() {
@@ -249,27 +313,26 @@ SessionManager& BindingData::session_manager() {
 void BindingData::ScheduleSessionFlush(const BaseObjectPtr<Session>& session) {
   pending_flush_sessions_.push_back(session);
   if (!flush_check_started_) {
-    uv_check_start(&flush_check_, OnFlushCheck);
+    flush_check_.Start();
     flush_check_started_ = true;
   }
 }
 
-void BindingData::OnFlushCheck(uv_check_t* handle) {
-  auto* binding = static_cast<BindingData*>(handle->data);
-  if (binding->pending_flush_sessions_.empty()) {
-    uv_check_stop(&binding->flush_check_);
-    binding->flush_check_started_ = false;
+void BindingData::OnFlushCheck() {
+  if (pending_flush_sessions_.empty()) {
+    flush_check_.Stop();
+    flush_check_started_ = false;
     return;
   }
 
-  HandleScope scope(binding->env()->isolate());
+  HandleScope scope(env()->isolate());
 
   // Swap to a local vector before iterating. SendPendingData may trigger
   // MakeCallback which runs JS that could cause more packet receives via
   // re-entry (e.g., a stream data callback that synchronously writes to
   // another session). Any sessions added during the flush remain in
   // pending_flush_sessions_ and are picked up on the next check tick.
-  auto sessions = std::move(binding->pending_flush_sessions_);
+  auto sessions = std::move(pending_flush_sessions_);
   for (auto& session : sessions) {
     session->pending_flush_ = false;
     if (!session->is_destroyed()) {
@@ -279,9 +342,9 @@ void BindingData::OnFlushCheck(uv_check_t* handle) {
 
   // If no new sessions were added during the flush, stop the check
   // to avoid per-tick callback overhead when idle.
-  if (binding->pending_flush_sessions_.empty()) {
-    uv_check_stop(&binding->flush_check_);
-    binding->flush_check_started_ = false;
+  if (pending_flush_sessions_.empty()) {
+    flush_check_.Stop();
+    flush_check_started_ = false;
   }
 }
 

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -93,6 +93,7 @@ class SessionManager;
   V(groups, "groups")                                                          \
   V(handshake_timeout, "handshakeTimeout")                                     \
   V(http3_alpn, &NGHTTP3_ALPN_H3[1])                                           \
+  V(initial_rtt, "initialRtt")                                                 \
   V(keep_alive_timeout, "keepAlive")                                           \
   V(initial_max_data, "initialMaxData")                                        \
   V(initial_max_stream_data_bidi_local, "initialMaxStreamDataBidiLocal")       \

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -306,6 +306,9 @@ class BindingData final
   void set_transport_params_template(v8::Local<v8::DictionaryTemplate> tmpl);
   v8::Local<v8::DictionaryTemplate> transport_params_template() const;
 
+  void set_application_options_template(v8::Local<v8::DictionaryTemplate> tmpl);
+  v8::Local<v8::DictionaryTemplate> application_options_template() const;
+
 #define V(name, _)                                                             \
   void set_##name##_callback(v8::Local<v8::Function> fn);                      \
   v8::Local<v8::Function> name##_callback() const;
@@ -325,6 +328,7 @@ class BindingData final
 #undef V
 
   v8::Global<v8::DictionaryTemplate> transport_params_template_;
+  v8::Global<v8::DictionaryTemplate> application_options_template_;
 
 #define V(name, _) v8::Global<v8::Function> name##_callback_;
   QUIC_JS_CALLBACKS(V)

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -303,6 +303,9 @@ class BindingData final
   QUIC_CONSTRUCTORS(V)
 #undef V
 
+  void set_transport_params_template(v8::Local<v8::DictionaryTemplate> tmpl);
+  v8::Local<v8::DictionaryTemplate> transport_params_template() const;
+
 #define V(name, _)                                                             \
   void set_##name##_callback(v8::Local<v8::Function> fn);                      \
   v8::Local<v8::Function> name##_callback() const;
@@ -320,6 +323,8 @@ class BindingData final
 #define V(name) v8::Global<v8::FunctionTemplate> name##_constructor_template_;
   QUIC_CONSTRUCTORS(V)
 #undef V
+
+  v8::Global<v8::DictionaryTemplate> transport_params_template_;
 
 #define V(name, _) v8::Global<v8::Function> name##_callback_;
   QUIC_JS_CALLBACKS(V)

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -257,6 +257,19 @@ class BindingData final
 
   std::unique_ptr<SessionManager> session_manager_;
 
+  // Type-erased arena storage. The concrete AliasedStructArena<T> types
+  // are only complete in the .cc files where Stream::State etc. are defined.
+  // Each .cc file provides typed accessor methods. The deleters are set
+  // when the arenas are created so that ~BindingData destroys them correctly.
+  using ArenaDeleter = void (*)(void*);
+  using ArenaPtr = std::unique_ptr<void, ArenaDeleter>;
+  ArenaPtr stream_state_arena_{nullptr, +[](void*) {}};
+  ArenaPtr stream_stats_arena_{nullptr, +[](void*) {}};
+  ArenaPtr session_state_arena_{nullptr, +[](void*) {}};
+  ArenaPtr session_stats_arena_{nullptr, +[](void*) {}};
+  ArenaPtr endpoint_state_arena_{nullptr, +[](void*) {}};
+  ArenaPtr endpoint_stats_arena_{nullptr, +[](void*) {}};
+
   // Deferred send flush state. The uv_check_t fires immediately after
   // the I/O poll phase in the same event loop tick, allowing batched
   // receive processing: all packets are read during poll, then

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -12,6 +12,7 @@
 #include <node_mem.h>
 #include <uv.h>
 #include <v8.h>
+#include <functional>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -157,6 +158,81 @@ class SessionManager;
   V(version, "version")
 
 // =============================================================================
+// Lightweight wrappers around uv_check_t that ensure safe handle closure.
+// The check handle is embedded in a heap-allocated CheckWrap whose destruction
+// is deferred until the uv_close callback fires, preventing use-after-free
+// when the owning object is destroyed before libuv finishes closing the handle.
+// Follows the same two-layer pattern as TimerWrap / TimerWrapHandle
+// (see timer_wrap.h).
+// TODO(@jasnell): Consider moving it out to a separate file like timer_wrap.h.
+class CheckWrap final : public MemoryRetainer {
+ public:
+  using CheckCb = std::function<void()>;
+
+  template <typename... Args>
+  explicit CheckWrap(Environment* env, Args&&... args)
+      : env_(env), fn_(std::forward<Args>(args)...) {
+    uv_check_init(env->event_loop(), &check_);
+    check_.data = this;
+  }
+
+  DISALLOW_COPY_AND_MOVE(CheckWrap)
+
+  inline Environment* env() const { return env_; }
+
+  void Start();
+  void Stop();
+  void Close();
+  void Ref();
+  void Unref();
+
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(CheckWrap)
+  SET_SELF_SIZE(CheckWrap)
+
+ private:
+  static void OnCheck(uv_check_t* check);
+  static void CheckClosedCb(uv_handle_t* handle);
+  ~CheckWrap() = default;
+
+  Environment* env_;
+  CheckCb fn_;
+  uv_check_t check_;
+
+  friend std::unique_ptr<CheckWrap>::deleter_type;
+};
+
+class CheckWrapHandle : public MemoryRetainer {
+ public:
+  template <typename... Args>
+  explicit CheckWrapHandle(Environment* env, Args&&... args)
+      : check_(new CheckWrap(env, std::forward<Args>(args)...)) {
+    env->AddCleanupHook(CleanupHook, this);
+  }
+
+  DISALLOW_COPY_AND_MOVE(CheckWrapHandle)
+
+  ~CheckWrapHandle() { Close(); }
+
+  inline operator bool() const { return check_ != nullptr; }
+
+  void Start();
+  void Stop();
+  void Close();
+  void Ref();
+  void Unref();
+
+  void MemoryInfo(node::MemoryTracker* tracker) const override;
+
+  SET_MEMORY_INFO_NAME(CheckWrapHandle)
+  SET_SELF_SIZE(CheckWrapHandle)
+
+ private:
+  static void CleanupHook(void* data);
+  CheckWrap* check_;
+};
+
+// =============================================================================
 // The BindingState object holds state for the internalBinding('quic') binding
 // instance. It is mostly used to hold the persistent constructors, strings, and
 // callback references used for the rest of the implementation.
@@ -270,16 +346,15 @@ class BindingData final
   ArenaPtr endpoint_state_arena_{nullptr, +[](void*) {}};
   ArenaPtr endpoint_stats_arena_{nullptr, +[](void*) {}};
 
-  // Deferred send flush state. The uv_check_t fires immediately after
+  // Deferred send flush state. The CheckWrapHandle fires immediately after
   // the I/O poll phase in the same event loop tick, allowing batched
   // receive processing: all packets are read during poll, then
   // SendPendingData is called once per dirty session in the check callback.
-  uv_check_t flush_check_;
+  CheckWrapHandle flush_check_;
   std::vector<BaseObjectPtr<Session>> pending_flush_sessions_;
   bool flush_check_started_ = false;
-  bool flush_check_initialized_ = false;
 
-  static void OnFlushCheck(uv_check_t* handle);
+  void OnFlushCheck();
 };
 
 JS_METHOD_IMPL(IllegalConstructor);

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -101,6 +101,7 @@ class SessionManager;
   V(initial_max_streams_bidi, "initialMaxStreamsBidi")                         \
   V(initial_max_streams_uni, "initialMaxStreamsUni")                           \
   V(ipv6_only, "ipv6Only")                                                     \
+  V(reuse_port, "reusePort")                                                   \
   V(keylog, "keylog")                                                          \
   V(keys, "keys")                                                              \
   V(lost, "lost")                                                              \

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -10,9 +10,11 @@
 #include <ngtcp2/ngtcp2_crypto.h>
 #include <node.h>
 #include <node_mem.h>
+#include <uv.h>
 #include <v8.h>
 #include <memory>
 #include <unordered_map>
+#include <vector>
 #include "defs.h"
 
 namespace node::quic {
@@ -201,6 +203,13 @@ class BindingData final
   // routing so that any endpoint can route packets to any session.
   SessionManager& session_manager();
 
+  // Schedule a session for deferred SendPendingData. Sessions are accumulated
+  // during the I/O poll phase (via Endpoint::Receive -> Session::ReadPacket)
+  // and flushed in a uv_check callback immediately after poll completes.
+  // This batches multiple received packets before generating responses,
+  // allowing ngtcp2 to make better ACK coalescing decisions.
+  void ScheduleSessionFlush(const BaseObjectPtr<Session>& session);
+
   std::unordered_map<Endpoint*, BaseObjectPtr<BaseObject>> listening_endpoints;
 
   size_t current_ngtcp2_memory_ = 0;
@@ -247,6 +256,17 @@ class BindingData final
 #undef V
 
   std::unique_ptr<SessionManager> session_manager_;
+
+  // Deferred send flush state. The uv_check_t fires immediately after
+  // the I/O poll phase in the same event loop tick, allowing batched
+  // receive processing: all packets are read during poll, then
+  // SendPendingData is called once per dirty session in the check callback.
+  uv_check_t flush_check_;
+  std::vector<BaseObjectPtr<Session>> pending_flush_sessions_;
+  bool flush_check_started_ = false;
+  bool flush_check_initialized_ = false;
+
+  static void OnFlushCheck(uv_check_t* handle);
 };
 
 JS_METHOD_IMPL(IllegalConstructor);

--- a/src/quic/data.cc
+++ b/src/quic/data.cc
@@ -137,7 +137,9 @@ Store Store::CopyFrom(Local<ArrayBuffer> buffer) {
   auto backing = buffer->GetBackingStore();
   auto length = buffer->ByteLength();
   auto dest = ArrayBuffer::NewBackingStore(
-      isolate, length, BackingStoreInitializationMode::kUninitialized,
+      isolate,
+      length,
+      BackingStoreInitializationMode::kUninitialized,
       BackingStoreOnFailureMode::kReturnNull);
   if (!dest) {
     THROW_ERR_MEMORY_ALLOCATION_FAILED(Environment::GetCurrent(isolate));
@@ -154,7 +156,9 @@ Store Store::CopyFrom(Local<ArrayBufferView> view) {
   auto length = view->ByteLength();
   auto offset = view->ByteOffset();
   auto dest = ArrayBuffer::NewBackingStore(
-      isolate, length, BackingStoreInitializationMode::kUninitialized,
+      isolate,
+      length,
+      BackingStoreInitializationMode::kUninitialized,
       BackingStoreOnFailureMode::kReturnNull);
   // copy content
   if (!dest) {

--- a/src/quic/data.cc
+++ b/src/quic/data.cc
@@ -17,7 +17,10 @@ using v8::Array;
 using v8::ArrayBuffer;
 using v8::ArrayBufferView;
 using v8::BackingStore;
+using v8::BackingStoreInitializationMode;
+using v8::BackingStoreOnFailureMode;
 using v8::BigInt;
+using v8::Isolate;
 using v8::Just;
 using v8::Local;
 using v8::Maybe;
@@ -89,14 +92,14 @@ Store::Store(std::unique_ptr<BackingStore> store, size_t length, size_t offset)
 }
 
 Maybe<Store> Store::From(Local<ArrayBuffer> buffer) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(isolate->GetCurrentContext());
   auto length = buffer->ByteLength();
   auto dest = ArrayBuffer::NewBackingStore(
       isolate,
       length,
-      v8::BackingStoreInitializationMode::kUninitialized,
-      v8::BackingStoreOnFailureMode::kReturnNull);
+      BackingStoreInitializationMode::kUninitialized,
+      BackingStoreOnFailureMode::kReturnNull);
   if (!dest) {
     THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
     return Nothing<Store>();
@@ -108,15 +111,15 @@ Maybe<Store> Store::From(Local<ArrayBuffer> buffer) {
 }
 
 Maybe<Store> Store::From(Local<ArrayBufferView> view) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  Isolate* isolate = Isolate::GetCurrent();
   Environment* env = Environment::GetCurrent(isolate->GetCurrentContext());
   auto length = view->ByteLength();
   auto offset = view->ByteOffset();
   auto dest = ArrayBuffer::NewBackingStore(
       isolate,
       length,
-      v8::BackingStoreInitializationMode::kUninitialized,
-      v8::BackingStoreOnFailureMode::kReturnNull);
+      BackingStoreInitializationMode::kUninitialized,
+      BackingStoreOnFailureMode::kReturnNull);
   if (!dest) {
     THROW_ERR_MEMORY_ALLOCATION_FAILED(env);
     return Nothing<Store>();
@@ -130,24 +133,34 @@ Maybe<Store> Store::From(Local<ArrayBufferView> view) {
 }
 
 Store Store::CopyFrom(Local<ArrayBuffer> buffer) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  Isolate* isolate = Isolate::GetCurrent();
   auto backing = buffer->GetBackingStore();
   auto length = buffer->ByteLength();
   auto dest = ArrayBuffer::NewBackingStore(
-      isolate, length, v8::BackingStoreInitializationMode::kUninitialized);
+      isolate, length, BackingStoreInitializationMode::kUninitialized,
+      BackingStoreOnFailureMode::kReturnNull);
+  if (!dest) {
+    THROW_ERR_MEMORY_ALLOCATION_FAILED(Environment::GetCurrent(isolate));
+    return Store();
+  }
   // copy content
   memcpy(dest->Data(), backing->Data(), length);
   return Store(std::move(dest), length, 0);
 }
 
 Store Store::CopyFrom(Local<ArrayBufferView> view) {
-  v8::Isolate* isolate = v8::Isolate::GetCurrent();
+  Isolate* isolate = Isolate::GetCurrent();
   auto backing = view->Buffer()->GetBackingStore();
   auto length = view->ByteLength();
   auto offset = view->ByteOffset();
   auto dest = ArrayBuffer::NewBackingStore(
-      isolate, length, v8::BackingStoreInitializationMode::kUninitialized);
+      isolate, length, BackingStoreInitializationMode::kUninitialized,
+      BackingStoreOnFailureMode::kReturnNull);
   // copy content
+  if (!dest) {
+    THROW_ERR_MEMORY_ALLOCATION_FAILED(Environment::GetCurrent(isolate));
+    return Store();
+  }
   memcpy(dest->Data(), static_cast<char*>(backing->Data()) + offset, length);
   return Store(std::move(dest), length, 0);
 }

--- a/src/quic/data.h
+++ b/src/quic/data.h
@@ -19,6 +19,40 @@ namespace node::quic {
 template <typename T>
 concept OneByteType = sizeof(T) == 1;
 
+// Lightweight wrapper around ngtcp2_pkt_info. Insulates the Node.js QUIC
+// code from the ngtcp2 struct layout and provides a clean API boundary
+// for per-packet metadata (currently ECN codepoint; may grow as ngtcp2
+// and libuv evolve).
+//
+// Default-constructed PacketInfo is zero-initialized, which ngtcp2 treats
+// as ECN Not-ECT — identical to passing nullptr for the pkt_info parameter.
+class PacketInfo final {
+ public:
+  // ECN codepoints as defined by RFC 3168.
+  enum class Ecn : uint32_t {
+    NOT_ECT = 0,  // Not ECN-Capable Transport
+    ECT_1 = 1,    // ECN-Capable Transport(1)
+    ECT_0 = 2,    // ECN-Capable Transport(0)
+    CE = 3,       // Congestion Experienced
+  };
+
+  PacketInfo() : info_{} {}
+  explicit PacketInfo(const ngtcp2_pkt_info& info) : info_(info) {}
+
+  // ECN codepoint for this packet. When libuv gains per-packet ECN
+  // reporting, populate via set_ecn() from the receive metadata
+  // before passing to ReadPacket().
+  Ecn ecn() const { return static_cast<Ecn>(info_.ecn); }
+  void set_ecn(Ecn ecn) { info_.ecn = static_cast<uint32_t>(ecn); }
+
+  // Conversion operators for ngtcp2 API calls.
+  operator const ngtcp2_pkt_info*() const { return &info_; }
+  operator ngtcp2_pkt_info*() { return &info_; }
+
+ private:
+  ngtcp2_pkt_info info_;
+};
+
 struct Path final : public ngtcp2_path {
   explicit Path(const SocketAddress& local, const SocketAddress& remote);
   Path(Path&& other) noexcept = default;

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -492,12 +492,22 @@ int Endpoint::UDP::Send(Packet::Ptr packet) {
   return err;
 }
 
-int Endpoint::UDP::TrySend(Packet* packet) {
-  DCHECK_NOT_NULL(packet);
+int Endpoint::UDP::TrySend(const Packet::Ptr& packet) {
+  DCHECK(packet);
   if (is_closed_or_closing()) return UV_EBADF;
   uv_buf_t buf = *packet;
   return uv_udp_try_send(
       &impl_->handle_, &buf, 1, packet->destination().data());
+}
+
+int Endpoint::UDP::TrySendBatch(uv_buf_t* bufs[],
+                                unsigned int nbufs[],
+                                struct sockaddr* addrs[],
+                                size_t count) {
+  DCHECK_GT(count, 0);
+  if (is_closed_or_closing()) return UV_EBADF;
+  return uv_udp_try_send2(
+      &impl_->handle_, static_cast<unsigned int>(count), bufs, nbufs, addrs, 0);
 }
 
 void Endpoint::UDP::MemoryInfo(MemoryTracker* tracker) const {
@@ -827,20 +837,19 @@ void Endpoint::SendOrTrySend(Packet::Ptr packet) {
   }
 #endif
 
-  if (is_closed() || is_closing() || packet->length() == 0) {
+  if (is_closed() || is_closing() || !packet || packet->length() == 0) {
     return;
   }
 
   Debug(this, "TrySend %s", packet->ToString());
-  size_t packet_length = packet->length();
 
   // Attempt synchronous send. On success (returns number of bytes sent),
   // the packet is delivered immediately — no callback overhead, no
   // waiting for the next poll cycle.
-  int err = udp_.TrySend(packet.get());
+  int err = udp_.TrySend(packet);
   if (err >= 0) {
-    // Synchronous send succeeded. Release the packet immediately.
-    STAT_INCREMENT_N(Stats, bytes_sent, packet_length);
+    // Synchronous send succeeded.
+    STAT_INCREMENT_N(Stats, bytes_sent, packet->length());
     STAT_INCREMENT(Stats, packets_sent);
     // Ptr destructor releases back to arena pool.
     return;
@@ -857,6 +866,73 @@ void Endpoint::SendOrTrySend(Packet::Ptr packet) {
   // Other errors are fatal.
   Debug(this, "TrySend failed with error %d", err);
   Destroy(CloseContext::SEND_FAILURE, err);
+}
+
+void Endpoint::SendBatch(Packet::Ptr* packets, size_t count) {
+  if (count == 0) return;
+
+#ifdef DEBUG
+  if (is_diagnostic_packet_loss(options_.tx_loss)) [[unlikely]] {
+    for (size_t i = 0; i < count; i++) packets[i].reset();
+    return;
+  }
+#endif
+
+  if (is_closed() || is_closing()) {
+    for (size_t i = 0; i < count; i++) packets[i].reset();
+    return;
+  }
+
+  static constexpr size_t kMaxBatch = 64;
+  DCHECK_LE(count, kMaxBatch);
+
+  // Build libuv argument arrays directly from the Ptr array.
+  // Packets with zero length are released and skipped.
+  uv_buf_t bufs[kMaxBatch];
+  uv_buf_t* buf_ptrs[kMaxBatch];
+  unsigned int nbufs[kMaxBatch];
+  struct sockaddr* addrs[kMaxBatch];
+  // Map from valid-index back to the original packets[] index.
+  size_t index_map[kMaxBatch];
+  size_t valid_count = 0;
+
+  for (size_t i = 0; i < count; i++) {
+    if (!packets[i] || packets[i]->length() == 0) {
+      packets[i].reset();
+      continue;
+    }
+    bufs[valid_count] = *packets[i];
+    buf_ptrs[valid_count] = &bufs[valid_count];
+    nbufs[valid_count] = 1;
+    addrs[valid_count] =
+        const_cast<struct sockaddr*>(packets[i]->destination().data());
+    index_map[valid_count] = i;
+    valid_count++;
+  }
+
+  if (valid_count == 0) return;
+
+  // Attempt synchronous batched send via sendmmsg.
+  int sent = udp_.TrySendBatch(buf_ptrs, nbufs, addrs, valid_count);
+
+  if (sent > 0) {
+    // Packets [0, sent) were delivered synchronously.
+    // Release them immediately — no async callback needed.
+    for (size_t i = 0; i < static_cast<size_t>(sent); i++) {
+      size_t idx = index_map[i];
+      STAT_INCREMENT_N(Stats, bytes_sent, packets[idx]->length());
+      STAT_INCREMENT(Stats, packets_sent);
+      packets[idx].reset();
+    }
+  }
+
+  // Any unsent packets (EAGAIN, partial send, or total failure) fall
+  // back to async uv_udp_send.
+  size_t start = (sent > 0) ? static_cast<size_t>(sent) : 0;
+  for (size_t i = start; i < valid_count; i++) {
+    size_t idx = index_map[i];
+    Send(std::move(packets[idx]));
+  }
 }
 
 void Endpoint::SendRetry(const PathDescriptor& options) {

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -312,10 +312,18 @@ class Endpoint::UDP::Impl final : public HandleWrap {
   SET_SELF_SIZE(Impl)
 
  private:
+  // Pre-allocated receive buffer. Reused across all datagrams because
+  // ngtcp2_conn_read_pkt is synchronous — it copies what it needs and
+  // does not retain a reference to the buffer after returning. This
+  // eliminates a malloc(64KB)/free(64KB) cycle per received datagram.
+  static constexpr size_t kRecvBufferSize = 65536;  // UV__UDP_DGRAM_MAXSIZE
+  char recv_buf_[kRecvBufferSize];
+
   static void OnAlloc(uv_handle_t* handle,
                       size_t suggested_size,
                       uv_buf_t* buf) {
-    *buf = From(handle)->env()->allocate_managed_buffer(suggested_size);
+    auto* impl = From(handle);
+    *buf = uv_buf_init(impl->recv_buf_, kRecvBufferSize);
   }
 
   static void OnReceive(uv_udp_t* handle,
@@ -327,26 +335,22 @@ class Endpoint::UDP::Impl final : public HandleWrap {
     DCHECK_NOT_NULL(impl);
     DCHECK_NOT_NULL(impl->endpoint_);
 
-    auto release_buf = [&]() {
-      if (buf->base != nullptr) impl->env()->release_managed_buffer(*buf);
-    };
-
     // Nothing to do in these cases. Specifically, if the nread
     // is zero or we have received a partial packet, we are just
-    // going to ignore it.
+    // going to ignore it. No buffer release needed — recv_buf_
+    // is pre-allocated and reused.
     if (nread == 0 || flags & UV_UDP_PARTIAL) {
-      release_buf();
       return;
     }
 
     if (nread < 0) {
-      release_buf();
       impl->endpoint_->Destroy(CloseContext::RECEIVE_FAILURE,
                                static_cast<int>(nread));
       return;
     }
 
-    impl->endpoint_->Receive(uv_buf_init(buf->base, static_cast<size_t>(nread)),
+    impl->endpoint_->Receive(reinterpret_cast<const uint8_t*>(buf->base),
+                             static_cast<size_t>(nread),
                              SocketAddress(addr));
   }
 
@@ -1240,24 +1244,25 @@ void Endpoint::CloseGracefully() {
   MaybeDestroy();
 }
 
-void Endpoint::Receive(const uv_buf_t& buf,
+void Endpoint::Receive(const uint8_t* data,
+                       size_t len,
                        const SocketAddress& remote_address) {
   const auto receive = [&](Session* session,
-                           Store&& store,
+                           const uint8_t* pkt_data,
+                           size_t pkt_len,
                            const SocketAddress& local_address,
                            const SocketAddress& remote_address,
                            const CID& dcid,
                            const CID& scid) {
     DCHECK_NOT_NULL(session);
     if (session->is_destroyed()) return;
-    size_t len = store.length();
     // Use ReadPacket (no SendPendingDataScope) so that multiple packets
     // received in the same I/O burst are processed before any responses
     // are generated. The deferred flush via BindingData's uv_check
     // callback calls SendPendingData once per dirty session after all
     // packets in the burst have been read.
-    if (session->ReadPacket(std::move(store), local_address, remote_address)) {
-      STAT_INCREMENT_N(Stats, bytes_received, len);
+    if (session->ReadPacket(pkt_data, pkt_len, local_address, remote_address)) {
+      STAT_INCREMENT_N(Stats, bytes_received, pkt_len);
       STAT_INCREMENT(Stats, packets_received);
     }
     // Schedule the session for deferred SendPendingData if it hasn't
@@ -1269,7 +1274,9 @@ void Endpoint::Receive(const uv_buf_t& buf,
     }
   };
 
-  const auto accept = [&](const Session::Config& config, Store&& store) {
+  const auto accept = [&](const Session::Config& config,
+                          const uint8_t* pkt_data,
+                          size_t pkt_len) {
     // One final check. If the endpoint is closed, closing, or is not listening
     // as a server, then we cannot accept the initial packet.
     if (is_closed() || is_closing() || !is_listening()) return;
@@ -1299,7 +1306,8 @@ void Endpoint::Receive(const uv_buf_t& buf,
       return;
 
     receive(session.get(),
-            std::move(store),
+            pkt_data,
+            pkt_len,
             config.local_address,
             config.remote_address,
             config.dcid,
@@ -1309,7 +1317,8 @@ void Endpoint::Receive(const uv_buf_t& buf,
   const auto acceptInitialPacket = [&](const uint32_t version,
                                        const CID& dcid,
                                        const CID& scid,
-                                       Store&& store,
+                                       const uint8_t* pkt_data,
+                                       size_t pkt_len,
                                        const SocketAddress& local_address,
                                        const SocketAddress& remote_address) {
     // If we're not listening as a server, do not accept an initial packet.
@@ -1319,8 +1328,7 @@ void Endpoint::Receive(const uv_buf_t& buf,
 
     // This is our first condition check... A minimal check to see if ngtcp2 can
     // even recognize this packet as a quic packet.
-    ngtcp2_vec vec = store;
-    if (ngtcp2_accept(&hd, vec.base, vec.len) != NGTCP2_SUCCESS) {
+    if (ngtcp2_accept(&hd, pkt_data, pkt_len) != NGTCP2_SUCCESS) {
       // Per the ngtcp2 docs, ngtcp2_accept returns 0 if the check was
       // successful, or an error code if it was not. Currently there's only one
       // documented error code (NGTCP2_ERR_INVALID_ARGUMENT) but we'll handle
@@ -1558,7 +1566,7 @@ void Endpoint::Receive(const uv_buf_t& buf,
       }
     }
 
-    accept(config, std::move(store));
+    accept(config, pkt_data, pkt_len);
   };
 
   // When a received packet contains a QUIC short header but cannot be matched
@@ -1574,14 +1582,15 @@ void Endpoint::Receive(const uv_buf_t& buf,
   // possible to avoid a DOS vector.
   const auto maybeStatelessReset = [&](const CID& dcid,
                                        const CID& scid,
-                                       Store& store,
+                                       const uint8_t* pkt_data,
+                                       size_t pkt_len,
                                        const SocketAddress& local_address,
                                        const SocketAddress& remote_address) {
     // Support for stateless resets can be disabled by the application. If that
     // case, or if the packet is too short to contain a reset token, then we
     // skip the remaining checks.
     if (options_.disable_stateless_reset ||
-        store.length() < NGTCP2_STATELESS_RESET_TOKENLEN) {
+        pkt_len < NGTCP2_STATELESS_RESET_TOKENLEN) {
       return false;
     }
 
@@ -1589,20 +1598,21 @@ void Endpoint::Receive(const uv_buf_t& buf,
     // NGTCP2_STATELESS_RESET_TOKENLEN bytes in the received packet. If it is a
     // stateless reset then then rest of the bytes in the packet are garbage
     // that we'll ignore.
-    ngtcp2_vec vec = store;
-    vec.base += (vec.len - NGTCP2_STATELESS_RESET_TOKENLEN);
+    const uint8_t* token_pos =
+        pkt_data + (pkt_len - NGTCP2_STATELESS_RESET_TOKENLEN);
 
     // If a Session has been associated with the token, then it is a valid
     // stateless reset token. We need to dispatch it to the session to be
     // processed.
     auto* session = session_manager().FindSessionByStatelessResetToken(
-        StatelessResetToken(vec.base));
+        StatelessResetToken(token_pos));
     if (session != nullptr) {
       // If the session happens to have been destroyed already, we'll
       // just ignore the packet.
       if (!session->is_destroyed()) [[likely]] {
         receive(session,
-                std::move(store),
+                pkt_data,
+                pkt_len,
                 local_address,
                 remote_address,
                 dcid,
@@ -1630,22 +1640,8 @@ void Endpoint::Receive(const uv_buf_t& buf,
   //   return;
   // }
 
-  Debug(this, "Received %zu-byte packet from %s", buf.len, remote_address);
+  Debug(this, "Received %zu-byte packet from %s", len, remote_address);
 
-  // The managed buffer here contains the received packet. We do not yet know
-  // at this point if it is a valid QUIC packet. We need to do some basic
-  // checks. It is critical at this point that we do as little work as possible
-  // to avoid a DOS vector.
-  std::shared_ptr<BackingStore> backing = env()->release_managed_buffer(buf);
-  if (!backing) [[unlikely]] {
-    // At this point something bad happened and we need to treat this as a fatal
-    // case. There's likely no way to test this specific condition reliably.
-    return Destroy(CloseContext::RECEIVE_FAILURE, UV_ENOMEM);
-  }
-
-  Store store(std::move(backing), buf.len, 0);
-
-  ngtcp2_vec vec = store;
   ngtcp2_version_cid pversion_cid;
 
   // This is our first check to see if the received data can be processed as a
@@ -1654,7 +1650,7 @@ void Endpoint::Receive(const uv_buf_t& buf,
   // valid QUIC header but there is still no guarantee that the packet can be
   // successfully processed.
   switch (ngtcp2_pkt_decode_version_cid(
-      &pversion_cid, vec.base, vec.len, NGTCP2_MAX_CIDLEN)) {
+      &pversion_cid, data, len, NGTCP2_MAX_CIDLEN)) {
     case 0:
       break;  // Supported version, continue processing.
     case NGTCP2_ERR_VERSION_NEGOTIATION: {
@@ -1732,7 +1728,7 @@ void Endpoint::Receive(const uv_buf_t& buf,
     // necessary here. We want to return immediately without committing any
     // further resources.
     if (pversion_cid.version == 0 &&
-        maybeStatelessReset(dcid, scid, store, addr, remote_address)) {
+        maybeStatelessReset(dcid, scid, data, len, addr, remote_address)) {
       Debug(this, "Packet was a stateless reset");
       return;  // Stateless reset! Don't do any further processing.
     }
@@ -1747,17 +1743,13 @@ void Endpoint::Receive(const uv_buf_t& buf,
       SendStatelessReset(
           PathDescriptor{
               pversion_cid.version, dcid, scid, addr, remote_address},
-          store.length());
+          len);
       return;
     }
 
     // Process the packet as an initial packet...
-    return acceptInitialPacket(pversion_cid.version,
-                               dcid,
-                               scid,
-                               std::move(store),
-                               addr,
-                               remote_address);
+    return acceptInitialPacket(
+        pversion_cid.version, dcid, scid, data, len, addr, remote_address);
   }
 
   if (session->is_destroyed()) [[unlikely]] {
@@ -1769,7 +1761,7 @@ void Endpoint::Receive(const uv_buf_t& buf,
   // If we got here, the dcid matched the scid of a known local session. Yay!
   // The session will take over any further processing of the packet.
   Debug(this, "Dispatching packet to known session");
-  receive(session.get(), std::move(store), addr, remote_address, dcid, scid);
+  receive(session.get(), data, len, addr, remote_address, dcid, scid);
 
   // It is important to note that the session may have been destroyed during
   // the call to receive(...). If that's the case, the session object still

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -735,7 +735,9 @@ void Endpoint::RemoveSession(const CID& cid,
     }
   }
   if (primary_session_count_ > 0 && --primary_session_count_ == 0) {
-    udp_.Unref();
+    if (!is_listening()) {
+      udp_.Unref();
+    }
     session_manager().RemoveSession(cid);
     // The endpoint may be idle (no sessions, not listening). MaybeDestroy
     // handles both closing (immediate destroy) and idle timeout (start

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -197,7 +197,7 @@ Maybe<Endpoint::Options> Endpoint::Options::From(Environment* env,
   if (!SET(retry_token_expiration) || !SET(token_expiration) ||
       !SET(max_stateless_resets) || !SET(address_lru_size) ||
       !SET(max_retries) || !SET(validate_address) ||
-      !SET(disable_stateless_reset) || !SET(ipv6_only) ||
+      !SET(disable_stateless_reset) || !SET(ipv6_only) || !SET(reuse_port) ||
 #ifdef DEBUG
       !SET(rx_loss) || !SET(tx_loss) ||
 #endif
@@ -265,6 +265,7 @@ std::string Endpoint::Options::ToString() const {
   res += prefix + "reset token secret: " + reset_token_secret.ToString();
   res += prefix + "token secret: " + token_secret.ToString();
   res += prefix + "ipv6 only: " + boolToString(ipv6_only);
+  res += prefix + "reuse port: " + boolToString(reuse_port);
   res += prefix +
          "udp receive buffer size: " + std::to_string(udp_receive_buffer_size);
   res +=
@@ -384,6 +385,7 @@ int Endpoint::UDP::Bind(const Options& options) {
   int flags = 0;
   if (options.local_address->family() == AF_INET6 && options.ipv6_only)
     flags |= UV_UDP_IPV6ONLY;
+  if (options.reuse_port) flags |= UV_UDP_REUSEPORT;
   int err = uv_udp_bind(&impl_->handle_, options.local_address->data(), flags);
   int size;
 

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -303,7 +303,10 @@ class Endpoint::UDP::Impl final : public HandleWrap {
                    reinterpret_cast<uv_handle_t*>(&handle_),
                    PROVIDER_QUIC_UDP),
         endpoint_(endpoint) {
-    CHECK_EQ(uv_udp_init(endpoint->env()->event_loop(), &handle_), 0);
+    CHECK_EQ(uv_udp_init_ex(endpoint->env()->event_loop(),
+                            &handle_,
+                            AF_UNSPEC | UV_UDP_RECVMMSG),
+             0);
     handle_.data = this;
   }
 
@@ -312,18 +315,26 @@ class Endpoint::UDP::Impl final : public HandleWrap {
   SET_SELF_SIZE(Impl)
 
  private:
-  // Pre-allocated receive buffer. Reused across all datagrams because
-  // ngtcp2_conn_read_pkt is synchronous — it copies what it needs and
-  // does not retain a reference to the buffer after returning. This
-  // eliminates a malloc(64KB)/free(64KB) cycle per received datagram.
-  static constexpr size_t kRecvBufferSize = 65536;  // UV__UDP_DGRAM_MAXSIZE
-  char recv_buf_[kRecvBufferSize];
+  // Pre-allocated receive buffer sized for recvmmsg batching. libuv's
+  // recvmmsg path partitions the alloc buffer into 64KB chunks (one per
+  // datagram). With kRecvBatchSize chunks we can receive up to that many
+  // packets in a single recvmmsg syscall. ngtcp2_conn_read_pkt is
+  // synchronous — it copies what it needs — so the buffer is safely
+  // reused across batches.
+  // libuv's recvmmsg partitions the buffer into UV__UDP_DGRAM_MAXSIZE (64KB)
+  // chunks regardless of actual packet size. QUIC packets are ~1200 bytes,
+  // so most of each 64KB chunk is wasted. We use a modest batch size to
+  // balance syscall reduction against memory usage.
+  static constexpr size_t kDgramMaxSize = 65536;  // UV__UDP_DGRAM_MAXSIZE
+  static constexpr size_t kRecvBatchSize = 5;
+  static constexpr size_t kRecvBufferSize = kDgramMaxSize * kRecvBatchSize;
+  std::array<char, kRecvBufferSize> recv_buf_ = {};
 
   static void OnAlloc(uv_handle_t* handle,
                       size_t suggested_size,
                       uv_buf_t* buf) {
     auto* impl = From(handle);
-    *buf = uv_buf_init(impl->recv_buf_, kRecvBufferSize);
+    *buf = uv_buf_init(impl->recv_buf_.data(), kRecvBufferSize);
   }
 
   static void OnReceive(uv_udp_t* handle,
@@ -334,6 +345,13 @@ class Endpoint::UDP::Impl final : public HandleWrap {
     auto impl = From(handle);
     DCHECK_NOT_NULL(impl);
     DCHECK_NOT_NULL(impl->endpoint_);
+
+    // UV_UDP_MMSG_FREE signals the end of a recvmmsg batch — the
+    // buffer can be reused. Since our buffer is pre-allocated and
+    // persistent, there is nothing to free.
+    if (flags & UV_UDP_MMSG_FREE) {
+      return;
+    }
 
     // Nothing to do in these cases. Specifically, if the nread
     // is zero or we have received a partial packet, we are just
@@ -349,6 +367,9 @@ class Endpoint::UDP::Impl final : public HandleWrap {
       return;
     }
 
+    // UV_UDP_MMSG_CHUNK is set for each packet in a recvmmsg batch.
+    // Processing is the same as for a single-message receive — ngtcp2
+    // copies what it needs synchronously from the buf slice.
     impl->endpoint_->Receive(reinterpret_cast<const uint8_t*>(buf->base),
                              static_cast<size_t>(nread),
                              SocketAddress(addr));

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -966,22 +966,30 @@ void Endpoint::SendRetry(const PathDescriptor& options) {
 
 void Endpoint::SendVersionNegotiation(const PathDescriptor& options) {
   Debug(this, "Sending version negotiation on path %s", options);
-  // While creating and sending a version negotiation packet does consume a
-  // small amount of system resources, and while it is fairly trivial for a
-  // malicious peer to force a version negotiation to be sent, these are more
-  // trivial to create than the cryptographically generated retry and stateless
-  // reset packets. If the packet is sent, then we'll at least increment the
-  // version_negotiation_count statistic so that application code can keep an
-  // eye on it.
+  // A malicious peer can trivially force version negotiation packets by
+  // sending packets with unsupported QUIC versions, potentially from
+  // spoofed source addresses. Rate-limit per remote host to prevent
+  // amplification attacks.
+  const auto exceeds_limits = [&] {
+    SocketAddressInfoTraits::Type* counts =
+        addr_validation_lru_.Peek(options.remote_address);
+    auto count = counts != nullptr ? counts->version_negotiation_count : 0;
+    return count >= kMaxVersionNegotiations;
+  };
+
+  if (exceeds_limits()) {
+    Debug(this, "Version negotiation rate limit exceeded for %s",
+          options.remote_address);
+    return;
+  }
+
   auto packet = Packet::CreateVersionNegotiationPacket(*this, options);
   if (packet) {
+    addr_validation_lru_.Upsert(options.remote_address)
+        ->version_negotiation_count++;
     STAT_INCREMENT(Stats, version_negotiation_count);
     Send(std::move(packet));
   }
-
-  // If creating the packet is unsuccessful, we just drop things on the floor.
-  // It's not worth committing any further resources to this one packet. We
-  // might want to log the failure at some point tho.
 }
 
 bool Endpoint::SendStatelessReset(const PathDescriptor& options,
@@ -1028,11 +1036,27 @@ void Endpoint::SendImmediateConnectionClose(const PathDescriptor& options,
         "Sending immediate connection close on path %s with reason %s",
         options,
         reason);
-  // While it is possible for a malicious peer to cause us to create a large
-  // number of these, generating them is fairly trivial.
+  // A malicious peer can trigger immediate connection close packets by
+  // sending Initial packets with invalid tokens or when the server is
+  // busy. Rate-limit per remote host to prevent amplification attacks.
+  const auto exceeds_limits = [&] {
+    SocketAddressInfoTraits::Type* counts =
+        addr_validation_lru_.Peek(options.remote_address);
+    auto count = counts != nullptr ? counts->immediate_close_count : 0;
+    return count >= kMaxImmediateCloses;
+  };
+
+  if (exceeds_limits()) {
+    Debug(this, "Immediate connection close rate limit exceeded for %s",
+          options.remote_address);
+    return;
+  }
+
   auto packet =
       Packet::CreateImmediateConnectionClosePacket(*this, options, reason);
   if (packet) {
+    addr_validation_lru_.Upsert(options.remote_address)
+        ->immediate_close_count++;
     STAT_INCREMENT(Stats, immediate_close_count);
     Send(std::move(packet));
   }

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -978,7 +978,8 @@ void Endpoint::SendVersionNegotiation(const PathDescriptor& options) {
   };
 
   if (exceeds_limits()) {
-    Debug(this, "Version negotiation rate limit exceeded for %s",
+    Debug(this,
+          "Version negotiation rate limit exceeded for %s",
           options.remote_address);
     return;
   }
@@ -1047,7 +1048,8 @@ void Endpoint::SendImmediateConnectionClose(const PathDescriptor& options,
   };
 
   if (exceeds_limits()) {
-    Debug(this, "Immediate connection close rate limit exceeded for %s",
+    Debug(this,
+          "Immediate connection close rate limit exceeded for %s",
           options.remote_address);
     return;
   }

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -378,7 +378,7 @@ Endpoint::UDP::~UDP() {
 }
 
 int Endpoint::UDP::Bind(const Options& options) {
-  if (is_bound_) return UV_EALREADY;
+  if (flags_.is_bound) return UV_EALREADY;
   if (is_closed_or_closing()) return UV_EBADF;
 
   int flags = 0;
@@ -388,7 +388,7 @@ int Endpoint::UDP::Bind(const Options& options) {
   int size;
 
   if (!err) {
-    is_bound_ = true;
+    flags_.is_bound = true;
     size = static_cast<int>(options.udp_receive_buffer_size);
     if (size > 0) {
       err = uv_recv_buffer_size(reinterpret_cast<uv_handle_t*>(&impl_->handle_),
@@ -427,34 +427,34 @@ void Endpoint::UDP::Unref() {
 
 int Endpoint::UDP::Start() {
   if (is_closed_or_closing()) return UV_EBADF;
-  if (is_started_) return 0;
+  if (flags_.is_started) return 0;
   int err = uv_udp_recv_start(&impl_->handle_, Impl::OnAlloc, Impl::OnReceive);
-  is_started_ = (err == 0);
+  flags_.is_started = (err == 0);
   return err;
 }
 
 void Endpoint::UDP::Stop() {
-  if (is_closed_or_closing() || !is_started_) return;
+  if (is_closed_or_closing() || !flags_.is_started) return;
   USE(uv_udp_recv_stop(&impl_->handle_));
-  is_started_ = false;
+  flags_.is_started = false;
 }
 
 void Endpoint::UDP::Close() {
   if (is_closed_or_closing()) return;
   DCHECK(impl_);
   Stop();
-  is_bound_ = false;
-  is_closed_ = true;
+  flags_.is_bound = false;
+  flags_.is_closed = true;
   impl_->Close();
   impl_.reset();
 }
 
 bool Endpoint::UDP::is_bound() const {
-  return is_bound_;
+  return flags_.is_bound;
 }
 
 bool Endpoint::UDP::is_closed() const {
-  return is_closed_;
+  return flags_.is_closed;
 }
 
 bool Endpoint::UDP::is_closed_or_closing() const {
@@ -1294,8 +1294,8 @@ void Endpoint::Receive(const uint8_t* data,
     }
     // Schedule the session for deferred SendPendingData if it hasn't
     // been scheduled already in this burst.
-    if (!session->is_destroyed() && !session->pending_flush_) {
-      session->pending_flush_ = true;
+    if (!session->is_destroyed() && !session->flags_.pending_flush) {
+      session->flags_.pending_flush = true;
       BindingData::Get(env()).ScheduleSessionFlush(
           BaseObjectPtr<Session>(session));
     }

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -29,7 +29,6 @@ namespace node {
 
 using v8::Array;
 using v8::ArrayBufferView;
-using v8::BackingStore;
 using v8::HandleScope;
 using v8::Integer;
 using v8::Just;

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -492,6 +492,14 @@ int Endpoint::UDP::Send(Packet::Ptr packet) {
   return err;
 }
 
+int Endpoint::UDP::TrySend(Packet* packet) {
+  DCHECK_NOT_NULL(packet);
+  if (is_closed_or_closing()) return UV_EBADF;
+  uv_buf_t buf = *packet;
+  return uv_udp_try_send(
+      &impl_->handle_, &buf, 1, packet->destination().data());
+}
+
 void Endpoint::UDP::MemoryInfo(MemoryTracker* tracker) const {
   if (impl_) tracker->TrackField("impl", impl_);
 }
@@ -812,6 +820,45 @@ void Endpoint::Send(Packet::Ptr packet) {
   STAT_INCREMENT(Stats, packets_sent);
 }
 
+void Endpoint::SendOrTrySend(Packet::Ptr packet) {
+#ifdef DEBUG
+  if (is_diagnostic_packet_loss(options_.tx_loss)) [[unlikely]] {
+    return;
+  }
+#endif
+
+  if (is_closed() || is_closing() || packet->length() == 0) {
+    return;
+  }
+
+  Debug(this, "TrySend %s", packet->ToString());
+  size_t packet_length = packet->length();
+
+  // Attempt synchronous send. On success (returns number of bytes sent),
+  // the packet is delivered immediately — no callback overhead, no
+  // waiting for the next poll cycle.
+  int err = udp_.TrySend(packet.get());
+  if (err >= 0) {
+    // Synchronous send succeeded. Release the packet immediately.
+    STAT_INCREMENT_N(Stats, bytes_sent, packet_length);
+    STAT_INCREMENT(Stats, packets_sent);
+    // Ptr destructor releases back to arena pool.
+    return;
+  }
+
+  if (err == UV_EAGAIN) {
+    // Socket not writable or async sends are queued. Fall back to the
+    // async path — the packet will be queued and flushed on the next
+    // POLLOUT cycle.
+    Debug(this, "TrySend got EAGAIN, falling back to async Send");
+    return Send(std::move(packet));
+  }
+
+  // Other errors are fatal.
+  Debug(this, "TrySend failed with error %d", err);
+  Destroy(CloseContext::SEND_FAILURE, err);
+}
+
 void Endpoint::SendRetry(const PathDescriptor& options) {
   // Generating and sending retry packets does consume some system resources,
   // and it is possible for a malicious peer to trigger sending a large number
@@ -1128,9 +1175,21 @@ void Endpoint::Receive(const uv_buf_t& buf,
     DCHECK_NOT_NULL(session);
     if (session->is_destroyed()) return;
     size_t len = store.length();
-    if (session->Receive(std::move(store), local_address, remote_address)) {
+    // Use ReadPacket (no SendPendingDataScope) so that multiple packets
+    // received in the same I/O burst are processed before any responses
+    // are generated. The deferred flush via BindingData's uv_check
+    // callback calls SendPendingData once per dirty session after all
+    // packets in the burst have been read.
+    if (session->ReadPacket(std::move(store), local_address, remote_address)) {
       STAT_INCREMENT_N(Stats, bytes_received, len);
       STAT_INCREMENT(Stats, packets_received);
+    }
+    // Schedule the session for deferred SendPendingData if it hasn't
+    // been scheduled already in this burst.
+    if (!session->is_destroyed() && !session->pending_flush_) {
+      session->pending_flush_ = true;
+      BindingData::Get(env()).ScheduleSessionFlush(
+          BaseObjectPtr<Session>(session));
     }
   };
 

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -47,6 +47,20 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
   // intentionally triggering generation of a large number of retries.
   static constexpr uint64_t DEFAULT_MAX_RETRY_LIMIT = 10;
 
+  // Maximum number of version negotiation packets that will be sent to a
+  // given remote host within the LRU tracking window. Version negotiation
+  // packets are cheap to generate but can be used as an amplification
+  // vector with spoofed source addresses.
+  // TODO(@jasnell): Consider making this configurable via Endpoint::Options.
+  static constexpr uint64_t kMaxVersionNegotiations = 10;
+
+  // Maximum number of immediate connection close packets that will be sent
+  // to a given remote host within the LRU tracking window. These are sent
+  // when the server is busy or a token is invalid — a malicious peer could
+  // trigger a large number of them.
+  // TODO(@jasnell): Consider making this configurable via Endpoint::Options.
+  static constexpr uint64_t kMaxImmediateCloses = 10;
+
   // Endpoint configuration options
   struct Options final : public MemoryRetainer {
     // The local socket address to which the UDP port will be bound. The port
@@ -454,6 +468,8 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     struct Type final {
       size_t reset_count;
       size_t retry_count;
+      size_t version_negotiation_count;
+      size_t immediate_close_count;
       uint64_t timestamp;
       bool validated;
     };

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -215,6 +215,13 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
   // the one-tick latency of async uv_udp_send.
   void SendOrTrySend(Packet::Ptr packet);
 
+  // Send a batch of packets using uv_udp_try_send2 (sendmmsg) for
+  // synchronous batched delivery. Packets successfully sent are released
+  // immediately. On EAGAIN or partial send, remaining packets fall back
+  // to async uv_udp_send. The Packet::Ptr array is consumed: all entries
+  // will be empty (released or moved) on return.
+  void SendBatch(Packet::Ptr* packets, size_t count);
+
   // Acquire a Packet from the pool. length sets the initial working
   // size (must be <= pool capacity). The slot is always allocated at
   // full capacity to avoid fragmentation.
@@ -288,11 +295,19 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     void Close();
     int Send(Packet::Ptr packet);
 
-    // Synchronous send using uv_udp_try_send. Returns 0 on success,
-    // UV_EAGAIN if the socket is not writable or the send queue is
-    // non-empty, or another negative error code on failure.
-    // On success, the caller is responsible for releasing the packet.
-    int TrySend(Packet* packet);
+    // Synchronous send using uv_udp_try_send. Returns the number of
+    // bytes sent on success, UV_EAGAIN if the socket is not writable
+    // or the send queue is non-empty, or another negative error code.
+    // The Ptr is not consumed — the caller manages the lifecycle.
+    int TrySend(const Packet::Ptr& packet);
+
+    // Synchronous batched send using uv_udp_try_send2 (sendmmsg).
+    // Takes pre-built libuv argument arrays. Returns the number of
+    // messages successfully sent (>= 0), or a negative error code.
+    int TrySendBatch(uv_buf_t* bufs[],
+                     unsigned int nbufs[],
+                     struct sockaddr* addrs[],
+                     size_t count);
 
     // Returns the local UDP socket address to which we are bound,
     // or fail with an assert if we are not bound.

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -208,6 +208,13 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
 
   void Send(Packet::Ptr packet);
 
+  // Attempt synchronous send via uv_udp_try_send. If the socket is
+  // writable, the packet is sent immediately and the Ptr is released.
+  // If the socket is not writable (UV_EAGAIN), falls back to the
+  // async Send path. Used by the deferred flush callback to avoid
+  // the one-tick latency of async uv_udp_send.
+  void SendOrTrySend(Packet::Ptr packet);
+
   // Acquire a Packet from the pool. length sets the initial working
   // size (must be <= pool capacity). The slot is always allocated at
   // full capacity to avoid fragmentation.
@@ -280,6 +287,12 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     void Stop();
     void Close();
     int Send(Packet::Ptr packet);
+
+    // Synchronous send using uv_udp_try_send. Returns 0 on success,
+    // UV_EAGAIN if the socket is not writable or the send queue is
+    // non-empty, or another negative error code on failure.
+    // On success, the caller is responsible for releasing the packet.
+    int TrySend(Packet* packet);
 
     // Returns the local UDP socket address to which we are bound,
     // or fail with an assert if we are not bound.

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -343,9 +343,12 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     class Impl;
 
     BaseObjectWeakPtr<Impl> impl_;
-    bool is_bound_ = false;
-    bool is_started_ = false;
-    bool is_closed_ = false;
+    struct Flags {
+      uint8_t is_bound : 1 = 0;
+      uint8_t is_started : 1 = 0;
+      uint8_t is_closed : 1 = 0;
+    };
+    Flags flags_;
   };
 
   bool is_closed() const;

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -409,7 +409,7 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
   // Ref() causes a listening Endpoint to keep the event loop active.
   JS_METHOD(Ref);
 
-  void Receive(const uv_buf_t& buf, const SocketAddress& from);
+  void Receive(const uint8_t* data, size_t len, const SocketAddress& from);
 
   AliasedStruct<Stats> stats_;
   AliasedStruct<State> state_;

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -148,6 +148,12 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     // flag on the underlying uv_udp_t.
     bool ipv6_only = false;
 
+    // When true, multiple endpoints (across separate processes) can bind to
+    // the same address:port and the kernel will load-balance incoming UDP
+    // datagrams across them. This sets the UV_UDP_REUSEPORT flag on the
+    // underlying uv_udp_t. Supported on Linux 3.9+ and DragonFlyBSD 3.6+.
+    bool reuse_port = false;
+
     uint32_t udp_receive_buffer_size = 0;
     uint32_t udp_send_buffer_size = 0;
 

--- a/src/quic/http3.cc
+++ b/src/quic/http3.cc
@@ -262,11 +262,17 @@ class Http3ApplicationImpl final : public Session::Application {
   }
 
   void BeginShutdown() override {
-    if (conn_) nghttp3_conn_submit_shutdown_notice(*this);
+    // Only submit a shutdown notice if the H3 connection was fully
+    // started (control streams bound). If the TLS handshake failed
+    // before Start() was called, conn_ exists but its control streams
+    // are unbound, and nghttp3_conn_submit_shutdown_notice would crash.
+    if (conn_ && started_) nghttp3_conn_submit_shutdown_notice(*this);
   }
 
   void CompleteShutdown() override {
-    if (conn_) nghttp3_conn_shutdown(*this);
+    // Same guard as BeginShutdown — nghttp3_conn_shutdown asserts
+    // that the control stream is bound (conn->tx.ctrl != NULL).
+    if (conn_ && started_) nghttp3_conn_shutdown(*this);
   }
 
   bool ReceiveStreamData(stream_id id,

--- a/src/quic/http3.cc
+++ b/src/quic/http3.cc
@@ -333,9 +333,7 @@ class Http3ApplicationImpl final : public Session::Application {
     // We cannot add the header if we've either reached
     // * the max number of header pairs or
     // * the max number of header bytes (name + value combined)
-    // current_count is the number of entries in the headers vector
-    // (each pair = name entry + value entry = 2 entries).
-    return (current_count / 2 < options_.max_header_pairs) &&
+    return (current_count < options_.max_header_pairs) &&
            (current_headers_length + this_header_length) <=
                options_.max_header_length;
   }
@@ -825,12 +823,12 @@ class Http3ApplicationImpl final : public Session::Application {
     stream->BeginHeaders(HeadersKind::INITIAL);
   }
 
-  void OnReceiveHeader(stream_id id, Http3Header&& header) {
+  void OnReceiveHeader(stream_id id, std::unique_ptr<Http3Header> header) {
     auto stream = session().FindStream(id);
 
     if (!stream) [[unlikely]]
       return;
-    if (header.name() == ":status" && header.value()[0] == '1') {
+    if (header->name() == ":status" && header->value()[0] == '1') {
       Debug(&session(),
             "HTTP/3 application switching to hints headers for stream %" PRIi64,
             stream->id());
@@ -839,8 +837,8 @@ class Http3ApplicationImpl final : public Session::Application {
     IF_QUIC_DEBUG(env()) {
       Debug(&session(),
             "Received header \"%s: %s\"",
-            header.name(),
-            header.value());
+            header->name(),
+            header->value());
     }
     stream->AddHeader(std::move(header));
   }
@@ -874,15 +872,15 @@ class Http3ApplicationImpl final : public Session::Application {
     stream->BeginHeaders(HeadersKind::TRAILING);
   }
 
-  void OnReceiveTrailer(stream_id id, Http3Header&& header) {
+  void OnReceiveTrailer(stream_id id, std::unique_ptr<Http3Header> header) {
     auto stream = session().FindStream(id);
     if (!stream) [[unlikely]]
       return;
     IF_QUIC_DEBUG(env()) {
       Debug(&session(),
             "Received header \"%s: %s\"",
-            header.name(),
-            header.value());
+            header->name(),
+            header->value());
     }
     stream->AddHeader(std::move(header));
   }
@@ -1239,7 +1237,9 @@ class Http3ApplicationImpl final : public Session::Application {
       return NGHTTP3_ERR_CALLBACK_FAILURE;
     }
     if (Http3Header::IsZeroLength(token, name, value)) return NGTCP2_SUCCESS;
-    app.OnReceiveHeader(id, Http3Header(app.env(), token, name, value, flags));
+    app.OnReceiveHeader(
+        id,
+        std::make_unique<Http3Header>(app.env(), token, name, value, flags));
     return NGTCP2_SUCCESS;
   }
 
@@ -1281,7 +1281,9 @@ class Http3ApplicationImpl final : public Session::Application {
       return NGHTTP3_ERR_CALLBACK_FAILURE;
     }
     if (Http3Header::IsZeroLength(token, name, value)) return NGTCP2_SUCCESS;
-    app.OnReceiveTrailer(id, Http3Header(app.env(), token, name, value, flags));
+    app.OnReceiveTrailer(
+        id,
+        std::make_unique<Http3Header>(app.env(), token, name, value, flags));
     return NGTCP2_SUCCESS;
   }
 

--- a/src/quic/http3.cc
+++ b/src/quic/http3.cc
@@ -157,6 +157,8 @@ class Http3ApplicationImpl final : public Session::Application {
     session->set_priority_supported();
   }
 
+  const Options& options() const override { return options_; }
+
   Session::Application::Type type() const override {
     return Session::Application::Type::HTTP3;
   }

--- a/src/quic/packet.h
+++ b/src/quic/packet.h
@@ -68,6 +68,8 @@ class Packet final {
   size_t length() const { return length_; }
   size_t capacity() const { return capacity_; }
   const SocketAddress& destination() const { return destination_; }
+  const PacketInfo& pkt_info() const { return pkt_info_; }
+  void set_pkt_info(const PacketInfo& pi) { pkt_info_ = pi; }
   Listener* listener() const { return listener_; }
 
   // Redirect the packet to a different endpoint for cross-endpoint sends
@@ -148,6 +150,7 @@ class Packet final {
   Listener* listener_;
 
   // Touched at send time.
+  PacketInfo pkt_info_;
   SocketAddress destination_;
 
   // Only touched by libuv during uv_udp_send and in the send callback.

--- a/src/quic/preferredaddress.cc
+++ b/src/quic/preferredaddress.cc
@@ -17,6 +17,7 @@ namespace node {
 using v8::Just;
 using v8::Local;
 using v8::Maybe;
+using v8::Object;
 using v8::Value;
 
 namespace quic {
@@ -131,7 +132,7 @@ Maybe<PreferredAddress::Policy> PreferredAddress::tryGetPolicy(
                               : Just(FromV8Value<Policy>(value));
 }
 
-void PreferredAddress::Initialize(Environment* env, Local<v8::Object> target) {
+void PreferredAddress::Initialize(Environment* env, Local<Object> target) {
   // The QUIC_* constants are expected to be exported out to be used on
   // the JavaScript side of the API.
   static constexpr auto PREFERRED_ADDRESS_USE =

--- a/src/quic/quic.cc
+++ b/src/quic/quic.cc
@@ -13,7 +13,7 @@
 #include "node_external_reference.h"
 
 #include <ngtcp2/ngtcp2_crypto_ossl.h>
-#include <mutex>
+
 namespace node {
 
 using v8::Context;
@@ -25,7 +25,11 @@ using v8::Value;
 namespace quic {
 
 namespace {
-std::once_flag crypto_init_flag;
+uv_once_t crypto_init_flag = UV_ONCE_INIT;
+
+void InitNgtcp2CryptoOnce() {
+  ngtcp2_crypto_ossl_init();
+}
 }  // namespace
 
 void CreatePerIsolateProperties(IsolateData* isolate_data,
@@ -39,8 +43,8 @@ void CreatePerContextProperties(Local<Object> target,
                                 Local<Value> unused,
                                 Local<Context> context,
                                 void* priv) {
+  uv_once(&crypto_init_flag, InitNgtcp2CryptoOnce);
   Realm* realm = Realm::GetCurrent(context);
-  std::call_once(crypto_init_flag, ngtcp2_crypto_ossl_init);
   BindingData::InitPerContext(realm, target);
   Endpoint::InitPerContext(realm, target);
   Session::InitPerContext(realm, target);

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2141,12 +2141,8 @@ bool Session::ReadPacket(Store&& store,
     // libuv does not currently deliver per-packet ECN metadata. When
     // libuv gains ECN receive reporting, the pkt_info should be
     // populated from the per-packet metadata and passed through here.
-    err = ngtcp2_conn_read_pkt(*this,
-                               &path,
-                               nullptr,
-                               vec.base,
-                               vec.len,
-                               uv_hrtime());
+    err = ngtcp2_conn_read_pkt(
+        *this, &path, nullptr, vec.base, vec.len, uv_hrtime());
   }
   if (is_destroyed()) return false;
 
@@ -2253,6 +2249,61 @@ bool Session::ReadPacket(Store&& store,
     Close();
   }
   return false;
+}
+
+void Session::SendBatch(Packet::Ptr* packets,
+                        PathStorage* paths,
+                        size_t count) {
+  DCHECK(!is_destroyed());
+  if (count == 0) return;
+
+  // Separate packets into those going to the primary endpoint and those
+  // redirected to other endpoints (rare: path validation, preferred address).
+  // Redirected packets are sent individually via the target endpoint.
+  static constexpr size_t kMaxBatch = 64;
+  DCHECK_LE(count, kMaxBatch);
+  Packet::Ptr primary_packets[kMaxBatch];
+  size_t primary_count = 0;
+
+  for (size_t i = 0; i < count; i++) {
+    if (!packets[i] || !can_send_packets()) {
+      packets[i].reset();
+      continue;
+    }
+
+    UpdatePath(paths[i]);
+
+    // Check for cross-endpoint redirect.
+    bool redirected = false;
+    if (paths[i].path.local.addrlen > 0) {
+      SocketAddress local_addr(paths[i].path.local.addr);
+      auto& mgr = BindingData::Get(env()).session_manager();
+      Endpoint* target = mgr.FindEndpointForAddress(local_addr);
+      if (target != nullptr && target != &endpoint()) {
+        SocketAddress remote_addr(paths[i].path.remote.addr);
+        packets[i]->Redirect(static_cast<Packet::Listener*>(target),
+                             remote_addr);
+        target->Send(std::move(packets[i]));
+        redirected = true;
+      }
+    }
+
+    if (!redirected) {
+      primary_packets[primary_count++] = std::move(packets[i]);
+    }
+  }
+
+  if (primary_count == 0) return;
+
+  // Use batched send for the primary endpoint.
+  if (prefer_try_send_) {
+    endpoint().SendBatch(primary_packets, primary_count);
+  } else {
+    // Non-flush path: send individually via async uv_udp_send.
+    for (size_t i = 0; i < primary_count; i++) {
+      Send(std::move(primary_packets[i]));
+    }
+  }
 }
 
 void Session::FlushPendingData() {

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -197,6 +197,46 @@ struct Session::State final {
 
 STAT_STRUCT(Session, SESSION)
 
+using SessionStateArena = AliasedStructArena<Session::State>;
+using SessionStatsArena = AliasedStructArena<Session::Stats>;
+
+// Session uses arena-allocated stats, not AliasedStruct, so override the
+// STAT_* macros to use impl_->stats() instead of stats_.Data().
+#undef STAT_INCREMENT
+#undef STAT_INCREMENT_N
+#undef STAT_RECORD_TIMESTAMP
+#undef STAT_SET
+#undef STAT_GET
+#define STAT_INCREMENT(Type, name)                                             \
+  IncrementStat<Type, &Type::name>(impl_->stats());
+#define STAT_INCREMENT_N(Type, name, amt)                                      \
+  IncrementStat<Type, &Type::name>(impl_->stats(), amt);
+#define STAT_RECORD_TIMESTAMP(Type, name)                                      \
+  RecordTimestampStat<Type, &Type::name>(impl_->stats());
+#define STAT_SET(Type, name, val)                                              \
+  SetStat<Type, &Type::name>(impl_->stats(), val)
+#define STAT_GET(Type, name) GetStat<Type, &Type::name>(impl_->stats())
+
+namespace {
+SessionStateArena& GetSessionStateArena(BindingData& binding) {
+  if (!binding.session_state_arena_) {
+    auto* arena = new SessionStateArena();
+    binding.session_state_arena_ = BindingData::ArenaPtr(
+        arena, +[](void* p) { delete static_cast<SessionStateArena*>(p); });
+  }
+  return *static_cast<SessionStateArena*>(binding.session_state_arena_.get());
+}
+
+SessionStatsArena& GetSessionStatsArena(BindingData& binding) {
+  if (!binding.session_stats_arena_) {
+    auto* arena = new SessionStatsArena();
+    binding.session_stats_arena_ = BindingData::ArenaPtr(
+        arena, +[](void* p) { delete static_cast<SessionStatsArena*>(p); });
+  }
+  return *static_cast<SessionStatsArena*>(binding.session_stats_arena_.get());
+}
+}  // namespace
+
 // ============================================================================
 
 class Http3Application;
@@ -712,8 +752,8 @@ std::string Session::Options::ToString() const {
 // Session::Impl maintains most of the internal state of an active Session.
 struct Session::Impl final : public MemoryRetainer {
   Session* session_;
-  AliasedStruct<Stats> stats_;
-  AliasedStruct<State> state_;
+  ArenaSlotBase stats_slot_;
+  ArenaSlotBase state_slot_;
   BaseObjectWeakPtr<Endpoint> endpoint_;
   Config config_;
   SocketAddress local_address_;
@@ -741,20 +781,30 @@ struct Session::Impl final : public MemoryRetainer {
   // and the stream/datagram data is included in the 0-RTT flight.
   bool handshake_deferred_ = false;
 
+  Stats* stats() { return static_cast<Stats*>(stats_slot_.ptr); }
+  const Stats* stats() const {
+    return static_cast<const Stats*>(stats_slot_.ptr);
+  }
+  State* state() { return static_cast<State*>(state_slot_.ptr); }
+  const State* state() const {
+    return static_cast<const State*>(state_slot_.ptr);
+  }
+
   Impl(Session* session, Endpoint* endpoint, const Config& config)
       : session_(session),
-        stats_(env()->isolate()),
-        state_(env()->isolate()),
         endpoint_(endpoint),
         config_(config),
         local_address_(config.local_address),
         remote_address_(config.remote_address),
         timer_(session_->env(), [this] { session_->OnTimeout(); }) {
+    auto& binding = BindingData::Get(env());
+    stats_slot_ = GetSessionStatsArena(binding).Allocate(env()->isolate());
+    state_slot_ = GetSessionStateArena(binding).Allocate(env()->isolate());
     timer_.Unref();
   }
   DISALLOW_COPY_AND_MOVE(Impl)
 
-  inline bool is_closing() const { return state_->closing; }
+  inline bool is_closing() const { return state()->closing; }
 
   ~Impl() {
     // Ensure that Close() was called before dropping
@@ -790,6 +840,10 @@ struct Session::Impl final : public MemoryRetainer {
     }
 
     endpoint->RemoveSession(config_.scid, remote_address_);
+
+    auto& binding = BindingData::Get(env());
+    if (stats_slot_) GetSessionStatsArena(binding).ReleaseSlot(stats_slot_);
+    if (state_slot_) GetSessionStateArena(binding).ReleaseSlot(state_slot_);
   }
 
   void MemoryInfo(MemoryTracker* tracker) const override {
@@ -1309,7 +1363,7 @@ struct Session::Impl final : public MemoryRetainer {
     // NGTCP2_ERR_DRAINING. The actual close handling happens in
     // Session::Receive when it processes that return value and
     // checks this flag.
-    session->impl_->state_->stateless_reset = 1;
+    session->impl_->state()->stateless_reset = 1;
     return NGTCP2_SUCCESS;
   }
 
@@ -1634,10 +1688,7 @@ Session::Session(Endpoint* endpoint,
       connection_(InitConnection()),
       tls_session_(tls_context->NewSession(this, session_ticket)) {
   DCHECK(impl_);
-  {
-    auto& stats_ = impl_->stats_;
-    STAT_RECORD_TIMESTAMP(Stats, created_at);
-  }
+  STAT_RECORD_TIMESTAMP(Stats, created_at);
 
   // For clients, select the Application immediately — the ALPN is
   // known upfront from the options. For servers, application_ stays
@@ -1666,10 +1717,33 @@ Session::Session(Endpoint* endpoint,
   MakeWeak();
   Debug(this, "Session created.");
 
-  JS_DEFINE_READONLY_PROPERTY(
-      env(), object, env()->stats_string(), impl_->stats_.GetArrayBuffer());
-  JS_DEFINE_READONLY_PROPERTY(
-      env(), object, env()->state_string(), impl_->state_.GetArrayBuffer());
+  {
+    const v8::HandleScope handle_scope(env()->isolate());
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        env()->state_string(),
+        impl_->state_slot_.GetPageDataView(env()->isolate()));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        FIXED_ONE_BYTE_STRING(env()->isolate(), "stateByteOffset"),
+        v8::Integer::NewFromUnsigned(
+            env()->isolate(),
+            static_cast<uint32_t>(impl_->state_slot_.GetByteOffset())));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        env()->stats_string(),
+        impl_->stats_slot_.GetPageBigUint64Array(env()->isolate()));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        FIXED_ONE_BYTE_STRING(env()->isolate(), "statsByteOffset"),
+        v8::Integer::NewFromUnsigned(
+            env()->isolate(),
+            static_cast<uint32_t>(impl_->stats_slot_.GetByteOffset())));
+  }
 
   UpdateDataStats();
 }
@@ -1737,12 +1811,11 @@ bool Session::is_destroyed() const {
 }
 
 bool Session::is_destroyed_or_closing() const {
-  return !impl_ || impl_->state_->closing;
+  return !impl_ || impl_->state()->closing;
 }
 
 void Session::Close(CloseMethod method) {
   if (is_destroyed()) return;
-  auto& stats_ = impl_->stats_;
 
   // If the handshake was deferred (0-RTT client that never sent),
   // no packets were ever transmitted. Close silently since there is
@@ -1757,7 +1830,7 @@ void Session::Close(CloseMethod method) {
   }
 
   STAT_RECORD_TIMESTAMP(Stats, closing_at);
-  impl_->state_->closing = 1;
+  impl_->state()->closing = 1;
 
   // With both the DEFAULT and SILENT options, we will proceed to closing
   // the session immediately. All open streams will be immediately destroyed
@@ -1773,27 +1846,27 @@ void Session::Close(CloseMethod method) {
   switch (method) {
     case CloseMethod::DEFAULT: {
       Debug(this, "Immediately closing session");
-      impl_->state_->silent_close = 0;
+      impl_->state()->silent_close = 0;
       return FinishClose();
     }
     case CloseMethod::SILENT: {
       Debug(this, "Immediately closing session silently");
-      impl_->state_->silent_close = 1;
+      impl_->state()->silent_close = 1;
       return FinishClose();
     }
     case CloseMethod::GRACEFUL: {
       // If we are already closing gracefully, do nothing.
-      if (impl_->state_->graceful_close) [[unlikely]] {
+      if (impl_->state()->graceful_close) [[unlikely]] {
         return;
       }
-      impl_->state_->graceful_close = 1;
+      impl_->state()->graceful_close = 1;
 
       // application_ may be null for server sessions if close() is called
       // before the TLS handshake selects the ALPN. Without an application
       // we cannot do a graceful shutdown (GOAWAY, CONNECTION_CLOSE etc.),
       // so fall through to a silent close.
       if (!impl_->application_) {
-        impl_->state_->silent_close = 1;
+        impl_->state()->silent_close = 1;
         return FinishClose();
       }
 
@@ -1811,7 +1884,7 @@ void Session::Close(CloseMethod method) {
       // If there are no open streams, then we can close immediately and
       // not worry about waiting around.
       if (impl_->streams_.empty()) {
-        impl_->state_->silent_close = 0;
+        impl_->state()->silent_close = 0;
         return FinishClose();
       }
 
@@ -1855,11 +1928,11 @@ void Session::FinishClose() {
   // trigger MakeCallback (stream destruction, pending queue rejection,
   // SendConnectionClose, EmitClose).
   if (is_destroyed()) return;
-  DCHECK(impl_->state_->closing);
+  DCHECK(impl_->state()->closing);
 
   // Clear the graceful_close flag to prevent RemoveStream() from
   // re-entering FinishClose() when we destroy streams below.
-  impl_->state_->graceful_close = 0;
+  impl_->state()->graceful_close = 0;
 
   // Destroy all open streams immediately. We copy the map because
   // streams remove themselves during destruction. Each Destroy() call
@@ -1881,7 +1954,7 @@ void Session::FinishClose() {
 
   // Send final application-level shutdown and CONNECTION_CLOSE
   // unless this is a silent close.
-  if (!impl_->state_->silent_close) {
+  if (!impl_->state()->silent_close) {
     if (impl_->application_) {
       application().CompleteShutdown();
     }
@@ -1894,7 +1967,7 @@ void Session::FinishClose() {
   // If the session was passed to JavaScript, we need to round-trip
   // through JS so it can clean up before we destroy. The JS side
   // will synchronously call destroy(), which calls Session::Destroy().
-  if (impl_->state_->wrapped) {
+  if (impl_->state()->wrapped) {
     EmitClose(impl_->last_error_);
   } else {
     Destroy();
@@ -1906,7 +1979,7 @@ void Session::Destroy() {
   // Ensure the closing flag is set for the ~Impl() DCHECK. Normally
   // this is set by Session::Close(), but JS destroy() can be called
   // directly without going through Close() first.
-  impl_->state_->closing = 1;
+  impl_->state()->closing = 1;
 
   // If we're inside a ngtcp2 or nghttp3 callback scope, we cannot
   // destroy impl_ now because the callback is executing methods on
@@ -1919,10 +1992,7 @@ void Session::Destroy() {
   }
 
   Debug(this, "Session destroyed");
-  {
-    auto& stats_ = impl_->stats_;
-    STAT_RECORD_TIMESTAMP(Stats, destroyed_at);
-  }
+  STAT_RECORD_TIMESTAMP(Stats, destroyed_at);
   impl_.reset();
 }
 
@@ -1998,16 +2068,16 @@ void Session::SetApplication(std::unique_ptr<Application> app) {
       return;
     }
   }
-  impl_->state_->application_type = static_cast<uint8_t>(app->type());
-  impl_->state_->headers_supported = static_cast<uint8_t>(
+  impl_->state()->application_type = static_cast<uint8_t>(app->type());
+  impl_->state()->headers_supported = static_cast<uint8_t>(
       app->SupportsHeaders() ? HeadersSupportState::SUPPORTED
                              : HeadersSupportState::UNSUPPORTED);
   // Surface the application's "no error" and "internal error" codes via
   // session state so that JS-side code (e.g. the stream writer's fail()
   // path) can resolve the right wire code for the negotiated ALPN
   // without duplicating the per-application table.
-  impl_->state_->no_error_code = app->GetNoErrorCode();
-  impl_->state_->internal_error_code = app->GetInternalErrorCode();
+  impl_->state()->no_error_code = app->GetNoErrorCode();
+  impl_->state()->internal_error_code = app->GetInternalErrorCode();
   impl_->application_ = std::move(app);
 }
 
@@ -2165,7 +2235,6 @@ bool Session::ReadPacket(const uint8_t* data,
     case 0: {
       Debug(this, "Session successfully received %zu-byte packet", len);
       if (!is_destroyed()) [[likely]] {
-        auto& stats_ = impl_->stats_;
         STAT_INCREMENT_N(Stats, bytes_received, len);
         // Process deferred operations that couldn't run inside callback
         // scopes (e.g., HTTP/3 GOAWAY handling that calls into JS).
@@ -2197,7 +2266,7 @@ bool Session::ReadPacket(const uint8_t* data,
       //    There is no point in waiting for a draining period — the
       //    peer has no state. Close immediately with an error.
       if (!is_destroyed()) [[likely]] {
-        if (impl_->state_->stateless_reset) {
+        if (impl_->state()->stateless_reset) {
           Debug(this, "Session received stateless reset, closing");
           SetLastError(QuicError::ForNgtcp2Error(NGTCP2_ERR_DRAINING));
           Close(CloseMethod::SILENT);
@@ -2428,10 +2497,10 @@ datagram_id Session::SendDatagram(Store&& data) {
   }
 
   // Assign the datagram ID.
-  datagram_id did = ++impl_->state_->last_datagram_id;
+  datagram_id did = ++impl_->state()->last_datagram_id;
 
   // Check queue capacity. Apply the drop policy when full.
-  auto max_pending = impl_->state_->max_pending_datagrams;
+  auto max_pending = impl_->state()->max_pending_datagrams;
   if (max_pending > 0 && impl_->pending_datagrams_.size() >= max_pending) {
     auto drop_policy = impl_->config_.options.datagram_drop_policy;
     if (drop_policy == DatagramDropPolicy::DROP_OLDEST) {
@@ -2602,7 +2671,6 @@ void Session::AddStream(BaseObjectPtr<Stream> stream,
 
   // Update tracking statistics for the number of streams associated with this
   // session.
-  auto& stats_ = impl_->stats_;
   if (ngtcp2_conn_is_local_stream(*this, id)) {
     switch (direction) {
       case Direction::BIDIRECTIONAL: {
@@ -2654,7 +2722,7 @@ void Session::RemoveStream(stream_id id) {
   // then we can proceed to finishing the close now. Note that the
   // expectation is that the session will be destroyed once FinishClose
   // returns.
-  if (impl_->state_->closing && impl_->state_->graceful_close) {
+  if (impl_->state()->closing && impl_->state()->graceful_close) {
     FinishClose();
     CHECK(is_destroyed());
   }
@@ -2692,7 +2760,6 @@ void Session::ShutdownStreamWrite(stream_id id, QuicError code) {
 
 void Session::StreamDataBlocked(stream_id id) {
   DCHECK(!is_destroyed());
-  auto& stats_ = impl_->stats_;
   STAT_INCREMENT(Stats, block_count);
   application().BlockStream(id);
 }
@@ -2763,20 +2830,20 @@ bool Session::is_in_draining_period() const {
 
 bool Session::wants_session_ticket() const {
   return !is_destroyed() &&
-         HasListenerFlag(impl_->state_->listener_flags,
+         HasListenerFlag(impl_->state()->listener_flags,
                          SessionListenerFlags::SESSION_TICKET);
 }
 
 void Session::SetStreamOpenAllowed() {
   DCHECK(!is_destroyed());
-  impl_->state_->stream_open_allowed = 1;
+  impl_->state()->stream_open_allowed = 1;
 }
 
 void Session::PopulateEarlyTransportParamsState() {
   DCHECK(!is_destroyed());
   const ngtcp2_transport_params* tp = remote_transport_params();
   if (tp != nullptr) {
-    impl_->state_->max_datagram_size =
+    impl_->state()->max_datagram_size =
         MaxDatagramPayload(tp->max_datagram_frame_size);
   }
 }
@@ -2797,7 +2864,7 @@ bool Session::can_create_streams() const {
 }
 
 bool Session::can_open_streams() const {
-  return !is_destroyed() && impl_->state_->stream_open_allowed;
+  return !is_destroyed() && impl_->state()->stream_open_allowed;
 }
 
 uint64_t Session::max_data_left() const {
@@ -2818,12 +2885,12 @@ uint64_t Session::max_local_streams_bidi() const {
 
 void Session::set_wrapped() {
   DCHECK(!is_destroyed());
-  impl_->state_->wrapped = 1;
+  impl_->state()->wrapped = 1;
 }
 
 void Session::set_priority_supported(bool on) {
   DCHECK(!is_destroyed());
-  impl_->state_->priority_supported = on ? 1 : 0;
+  impl_->state()->priority_supported = on ? 1 : 0;
 }
 
 void Session::ExtendStreamOffset(stream_id id, size_t amount) {
@@ -2856,14 +2923,13 @@ size_t Session::PendingDatagramCount() const {
 
 void Session::DatagramSent(datagram_id id) {
   Debug(this, "Datagram %" PRIu64 " sent", id);
-  auto& stats_ = impl_->stats_;
   STAT_INCREMENT(Stats, datagrams_sent);
 }
 
 void Session::UpdateDataStats() {
   if (is_destroyed()) return;
   Debug(this, "Updating data stats");
-  auto& stats_ = impl_->stats_;
+
   ngtcp2_conn_info info;
   ngtcp2_conn_get_conn_info(*this, &info);
   STAT_SET(Stats, bytes_in_flight, info.bytes_in_flight);
@@ -3017,7 +3083,7 @@ void Session::UpdateTimer() {
 void Session::DatagramStatus(datagram_id datagramId,
                              quic::DatagramStatus status) {
   DCHECK(!is_destroyed());
-  auto& stats_ = impl_->stats_;
+
   switch (status) {
     case DatagramStatus::ACKNOWLEDGED: {
       Debug(this, "Datagram %" PRIu64 " was acknowledged", datagramId);
@@ -3035,7 +3101,7 @@ void Session::DatagramStatus(datagram_id datagramId,
       break;
     }
   }
-  if (HasListenerFlag(impl_->state_->listener_flags,
+  if (HasListenerFlag(impl_->state()->listener_flags,
                       SessionListenerFlags::DATAGRAM_STATUS)) {
     EmitDatagramStatus(datagramId, status);
   }
@@ -3047,13 +3113,13 @@ void Session::DatagramReceived(const uint8_t* data,
   DCHECK(!is_destroyed());
   // If there is nothing watching for the datagram on the JavaScript side,
   // or if the datagram is zero-length, we just drop it on the floor.
-  if (!HasListenerFlag(impl_->state_->listener_flags,
+  if (!HasListenerFlag(impl_->state()->listener_flags,
                        SessionListenerFlags::DATAGRAM) ||
       datalen == 0)
     return;
 
   Debug(this, "Session is receiving datagram of size %zu", datalen);
-  auto& stats_ = impl_->stats_;
+
   STAT_INCREMENT(Stats, datagrams_received);
   JS_TRY_ALLOCATE_BACKING(env(), backing, datalen)
   memcpy(backing->Data(), data, datalen);
@@ -3074,18 +3140,18 @@ void Session::GenerateNewConnectionId(ngtcp2_cid* cid,
 
 bool Session::HandshakeCompleted() {
   DCHECK(!is_destroyed());
-  DCHECK(!impl_->state_->handshake_completed);
+  DCHECK(!impl_->state()->handshake_completed);
 
   Debug(this, "Session handshake completed");
-  impl_->state_->handshake_completed = 1;
-  auto& stats_ = impl_->stats_;
+  impl_->state()->handshake_completed = 1;
+
   STAT_RECORD_TIMESTAMP(Stats, handshake_completed_at);
   SetStreamOpenAllowed();
 
   // Capture the peer's max datagram frame size from the remote transport
   // parameters so JavaScript can check it without a C++ round-trip.
   const ngtcp2_transport_params* tp = remote_transport_params();
-  impl_->state_->max_datagram_size =
+  impl_->state()->max_datagram_size =
       MaxDatagramPayload(tp->max_datagram_frame_size);
 
   // If early data was attempted but rejected by the server,
@@ -3120,10 +3186,10 @@ bool Session::HandshakeCompleted() {
 
 void Session::HandshakeConfirmed() {
   DCHECK(!is_destroyed());
-  DCHECK(!impl_->state_->handshake_confirmed);
+  DCHECK(!impl_->state()->handshake_confirmed);
   Debug(this, "Session handshake confirmed");
-  impl_->state_->handshake_confirmed = 1;
-  auto& stats_ = impl_->stats_;
+  impl_->state()->handshake_confirmed = 1;
+
   STAT_RECORD_TIMESTAMP(Stats, handshake_confirmed_at);
 }
 
@@ -3261,7 +3327,7 @@ void Session::EmitClose(const QuicError& error) {
 
 void Session::set_max_datagram_size(uint16_t size) {
   if (!is_destroyed()) {
-    impl_->state_->max_datagram_size = size;
+    impl_->state()->max_datagram_size = size;
   }
 }
 
@@ -3376,7 +3442,7 @@ void Session::EmitPathValidation(PathValidationResult result,
 
   if (!env()->can_call_into_js()) return;
 
-  if (!HasListenerFlag(impl_->state_->listener_flags,
+  if (!HasListenerFlag(impl_->state()->listener_flags,
                        SessionListenerFlags::PATH_VALIDATION)) [[likely]] {
     return;
   }
@@ -3422,7 +3488,7 @@ void Session::EmitSessionTicket(Store&& ticket) {
 
   // If there is nothing listening for the session ticket, don't bother
   // emitting.
-  if (!HasListenerFlag(impl_->state_->listener_flags,
+  if (!HasListenerFlag(impl_->state()->listener_flags,
                        SessionListenerFlags::SESSION_TICKET)) [[likely]] {
     Debug(this, "Session ticket was discarded");
     return;
@@ -3479,7 +3545,7 @@ void Session::EmitEarlyDataRejected() {
 
 void Session::EmitNewToken(const uint8_t* token, size_t len) {
   DCHECK(!is_destroyed());
-  if (!HasListenerFlag(impl_->state_->listener_flags,
+  if (!HasListenerFlag(impl_->state()->listener_flags,
                        SessionListenerFlags::NEW_TOKEN))
     return;
   if (!env()->can_call_into_js()) return;
@@ -3555,7 +3621,7 @@ void Session::EmitVersionNegotiation(const ngtcp2_pkt_hd& hd,
 
 void Session::EmitOrigins(std::vector<std::string>&& origins) {
   DCHECK(!is_destroyed());
-  if (!HasListenerFlag(impl_->state_->listener_flags,
+  if (!HasListenerFlag(impl_->state()->listener_flags,
                        SessionListenerFlags::ORIGIN))
     return;
   if (!env()->can_call_into_js()) return;

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2103,19 +2103,21 @@ void Session::SetLastError(QuicError&& error) {
 
 bool Session::Receive(Store&& store,
                       const SocketAddress& local_address,
-                      const SocketAddress& remote_address) {
+                      const SocketAddress& remote_address,
+                      const PacketInfo& pkt_info) {
   // Convenience wrapper: reads the packet and immediately triggers
   // SendPendingData. Used by paths that need an immediate response
   // (e.g., Endpoint::Connect for client Initial packets).
   // The hot receive path uses ReadPacket() directly with deferred
   // flush via BindingData's uv_check callback.
   SendPendingDataScope send_scope(this);
-  return ReadPacket(std::move(store), local_address, remote_address);
+  return ReadPacket(std::move(store), local_address, remote_address, pkt_info);
 }
 
 bool Session::ReadPacket(Store&& store,
                          const SocketAddress& local_address,
-                         const SocketAddress& remote_address) {
+                         const SocketAddress& remote_address,
+                         const PacketInfo& pkt_info) {
   DCHECK(!is_destroyed());
   impl_->remote_address_ = remote_address;
 
@@ -2137,12 +2139,12 @@ bool Session::ReadPacket(Store&& store,
   int err;
   {
     NgTcp2CallbackScope callback_scope(this);
-    // ECN codepoint (ngtcp2_pkt_info.ecn) is not yet populated because
-    // libuv does not currently deliver per-packet ECN metadata. When
-    // libuv gains ECN receive reporting, the pkt_info should be
-    // populated from the per-packet metadata and passed through here.
+    // The PacketInfo carries per-packet metadata (currently ECN codepoint).
+    // When libuv gains per-packet ECN reporting, the caller should
+    // populate pkt_info from the receive metadata before calling
+    // ReadPacket().
     err = ngtcp2_conn_read_pkt(
-        *this, &path, nullptr, vec.base, vec.len, uv_hrtime());
+        *this, &path, pkt_info, vec.base, vec.len, uv_hrtime());
   }
   if (is_destroyed()) return false;
 

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -3018,6 +3018,15 @@ void Session::SendConnectionClose() {
 void Session::OnTimeout() {
   if (is_destroyed()) return;
   if (!impl_->application_) return;
+  // Hold a strong reference to prevent the Session from being freed during
+  // re-entrant calls. SendPendingData's scope guard calls UpdateTimer(),
+  // which can synchronously re-enter OnTimeout() when the timer has already
+  // expired. That re-entrant path can reach FinishClose → EmitClose →
+  // Destroy → impl_.reset() → ~Impl → RemoveSession(), dropping the last
+  // BaseObjectPtr from the endpoint map and freeing the Session. Without
+  // this guard, the outer OnTimeout / SendPendingData frames would operate
+  // on a freed object.
+  BaseObjectPtr<Session> ref(this);
   HandleScope scope(env()->isolate());
   int ret;
   {

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -193,6 +193,7 @@ uint64_t MaxDatagramPayload(uint64_t max_frame_size) {
   V(SendDatagram, sendDatagram, SIDE_EFFECT)                                   \
   V(LocalTransportParams, localTransportParams, NO_SIDE_EFFECT)                \
   V(RemoteTransportParams, remoteTransportParams, NO_SIDE_EFFECT)              \
+  V(ApplicationOptions, applicationOptions, NO_SIDE_EFFECT)
 
 struct Session::State final {
 #define V(_, name, type) type name;
@@ -1195,6 +1196,24 @@ struct Session::Impl final : public MemoryRetainer {
       args.GetReturnValue().Set(obj);
     }
   }
+
+  JS_METHOD(ApplicationOptions) {
+    auto env = Environment::GetCurrent(args);
+    Session* session;
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
+
+    Local<Object> obj;
+    if (!session->has_application()) {
+      // The application has not yet been selected (ALPN negotiation is not
+      // yet complete on the server) or the session has been destroyed. In
+      // either case, the application options are not available.
+      return args.GetReturnValue().SetUndefined();
+    }
+    auto& options = session->application().options();
+    if (options.ToObject(env).ToLocal(&obj)) {
+      args.GetReturnValue().Set(obj);
+    }
+  }
   // Internal ngtcp2 callbacks
 
   static int on_acknowledge_stream_data_offset(ngtcp2_conn* conn,
@@ -2072,6 +2091,10 @@ Endpoint& Session::endpoint() const {
 TLSSession& Session::tls_session() const {
   DCHECK(!is_destroyed());
   return *tls_session_;
+}
+
+bool Session::has_application() const {
+  return !is_destroyed() && impl_->application_ != nullptr;
 }
 
 Session::Application& Session::application() const {

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2104,20 +2104,23 @@ void Session::SetLastError(QuicError&& error) {
 bool Session::Receive(Store&& store,
                       const SocketAddress& local_address,
                       const SocketAddress& remote_address,
-                      const PacketInfo& pkt_info) {
+                      const PacketInfo& pkt_info,
+                      uint64_t ts) {
   // Convenience wrapper: reads the packet and immediately triggers
   // SendPendingData. Used by paths that need an immediate response
   // (e.g., Endpoint::Connect for client Initial packets).
   // The hot receive path uses ReadPacket() directly with deferred
   // flush via BindingData's uv_check callback.
   SendPendingDataScope send_scope(this);
-  return ReadPacket(std::move(store), local_address, remote_address, pkt_info);
+  return ReadPacket(
+      std::move(store), local_address, remote_address, pkt_info, ts);
 }
 
 bool Session::ReadPacket(Store&& store,
                          const SocketAddress& local_address,
                          const SocketAddress& remote_address,
-                         const PacketInfo& pkt_info) {
+                         const PacketInfo& pkt_info,
+                         uint64_t ts) {
   DCHECK(!is_destroyed());
   impl_->remote_address_ = remote_address;
 
@@ -2143,8 +2146,12 @@ bool Session::ReadPacket(Store&& store,
     // When libuv gains per-packet ECN reporting, the caller should
     // populate pkt_info from the receive metadata before calling
     // ReadPacket().
+    // When ts is 0 (the default), call uv_hrtime() here. The batched
+    // receive path caches a timestamp and passes it to all ReadPacket()
+    // calls in the same I/O burst.
+    if (ts == 0) ts = uv_hrtime();
     err = ngtcp2_conn_read_pkt(
-        *this, &path, pkt_info, vec.base, vec.len, uv_hrtime());
+        *this, &path, pkt_info, vec.base, vec.len, ts);
   }
   if (is_destroyed()) return false;
 

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -1810,7 +1810,7 @@ bool Session::is_server() const {
 }
 
 bool Session::is_destroyed() const {
-  return !impl_ || destroy_deferred_;
+  return !impl_ || flags_.destroy_deferred;
 }
 
 bool Session::is_destroyed_or_closing() const {
@@ -1988,9 +1988,9 @@ void Session::Destroy() {
   // destroy impl_ now because the callback is executing methods on
   // objects owned by impl_ (e.g., the Application). Defer the
   // destruction until the scope exits.
-  if (in_ngtcp2_callback_scope_ || in_nghttp3_callback_scope_) {
+  if (flags_.in_ngtcp2_callback_scope || flags_.in_nghttp3_callback_scope) {
     Debug(this, "Session destroy deferred (in callback scope)");
-    destroy_deferred_ = true;
+    flags_.destroy_deferred = true;
     return;
   }
 
@@ -2131,8 +2131,8 @@ void Session::EmitQlog(uint32_t flags, std::string_view data) {
   if (is_destroyed()) {
     auto isolate = env()->isolate();
     Global<Object> recv(isolate, object());
-    Global<Function> cb(
-        isolate, BindingData::Get(env()).session_qlog_callback());
+    Global<Function> cb(isolate,
+                        BindingData::Get(env()).session_qlog_callback());
     std::string buf(data);
     env()->SetImmediate([recv = std::move(recv),
                          cb = std::move(cb),
@@ -2381,7 +2381,7 @@ void Session::SendBatch(Packet::Ptr* packets,
   if (primary_count == 0) return;
 
   // Use batched send for the primary endpoint.
-  if (prefer_try_send_) {
+  if (flags_.prefer_try_send) {
     endpoint().SendBatch(primary_packets, primary_count);
   } else {
     // Non-flush path: send individually via async uv_udp_send.
@@ -2396,9 +2396,9 @@ void Session::FlushPendingData() {
   if (impl_->application_) {
     // Prefer synchronous sends during the deferred flush to avoid the
     // one-tick latency of async uv_udp_send from the uv_check callback.
-    prefer_try_send_ = true;
+    flags_.prefer_try_send = true;
     application().SendPendingData();
-    prefer_try_send_ = false;
+    flags_.prefer_try_send = false;
   }
 }
 
@@ -2422,7 +2422,7 @@ void Session::Send(Packet::Ptr packet) {
   // prefer synchronous send to avoid the one-tick latency of async
   // uv_udp_send. SendOrTrySend uses uv_udp_try_send first, falling
   // back to uv_udp_send on EAGAIN.
-  if (prefer_try_send_) {
+  if (flags_.prefer_try_send) {
     Debug(this, "Session is sending (try_send) %s", packet->ToString());
     endpoint().SendOrTrySend(std::move(packet));
     return;
@@ -2857,7 +2857,7 @@ bool Session::can_send_packets() const {
   // or closing period. The callback scope check is per-session so that
   // one session's ngtcp2 callback does not block unrelated sessions
   // from sending.
-  return !is_destroyed() && !in_ngtcp2_callback_scope_ &&
+  return !is_destroyed() && !flags_.in_ngtcp2_callback_scope &&
          !is_in_draining_period() && !is_in_closing_period();
 }
 

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2101,7 +2101,8 @@ void Session::SetLastError(QuicError&& error) {
   impl_->last_error_ = std::move(error);
 }
 
-bool Session::Receive(Store&& store,
+bool Session::Receive(const uint8_t* data,
+                      size_t len,
                       const SocketAddress& local_address,
                       const SocketAddress& remote_address,
                       const PacketInfo& pkt_info,
@@ -2112,11 +2113,11 @@ bool Session::Receive(Store&& store,
   // The hot receive path uses ReadPacket() directly with deferred
   // flush via BindingData's uv_check callback.
   SendPendingDataScope send_scope(this);
-  return ReadPacket(
-      std::move(store), local_address, remote_address, pkt_info, ts);
+  return ReadPacket(data, len, local_address, remote_address, pkt_info, ts);
 }
 
-bool Session::ReadPacket(Store&& store,
+bool Session::ReadPacket(const uint8_t* data,
+                         size_t len,
                          const SocketAddress& local_address,
                          const SocketAddress& remote_address,
                          const PacketInfo& pkt_info,
@@ -2124,12 +2125,11 @@ bool Session::ReadPacket(Store&& store,
   DCHECK(!is_destroyed());
   impl_->remote_address_ = remote_address;
 
-  ngtcp2_vec vec = store;
   Path path(local_address, remote_address);
 
   Debug(this,
         "Session is receiving %zu-byte packet received along path %s",
-        vec.len,
+        len,
         path);
 
   // It is important to understand that reading the packet will cause
@@ -2150,19 +2150,18 @@ bool Session::ReadPacket(Store&& store,
     // receive path caches a timestamp and passes it to all ReadPacket()
     // calls in the same I/O burst.
     if (ts == 0) ts = uv_hrtime();
-    err = ngtcp2_conn_read_pkt(
-        *this, &path, pkt_info, vec.base, vec.len, ts);
+    err = ngtcp2_conn_read_pkt(*this, &path, pkt_info, data, len, ts);
   }
   if (is_destroyed()) return false;
 
-  Debug(this, "Session receiving %zu-byte packet with result %d", vec.len, err);
+  Debug(this, "Session receiving %zu-byte packet with result %d", len, err);
 
   switch (err) {
     case 0: {
-      Debug(this, "Session successfully received %zu-byte packet", vec.len);
+      Debug(this, "Session successfully received %zu-byte packet", len);
       if (!is_destroyed()) [[likely]] {
         auto& stats_ = impl_->stats_;
-        STAT_INCREMENT_N(Stats, bytes_received, vec.len);
+        STAT_INCREMENT_N(Stats, bytes_received, len);
         // Process deferred operations that couldn't run inside callback
         // scopes (e.g., HTTP/3 GOAWAY handling that calls into JS).
         application().PostReceive();

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -513,6 +513,12 @@ Session::Config::Config(Environment* env,
       options.handshake_timeout == UINT64_MAX
           ? UINT64_MAX
           : options.handshake_timeout * NGTCP2_MILLISECONDS;
+
+  // The initial_rtt option is in milliseconds; ngtcp2 expects nanoseconds.
+  // A value of 0 leaves the ngtcp2 default (333ms) unchanged.
+  if (options.initial_rtt > 0)
+    settings.initial_rtt = options.initial_rtt * NGTCP2_MILLISECONDS;
+
   settings.max_stream_window = options.max_stream_window;
   settings.max_window = options.max_window;
   settings.ack_thresh = options.unacknowledged_packet_threshold;
@@ -604,10 +610,11 @@ Maybe<Session::Options> Session::Options::From(Environment* env,
 
   if (!SET(version) || !SET(min_version) || !SET(preferred_address_strategy) ||
       !SET(transport_params) || !SET(tls_options) || !SET(qlog) ||
-      !SET(handshake_timeout) || !SET(keep_alive_timeout) ||
-      !SET(max_stream_window) || !SET(max_window) || !SET(max_payload_size) ||
-      !SET(unacknowledged_packet_threshold) || !SET(cc_algorithm) ||
-      !SET(draining_period_multiplier) || !SET(max_datagram_send_attempts)) {
+      !SET(handshake_timeout) || !SET(initial_rtt) ||
+      !SET(keep_alive_timeout) || !SET(max_stream_window) || !SET(max_window) ||
+      !SET(max_payload_size) || !SET(unacknowledged_packet_threshold) ||
+      !SET(cc_algorithm) || !SET(draining_period_multiplier) ||
+      !SET(max_datagram_send_attempts)) {
     return Nothing<Options>();
   }
 
@@ -725,6 +732,12 @@ std::string Session::Options::ToString() const {
   } else {
     res += prefix + "handshake timeout: " + std::to_string(handshake_timeout) +
            " nanoseconds";
+  }
+  if (initial_rtt > 0) {
+    res += prefix + "initial rtt: " + std::to_string(initial_rtt) +
+           " milliseconds";
+  } else {
+    res += prefix + "initial rtt: <default>";
   }
   res += prefix + "max stream window: " + std::to_string(max_stream_window);
   res += prefix + "max window: " + std::to_string(max_window);

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -40,7 +40,9 @@ using v8::Array;
 using v8::ArrayBufferView;
 using v8::BigInt;
 using v8::Boolean;
+using v8::Function;
 using v8::FunctionCallbackInfo;
+using v8::Global;
 using v8::HandleScope;
 using v8::Int32;
 using v8::Integer;
@@ -54,6 +56,7 @@ using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::String;
+using v8::Uint32;
 using v8::Undefined;
 using v8::Value;
 
@@ -420,9 +423,9 @@ bool SetOption(Environment* env,
 template <typename Opt, uint8_t Opt::*member>
 bool SetOption(Environment* env,
                Opt* options,
-               const v8::Local<v8::Object>& object,
-               const v8::Local<v8::String>& name) {
-  v8::Local<v8::Value> value;
+               const Local<Object>& object,
+               const Local<String>& name) {
+  Local<Value> value;
   if (!object->Get(env->context(), name).ToLocal(&value)) return false;
   if (!value->IsUndefined()) {
     if (!value->IsUint32()) {
@@ -431,7 +434,7 @@ bool SetOption(Environment* env,
           env, "The %s option must be an uint8", *nameStr);
       return false;
     }
-    uint32_t val = value.As<v8::Uint32>()->Value();
+    uint32_t val = value.As<Uint32>()->Value();
     if (val > 255) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
@@ -1718,7 +1721,7 @@ Session::Session(Endpoint* endpoint,
   Debug(this, "Session created.");
 
   {
-    const v8::HandleScope handle_scope(env()->isolate());
+    const HandleScope handle_scope(env()->isolate());
     JS_DEFINE_READONLY_PROPERTY(
         env(),
         object,
@@ -1728,7 +1731,7 @@ Session::Session(Endpoint* endpoint,
         env(),
         object,
         FIXED_ONE_BYTE_STRING(env()->isolate(), "stateByteOffset"),
-        v8::Integer::NewFromUnsigned(
+        Integer::NewFromUnsigned(
             env()->isolate(),
             static_cast<uint32_t>(impl_->state_slot_.GetByteOffset())));
     JS_DEFINE_READONLY_PROPERTY(
@@ -1740,7 +1743,7 @@ Session::Session(Endpoint* endpoint,
         env(),
         object,
         FIXED_ONE_BYTE_STRING(env()->isolate(), "statsByteOffset"),
-        v8::Integer::NewFromUnsigned(
+        Integer::NewFromUnsigned(
             env()->isolate(),
             static_cast<uint32_t>(impl_->stats_slot_.GetByteOffset())));
   }
@@ -2127,8 +2130,8 @@ void Session::EmitQlog(uint32_t flags, std::string_view data) {
   // ngtcp2_conn is mid-destruction. Defer the final chunk via SetImmediate.
   if (is_destroyed()) {
     auto isolate = env()->isolate();
-    v8::Global<v8::Object> recv(isolate, object());
-    v8::Global<v8::Function> cb(
+    Global<Object> recv(isolate, object());
+    Global<Function> cb(
         isolate, BindingData::Get(env()).session_qlog_callback());
     std::string buf(data);
     env()->SetImmediate([recv = std::move(recv),

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -190,7 +190,9 @@ uint64_t MaxDatagramPayload(uint64_t max_frame_size) {
   V(SilentClose, silentClose, SIDE_EFFECT)                                     \
   V(UpdateKey, updateKey, SIDE_EFFECT)                                         \
   V(OpenStream, openStream, SIDE_EFFECT)                                       \
-  V(SendDatagram, sendDatagram, SIDE_EFFECT)
+  V(SendDatagram, sendDatagram, SIDE_EFFECT)                                   \
+  V(LocalTransportParams, localTransportParams, NO_SIDE_EFFECT)                \
+  V(RemoteTransportParams, remoteTransportParams, NO_SIDE_EFFECT)              \
 
 struct Session::State final {
 #define V(_, name, type) type name;
@@ -1163,6 +1165,36 @@ struct Session::Impl final : public MemoryRetainer {
         BigInt::New(env->isolate(), session->SendDatagram(std::move(store))));
   }
 
+  JS_METHOD(LocalTransportParams) {
+    auto env = Environment::GetCurrent(args);
+    Session* session;
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
+
+    ngtcp2_conn* conn = *session;
+    TransportParams params(ngtcp2_conn_get_local_transport_params(conn));
+    Local<Object> obj;
+    if (params.ToObject(env).ToLocal(&obj)) {
+      args.GetReturnValue().Set(obj);
+    }
+  }
+
+  JS_METHOD(RemoteTransportParams) {
+    auto env = Environment::GetCurrent(args);
+    Session* session;
+    ASSIGN_OR_RETURN_UNWRAP(&session, args.This());
+
+    ngtcp2_conn* conn = *session;
+    auto params = ngtcp2_conn_get_remote_transport_params(conn);
+    if (params == nullptr) {
+      // Remote transport parameters are not yet available.
+      return args.GetReturnValue().SetUndefined();
+    }
+    TransportParams tp(params);
+    Local<Object> obj;
+    if (tp.ToObject(env).ToLocal(&obj)) {
+      args.GetReturnValue().Set(obj);
+    }
+  }
   // Internal ngtcp2 callbacks
 
   static int on_acknowledge_stream_data_offset(ngtcp2_conn* conn,

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -3729,6 +3729,8 @@ void Session::InitPerContext(Realm* realm, Local<Object> target) {
   SESSION_STATE(V)
 #undef V
 
+  NODE_DEFINE_CONSTANT(target, IDX_STATS_SESSION_COUNT);
+
 #define V(name, _) NODE_DEFINE_CONSTANT(target, IDX_STATS_SESSION_##name);
   SESSION_STATS(V)
   NODE_DEFINE_CONSTANT(target, IDX_STATS_SESSION_COUNT);

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -464,7 +464,12 @@ Session::Config::Config(Environment* env,
     settings.log_printf = ngtcp2_debug_log;
   }
 
-  settings.handshake_timeout = options.handshake_timeout;
+  // The handshake_timeout option is in milliseconds; ngtcp2 expects
+  // nanoseconds (ngtcp2_duration). UINT64_MAX means no timeout.
+  settings.handshake_timeout =
+      options.handshake_timeout == UINT64_MAX
+          ? UINT64_MAX
+          : options.handshake_timeout * NGTCP2_MILLISECONDS;
   settings.max_stream_window = options.max_stream_window;
   settings.max_window = options.max_window;
   settings.ack_thresh = options.unacknowledged_packet_threshold;
@@ -3639,6 +3644,10 @@ void Session::InitPerContext(Realm* realm, Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, DEFAULT_MAX_HEADER_LENGTH);
   NODE_DEFINE_CONSTANT(target, QUIC_PROTO_MAX);
   NODE_DEFINE_CONSTANT(target, QUIC_PROTO_MIN);
+
+  static constexpr auto DEFAULT_HANDSHAKE_TIMEOUT =
+      Session::Options::DEFAULT_HANDSHAKE_TIMEOUT;
+  NODE_DEFINE_CONSTANT(target, DEFAULT_HANDSHAKE_TIMEOUT);
 
   NODE_DEFINE_STRING_CONSTANT(
       target, "DEFAULT_CIPHERS", TLSContext::DEFAULT_CIPHERS);

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2104,12 +2104,20 @@ void Session::SetLastError(QuicError&& error) {
 bool Session::Receive(Store&& store,
                       const SocketAddress& local_address,
                       const SocketAddress& remote_address) {
+  // Convenience wrapper: reads the packet and immediately triggers
+  // SendPendingData. Used by paths that need an immediate response
+  // (e.g., Endpoint::Connect for client Initial packets).
+  // The hot receive path uses ReadPacket() directly with deferred
+  // flush via BindingData's uv_check callback.
+  SendPendingDataScope send_scope(this);
+  return ReadPacket(std::move(store), local_address, remote_address);
+}
+
+bool Session::ReadPacket(Store&& store,
+                         const SocketAddress& local_address,
+                         const SocketAddress& remote_address) {
   DCHECK(!is_destroyed());
   impl_->remote_address_ = remote_address;
-
-  // When we are done processing this packet, we arrange to send any
-  // pending data for this session.
-  SendPendingDataScope send_scope(this);
 
   ngtcp2_vec vec = store;
   Path path(local_address, remote_address);
@@ -2125,14 +2133,16 @@ bool Session::Receive(Store&& store,
   // ensures that any deferred destroy waits until all callbacks for this
   // packet have completed. After calling ngtcp2_conn_read_pkt here, we
   // will need to double check that the session is not destroyed before
-  // we try doing anything with it (like updating stats, sending pending
-  // data, etc).
+  // we try doing anything with it (like updating stats, etc).
   int err;
   {
     NgTcp2CallbackScope callback_scope(this);
+    // ECN codepoint (ngtcp2_pkt_info.ecn) is not yet populated because
+    // libuv does not currently deliver per-packet ECN metadata. When
+    // libuv gains ECN receive reporting, the pkt_info should be
+    // populated from the per-packet metadata and passed through here.
     err = ngtcp2_conn_read_pkt(*this,
                                &path,
-                               // TODO(@jasnell): ECN pkt_info blocked on libuv
                                nullptr,
                                vec.base,
                                vec.len,
@@ -2245,6 +2255,17 @@ bool Session::Receive(Store&& store,
   return false;
 }
 
+void Session::FlushPendingData() {
+  DCHECK(!is_destroyed());
+  if (impl_->application_) {
+    // Prefer synchronous sends during the deferred flush to avoid the
+    // one-tick latency of async uv_udp_send from the uv_check callback.
+    prefer_try_send_ = true;
+    application().SendPendingData();
+    prefer_try_send_ = false;
+  }
+}
+
 void Session::Send(Packet::Ptr packet) {
   // Sending a Packet is generally best effort. If we're not in a state
   // where we can send a packet, it's ok to drop it on the floor. The
@@ -2258,6 +2279,16 @@ void Session::Send(Packet::Ptr packet) {
 
   if (!can_send_packets()) [[unlikely]] {
     // Ptr destructor releases the packet back to the pool.
+    return;
+  }
+
+  // When called from the deferred flush path (uv_check callback),
+  // prefer synchronous send to avoid the one-tick latency of async
+  // uv_udp_send. SendOrTrySend uses uv_udp_try_send first, falling
+  // back to uv_udp_send on EAGAIN.
+  if (prefer_try_send_) {
+    Debug(this, "Session is sending (try_send) %s", packet->ToString());
+    endpoint().SendOrTrySend(std::move(packet));
     return;
   }
 

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -353,7 +353,8 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
     bool early = false;
   };
 
-  bool Receive(Store&& store,
+  bool Receive(const uint8_t* data,
+               size_t len,
                const SocketAddress& local_address,
                const SocketAddress& remote_address,
                const PacketInfo& pkt_info = PacketInfo(),
@@ -367,10 +368,14 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   // Receive() is kept as a convenience wrapper that calls ReadPacket()
   // then triggers SendPendingData (for paths like Connect that need
   // immediate response).
+  // The data pointer is used synchronously — ngtcp2_conn_read_pkt does
+  // not retain a reference after returning, so the caller's buffer can
+  // be reused immediately.
   // When ts is 0 (the default), uv_hrtime() is called internally.
   // The batched receive path caches a timestamp and passes it to all
   // ReadPacket() calls in the same I/O burst.
-  bool ReadPacket(Store&& store,
+  bool ReadPacket(const uint8_t* data,
+                  size_t len,
                   const SocketAddress& local_address,
                   const SocketAddress& remote_address,
                   const PacketInfo& pkt_info = PacketInfo(),

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -606,25 +606,30 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   Side side_;
   const ngtcp2_mem* allocator_;
   std::unique_ptr<Impl> impl_;
-  // These flags live on Session (not Impl) so that the NgTcp2CallbackScope
-  // and NgHttp3CallbackScope destructors can safely clear them even after
-  // Impl has been destroyed via MakeCallback re-entrancy during a callback.
-  // The scope is placed at the ngtcp2/nghttp3 entry point (e.g. Receive,
-  // OnTimeout) rather than on individual callbacks, so the deferred destroy
-  // only fires after all callbacks for that entry point have completed.
-  bool in_ngtcp2_callback_scope_ = false;
-  bool in_nghttp3_callback_scope_ = false;
-  bool destroy_deferred_ = false;
-  // Set when this session is in BindingData's pending_flush_sessions_ vector.
-  // Cleared by the flush callback before calling SendPendingData.
-  // Provides O(1) dedup so a session receiving multiple packets in one I/O
-  // burst is only scheduled for flush once.
-  bool pending_flush_ = false;
-  // When true, Session::Send prefers synchronous delivery via
-  // Endpoint::SendOrTrySend (uv_udp_try_send with async fallback).
-  // Set during FlushPendingData to avoid the one-tick latency of
-  // async-only sends from the uv_check callback.
-  bool prefer_try_send_ = false;
+
+  struct Flags {
+    // These flags live on Session (not Impl) so that the NgTcp2CallbackScope
+    // and NgHttp3CallbackScope destructors can safely clear them even after
+    // Impl has been destroyed via MakeCallback re-entrancy during a callback.
+    // The scope is placed at the ngtcp2/nghttp3 entry point (e.g. Receive,
+    // OnTimeout) rather than on individual callbacks, so the deferred destroy
+    // only fires after all callbacks for that entry point have completed.
+    uint8_t in_ngtcp2_callback_scope : 1 = 0;
+    uint8_t in_nghttp3_callback_scope : 1 = 0;
+    uint8_t destroy_deferred : 1 = 0;
+    // Set when this session is in BindingData's pending_flush_sessions_ vector.
+    // Cleared by the flush callback before calling SendPendingData.
+    // Provides O(1) dedup so a session receiving multiple packets in one I/O
+    // burst is only scheduled for flush once.
+    uint8_t pending_flush : 1 = 0;
+    // When true, Session::Send prefers synchronous delivery via
+    // Endpoint::SendOrTrySend (uv_udp_try_send with async fallback).
+    // Set during FlushPendingData to avoid the one-tick latency of
+    // async-only sends from the uv_check callback.
+    uint8_t prefer_try_send : 1 = 0;
+  };
+  Flags flags_;
+
   QuicConnectionPointer connection_;
   std::unique_ptr<TLSSession> tls_session_;
   friend struct NgTcp2CallbackScope;

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -91,6 +91,8 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
 
     std::string ToString() const;
 
+    v8::MaybeLocal<v8::Object> ToObject(Environment* env) const;
+
     static const Application_Options kDefault;
   };
 
@@ -324,6 +326,7 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   uint32_t version() const;
   Endpoint& endpoint() const;
   TLSSession& tls_session() const;
+  bool has_application() const;
   Application& application() const;
   const Config& config() const;
   const Options& options() const;

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -355,7 +355,8 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
 
   bool Receive(Store&& store,
                const SocketAddress& local_address,
-               const SocketAddress& remote_address);
+               const SocketAddress& remote_address,
+               const PacketInfo& pkt_info = PacketInfo());
 
   // ReadPacket processes a single inbound packet through ngtcp2 without
   // triggering SendPendingData. This is the building block for batched
@@ -367,7 +368,8 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   // immediate response).
   bool ReadPacket(Store&& store,
                   const SocketAddress& local_address,
-                  const SocketAddress& remote_address);
+                  const SocketAddress& remote_address,
+                  const PacketInfo& pkt_info = PacketInfo());
 
   // Called by BindingData's flush callback to trigger SendPendingData
   // on this session. Encapsulates the application() access so that

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -374,6 +374,13 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   // bindingdata.cc doesn't need the full Application type definition.
   void FlushPendingData();
 
+  // Send a batch of packets accumulated by SendPendingData. Uses
+  // Endpoint::SendBatch (uv_udp_try_send2 / sendmmsg) for synchronous
+  // batched delivery when called from the deferred flush path.
+  // Handles per-packet path updates and cross-endpoint redirects.
+  // All Ptr entries are consumed (released or moved) on return.
+  void SendBatch(Packet::Ptr* packets, PathStorage* paths, size_t count);
+
   void Send(Packet::Ptr packet);
   void Send(Packet::Ptr packet, const PathStorage& path);
   datagram_id SendDatagram(Store&& data);

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -356,7 +356,8 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   bool Receive(Store&& store,
                const SocketAddress& local_address,
                const SocketAddress& remote_address,
-               const PacketInfo& pkt_info = PacketInfo());
+               const PacketInfo& pkt_info = PacketInfo(),
+               uint64_t ts = 0);
 
   // ReadPacket processes a single inbound packet through ngtcp2 without
   // triggering SendPendingData. This is the building block for batched
@@ -366,10 +367,14 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   // Receive() is kept as a convenience wrapper that calls ReadPacket()
   // then triggers SendPendingData (for paths like Connect that need
   // immediate response).
+  // When ts is 0 (the default), uv_hrtime() is called internally.
+  // The batched receive path caches a timestamp and passes it to all
+  // ReadPacket() calls in the same I/O burst.
   bool ReadPacket(Store&& store,
                   const SocketAddress& local_address,
                   const SocketAddress& remote_address,
-                  const PacketInfo& pkt_info = PacketInfo());
+                  const PacketInfo& pkt_info = PacketInfo(),
+                  uint64_t ts = 0);
 
   // Called by BindingData's flush callback to trigger SendPendingData
   // on this session. Encapsulates the application() access so that

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -163,6 +163,15 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
     static constexpr uint64_t DEFAULT_HANDSHAKE_TIMEOUT = 10'000;
     uint64_t handshake_timeout = DEFAULT_HANDSHAKE_TIMEOUT;
 
+    // The initial round-trip time estimate in milliseconds. ngtcp2 uses this
+    // for PTO computation, initial pacing, and early loss detection before
+    // the first RTT sample is collected. The default of 0 uses ngtcp2's
+    // built-in default of 333ms, which is appropriate for the general
+    // internet. For low-latency environments (e.g., loopback or same-rack
+    // deployments), setting a value closer to the actual RTT avoids
+    // unnecessarily conservative initial behavior.
+    uint64_t initial_rtt = 0;
+
     // The keep-alive timeout in milliseconds. When set to a non-zero value,
     // ngtcp2 will automatically send PING frames to keep the connection alive
     // before the idle timeout fires. Set to 0 to disable (default).

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -153,8 +153,15 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
     bool qlog = false;
 
     // The amount of time (in milliseconds) that the endpoint will wait for the
-    // completion of the tls handshake.
-    uint64_t handshake_timeout = UINT64_MAX;
+    // completion of the TLS handshake. If the handshake does not complete
+    // within this time, the session is closed. This prevents a peer from
+    // holding a session open indefinitely in the handshake state, consuming
+    // server resources (ngtcp2 connection, TLS state, JS objects) without
+    // ever completing the connection. The default of 10 seconds is generous
+    // enough to accommodate slow networks with retransmissions while still
+    // bounding resource exposure. Set to UINT64_MAX to disable.
+    static constexpr uint64_t DEFAULT_HANDSHAKE_TIMEOUT = 10'000;
+    uint64_t handshake_timeout = DEFAULT_HANDSHAKE_TIMEOUT;
 
     // The keep-alive timeout in milliseconds. When set to a non-zero value,
     // ngtcp2 will automatically send PING frames to keep the connection alive

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -357,6 +357,23 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
                const SocketAddress& local_address,
                const SocketAddress& remote_address);
 
+  // ReadPacket processes a single inbound packet through ngtcp2 without
+  // triggering SendPendingData. This is the building block for batched
+  // receive processing: the caller (Endpoint::Receive) accumulates
+  // dirty sessions and a uv_check callback flushes them after all
+  // packets in the I/O burst have been read.
+  // Receive() is kept as a convenience wrapper that calls ReadPacket()
+  // then triggers SendPendingData (for paths like Connect that need
+  // immediate response).
+  bool ReadPacket(Store&& store,
+                  const SocketAddress& local_address,
+                  const SocketAddress& remote_address);
+
+  // Called by BindingData's flush callback to trigger SendPendingData
+  // on this session. Encapsulates the application() access so that
+  // bindingdata.cc doesn't need the full Application type definition.
+  void FlushPendingData();
+
   void Send(Packet::Ptr packet);
   void Send(Packet::Ptr packet, const PathStorage& path);
   datagram_id SendDatagram(Store&& data);
@@ -572,11 +589,22 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   bool in_ngtcp2_callback_scope_ = false;
   bool in_nghttp3_callback_scope_ = false;
   bool destroy_deferred_ = false;
+  // Set when this session is in BindingData's pending_flush_sessions_ vector.
+  // Cleared by the flush callback before calling SendPendingData.
+  // Provides O(1) dedup so a session receiving multiple packets in one I/O
+  // burst is only scheduled for flush once.
+  bool pending_flush_ = false;
+  // When true, Session::Send prefers synchronous delivery via
+  // Endpoint::SendOrTrySend (uv_udp_try_send with async fallback).
+  // Set during FlushPendingData to avoid the one-tick latency of
+  // async-only sends from the uv_check callback.
+  bool prefer_try_send_ = false;
   QuicConnectionPointer connection_;
   std::unique_ptr<TLSSession> tls_session_;
   friend struct NgTcp2CallbackScope;
   friend struct NgHttp3CallbackScope;
   friend class Application;
+  friend class BindingData;
   friend class DefaultApplication;
   friend class Http3ApplicationImpl;
   friend class Endpoint;

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -151,6 +151,44 @@ struct Stream::State {
 
 STAT_STRUCT(Stream, STREAM)
 
+// Stream uses arena-allocated stats, not AliasedStruct, so override the
+// STAT_* macros to use the stats() accessor instead of stats_.Data().
+#undef STAT_INCREMENT
+#undef STAT_INCREMENT_N
+#undef STAT_RECORD_TIMESTAMP
+#undef STAT_SET
+#undef STAT_GET
+#define STAT_INCREMENT(Type, name) IncrementStat<Type, &Type::name>(stats());
+#define STAT_INCREMENT_N(Type, name, amt)                                      \
+  IncrementStat<Type, &Type::name>(stats(), amt);
+#define STAT_RECORD_TIMESTAMP(Type, name)                                      \
+  RecordTimestampStat<Type, &Type::name>(stats());
+#define STAT_SET(Type, name, val) SetStat<Type, &Type::name>(stats(), val)
+#define STAT_GET(Type, name) GetStat<Type, &Type::name>(stats())
+
+using StreamStateArena = AliasedStructArena<Stream::State>;
+using StreamStatsArena = AliasedStructArena<Stream::Stats>;
+
+namespace {
+StreamStateArena& GetStreamStateArena(BindingData& binding) {
+  if (!binding.stream_state_arena_) {
+    auto* arena = new StreamStateArena();
+    binding.stream_state_arena_ = BindingData::ArenaPtr(
+        arena, +[](void* p) { delete static_cast<StreamStateArena*>(p); });
+  }
+  return *static_cast<StreamStateArena*>(binding.stream_state_arena_.get());
+}
+
+StreamStatsArena& GetStreamStatsArena(BindingData& binding) {
+  if (!binding.stream_stats_arena_) {
+    auto* arena = new StreamStatsArena();
+    binding.stream_stats_arena_ = BindingData::ArenaPtr(
+        arena, +[](void* p) { delete static_cast<StreamStatsArena*>(p); });
+  }
+  return *static_cast<StreamStatsArena*>(binding.stream_stats_arena_.get());
+}
+}  // namespace
+
 // ============================================================================
 
 namespace {
@@ -382,14 +420,14 @@ struct Stream::Impl {
       code = args[0].As<BigInt>()->Uint64Value(&lossless);
     }
 
-    if (stream->state_->reset == 1) return;
+    if (stream->state()->reset == 1) return;
 
     stream->EndWritable();
     // We can release our outbound here now. Since the stream is being reset
     // on the ngtcp2 side, we do not need to keep any of the data around
     // waiting for acknowledgement that will never come.
     stream->outbound_.reset();
-    stream->state_->reset = 1;
+    stream->state()->reset = 1;
 
     if (!stream->is_pending()) {
       if (stream->is_remote_unidirectional()) return;
@@ -993,30 +1031,56 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
                stream_id id,
                std::shared_ptr<DataQueue> source)
     : AsyncWrap(session->env(), object, PROVIDER_QUIC_STREAM),
-      stats_(env()->isolate()),
-      state_(env()->isolate()),
       session_(std::move(session)),
       inbound_(DataQueue::Create()),
       headers_(env()->isolate()) {
+  auto& binding = BindingData::Get(env());
+  stats_slot_ = GetStreamStatsArena(binding).Allocate(env()->isolate());
+  state_slot_ = GetStreamStateArena(binding).Allocate(env()->isolate());
   MakeWeak();
   DCHECK(id < kMaxStreamId);
-  state_->id = id;
-  state_->pending = 0;
+  state()->id = id;
+  state()->pending = 0;
   // Allows us to be notified when data is actually read from the
   // inbound queue so that we can update the stream flow control.
   inbound_->addBackpressureListener(this);
 
-  JS_DEFINE_READONLY_PROPERTY(
-      env(), object, env()->state_string(), state_.GetArrayBuffer());
-  JS_DEFINE_READONLY_PROPERTY(
-      env(), object, env()->stats_string(), stats_.GetArrayBuffer());
+  {
+    const v8::HandleScope handle_scope(env()->isolate());
+    // Pass the page's shared views and this slot's byte offset. JS uses
+    // the offset to index into the shared view — no per-stream V8 object
+    // creation.
+    JS_DEFINE_READONLY_PROPERTY(env(),
+                                object,
+                                env()->state_string(),
+                                state_slot_.GetPageDataView(env()->isolate()));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        FIXED_ONE_BYTE_STRING(env()->isolate(), "stateByteOffset"),
+        v8::Integer::NewFromUnsigned(
+            env()->isolate(),
+            static_cast<uint32_t>(state_slot_.GetByteOffset())));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        env()->stats_string(),
+        stats_slot_.GetPageBigUint64Array(env()->isolate()));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        FIXED_ONE_BYTE_STRING(env()->isolate(), "statsByteOffset"),
+        v8::Integer::NewFromUnsigned(
+            env()->isolate(),
+            static_cast<uint32_t>(stats_slot_.GetByteOffset())));
+  }
 
   set_outbound(std::move(source));
 
   STAT_RECORD_TIMESTAMP(Stats, created_at);
   auto params = ngtcp2_conn_get_local_transport_params(this->session());
   STAT_SET(Stats, max_offset, params->initial_max_data);
-  STAT_SET(Stats, opened_at, stats_->created_at);
+  STAT_SET(Stats, opened_at, stats()->created_at);
 }
 
 Stream::Stream(BaseObjectWeakPtr<Session> session,
@@ -1024,25 +1088,48 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
                Direction direction,
                std::shared_ptr<DataQueue> source)
     : AsyncWrap(session->env(), object, PROVIDER_QUIC_STREAM),
-      stats_(env()->isolate()),
-      state_(env()->isolate()),
       session_(std::move(session)),
       inbound_(DataQueue::Create()),
       maybe_pending_stream_(
           std::make_unique<PendingStream>(direction, this, session_)),
       headers_(env()->isolate()) {
+  auto& binding = BindingData::Get(env());
+  stats_slot_ = GetStreamStatsArena(binding).Allocate(env()->isolate());
+  state_slot_ = GetStreamStateArena(binding).Allocate(env()->isolate());
   MakeWeak();
-  state_->id = kMaxStreamId;
-  state_->pending = 1;
+  state()->id = kMaxStreamId;
+  state()->pending = 1;
 
   // Allows us to be notified when data is actually read from the
   // inbound queue so that we can update the stream flow control.
   inbound_->addBackpressureListener(this);
 
-  JS_DEFINE_READONLY_PROPERTY(
-      env(), object, env()->state_string(), state_.GetArrayBuffer());
-  JS_DEFINE_READONLY_PROPERTY(
-      env(), object, env()->stats_string(), stats_.GetArrayBuffer());
+  {
+    const v8::HandleScope handle_scope(env()->isolate());
+    JS_DEFINE_READONLY_PROPERTY(env(),
+                                object,
+                                env()->state_string(),
+                                state_slot_.GetPageDataView(env()->isolate()));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        FIXED_ONE_BYTE_STRING(env()->isolate(), "stateByteOffset"),
+        v8::Integer::NewFromUnsigned(
+            env()->isolate(),
+            static_cast<uint32_t>(state_slot_.GetByteOffset())));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        env()->stats_string(),
+        stats_slot_.GetPageBigUint64Array(env()->isolate()));
+    JS_DEFINE_READONLY_PROPERTY(
+        env(),
+        object,
+        FIXED_ONE_BYTE_STRING(env()->isolate(), "statsByteOffset"),
+        v8::Integer::NewFromUnsigned(
+            env()->isolate(),
+            static_cast<uint32_t>(stats_slot_.GetByteOffset())));
+  }
 
   set_outbound(std::move(source));
 
@@ -1053,15 +1140,24 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
 
 Stream::~Stream() {
   // Make sure that Destroy() was called before Stream is actually destructed.
-  DCHECK_NE(stats_->destroyed_at, 0);
+  DCHECK_NE(stats()->destroyed_at, 0);
+
+  // Release arena slots back to the freelist.
+  auto& binding = BindingData::Get(env());
+  if (stats_slot_) {
+    GetStreamStatsArena(binding).ReleaseSlot(stats_slot_);
+  }
+  if (state_slot_) {
+    GetStreamStateArena(binding).ReleaseSlot(state_slot_);
+  }
 }
 
 void Stream::NotifyStreamOpened(stream_id id) {
   CHECK(is_pending());
   DCHECK(id < kMaxStreamId);
   Debug(this, "Pending stream opened with id %" PRIi64, id);
-  state_->pending = 0;
-  state_->id = id;
+  state()->pending = 0;
+  state()->id = id;
   STAT_RECORD_TIMESTAMP(Stats, opened_at);
   // Now that the stream is actually opened, add it to the sessions
   // list of known open streams.
@@ -1132,26 +1228,26 @@ void Stream::EnqueuePendingHeaders(HeadersKind kind,
 }
 
 bool Stream::is_pending() const {
-  return state_->pending;
+  return state()->pending;
 }
 
 stream_id Stream::id() const {
-  return state_->id;
+  return state()->id;
 }
 
 Side Stream::origin() const {
   CHECK(!is_pending());
-  return (state_->id & 0b01) ? Side::SERVER : Side::CLIENT;
+  return (state()->id & 0b01) ? Side::SERVER : Side::CLIENT;
 }
 
 Direction Stream::direction() const {
-  if (state_->pending) {
+  if (state()->pending) {
     CHECK(maybe_pending_stream_.has_value());
     auto& val = maybe_pending_stream_.value();
     return val->direction();
   }
-  return (state_->id & 0b10) ? Direction::UNIDIRECTIONAL
-                             : Direction::BIDIRECTIONAL;
+  return (state()->id & 0b10) ? Direction::UNIDIRECTIONAL
+                              : Direction::BIDIRECTIONAL;
 }
 
 Session& Stream::session() const {
@@ -1169,15 +1265,15 @@ bool Stream::is_remote_unidirectional() const {
 }
 
 bool Stream::is_eos() const {
-  return state_->fin_sent;
+  return state()->fin_sent;
 }
 
 bool Stream::wants_trailers() const {
-  return state_->wants_trailers;
+  return state()->wants_trailers;
 }
 
 void Stream::set_early() {
-  state_->received_early_data = 1;
+  state()->received_early_data = 1;
 }
 
 bool Stream::is_writable() const {
@@ -1187,7 +1283,7 @@ bool Stream::is_writable() const {
       !ngtcp2_conn_is_local_stream(session(), id())) {
     return false;
   }
-  return state_->write_ended == 0;
+  return state()->write_ended == 0;
 }
 
 bool Stream::has_outbound() const {
@@ -1209,21 +1305,21 @@ bool Stream::is_readable() const {
       ngtcp2_conn_is_local_stream(session(), id())) {
     return false;
   }
-  return state_->read_ended == 0;
+  return state()->read_ended == 0;
 }
 
 BaseObjectPtr<Blob::Reader> Stream::get_reader() {
-  if (!is_readable() || state_->has_reader) return {};
-  state_->has_reader = 1;
+  if (!is_readable() || state()->has_reader) return {};
+  state()->has_reader = 1;
   auto reader = Blob::Reader::Create(env(), Blob::Create(env(), inbound_));
   reader_ = reader;
   return reader;
 }
 
 void Stream::set_final_size(uint64_t final_size) {
-  DCHECK_IMPLIES(state_->fin_received == 1,
+  DCHECK_IMPLIES(state()->fin_received == 1,
                  final_size <= STAT_GET(Stats, final_size));
-  state_->fin_received = 1;
+  state()->fin_received = 1;
   STAT_SET(Stats, final_size, final_size);
 }
 
@@ -1232,7 +1328,7 @@ void Stream::set_outbound(std::shared_ptr<DataQueue> source) {
   Debug(this, "Setting the outbound data source");
   DCHECK_NULL(outbound_);
   outbound_ = std::make_unique<Outbound>(this, std::move(source));
-  state_->has_outbound = 1;
+  state()->has_outbound = 1;
   // Note: We intentionally do NOT call ResumeStream here. During
   // construction, the stream has not yet been added to the session's
   // streams map, so FindStream would fail. The caller (CreateStream /
@@ -1251,7 +1347,7 @@ void Stream::InitStreaming() {
   }
   Debug(this, "Initializing streaming outbound source");
   outbound_ = std::make_unique<Outbound>(this);
-  state_->has_outbound = 1;
+  state()->has_outbound = 1;
   if (!is_pending()) session_->ResumeStream(id());
 }
 
@@ -1397,7 +1493,7 @@ void Stream::Commit(size_t datalen, bool fin) {
   Debug(this, "Committing %zu bytes", datalen);
   STAT_INCREMENT_N(Stats, bytes_sent, datalen);
   if (outbound_) outbound_->Commit(datalen);
-  if (fin) state_->fin_sent = 1;
+  if (fin) state()->fin_sent = 1;
 }
 
 void Stream::EndWritable() {
@@ -1407,12 +1503,12 @@ void Stream::EndWritable() {
   // will be a non-op since we're not going to be writing any more data
   // into it anyway.
   if (outbound_) outbound_->Cap();
-  state_->write_ended = 1;
+  state()->write_ended = 1;
 }
 
 void Stream::EndReadable(std::optional<uint64_t> maybe_final_size) {
   if (!is_readable()) return;
-  state_->read_ended = 1;
+  state()->read_ended = 1;
   set_final_size(maybe_final_size.value_or(STAT_GET(Stats, bytes_received)));
   inbound_->cap(STAT_GET(Stats, final_size));
   // Notify the JS reader so it can see EOS. Pass fin=true so the
@@ -1422,20 +1518,20 @@ void Stream::EndReadable(std::optional<uint64_t> maybe_final_size) {
 }
 
 void Stream::Destroy(QuicError error) {
-  if (stats_->destroyed_at != 0) return;
+  if (stats()->destroyed_at != 0) return;
   // Record the destroyed at timestamp before notifying the JavaScript side
   // that the stream is being destroyed.
   STAT_RECORD_TIMESTAMP(Stats, destroyed_at);
 
   DCHECK_NOT_NULL(session_.get());
 
-  if (!state_->pending) {
+  if (!state()->pending) {
     Debug(
         this, "Stream %" PRIi64 " being destroyed with error %s", id(), error);
   } else {
     Debug(this, "Pending stream being destroyed with error %s", error);
   }
-  state_->pending = 0;
+  state()->pending = 0;
 
   maybe_pending_stream_.reset();
 
@@ -1482,12 +1578,12 @@ void Stream::ReceiveData(const uint8_t* data,
   // If reading has ended, or there is no data, there's nothing to do but maybe
   // end the readable side if this is the last bit of data we've received.
   Debug(this, "Receiving %zu bytes of data", len);
-  if (state_->read_ended == 1 || len == 0) {
+  if (state()->read_ended == 1 || len == 0) {
     if (flags.fin) EndReadable();
     return;
   }
 
-  if (flags.early) state_->received_early_data = 1;
+  if (flags.early) state()->received_early_data = 1;
   STAT_INCREMENT_N(Stats, bytes_received, len);
   STAT_SET(Stats, max_offset_received, STAT_GET(Stats, bytes_received));
   STAT_RECORD_TIMESTAMP(Stats, received_at);
@@ -1509,10 +1605,10 @@ void Stream::ReceiveStopSending(QuicError error) {
   // writable side has already been shut down (e.g. we already sent
   // RESET_STREAM ourselves or finished sending with FIN) there is
   // nothing more to do here. The previous guard checked
-  // `state_->read_ended` which is unrelated to the writable side and
+  // `state()->read_ended` which is unrelated to the writable side and
   // suppressed STOP_SENDING handling whenever a sibling RESET_STREAM
   // frame had been processed first within the same packet.
-  if (state_->write_ended) return;
+  if (state()->write_ended) return;
   Debug(this, "Received stop sending with error %s", error);
   ngtcp2_conn_shutdown_stream_write(session(), 0, id(), error.code());
   EndWritable();
@@ -1528,7 +1624,7 @@ void Stream::ReceiveStreamReset(uint64_t final_size, QuicError error) {
         "Received stream reset with final size %" PRIu64 " and error %s",
         final_size,
         error);
-  state_->reset_code = error.code();
+  state()->reset_code = error.code();
   EndReadable(final_size);
   EmitReset(error);
 }
@@ -1536,10 +1632,10 @@ void Stream::ReceiveStreamReset(uint64_t final_size, QuicError error) {
 // ============================================================================
 
 void Stream::EmitBlocked() {
-  // state_->wants_block will be set from the javascript side if the
+  // state()->wants_block will be set from the javascript side if the
   // stream object has a handler for the blocked event.
   Debug(this, "Blocked");
-  if (!env()->can_call_into_js() || !state_->wants_block) {
+  if (!env()->can_call_into_js() || !state()->wants_block) {
     return;
   }
   CallbackScope<Stream> cb_scope(this);
@@ -1556,7 +1652,7 @@ void Stream::UpdateWriteDesiredSize() {
   if (!outbound_ || !outbound_->is_streaming()) return;
 
   uint64_t available;
-  uint64_t hwm = state_->high_water_mark;
+  uint64_t hwm = state()->high_water_mark;
 
   if (is_pending()) {
     // Pending streams don't have a stream ID yet, so ngtcp2 can't
@@ -1589,8 +1685,8 @@ void Stream::UpdateWriteDesiredSize() {
   uint32_t clamped = static_cast<uint32_t>(
       std::min<uint64_t>(desired, std::numeric_limits<uint32_t>::max()));
 
-  uint32_t old_size = state_->write_desired_size;
-  state_->write_desired_size = clamped;
+  uint32_t old_size = state()->write_desired_size;
+  state()->write_desired_size = clamped;
 
   // Fire drain when transitioning from 0 to non-zero.
   // writeDesiredSize == 0 means the buffer is full or flow control is
@@ -1609,9 +1705,9 @@ void Stream::EmitClose(const QuicError& error) {
 }
 
 void Stream::EmitHeaders() {
-  // state_->wants_headers will be set from the javascript side if the
+  // state()->wants_headers will be set from the javascript side if the
   // stream object has a handler for the headers event.
-  if (!env()->can_call_into_js() || !state_->wants_headers) {
+  if (!env()->can_call_into_js() || !state()->wants_headers) {
     return;
   }
   CallbackScope<Stream> cb_scope(this);
@@ -1628,9 +1724,9 @@ void Stream::EmitHeaders() {
 }
 
 void Stream::EmitReset(const QuicError& error) {
-  // state_->wants_reset will be set from the javascript side if the
+  // state()->wants_reset will be set from the javascript side if the
   // stream object has a handler for the reset event.
-  if (!env()->can_call_into_js() || !state_->wants_reset) {
+  if (!env()->can_call_into_js() || !state()->wants_reset) {
     return;
   }
   CallbackScope<Stream> cb_scope(this);
@@ -1641,9 +1737,9 @@ void Stream::EmitReset(const QuicError& error) {
 }
 
 void Stream::EmitWantTrailers() {
-  // state_->wants_trailers will be set from the javascript side if the
+  // state()->wants_trailers will be set from the javascript side if the
   // stream object has a handler for the trailers event.
-  if (!env()->can_call_into_js() || !state_->wants_trailers) {
+  if (!env()->can_call_into_js() || !state()->wants_trailers) {
     return;
   }
   CallbackScope<Stream> cb_scope(this);

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -31,6 +31,7 @@ using v8::HandleScope;
 using v8::Integer;
 using v8::Just;
 using v8::Local;
+using v8::LocalVector;
 using v8::Maybe;
 using v8::Nothing;
 using v8::Object;
@@ -1126,8 +1127,7 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
                std::shared_ptr<DataQueue> source)
     : AsyncWrap(session->env(), object, PROVIDER_QUIC_STREAM),
       session_(std::move(session)),
-      inbound_(DataQueue::Create()),
-      headers_(env()->isolate()) {
+      inbound_(DataQueue::Create()) {
   auto& binding = BindingData::Get(env());
   stats_slot_ = GetStreamStatsArena(binding).Allocate(env()->isolate());
   state_slot_ = GetStreamStateArena(binding).Allocate(env()->isolate());
@@ -1185,8 +1185,7 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
       session_(std::move(session)),
       inbound_(DataQueue::Create()),
       maybe_pending_stream_(
-          std::make_unique<PendingStream>(direction, this, session_)),
-      headers_(env()->isolate()) {
+          std::make_unique<PendingStream>(direction, this, session_)) {
   auto& binding = BindingData::Get(env());
   stats_slot_ = GetStreamStatsArena(binding).Allocate(env()->isolate());
   state_slot_ = GetStreamStateArena(binding).Allocate(env()->isolate());
@@ -1567,27 +1566,16 @@ void Stream::set_headers_kind(HeadersKind kind) {
   headers_kind_ = kind;
 }
 
-bool Stream::AddHeader(const Header& header) {
-  size_t len = header.length();
+bool Stream::AddHeader(std::unique_ptr<Header> header) {
+  size_t len = header->length();
   if (!session_->application().CanAddHeader(
           headers_.size(), headers_length_, len)) {
     return false;
   }
 
   headers_length_ += len;
-
-  auto& state = BindingData::Get(env());
-
-  const auto push = [&](auto raw) {
-    Local<Value> value;
-    if (!raw.ToLocal(&value)) [[unlikely]] {
-      return false;
-    }
-    headers_.push_back(value);
-    return true;
-  };
-
-  return push(header.GetName(&state)) && push(header.GetValue(&state));
+  headers_.push_back(std::move(header));
+  return true;
 }
 
 void Stream::Acknowledge(size_t datalen) {
@@ -1899,19 +1887,35 @@ void Stream::EmitHeaders() {
   // state()->wants_headers will be set from the javascript side if the
   // stream object has a handler for the headers event.
   if (!env()->can_call_into_js() || !state()->wants_headers) {
+    headers_.clear();
     return;
   }
   CallbackScope<Stream> cb_scope(this);
 
-  Local<Value> argv[] = {
-      Array::New(env()->isolate(), headers_.data(), headers_.size()),
-      Integer::NewFromUnsigned(env()->isolate(),
-                               static_cast<uint32_t>(headers_kind_))};
+  auto& binding = BindingData::Get(env());
+  size_t count = headers_.size() * 2;
+  LocalVector<Value> values(env()->isolate(), count);
+
+  for (size_t i = 0; i < headers_.size(); i++) {
+    Local<Value> name;
+    Local<Value> value;
+    if (!headers_[i]->GetName(&binding).ToLocal(&name) ||
+        !headers_[i]->GetValue(&binding).ToLocal(&value)) [[unlikely]] {
+      headers_.clear();
+      return;
+    }
+    values[i * 2] = name;
+    values[i * 2 + 1] = value;
+  }
 
   headers_.clear();
 
-  MakeCallback(
-      BindingData::Get(env()).stream_headers_callback(), arraysize(argv), argv);
+  Local<Value> argv[] = {
+      Array::New(env()->isolate(), values.data(), count),
+      Integer::NewFromUnsigned(env()->isolate(),
+                               static_cast<uint32_t>(headers_kind_))};
+
+  MakeCallback(binding.stream_headers_callback(), arraysize(argv), argv);
 }
 
 void Stream::EmitReset(const QuicError& error) {

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -26,6 +26,7 @@ using v8::BackingStore;
 using v8::BigInt;
 using v8::FunctionCallbackInfo;
 using v8::Global;
+using v8::HandleScope;
 using v8::Integer;
 using v8::Just;
 using v8::Local;
@@ -34,6 +35,7 @@ using v8::Nothing;
 using v8::Object;
 using v8::ObjectTemplate;
 using v8::SharedArrayBuffer;
+using v8::String;
 using v8::Uint32;
 using v8::Uint8Array;
 using v8::Value;
@@ -277,7 +279,7 @@ Maybe<std::shared_ptr<DataQueue>> Stream::GetDataQueueFromSource(
   // object's constructor name is "FileHandle".
   if (value->IsObject()) {
     auto obj = value.As<Object>();
-    Local<v8::String> ctor_name;
+    Local<String> ctor_name;
     auto maybe_name = obj->GetConstructorName();
     if (!maybe_name.IsEmpty()) {
       ctor_name = maybe_name;
@@ -287,9 +289,8 @@ Maybe<std::shared_ptr<DataQueue>> Stream::GetDataQueueFromSource(
         ASSIGN_OR_RETURN_UNWRAP(
             &file_handle, value, Nothing<std::shared_ptr<DataQueue>>());
         Local<Value> path;
-        if (!v8::String::NewFromUtf8(env->isolate(),
-                                     file_handle->original_name().c_str())
-                 .ToLocal(&path)) {
+        if (!ToV8Value(env->context(), file_handle->original_name())
+            .ToLocal(&path)) {
           return Nothing<std::shared_ptr<DataQueue>>();
         }
         auto entry = DataQueue::CreateFdEntry(env, path);
@@ -1048,7 +1049,7 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
   inbound_->addBackpressureListener(this);
 
   {
-    const v8::HandleScope handle_scope(env()->isolate());
+    const HandleScope handle_scope(env()->isolate());
     // Pass the page's shared views and this slot's byte offset. JS uses
     // the offset to index into the shared view — no per-stream V8 object
     // creation.
@@ -1060,7 +1061,7 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
         env(),
         object,
         FIXED_ONE_BYTE_STRING(env()->isolate(), "stateByteOffset"),
-        v8::Integer::NewFromUnsigned(
+        Integer::NewFromUnsigned(
             env()->isolate(),
             static_cast<uint32_t>(state_slot_.GetByteOffset())));
     JS_DEFINE_READONLY_PROPERTY(
@@ -1072,7 +1073,7 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
         env(),
         object,
         FIXED_ONE_BYTE_STRING(env()->isolate(), "statsByteOffset"),
-        v8::Integer::NewFromUnsigned(
+        Integer::NewFromUnsigned(
             env()->isolate(),
             static_cast<uint32_t>(stats_slot_.GetByteOffset())));
   }
@@ -1107,7 +1108,7 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
   inbound_->addBackpressureListener(this);
 
   {
-    const v8::HandleScope handle_scope(env()->isolate());
+    const HandleScope handle_scope(env()->isolate());
     JS_DEFINE_READONLY_PROPERTY(env(),
                                 object,
                                 env()->state_string(),
@@ -1116,7 +1117,7 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
         env(),
         object,
         FIXED_ONE_BYTE_STRING(env()->isolate(), "stateByteOffset"),
-        v8::Integer::NewFromUnsigned(
+        Integer::NewFromUnsigned(
             env()->isolate(),
             static_cast<uint32_t>(state_slot_.GetByteOffset())));
     JS_DEFINE_READONLY_PROPERTY(
@@ -1128,7 +1129,7 @@ Stream::Stream(BaseObjectWeakPtr<Session> session,
         env(),
         object,
         FIXED_ONE_BYTE_STRING(env()->isolate(), "statsByteOffset"),
-        v8::Integer::NewFromUnsigned(
+        Integer::NewFromUnsigned(
             env()->isolate(),
             static_cast<uint32_t>(stats_slot_.GetByteOffset())));
   }

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -23,6 +23,7 @@ using v8::Array;
 using v8::ArrayBuffer;
 using v8::ArrayBufferView;
 using v8::BackingStore;
+using v8::BackingStoreInitializationMode;
 using v8::BigInt;
 using v8::FunctionCallbackInfo;
 using v8::Global;
@@ -85,7 +86,11 @@ namespace quic {
   V(MAX_OFFSET, max_offset)                                                    \
   V(MAX_OFFSET_ACK, max_offset_ack)                                            \
   V(MAX_OFFSET_RECV, max_offset_received)                                      \
-  V(FINAL_SIZE, final_size)
+  V(FINAL_SIZE, final_size)                                                    \
+  /* Bytes in the receive accumulation buffer */                               \
+  V(BYTES_ACCUMULATED, bytes_accumulated)                                      \
+  /* Peak bytes accumulated over stream lifetime */                            \
+  V(MAX_BYTES_ACCUMULATED, max_bytes_accumulated)
 
 #define STREAM_JS_METHODS(V)                                                   \
   V(AttachSource, attachSource, false)                                         \
@@ -99,6 +104,91 @@ namespace quic {
   V(InitStreamingSource, initStreamingSource, false)                           \
   V(Write, write, false)                                                       \
   V(EndWrite, endWrite, false)
+
+// ============================================================================
+// RecvAccumulator implementation
+
+RecvAccumulator::RecvAccumulator(size_t max_capacity)
+    : buf_(kMinCapacity), max_capacity_(std::max(max_capacity, kMinCapacity)) {}
+
+size_t RecvAccumulator::Write(const uint8_t* data, size_t len) {
+  if (len == 0) return 0;
+
+  size_t capacity = buf_.size();
+
+  // If the buffer is full, caller must flush or grow first.
+  size_t space = remaining();
+  if (space == 0) return 0;
+
+  size_t to_write = std::min(len, space);
+
+  // Write into the buffer, handling wrap-around.
+  size_t physical_write = write_pos_ % capacity;
+  size_t first_chunk = std::min(to_write, capacity - physical_write);
+  memcpy(buf_.data() + physical_write, data, first_chunk);
+  if (first_chunk < to_write) {
+    memcpy(buf_.data(), data + first_chunk, to_write - first_chunk);
+  }
+
+  write_pos_ += to_write;
+  len_ += to_write;
+  return to_write;
+}
+
+std::unique_ptr<DataQueue::Entry> RecvAccumulator::Flush(Environment* env) {
+  if (len_ == 0) return nullptr;
+
+  size_t capacity = buf_.size();
+
+  auto store = ArrayBuffer::NewBackingStore(
+      env->isolate(), len_, BackingStoreInitializationMode::kUninitialized);
+  auto* dest = static_cast<uint8_t*>(store->Data());
+
+  // Copy from the ring buffer. Handle the wrap-around case.
+  size_t physical_read = read_pos_ % capacity;
+  size_t first_chunk = std::min(len_, capacity - physical_read);
+  memcpy(dest, buf_.data() + physical_read, first_chunk);
+  if (first_chunk < len_) {
+    memcpy(dest + first_chunk, buf_.data(), len_ - first_chunk);
+  }
+
+  size_t flushed = len_;
+
+  // Reset cursors.
+  read_pos_ = 0;
+  write_pos_ = 0;
+  len_ = 0;
+
+  // Shrink back toward kMinCapacity if we had expanded.
+  if (capacity > kMinCapacity) {
+    buf_.resize(kMinCapacity);
+    buf_.shrink_to_fit();
+  }
+
+  return DataQueue::CreateInMemoryEntryFromBackingStore(
+      std::move(store), 0, flushed);
+}
+
+void RecvAccumulator::Grow() {
+  size_t capacity = buf_.size();
+  size_t new_capacity = std::min(capacity * 2, max_capacity_);
+  if (new_capacity <= capacity) return;  // already at max
+
+  // Linearize the data and grow in one step.
+  std::vector<uint8_t> new_buf(new_capacity);
+  if (len_ > 0) {
+    size_t physical_read = read_pos_ % capacity;
+    size_t first_chunk = std::min(len_, capacity - physical_read);
+    memcpy(new_buf.data(), buf_.data() + physical_read, first_chunk);
+    if (first_chunk < len_) {
+      memcpy(new_buf.data() + first_chunk, buf_.data(), len_ - first_chunk);
+    }
+  }
+
+  buf_ = std::move(new_buf);
+  read_pos_ = 0;
+  write_pos_ = len_;
+}
 
 // ============================================================================
 
@@ -1421,6 +1511,28 @@ void Stream::EntryRead(size_t amount) {
   session().ExtendOffset(amount);
 }
 
+void Stream::BeforePull() {
+  // Called before the DataQueue reader pulls. Flush any accumulated
+  // receive data into the DataQueue so the pull finds it immediately.
+  if (recv_accumulator_ && recv_accumulator_->available() > 0) {
+    FlushAccumulation();
+  }
+}
+
+void Stream::FlushAccumulation() {
+  if (!recv_accumulator_ || recv_accumulator_->available() == 0) return;
+  auto entry = recv_accumulator_->Flush(env());
+  if (entry) {
+    inbound_->append(std::move(entry));
+    // Notify the reader that data is now available in the DataQueue.
+    // This is the only place we notify — not on every ReceiveData call —
+    // so the reader only wakes up when there is a well-sized entry to
+    // consume.
+    if (reader_) reader_->NotifyPull();
+  }
+  STAT_SET(Stats, bytes_accumulated, 0);
+}
+
 int Stream::DoPull(bob::Next<ngtcp2_vec> next,
                    int options,
                    ngtcp2_vec* data,
@@ -1513,6 +1625,8 @@ void Stream::EndWritable() {
 void Stream::EndReadable(std::optional<uint64_t> maybe_final_size) {
   if (!is_readable()) return;
   state()->read_ended = 1;
+  // Flush any accumulated data before capping so the reader can see it.
+  FlushAccumulation();
   set_final_size(maybe_final_size.value_or(STAT_GET(Stats, bytes_received)));
   inbound_->cap(STAT_GET(Stats, final_size));
   // Notify the JS reader so it can see EOS. Pass fin=true so the
@@ -1547,6 +1661,10 @@ void Stream::Destroy(QuicError error) {
 
   // We are going to release our reference to the outbound_ queue here.
   outbound_.reset();
+
+  // EndReadable() above already flushed accumulated data. Just release
+  // the ring buffer memory.
+  recv_accumulator_.reset();
 
   // We reset the inbound here also. However, it's important to note that
   // the JavaScript side could still have a reader on the inbound DataQueue,
@@ -1594,15 +1712,81 @@ void Stream::ReceiveData(const uint8_t* data,
   STAT_INCREMENT_N(Stats, bytes_received, len);
   STAT_SET(Stats, max_offset_received, STAT_GET(Stats, bytes_received));
   STAT_RECORD_TIMESTAMP(Stats, received_at);
-  JS_TRY_ALLOCATE_BACKING(env(), backing, len)
-  memcpy(backing->Data(), data, len);
-  inbound_->append(DataQueue::CreateInMemoryEntryFromBackingStore(
-      std::move(backing), 0, len));
 
-  // Notify the JS reader that data is available.
-  if (reader_) reader_->NotifyPull();
+  // Lazy-allocate the receive accumulation buffer on first data-carrying
+  // call. Streams that never receive data (write-only, immediately reset)
+  // pay zero cost.
+  if (!recv_accumulator_) {
+    // Use the per-stream flow control window as the max capacity. The
+    // peer cannot send more than this without the JS side consuming and
+    // extending the window, so the ring buffer can never overflow.
+    auto params = ngtcp2_conn_get_local_transport_params(session());
+    size_t max_cap;
+    if (direction() == Direction::BIDIRECTIONAL) {
+      max_cap =
+          ngtcp2_conn_is_local_stream(session(), id())
+              ? static_cast<size_t>(params->initial_max_stream_data_bidi_local)
+              : static_cast<size_t>(
+                    params->initial_max_stream_data_bidi_remote);
+    } else {
+      max_cap = static_cast<size_t>(params->initial_max_stream_data_uni);
+    }
+    recv_accumulator_ = std::make_unique<RecvAccumulator>(max_cap);
+  }
 
-  if (flags.fin) EndReadable();
+  // Track whether the accumulator was empty before this call. Used to
+  // notify the reader exactly once per accumulation cycle (empty → non-empty
+  // transition) rather than on every callback.
+  bool was_empty = recv_accumulator_->available() == 0;
+
+  // Accumulate into the ring buffer. When the buffer reaches the flush
+  // threshold (64 KB of accumulated data), flush it into the DataQueue as
+  // a single entry and continue writing the remainder. If the reader is
+  // not consuming (no reader, or reader hasn't pulled), allow the buffer
+  // to grow beyond 64 KB up to the flow control window instead of
+  // flushing — keeping data in cheap C++ memory rather than creating
+  // V8 BackingStore entries nobody is reading yet.
+  while (len > 0) {
+    size_t written = recv_accumulator_->Write(data, len);
+    data += written;
+    len -= written;
+
+    if (len > 0) {
+      // Buffer is full. Decide whether to flush or grow.
+      if (recv_accumulator_->should_flush() && reader_) {
+        // Reader exists and we've hit the flush threshold — produce a
+        // well-sized DataQueue entry for the reader to consume.
+        FlushAccumulation();
+      } else if (recv_accumulator_->remaining() == 0) {
+        // No reader yet, or below flush threshold but physically full.
+        // Try to grow the buffer to absorb more data.
+        recv_accumulator_->Grow();
+        // If Grow() couldn't expand (already at max), flush as fallback.
+        if (recv_accumulator_->remaining() == 0) {
+          FlushAccumulation();
+        }
+      }
+    }
+  }
+
+  // Update accumulation stats.
+  STAT_SET(Stats, bytes_accumulated, recv_accumulator_->available());
+  if (recv_accumulator_->available() > STAT_GET(Stats, max_bytes_accumulated)) {
+    STAT_SET(Stats, max_bytes_accumulated, recv_accumulator_->available());
+  }
+
+  if (flags.fin) {
+    FlushAccumulation();
+    EndReadable();
+  } else if (reader_ && was_empty) {
+    // Notify the reader once when the accumulator transitions from empty
+    // to non-empty. This wakes the reader exactly once per accumulation
+    // cycle. When the reader wakes and calls pull(), BeforePull() flushes
+    // the accumulated data, and the subsequent EntryRead() extends the
+    // flow control window. We do NOT notify on every callback — that
+    // would defeat coalescing by flushing tiny amounts each time.
+    reader_->NotifyPull();
+  }
 }
 
 void Stream::ReceiveStopSending(QuicError error) {

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -290,7 +290,7 @@ Maybe<std::shared_ptr<DataQueue>> Stream::GetDataQueueFromSource(
             &file_handle, value, Nothing<std::shared_ptr<DataQueue>>());
         Local<Value> path;
         if (!ToV8Value(env->context(), file_handle->original_name())
-            .ToLocal(&path)) {
+                 .ToLocal(&path)) {
           return Nothing<std::shared_ptr<DataQueue>>();
         }
         auto entry = DataQueue::CreateFdEntry(env, path);
@@ -529,8 +529,9 @@ class Stream::Outbound final : public MemoryRetainer {
   explicit Outbound(Stream* stream)
       : stream_(stream),
         queue_(DataQueue::Create()),
-        reader_(queue_->get_reader()),
-        streaming_(true) {}
+        reader_(queue_->get_reader()) {
+    flags_.streaming = true;
+  }
 
   void Acknowledge(size_t amount) {
     size_t remaining = std::min(amount, total_ - uncommitted_);
@@ -603,7 +604,7 @@ class Stream::Outbound final : public MemoryRetainer {
     if (queue_) queue_->cap();
   }
 
-  bool is_streaming() const { return streaming_; }
+  bool is_streaming() const { return flags_.streaming; }
   size_t total() const { return total_; }
   size_t uncommitted() const { return uncommitted_; }
 
@@ -615,7 +616,7 @@ class Stream::Outbound final : public MemoryRetainer {
   // Appends an entry to the underlying DataQueue. Only valid when
   // the Outbound was created in streaming mode.
   bool AppendEntry(std::unique_ptr<DataQueue::Entry> entry) {
-    if (!streaming_ || !queue_) return false;
+    if (!flags_.streaming || !queue_) return false;
     auto size = entry->size();
     auto result = queue_->append(std::move(entry));
     if (result.has_value() && result.value()) {
@@ -630,7 +631,7 @@ class Stream::Outbound final : public MemoryRetainer {
            ngtcp2_vec* data,
            size_t count,
            size_t max_count_hint) {
-    if (next_pending_) {
+    if (flags_.next_pending) {
       // An async read is in flight, but there may be uncommitted bytes
       // from a previous read that ngtcp2 didn't accept (nwrite=0 due
       // to pacing/congestion). Return those bytes so the send loop can
@@ -643,14 +644,14 @@ class Stream::Outbound final : public MemoryRetainer {
       return bob::Status::STATUS_BLOCK;
     }
 
-    if (errored_) {
+    if (flags_.errored) {
       std::move(next)(UV_EBADF, nullptr, 0, [](int) {});
       return UV_EBADF;
     }
 
     // If eos_ is true and there are no uncommitted bytes we'll return eos,
     // otherwise, return whatever is in the uncommitted queue.
-    if (eos_) {
+    if (flags_.eos) {
       if (uncommitted_ > 0) {
         PullUncommitted(std::move(next));
         return bob::Status::STATUS_CONTINUE;
@@ -683,8 +684,8 @@ class Stream::Outbound final : public MemoryRetainer {
             // If next_pending_ is true then a pull from the reader ended up
             // being asynchronous, our stream is blocking waiting for the data,
             // but we have an error! oh no! We need to error the stream.
-            if (next_pending_) {
-              next_pending_ = false;
+            if (flags_.next_pending) {
+              flags_.next_pending = false;
               stream_->Destroy(
                   QuicError::ForNgtcp2Error(NGTCP2_INTERNAL_ERROR));
               // We do not need to worry about calling MarkErrored in this case
@@ -705,8 +706,8 @@ class Stream::Outbound final : public MemoryRetainer {
             // session will try to read from it again.
             // We must clear next_pending_ before calling ResumeStream because
             // ResumeStream can synchronously re-enter Outbound::Pull.
-            if (next_pending_) {
-              next_pending_ = false;
+            if (flags_.next_pending) {
+              flags_.next_pending = false;
               stream_->session().ResumeStream(stream_->id());
             }
             return;
@@ -732,8 +733,8 @@ class Stream::Outbound final : public MemoryRetainer {
           // pull from it again.
           // We must clear next_pending_ before calling ResumeStream because
           // ResumeStream can synchronously re-enter Outbound::Pull.
-          if (next_pending_) {
-            next_pending_ = false;
+          if (flags_.next_pending) {
+            flags_.next_pending = false;
             stream_->session().ResumeStream(stream_->id());
           }
         },
@@ -795,7 +796,7 @@ class Stream::Outbound final : public MemoryRetainer {
     // rather than blocking — the async callback will resume the stream when
     // more data arrives.
     if (ret == bob::Status::STATUS_WAIT) {
-      next_pending_ = true;
+      flags_.next_pending = true;
       if (uncommitted_ > 0) {
         PullUncommitted(std::move(next));
         return bob::Status::STATUS_CONTINUE;
@@ -843,7 +844,7 @@ class Stream::Outbound final : public MemoryRetainer {
   }
 
   void MarkErrored() {
-    errored_ = true;
+    flags_.errored = true;
     head_.reset();
     tail_ = nullptr;
     commit_head_ = nullptr;
@@ -854,7 +855,7 @@ class Stream::Outbound final : public MemoryRetainer {
   }
 
   void MarkEnded() {
-    eos_ = true;
+    flags_.eos = true;
     queue_.reset();
     reader_.reset();
   }
@@ -894,17 +895,17 @@ class Stream::Outbound final : public MemoryRetainer {
   std::shared_ptr<DataQueue> queue_;
   std::shared_ptr<DataQueue::Reader> reader_;
 
-  bool errored_ = false;
-
-  // True when in streaming mode (non-idempotent queue, appendable).
-  bool streaming_ = false;
-
-  // Will be set to true if the reader_ ends up providing a pull result
-  // asynchronously.
-  bool next_pending_ = false;
-
-  // Will be set to true once reader_ has returned eos.
-  bool eos_ = false;
+  struct Flags {
+    uint8_t errored : 1 = 0;
+    // True when in streaming mode (non-idempotent queue, appendable).
+    uint8_t streaming : 1 = 0;
+    // Will be set to true if the reader_ ends up providing a pull result
+    // asynchronously.
+    uint8_t next_pending : 1 = 0;
+    // Will be set to true once reader_ has returned eos.
+    uint8_t eos : 1 = 0;
+  };
+  Flags flags_;
 
   // The collection of buffers that we have pulled from reader_ and that we
   // are holding onto until they are acknowledged.

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -983,6 +983,8 @@ void Stream::InitPerContext(Realm* realm, Local<Object> target) {
   STREAM_STATE(V)
 #undef V
 
+  NODE_DEFINE_CONSTANT(target, IDX_STATS_STREAM_COUNT);
+
   constexpr int QUIC_STREAM_HEADERS_KIND_HINTS =
       static_cast<uint8_t>(HeadersKind::HINTS);
   constexpr int QUIC_STREAM_HEADERS_KIND_INITIAL =

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1563,8 +1563,11 @@ void Stream::Destroy(QuicError error) {
   auto session = session_;
   session_.reset();
   // EmitClose above triggers MakeCallback which can destroy the session
-  // via JS re-entrancy. The weak pointer may now be null.
-  if (session) session->RemoveStream(id());
+  // via JS re-entrancy. The weak pointer may still be non-null (the
+  // Session BaseObject can be kept alive by a BaseObjectPtr elsewhere,
+  // e.g. OnTimeout's ref) even though impl_ has been reset. We must
+  // check is_destroyed() to avoid dereferencing the null impl_.
+  if (session && !session->is_destroyed()) session->RemoveStream(id());
 
   // Critically, make sure that the RemoveStream call is the last thing
   // trying to use this stream object. Once that call is made, the stream

--- a/src/quic/streams.h
+++ b/src/quic/streams.h
@@ -304,6 +304,17 @@ class Stream final : public AsyncWrap,
   struct State;
   struct Stats;
 
+  // Typed accessors for arena-allocated state/stats. These are defined
+  // in streams.cc where State and Stats are complete types.
+  inline State* state() { return static_cast<State*>(state_slot_.ptr); }
+  inline const State* state() const {
+    return static_cast<const State*>(state_slot_.ptr);
+  }
+  inline Stats* stats() { return static_cast<Stats*>(stats_slot_.ptr); }
+  inline const Stats* stats() const {
+    return static_cast<const Stats*>(stats_slot_.ptr);
+  }
+
  private:
   struct Impl;
   struct PendingHeaders;
@@ -362,8 +373,8 @@ class Stream final : public AsyncWrap,
                              v8::Local<v8::Array> headers,
                              HeadersFlags flags);
 
-  AliasedStruct<Stats> stats_;
-  AliasedStruct<State> state_;
+  ArenaSlotBase stats_slot_;
+  ArenaSlotBase state_slot_;
   BaseObjectWeakPtr<Session> session_;
   std::unique_ptr<Outbound> outbound_;
   std::shared_ptr<DataQueue> inbound_;

--- a/src/quic/streams.h
+++ b/src/quic/streams.h
@@ -15,10 +15,60 @@
 #include "bindingdata.h"
 #include "data.h"
 
+#include <vector>
+
 namespace node::quic {
 
 class Session;
 class Stream;
+
+// An elastic ring buffer used by Stream to coalesce received data before
+// flushing it into the DataQueue. This avoids creating many small V8
+// BackingStore allocations from per-QUIC-frame ngtcp2 callbacks. Data is
+// memcpy'd into the ring buffer and flushed as a single right-sized
+// BackingStore when the reader pulls or the buffer reaches its flush
+// threshold. The buffer starts at kMinCapacity and can grow up to a
+// configured maximum (typically the stream flow control window).
+class RecvAccumulator final {
+ public:
+  static constexpr size_t kMinCapacity = 64 * 1024;        // 64 KB
+  static constexpr size_t kFlushThreshold = kMinCapacity;  // flush at 64 KB
+
+  explicit RecvAccumulator(size_t max_capacity);
+  ~RecvAccumulator() = default;
+
+  DISALLOW_COPY_AND_MOVE(RecvAccumulator)
+
+  // Append data. Returns the number of bytes written (may be less than
+  // len if the buffer is full). The caller should flush and retry with
+  // the remaining bytes.
+  size_t Write(const uint8_t* data, size_t len);
+
+  // Flush accumulated data as a single DataQueue entry backed by a
+  // right-sized V8 BackingStore. Returns nullptr if nothing is
+  // accumulated. Resets the read/write cursors and shrinks the buffer
+  // back toward kMinCapacity if it was expanded.
+  std::unique_ptr<DataQueue::Entry> Flush(Environment* env);
+
+  // Current number of bytes awaiting flush.
+  size_t available() const { return len_; }
+
+  // Number of bytes that can still be written before the buffer is full.
+  size_t remaining() const { return buf_.size() - len_; }
+
+  // True if accumulated data has reached the flush threshold.
+  bool should_flush() const { return len_ >= kFlushThreshold; }
+
+  // Grow the buffer capacity (doubles, up to max_capacity_).
+  void Grow();
+
+ private:
+  std::vector<uint8_t> buf_;
+  size_t max_capacity_;
+  size_t read_pos_ = 0;
+  size_t write_pos_ = 0;
+  size_t len_ = 0;  // write_pos_ - read_pos_, accounting for wrap
+};
 
 using Ngtcp2Source = bob::SourceImpl<ngtcp2_vec>;
 
@@ -253,6 +303,7 @@ class Stream final : public AsyncWrap,
   void EndWritable();
   void EndReadable(std::optional<uint64_t> maybe_final_size = std::nullopt);
   void EntryRead(size_t amount) override;
+  void BeforePull() override;
 
   // Pulls data from the internal outbound DataQueue configured for this stream.
   // This is called by the session/application when it is preparing to send
@@ -321,6 +372,10 @@ class Stream final : public AsyncWrap,
 
   class Outbound;
 
+  // Flushes any data accumulated in the receive ring buffer into the
+  // inbound DataQueue as a single right-sized entry.
+  void FlushAccumulation();
+
   // Gets a reader for the data received for this stream from the peer,
   BaseObjectPtr<Blob::Reader> get_reader();
 
@@ -379,6 +434,7 @@ class Stream final : public AsyncWrap,
   std::unique_ptr<Outbound> outbound_;
   std::shared_ptr<DataQueue> inbound_;
   BaseObjectWeakPtr<Blob::Reader> reader_;
+  std::unique_ptr<RecvAccumulator> recv_accumulator_;
 
   // If the stream cannot be opened yet, it will be created in a pending state.
   // Once the owning session is able to, it will complete opening of the stream

--- a/src/quic/streams.h
+++ b/src/quic/streams.h
@@ -344,7 +344,7 @@ class Stream final : public AsyncWrap,
   // Returns false if the header cannot be added. This will typically happen
   // if the application does not support headers, a maximum number of headers
   // have already been added, or the maximum total header length is reached.
-  bool AddHeader(const Header& header);
+  bool AddHeader(std::unique_ptr<Header> header);
 
   // TODO(@jasnell): Implement MemoryInfo to track outbound_, inbound_,
   // reader_, headers_, and pending_headers_queue_.
@@ -455,9 +455,11 @@ class Stream final : public AsyncWrap,
   const StoredPriority& stored_priority() const { return priority_; }
 
   // The headers_ field holds a block of headers that have been received and
-  // are being buffered for delivery to the JavaScript side.
-  // TODO(@jasnell): Use v8::Global instead of v8::Local here.
-  v8::LocalVector<v8::Value> headers_;
+  // are being buffered for delivery to the JavaScript side. Headers are
+  // stored as C++ objects during collection (AddHeader) and converted to
+  // V8 strings only when emitted (EmitHeaders), avoiding StrongRootAllocator
+  // mutex contention on the per-header hot path.
+  std::vector<std::unique_ptr<Header>> headers_;
 
   // The headers_kind_ field indicates the kind of headers that are being
   // buffered.

--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -50,7 +50,7 @@ namespace quic {
 namespace {
 
 // Temporarily wraps an SSL pointer but does not take ownership.
-// Use by a few of the TLSSession methods that need access to the SSL*
+// Used by a few of the TLSSession methods that need access to the SSL*
 // pointer held by the OSSLContext but cannot take ownership of it.
 class SSLPointerRef final {
  public:
@@ -188,7 +188,7 @@ void OSSLContext::reset() {
   if (ctx_) {
     // The SSL object inside the ngtcp2 ctx may not have been set if
     // SSL creation failed. Guard against null before clearing app data.
-    if (SSL* ssl = ngtcp2_crypto_ossl_ctx_get_ssl(ctx_); ssl != nullptr) {
+    if (SSL* ssl = *this; ssl != nullptr) {
       SSL_set_app_data(ssl, nullptr);
     }
     // connection_ is set during Initialize(). If Initialize() was
@@ -225,7 +225,7 @@ void OSSLContext::Initialize(SSL* ssl,
   connection_ = connection;
 }
 
-std::string OSSLContext::get_cipher_name() const {
+std::string_view OSSLContext::get_cipher_name() const {
   return SSL_get_cipher_name(*this);
 }
 

--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -30,13 +30,16 @@ using ncrypto::SSLCtxPointer;
 using ncrypto::SSLPointer;
 using ncrypto::SSLSessionPointer;
 using ncrypto::X509Pointer;
+using v8::Array;
 using v8::ArrayBuffer;
+using v8::ArrayBufferView;
 using v8::Just;
 using v8::Local;
 using v8::Maybe;
 using v8::MaybeLocal;
 using v8::Nothing;
 using v8::Object;
+using v8::String;
 using v8::Undefined;
 using v8::Value;
 
@@ -95,7 +98,7 @@ template <typename T, typename Opt, std::vector<T> Opt::*member>
 bool SetOption(Environment* env,
                Opt* options,
                const Local<Object>& object,
-               const Local<v8::String>& name) {
+               const Local<String>& name) {
   Local<Value> value;
   if (!object->Get(env->context(), name).ToLocal(&value)) return false;
 
@@ -105,7 +108,7 @@ bool SetOption(Environment* env,
 
   if (value->IsArray()) {
     auto context = env->context();
-    auto values = value.As<v8::Array>();
+    auto values = value.As<Array>();
     uint32_t count = values->Length();
     for (uint32_t n = 0; n < count; n++) {
       Local<Value> item;
@@ -125,7 +128,7 @@ bool SetOption(Environment* env,
         }
       } else if constexpr (std::is_same<T, Store>::value) {
         if (item->IsArrayBufferView()) {
-          Store store = Store::CopyFrom(item.As<v8::ArrayBufferView>());
+          Store store = Store::CopyFrom(item.As<ArrayBufferView>());
           (options->*member).push_back(std::move(store));
         } else if (item->IsArrayBuffer()) {
           Store store = Store::CopyFrom(item.As<ArrayBuffer>());
@@ -154,7 +157,7 @@ bool SetOption(Environment* env,
       }
     } else if constexpr (std::is_same<T, Store>::value) {
       if (value->IsArrayBufferView()) {
-        Store store = Store::CopyFrom(value.As<v8::ArrayBufferView>());
+        Store store = Store::CopyFrom(value.As<ArrayBufferView>());
         (options->*member).push_back(std::move(store));
       } else if (value->IsArrayBuffer()) {
         Store store = Store::CopyFrom(value.As<ArrayBuffer>());

--- a/src/quic/tlscontext.h
+++ b/src/quic/tlscontext.h
@@ -45,7 +45,7 @@ class OSSLContext final {
                   ngtcp2_conn* connection,
                   SSL_CTX* ssl_ctx);
 
-  std::string get_cipher_name() const;
+  std::string_view get_cipher_name() const;
   std::string get_selected_alpn() const;
   std::string_view get_negotiated_group() const;
 

--- a/src/quic/transportparams.cc
+++ b/src/quic/transportparams.cc
@@ -347,23 +347,23 @@ v8::MaybeLocal<v8::Object> TransportParams::ToObject(Environment* env) const {
   auto& binding_data = BindingData::Get(env);
   auto tmpl = binding_data.transport_params_template();
   static constexpr std::string_view names[] = {
-    "preferredAddressIpv4",
-    "preferredAddressIpv6",
-    "originalDCID",
-    "initialSCID",
-    "retrySCID",
-    "initialMaxStreamDataBidiLocal",
-    "initialMaxStreamDataBidiRemote",
-    "initialMaxStreamDataUni",
-    "initialMaxData",
-    "initialMaxStreamsBidi",
-    "initialMaxStreamsUni",
-    "maxIdleTimeout",
-    "activeConnectionIDLimit",
-    "ackDelayExponent",
-    "maxAckDelay",
-    "maxDatagramFrameSize",
-    "disableActiveMigration",
+      "preferredAddressIpv4",
+      "preferredAddressIpv6",
+      "originalDCID",
+      "initialSCID",
+      "retrySCID",
+      "initialMaxStreamDataBidiLocal",
+      "initialMaxStreamDataBidiRemote",
+      "initialMaxStreamDataUni",
+      "initialMaxData",
+      "initialMaxStreamsBidi",
+      "initialMaxStreamsUni",
+      "maxIdleTimeout",
+      "activeConnectionIDLimit",
+      "ackDelayExponent",
+      "maxAckDelay",
+      "maxDatagramFrameSize",
+      "disableActiveMigration",
   };
   if (tmpl.IsEmpty()) {
     tmpl = DictionaryTemplate::New(env->isolate(), names);
@@ -457,42 +457,30 @@ v8::MaybeLocal<v8::Object> TransportParams::ToObject(Environment* env) const {
       values[kRetrySCIDIndex] = value;
     }
 
-    values[kInitialMaxStreamDataBidiLocalIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->initial_max_stream_data_bidi_local);
-    values[kInitialMaxStreamDataBidiRemoteIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->initial_max_stream_data_bidi_remote);
-    values[kInitialMaxStreamDataUniIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->initial_max_stream_data_uni);
+    values[kInitialMaxStreamDataBidiLocalIndex] = BigInt::NewFromUnsigned(
+        env->isolate(), ptr_->initial_max_stream_data_bidi_local);
+    values[kInitialMaxStreamDataBidiRemoteIndex] = BigInt::NewFromUnsigned(
+        env->isolate(), ptr_->initial_max_stream_data_bidi_remote);
+    values[kInitialMaxStreamDataUniIndex] = BigInt::NewFromUnsigned(
+        env->isolate(), ptr_->initial_max_stream_data_uni);
     values[kInitialMaxDataIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->initial_max_data);
+        BigInt::NewFromUnsigned(env->isolate(), ptr_->initial_max_data);
     values[kInitialMaxStreamsBidiIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->initial_max_streams_bidi);
+        BigInt::NewFromUnsigned(env->isolate(), ptr_->initial_max_streams_bidi);
     values[kInitialMaxStreamsUniIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->initial_max_streams_uni);
-    values[kMaxIdleTimeoutIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->max_idle_timeout / NGTCP2_SECONDS);
-    values[kActiveConnectionIDLimitIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->active_connection_id_limit);
+        BigInt::NewFromUnsigned(env->isolate(), ptr_->initial_max_streams_uni);
+    values[kMaxIdleTimeoutIndex] = BigInt::NewFromUnsigned(
+        env->isolate(), ptr_->max_idle_timeout / NGTCP2_SECONDS);
+    values[kActiveConnectionIDLimitIndex] = BigInt::NewFromUnsigned(
+        env->isolate(), ptr_->active_connection_id_limit);
     values[kAckDelayExponentIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->ack_delay_exponent);
+        BigInt::NewFromUnsigned(env->isolate(), ptr_->ack_delay_exponent);
     values[kMaxAckDelayIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->ack_delay_exponent);
+        BigInt::NewFromUnsigned(env->isolate(), ptr_->ack_delay_exponent);
     values[kMaxAckDelayIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->max_ack_delay);
+        BigInt::NewFromUnsigned(env->isolate(), ptr_->max_ack_delay);
     values[kMaxDatagramFrameSizeIndex] =
-        BigInt::NewFromUnsigned(env->isolate(),
-            ptr_->max_datagram_frame_size);
+        BigInt::NewFromUnsigned(env->isolate(), ptr_->max_datagram_frame_size);
     values[kDisableActiveMigrationIndex] =
         Boolean::New(env->isolate(), ptr_->disable_active_migration);
   }

--- a/src/quic/transportparams.cc
+++ b/src/quic/transportparams.cc
@@ -18,9 +18,13 @@
 
 namespace node {
 
+using v8::BigInt;
+using v8::Boolean;
+using v8::DictionaryTemplate;
 using v8::Just;
 using v8::Local;
 using v8::Maybe;
+using v8::MaybeLocal;
 using v8::Nothing;
 using v8::Object;
 using v8::Value;
@@ -337,6 +341,167 @@ void TransportParams::GeneratePreferredAddressToken(Session* session) {
     auto& mgr = BindingData::Get(session->env()).session_manager();
     mgr.AssociateCID(config.preferred_address_cid, config.scid);
   }
+}
+
+v8::MaybeLocal<v8::Object> TransportParams::ToObject(Environment* env) const {
+  auto& binding_data = BindingData::Get(env);
+  auto tmpl = binding_data.transport_params_template();
+  static constexpr std::string_view names[] = {
+    "preferredAddressIpv4",
+    "preferredAddressIpv6",
+    "originalDCID",
+    "initialSCID",
+    "retrySCID",
+    "initialMaxStreamDataBidiLocal",
+    "initialMaxStreamDataBidiRemote",
+    "initialMaxStreamDataUni",
+    "initialMaxData",
+    "initialMaxStreamsBidi",
+    "initialMaxStreamsUni",
+    "maxIdleTimeout",
+    "activeConnectionIDLimit",
+    "ackDelayExponent",
+    "maxAckDelay",
+    "maxDatagramFrameSize",
+    "disableActiveMigration",
+  };
+  if (tmpl.IsEmpty()) {
+    tmpl = DictionaryTemplate::New(env->isolate(), names);
+    binding_data.set_transport_params_template(tmpl);
+  }
+
+  MaybeLocal<Value> values[] = {
+      Undefined(env->isolate()),  // preferredAddressIpv4
+      Undefined(env->isolate()),  // preferredAddressIpv6
+      Undefined(env->isolate()),  // originalDCID
+      Undefined(env->isolate()),  // initialSCID
+      Undefined(env->isolate()),  // retrySCID
+      Undefined(env->isolate()),  // initialMaxStreamDataBidiLocal
+      Undefined(env->isolate()),  // initialMaxStreamDataBidiRemote
+      Undefined(env->isolate()),  // initialMaxStreamDataUni
+      Undefined(env->isolate()),  // initialMaxData
+      Undefined(env->isolate()),  // initialMaxStreamsBidi
+      Undefined(env->isolate()),  // initialMaxStreamsUni
+      Undefined(env->isolate()),  // maxIdleTimeout
+      Undefined(env->isolate()),  // activeConnectionIDLimit
+      Undefined(env->isolate()),  // ackDelayExponent
+      Undefined(env->isolate()),  // maxAckDelay
+      Undefined(env->isolate()),  // maxDatagramFrameSize
+      Undefined(env->isolate()),  // disableActiveMigration
+  };
+
+  static_assert(std::size(values) == std::size(names));
+
+  static constexpr size_t kPreferredAddressIpv4Index = 0;
+  static constexpr size_t kPreferredAddressIpv6Index = 1;
+  static constexpr size_t kOriginalDCIDIndex = 2;
+  static constexpr size_t kInitialSCIDIndex = 3;
+  static constexpr size_t kRetrySCIDIndex = 4;
+  static constexpr size_t kInitialMaxStreamDataBidiLocalIndex = 5;
+  static constexpr size_t kInitialMaxStreamDataBidiRemoteIndex = 6;
+  static constexpr size_t kInitialMaxStreamDataUniIndex = 7;
+  static constexpr size_t kInitialMaxDataIndex = 8;
+  static constexpr size_t kInitialMaxStreamsBidiIndex = 9;
+  static constexpr size_t kInitialMaxStreamsUniIndex = 10;
+  static constexpr size_t kMaxIdleTimeoutIndex = 11;
+  static constexpr size_t kActiveConnectionIDLimitIndex = 12;
+  static constexpr size_t kAckDelayExponentIndex = 13;
+  static constexpr size_t kMaxAckDelayIndex = 14;
+  static constexpr size_t kMaxDatagramFrameSizeIndex = 15;
+  static constexpr size_t kDisableActiveMigrationIndex = 16;
+
+  if (ptr_ != nullptr) {
+    if (ptr_->preferred_addr_present) {
+      if (ptr_->preferred_addr.ipv4_present) {
+        auto address = std::make_shared<SocketAddress>(
+            reinterpret_cast<const sockaddr*>(&ptr_->preferred_addr.ipv4));
+        auto addr = SocketAddressBase::Create(env, std::move(address));
+        if (!addr) return {};
+        values[kPreferredAddressIpv4Index] = addr->object();
+      }
+
+      if (ptr_->preferred_addr.ipv6_present) {
+        auto address = std::make_shared<SocketAddress>(
+            reinterpret_cast<const sockaddr*>(&ptr_->preferred_addr.ipv6));
+        auto addr = SocketAddressBase::Create(env, std::move(address));
+        if (!addr) return {};
+        values[kPreferredAddressIpv6Index] = addr->object();
+      }
+      // ngtcp2_preferred_addr preferred_addr;
+    }
+
+    if (ptr_->original_dcid_present) {
+      CID cid(ptr_->original_dcid);
+      Local<Value> value;
+      if (!ToV8Value(env->context(), cid.ToString()).ToLocal(&value)) {
+        return {};
+      }
+      values[kOriginalDCIDIndex] = value;
+    }
+
+    if (ptr_->initial_scid_present) {
+      CID cid(ptr_->initial_scid);
+      Local<Value> value;
+      if (!ToV8Value(env->context(), cid.ToString()).ToLocal(&value)) {
+        return {};
+      }
+      values[kInitialSCIDIndex] = value;
+    }
+
+    if (ptr_->retry_scid_present) {
+      CID cid(ptr_->retry_scid);
+      Local<Value> value;
+      if (!ToV8Value(env->context(), cid.ToString()).ToLocal(&value)) {
+        return {};
+      }
+      values[kRetrySCIDIndex] = value;
+    }
+
+    values[kInitialMaxStreamDataBidiLocalIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->initial_max_stream_data_bidi_local);
+    values[kInitialMaxStreamDataBidiRemoteIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->initial_max_stream_data_bidi_remote);
+    values[kInitialMaxStreamDataUniIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->initial_max_stream_data_uni);
+    values[kInitialMaxDataIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->initial_max_data);
+    values[kInitialMaxStreamsBidiIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->initial_max_streams_bidi);
+    values[kInitialMaxStreamsUniIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->initial_max_streams_uni);
+    values[kMaxIdleTimeoutIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->max_idle_timeout / NGTCP2_SECONDS);
+    values[kActiveConnectionIDLimitIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->active_connection_id_limit);
+    values[kAckDelayExponentIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->ack_delay_exponent);
+    values[kMaxAckDelayIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->ack_delay_exponent);
+    values[kMaxAckDelayIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->max_ack_delay);
+    values[kMaxDatagramFrameSizeIndex] =
+        BigInt::NewFromUnsigned(env->isolate(),
+            ptr_->max_datagram_frame_size);
+    values[kDisableActiveMigrationIndex] =
+        Boolean::New(env->isolate(), ptr_->disable_active_migration);
+  }
+
+  auto obj = tmpl->NewInstance(env->context(), values);
+  if (obj->SetPrototypeV2(env->context(), Null(env->isolate())).IsNothing()) {
+    return {};
+  }
+  return obj;
 }
 
 TransportParams::operator const ngtcp2_transport_params&() const {

--- a/src/quic/transportparams.h
+++ b/src/quic/transportparams.h
@@ -164,6 +164,9 @@ class TransportParams final {
                      size_t len,
                      Version version = Version::V1) const;
 
+  // Returns a JavaScript object representing the transport parameters.
+  v8::MaybeLocal<v8::Object> ToObject(Environment* env) const;
+
  private:
   void SetPreferredAddress(const SocketAddress& address);
   void GeneratePreferredAddressToken(Session* session);

--- a/test/parallel/test-quic-alpn-h3.mjs
+++ b/test/parallel/test-quic-alpn-h3.mjs
@@ -43,4 +43,5 @@ async function checkClient() {
 }
 
 await Promise.all([serverOpened.promise, checkClient()]);
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-alpn-mismatch.mjs
+++ b/test/parallel/test-quic-alpn-mismatch.mjs
@@ -52,3 +52,4 @@ await rejects(clientSession.opened, expected);
 // The handshake should fail — opened may reject or never resolve.
 // The session should close with an error.
 await rejects(clientSession.closed, expected);
+await serverEndpoint.close();

--- a/test/parallel/test-quic-alpn.mjs
+++ b/test/parallel/test-quic-alpn.mjs
@@ -45,3 +45,4 @@ const clientSession = await connect(serverEndpoint.address, {
 
 await Promise.all([serverOpened.promise, checkSession(clientSession)]);
 await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onblocked.mjs
+++ b/test/parallel/test-quic-callback-error-onblocked.mjs
@@ -43,3 +43,4 @@ stream.setBody(new Uint8Array(4096));
 
 // The stream's closed promise should reject with the error from the throw.
 await rejects(stream.closed, testError);
+await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-ondatagram-async.mjs
+++ b/test/parallel/test-quic-callback-error-ondatagram-async.mjs
@@ -39,5 +39,4 @@ await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
 
 await serverDone.promise;
 await clientSession.closed;
-serverEndpoint.close();
-await serverEndpoint.closed;
+await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-ondatagram-async.mjs
+++ b/test/parallel/test-quic-callback-error-ondatagram-async.mjs
@@ -38,9 +38,6 @@ await clientSession.opened;
 await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
 
 await serverDone.promise;
-// The server session was destroyed abruptly (no CONNECTION_CLOSE sent).
-// The client may receive a stateless reset if it sends any packet
-// before its idle timeout fires, so closed may reject.
-await assert.rejects(clientSession.closed, { code: 'ERR_QUIC_TRANSPORT_ERROR' });
+await clientSession.closed;
 serverEndpoint.close();
 await serverEndpoint.closed;

--- a/test/parallel/test-quic-callback-error-ondatagram.mjs
+++ b/test/parallel/test-quic-callback-error-ondatagram.mjs
@@ -41,8 +41,5 @@ await clientSession.opened;
 await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
 
 await serverDone.promise;
-// The server session was destroyed abruptly (no CONNECTION_CLOSE sent).
-// The client may receive a stateless reset if it sends any packet
-// before its idle timeout fires, so closed may reject.
-await rejects(clientSession.closed, { code: 'ERR_QUIC_TRANSPORT_ERROR' });
+await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-ondatagramstatus.mjs
+++ b/test/parallel/test-quic-callback-error-ondatagramstatus.mjs
@@ -38,3 +38,4 @@ await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
 
 // The session's closed should reject with the error from the throw.
 await rejects(clientSession.closed, testError);
+await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onerror-option.mjs
+++ b/test/parallel/test-quic-callback-error-onerror-option.mjs
@@ -34,3 +34,4 @@ await clientSession.opened;
 clientSession.destroy(testError);
 
 await rejects(clientSession.closed, testError);
+await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onerror-validation.mjs
+++ b/test/parallel/test-quic-callback-error-onerror-validation.mjs
@@ -60,3 +60,4 @@ stream.onerror = undefined;
 strictEqual(stream.onerror, undefined);
 
 await clientSession.closed;
+await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onerror.mjs
+++ b/test/parallel/test-quic-callback-error-onerror.mjs
@@ -72,5 +72,4 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   await clientSession.closed;
 }
 
-serverEndpoint.close();
-await serverEndpoint.closed;
+await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-suppressed.mjs
+++ b/test/parallel/test-quic-callback-error-suppressed.mjs
@@ -50,3 +50,4 @@ clientSession.destroy(originalError);
 
 // Closed rejects with the original error (not the SuppressedError).
 await rejects(clientSession.closed, originalError);
+await serverEndpoint.close();

--- a/test/parallel/test-quic-connection-limits.mjs
+++ b/test/parallel/test-quic-connection-limits.mjs
@@ -27,9 +27,11 @@ const endpoint = new QuicEndpoint({ maxConnectionsTotal: 1 });
 
 // Verify the limits are readable and mutable.
 strictEqual(endpoint.maxConnectionsTotal, 1);
-strictEqual(endpoint.maxConnectionsPerHost, 0);
-endpoint.maxConnectionsPerHost = 100;
+// The default maxConnectionsPerHost is 100 — a non-zero default that
+// prevents a single host from exhausting server resources.
 strictEqual(endpoint.maxConnectionsPerHost, 100);
+endpoint.maxConnectionsPerHost = 50;
+strictEqual(endpoint.maxConnectionsPerHost, 50);
 endpoint.maxConnectionsPerHost = 0;
 
 let sessionCount = 0;

--- a/test/parallel/test-quic-enable-early-data.mjs
+++ b/test/parallel/test-quic-enable-early-data.mjs
@@ -56,3 +56,4 @@ clientSession.opened.then(mustCall((info) => {
 
 await Promise.all([serverOpened.promise, clientOpened.promise]);
 clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-endpoint-onsession-throws.mjs
+++ b/test/parallel/test-quic-endpoint-onsession-throws.mjs
@@ -49,6 +49,7 @@ const transportParams = { maxIdleTimeout: 1 };
   // robust to network-dropped close packets and stops the event loop
   // from waiting on the client's idle timer to expire.
   clientSession.destroy();
+  await rejects(serverEndpoint.close(), sessionError);
 }
 
 // -------------------------------------------------------------------
@@ -71,4 +72,5 @@ const transportParams = { maxIdleTimeout: 1 };
   await closedAssertion;
 
   clientSession.destroy();
+  await rejects(serverEndpoint.close(), sessionError);
 }

--- a/test/parallel/test-quic-h3-concurrent-requests.mjs
+++ b/test/parallel/test-quic-h3-concurrent-requests.mjs
@@ -87,4 +87,5 @@ const requests = paths.map(mustCall(async (path) => {
 }, REQUEST_COUNT));
 
 await Promise.all([...requests, serverDone.promise]);
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-datagram.mjs
+++ b/test/parallel/test-quic-h3-datagram.mjs
@@ -105,7 +105,8 @@ const decoder = new TextDecoder();
   await Promise.all([serverGotDatagram.promise, clientGotDatagram.promise]);
 
   await serverDone.promise;
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }
 
 // Test 2: Server has enableDatagrams: false. The peer's H3 SETTINGS
@@ -168,4 +169,5 @@ const decoder = new TextDecoder();
 
   await Promise.all([stream.closed, serverDone.promise]);
   clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-error-codes.mjs
+++ b/test/parallel/test-quic-h3-error-codes.mjs
@@ -70,7 +70,7 @@ const decoder = new TextDecoder();
     code: 'ERR_QUIC_APPLICATION_ERROR',
   });
 
-  serverEndpoint.close();
+  await serverEndpoint.close();
 }
 
 // Graceful close with no explicit error code.
@@ -118,5 +118,6 @@ const decoder = new TextDecoder();
   // Graceful close - session close promise resolves
   // because H3_NO_ERROR is a clean close.
   await serverDone.promise;
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-goaway-non-h3.mjs
+++ b/test/parallel/test-quic-h3-goaway-non-h3.mjs
@@ -61,5 +61,5 @@ await Promise.all([stream.closed, serverDone.promise]);
 
 // Wait a tick for any deferred callbacks to fire.
 await setImmediate();
-
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-goaway.mjs
+++ b/test/parallel/test-quic-h3-goaway.mjs
@@ -144,5 +144,6 @@ dc.subscribe('quic.session.goaway', mustCall((msg) => {
 
   // Both streams close cleanly.
   await Promise.all([stream1.closed, stream2.closed]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-handshake-failure.mjs
+++ b/test/parallel/test-quic-h3-handshake-failure.mjs
@@ -1,0 +1,56 @@
+// Flags: --experimental-quic --no-warnings
+
+// Regression test: HTTP/3 server must not crash when a session is closed
+// before the H3 application is fully started (control streams bound).
+// Previously, closing such a session would call nghttp3_conn_shutdown on
+// an H3 connection whose control streams were never bound, causing an
+// assertion failure in nghttp3 (conn->tx.ctrl != NULL).
+//
+// The test creates an H3 server and a client that immediately closes the
+// session before the handshake completes. The server creates the H3
+// application during ALPN negotiation, but Start() (which binds control
+// streams) hasn't been called yet when the session is torn down.
+// The server must handle this gracefully without crashing.
+
+import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
+import { setTimeout } from 'node:timers/promises';
+import * as fixtures from '../common/fixtures.mjs';
+
+const { readKey } = fixtures;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('node:quic');
+const { createPrivateKey } = await import('node:crypto');
+
+const key = createPrivateKey(readKey('agent1-key.pem'));
+const cert = readKey('agent1-cert.pem');
+
+const serverEndpoint = await listen(async (serverSession) => {
+  await serverSession.closed;
+}, {
+  sni: { '*': { keys: [key], certs: [cert] } },
+  onheaders: mustNotCall(),
+});
+
+// Connect then immediately close the session before the handshake completes.
+// This exercises the H3 shutdown path on the server while the H3 application
+// exists but hasn't started (control streams not yet bound).
+const clientSession = await connect(serverEndpoint.address, {
+  servername: 'localhost',
+  // h3 ALPN — must match the server so the H3 application is selected
+  // on the server side before we tear it down.
+});
+
+// Close immediately — don't wait for handshake.
+await clientSession.close();
+
+// Give the server time to process the close and tear down the session.
+await setTimeout(500);
+
+// The critical assertion: reaching this point without a crash means the
+// server correctly handled the H3 shutdown before control streams were
+// bound. Verify the endpoint is still alive by closing it gracefully.
+await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-header-validation.mjs
+++ b/test/parallel/test-quic-h3-header-validation.mjs
@@ -108,7 +108,8 @@ const decoder = new TextDecoder();
   const body = await bytes(stream);
   strictEqual(decoder.decode(body), 'ok');
   await Promise.all([stream.closed, serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }
 
 // Verify multiple pseudo-header combinations work correctly.
@@ -153,5 +154,6 @@ const decoder = new TextDecoder();
   });
 
   await Promise.all([bytes(stream), stream.closed, serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-headers-support.mjs
+++ b/test/parallel/test-quic-h3-headers-support.mjs
@@ -73,4 +73,5 @@ const stream = await clientSession.createBidirectionalStream({
 throws(() => stream.sendHeaders({ ':method': 'GET' }), { code: 'ERR_INVALID_STATE' });
 
 await serverDone.promise;
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-headers-support.mjs
+++ b/test/parallel/test-quic-h3-headers-support.mjs
@@ -27,43 +27,30 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     // Sending headers on non-H3 stream throws.
-    throws(() => {
-      stream.sendHeaders({ ':status': '200' });
-    }, { code: 'ERR_INVALID_STATE' });
+    throws(() => stream.sendHeaders({ ':status': '200' }), { code: 'ERR_INVALID_STATE' });
 
     // Setting onheaders on non-H3 stream throws.
-    throws(() => {
-      stream.onheaders = () => {};
-    }, { code: 'ERR_INVALID_STATE' });
+    throws(() => stream.onheaders = () => {}, { code: 'ERR_INVALID_STATE' });
 
     // Setting ontrailers on non-H3 stream throws.
-    throws(() => {
-      stream.ontrailers = () => {};
-    }, { code: 'ERR_INVALID_STATE' });
+    throws(() => stream.ontrailers = () => {}, { code: 'ERR_INVALID_STATE' });
 
     // Setting oninfo on non-H3 stream throws.
-    throws(() => {
-      stream.oninfo = () => {};
-    }, { code: 'ERR_INVALID_STATE' });
+    throws(() => stream.oninfo = () => {}, { code: 'ERR_INVALID_STATE' });
 
     // Setting onwanttrailers on non-H3 stream throws.
-    throws(() => {
-      stream.onwanttrailers = () => {};
-    }, { code: 'ERR_INVALID_STATE' });
+    throws(() => stream.onwanttrailers = () => {}, { code: 'ERR_INVALID_STATE' });
 
     // sendInformationalHeaders throws on non-H3.
-    throws(() => {
-      stream.sendInformationalHeaders({ ':status': '103' });
-    }, { code: 'ERR_INVALID_STATE' });
+    throws(() => stream.sendInformationalHeaders({ ':status': '103' }), {
+      code: 'ERR_INVALID_STATE',
+    });
 
     // sendTrailers throws on non-H3.
-    throws(() => {
-      stream.sendTrailers({ 'x-trailer': 'value' });
-    }, { code: 'ERR_INVALID_STATE' });
+    throws(() => stream.sendTrailers({ 'x-trailer': 'value' }), { code: 'ERR_INVALID_STATE' });
 
-    try { await stream.closed; } catch {
-      // Stream may close with error.
-    }
+    stream.writer.endSync();
+
     serverSession.close();
     serverDone.resolve();
   });
@@ -81,15 +68,9 @@ await clientSession.opened;
 const stream = await clientSession.createBidirectionalStream({
   body: encoder.encode('ping'),
 });
-stream.closed.catch(() => {});
 
 // Client side — sending headers on non-H3 stream throws.
-throws(() => {
-  stream.sendHeaders({ ':method': 'GET' });
-}, { code: 'ERR_INVALID_STATE' });
+throws(() => stream.sendHeaders({ ':method': 'GET' }), { code: 'ERR_INVALID_STATE' });
 
-try { await stream.closed; } catch {
-  // Stream may close with error.
-}
 await serverDone.promise;
 clientSession.close();

--- a/test/parallel/test-quic-h3-informational-headers.mjs
+++ b/test/parallel/test-quic-h3-informational-headers.mjs
@@ -112,4 +112,5 @@ strictEqual(decoder.decode(body), responseBody);
 strictEqual(stream.headers[':status'], '200');
 
 await Promise.all([stream.closed, serverDone.promise]);
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-origin.mjs
+++ b/test/parallel/test-quic-h3-origin.mjs
@@ -87,7 +87,8 @@ const decoder = new TextDecoder();
   strictEqual(decoder.decode(body), 'ok');
 
   await Promise.all([originReceived.promise, stream.closed, serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }
 
 // port: 8443 produces origin "https://hostname:8443"
@@ -181,5 +182,6 @@ const decoder = new TextDecoder();
   strictEqual(decoder.decode(body), 'ok');
 
   await Promise.all([originReceived.promise, stream.closed, serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-pending-stream.mjs
+++ b/test/parallel/test-quic-h3-pending-stream.mjs
@@ -83,5 +83,6 @@ const decoder = new TextDecoder();
   const body = await bytes(stream);
   strictEqual(decoder.decode(body), 'ok');
   await Promise.all([stream.closed, serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-post-request.mjs
+++ b/test/parallel/test-quic-h3-post-request.mjs
@@ -98,4 +98,5 @@ const responseBody = await bytes(stream);
 strictEqual(decoder.decode(responseBody), 'echo:' + requestBody);
 
 await Promise.all([stream.closed, serverDone.promise]);
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-priority.mjs
+++ b/test/parallel/test-quic-h3-priority.mjs
@@ -151,7 +151,8 @@ const decoder = new TextDecoder();
                      stream3.closed,
                      stream4.closed,
                      serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }
 
 // Server priority getter reflects peer's PRIORITY_UPDATE.
@@ -235,5 +236,6 @@ const decoder = new TextDecoder();
   await Promise.all([serverSawHighPriority.promise,
                      stream.closed,
                      serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-qpack-settings.mjs
+++ b/test/parallel/test-quic-h3-qpack-settings.mjs
@@ -81,7 +81,8 @@ async function makeRequest(clientSession, path) {
   await makeRequest(clientSession, '/second');
 
   await serverDone.promise;
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }
 
 // Custom qpackMaxDTableCapacity = 8192 (larger than default).
@@ -115,5 +116,6 @@ async function makeRequest(clientSession, path) {
   await makeRequest(clientSession, '/beta');
 
   await serverDone.promise;
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-request-response.mjs
+++ b/test/parallel/test-quic-h3-request-response.mjs
@@ -111,4 +111,5 @@ strictEqual(decoder.decode(body), responseBody);
 strictEqual(stream.headers[':status'], '200');
 
 await Promise.all([stream.closed, serverDone.promise]);
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-settings.mjs
+++ b/test/parallel/test-quic-h3-settings.mjs
@@ -81,7 +81,8 @@ const decoder = new TextDecoder();
   strictEqual(decoder.decode(body), 'ok');
   await stream.closed;
   await serverDone.promise;
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }
 
 // maxHeaderLength enforcement.
@@ -136,7 +137,8 @@ const decoder = new TextDecoder();
   const body = await bytes(stream);
   strictEqual(decoder.decode(body), 'ok');
   await Promise.all([stream.closed, serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }
 
 // enableConnectProtocol and enableDatagrams settings.
@@ -181,5 +183,6 @@ const decoder = new TextDecoder();
   const body = await bytes(stream);
   strictEqual(decoder.decode(body), 'settings-ok');
   await Promise.all([stream.closed, serverDone.promise]);
-  clientSession.close();
+  await clientSession.close();
+  await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-h3-stream-destroy-with-headers.mjs
+++ b/test/parallel/test-quic-h3-stream-destroy-with-headers.mjs
@@ -54,5 +54,6 @@ stream.destroy();
 strictEqual(stream.destroyed, true);
 
 // Close everything cleanly.
-clientSession.close();
+await clientSession.close();
 await serverDone.promise;
+await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-trailing-headers.mjs
+++ b/test/parallel/test-quic-h3-trailing-headers.mjs
@@ -119,4 +119,5 @@ await clientTrailersReceived.promise;
 strictEqual(stream.headers[':status'], '200');
 
 await Promise.all([stream.closed, serverDone.promise]);
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-handshake-ipv6-only.mjs
+++ b/test/parallel/test-quic-handshake-ipv6-only.mjs
@@ -72,4 +72,5 @@ const info = await clientSession.opened;
 partialDeepStrictEqual(info, check);
 
 await serverOpened.promise;
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-handshake.mjs
+++ b/test/parallel/test-quic-handshake.mjs
@@ -60,4 +60,5 @@ const info = await clientSession.opened;
 partialDeepStrictEqual(info, check);
 
 await serverOpened.promise;
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-internal-endpoint-stats-state.mjs
+++ b/test/parallel/test-quic-internal-endpoint-stats-state.mjs
@@ -45,7 +45,7 @@ const {
     isBusy: false,
     maxConnectionsPerHost: 100,
     maxConnectionsTotal: 10_000,
-    pendingCallbacks: '0',
+    pendingCallbacks: 0,
   });
 
   endpoint.busy = true;

--- a/test/parallel/test-quic-internal-endpoint-stats-state.mjs
+++ b/test/parallel/test-quic-internal-endpoint-stats-state.mjs
@@ -43,8 +43,8 @@ const {
     isListening: false,
     isClosing: false,
     isBusy: false,
-    maxConnectionsPerHost: 0,
-    maxConnectionsTotal: 0,
+    maxConnectionsPerHost: 100,
+    maxConnectionsTotal: 10_000,
     pendingCallbacks: '0',
   });
 

--- a/test/parallel/test-quic-new-token.mjs
+++ b/test/parallel/test-quic-new-token.mjs
@@ -52,4 +52,5 @@ const clientSession = await connect(serverEndpoint.address, {
 
 await Promise.all([clientSession.opened, clientToken.promise]);
 
-clientSession.close();
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-session-application-options.mjs
+++ b/test/parallel/test-quic-session-application-options.mjs
@@ -1,0 +1,105 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// Test: session.applicationOptions
+// Verifies that applicationOptions is available after ALPN negotiation
+// completes (i.e., once the application has been selected), returns a
+// null-prototype object, and reflects the configured values.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import assert from 'node:assert';
+
+const { ok, strictEqual } = assert;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+
+const customAppOptions = {
+  maxHeaderPairs: 50n,
+  maxHeaderLength: 8192n,
+  maxFieldSectionSize: 16384n,
+  qpackMaxDTableCapacity: 2048n,
+  qpackEncoderMaxDTableCapacity: 2048n,
+  qpackBlockedStreams: 50n,
+  enableConnectProtocol: false,
+  enableDatagrams: false,
+};
+
+const serverDone = Promise.withResolvers();
+
+const serverEndpoint = await listen(mustCall((serverSession) => {
+  serverSession.onstream = mustCall(async (stream) => {
+    // After the stream arrives, the handshake and ALPN negotiation are
+    // complete, so applicationOptions should be available.
+    const opts = serverSession.applicationOptions;
+
+    ok(opts != null, 'server applicationOptions should be available after handshake');
+    strictEqual(typeof opts, 'object');
+    strictEqual(Object.getPrototypeOf(opts), null);
+
+    // Verify configured values are reflected.
+    strictEqual(opts.maxHeaderPairs, BigInt(customAppOptions.maxHeaderPairs));
+    strictEqual(opts.maxHeaderLength, BigInt(customAppOptions.maxHeaderLength));
+    strictEqual(opts.maxFieldSectionSize,
+                BigInt(customAppOptions.maxFieldSectionSize));
+    strictEqual(opts.qpackMaxDtableCapacity,
+                BigInt(customAppOptions.qpackMaxDTableCapacity));
+    strictEqual(opts.qpackEncoderMaxDtableCapacity,
+                BigInt(customAppOptions.qpackEncoderMaxDTableCapacity));
+    strictEqual(opts.qpackBlockedStreams,
+                BigInt(customAppOptions.qpackBlockedStreams));
+    strictEqual(opts.enableConnectProtocol,
+                customAppOptions.enableConnectProtocol);
+    strictEqual(opts.enableDatagrams, customAppOptions.enableDatagrams);
+
+    stream.writer.endSync();
+    await stream.closed;
+    serverSession.close();
+    serverDone.resolve();
+  });
+}), {
+  application: customAppOptions,
+});
+
+const clientSession = await connect(serverEndpoint.address, {
+  application: customAppOptions,
+});
+await clientSession.opened;
+
+// After opened, ALPN negotiation is complete and applicationOptions
+// should be available on the client session.
+const clientOpts = clientSession.applicationOptions;
+ok(clientOpts != null, 'client applicationOptions should be available after handshake');
+strictEqual(typeof clientOpts, 'object');
+strictEqual(Object.getPrototypeOf(clientOpts), null);
+
+// Verify configured values on the client side.
+strictEqual(clientOpts.maxHeaderPairs, BigInt(customAppOptions.maxHeaderPairs));
+strictEqual(clientOpts.maxHeaderLength, BigInt(customAppOptions.maxHeaderLength));
+strictEqual(clientOpts.maxFieldSectionSize,
+            customAppOptions.maxFieldSectionSize);
+strictEqual(clientOpts.qpackMaxDtableCapacity,
+            customAppOptions.qpackMaxDTableCapacity);
+strictEqual(clientOpts.qpackEncoderMaxDtableCapacity,
+            customAppOptions.qpackEncoderMaxDTableCapacity);
+strictEqual(clientOpts.qpackBlockedStreams,
+            customAppOptions.qpackBlockedStreams);
+strictEqual(clientOpts.enableConnectProtocol,
+            customAppOptions.enableConnectProtocol);
+strictEqual(clientOpts.enableDatagrams, customAppOptions.enableDatagrams);
+
+// Exchange data to let the server side run its assertions.
+const stream = await clientSession.createBidirectionalStream();
+stream.writer.endSync();
+
+// eslint-disable-next-line no-unused-vars
+for await (const _ of stream) { /* drain */ }
+await Promise.all([stream.closed, serverDone.promise]);
+
+// After close, applicationOptions should return null.
+await clientSession.close();
+strictEqual(clientSession.applicationOptions, null);
+
+await serverEndpoint.close();

--- a/test/parallel/test-quic-session-initial-rtt.mjs
+++ b/test/parallel/test-quic-session-initial-rtt.mjs
@@ -1,0 +1,60 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// Test: initialRtt session option is accepted and the session functions
+// correctly with a custom initial RTT estimate.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import assert from 'node:assert';
+
+const { ok } = assert;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+const { bytes } = await import('stream/iter');
+
+const encoder = new TextEncoder();
+const payload = encoder.encode('hello rtt');
+const serverDone = Promise.withResolvers();
+
+// Use a low initialRtt (1ms) to simulate a low-latency environment.
+// The session should complete successfully and the smoothed RTT in
+// stats should converge to a value well below the default 333ms.
+const serverEndpoint = await listen(mustCall((serverSession) => {
+  serverSession.onstream = mustCall(async (stream) => {
+    const data = await bytes(stream);
+    ok(data.byteLength > 0);
+    stream.writer.endSync();
+    await stream.closed;
+    serverSession.close();
+    serverDone.resolve();
+  });
+}), {
+  initialRtt: 1,  // 1ms
+});
+
+const clientSession = await connect(serverEndpoint.address, {
+  initialRtt: 1,  // 1ms
+});
+await clientSession.opened;
+
+const stream = await clientSession.createBidirectionalStream({
+  body: payload,
+});
+
+for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
+await stream.closed;
+await serverDone.promise;
+
+// After data exchange, the smoothed RTT should have converged to a
+// realistic value. On loopback it should be well under 10ms (10,000,000ns).
+// The stat is in nanoseconds.
+const smoothedRtt = clientSession.stats.smoothedRtt;
+ok(smoothedRtt > 0n, 'smoothedRtt should be non-zero after data exchange');
+ok(smoothedRtt < 10_000_000n,
+   `smoothedRtt should be under 10ms on loopback, got ${smoothedRtt}ns`);
+
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-session-stream-lifecycle.mjs
+++ b/test/parallel/test-quic-session-stream-lifecycle.mjs
@@ -90,8 +90,9 @@ strictEqual(clientSession.endpoint, null);
 strictEqual(clientSession.stats.isConnected, false);
 
 strictEqual(stream.destroyed, true);
-strictEqual(stream.session, null);
-strictEqual(stream.id, null);
-strictEqual(stream.direction, null);
+
+// The stream id and direction should still be available after destruction
+strictEqual(stream.id, 0n);
+strictEqual(stream.direction, 'bidi');
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-transport-params.mjs
+++ b/test/parallel/test-quic-session-transport-params.mjs
@@ -1,0 +1,139 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// Test: session.localTransportParams and session.remoteTransportParams
+// Verifies that local transport params are available immediately after
+// session creation, remote transport params are available after the
+// handshake completes, and values match what was configured.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import assert from 'node:assert';
+
+const { ok, strictEqual } = assert;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+
+const serverTransportParams = {
+  initialMaxStreamsBidi: 200,
+  initialMaxData: 2 * 1024 * 1024,
+};
+
+const clientTransportParams = {
+  initialMaxStreamsBidi: 500,
+  initialMaxData: 8 * 1024 * 1024,
+};
+
+const serverDone = Promise.withResolvers();
+let serverLocalParams;
+let serverRemoteParams;
+
+const serverEndpoint = await listen(mustCall((serverSession) => {
+  // localTransportParams should be available immediately.
+  serverLocalParams = serverSession.localTransportParams;
+  ok(serverLocalParams != null, 'server localTransportParams should be available immediately');
+  strictEqual(typeof serverLocalParams, 'object');
+  strictEqual(Object.getPrototypeOf(serverLocalParams), null);
+
+  // Verify server's configured values are reflected.
+  strictEqual(serverLocalParams.initialMaxStreamsBidi,
+              BigInt(serverTransportParams.initialMaxStreamsBidi));
+  strictEqual(serverLocalParams.initialMaxData,
+              BigInt(serverTransportParams.initialMaxData));
+
+  // Verify defaults are present and reasonable.
+  ok(serverLocalParams.activeConnectionIDLimit > 0n,
+     'activeConnectionIDLimit should be positive');
+  ok(serverLocalParams.ackDelayExponent > 0n,
+     'ackDelayExponent should be positive');
+  ok(serverLocalParams.maxAckDelay > 0n,
+     'maxAckDelay should be positive');
+  strictEqual(serverLocalParams.disableActiveMigration, false);
+
+  serverSession.onstream = mustCall(async (stream) => {
+    // After the stream arrives, the handshake is complete and
+    // remoteTransportParams should be available.
+    serverRemoteParams = serverSession.remoteTransportParams;
+    ok(serverRemoteParams != null,
+       'server remoteTransportParams should be available after handshake');
+    strictEqual(typeof serverRemoteParams, 'object');
+    strictEqual(Object.getPrototypeOf(serverRemoteParams), null);
+
+    // Remote params should reflect the client's configured values.
+    strictEqual(serverRemoteParams.initialMaxStreamsBidi,
+                BigInt(clientTransportParams.initialMaxStreamsBidi));
+    strictEqual(serverRemoteParams.initialMaxData,
+                BigInt(clientTransportParams.initialMaxData));
+
+    // CID fields should be present.
+    strictEqual(typeof serverRemoteParams.initialSCID, 'string');
+    ok(serverRemoteParams.initialSCID.length > 0,
+       'remote initialSCID should be non-empty');
+
+    stream.writer.endSync();
+    await stream.closed;
+    serverSession.close();
+    serverDone.resolve();
+  });
+}), {
+  transportParams: serverTransportParams,
+});
+
+const clientSession = await connect(serverEndpoint.address, {
+  transportParams: clientTransportParams,
+});
+await clientSession.opened;
+
+// After opened, the handshake is complete. Both local and remote
+// transport params should be available on the client session.
+const clientLocalParams = clientSession.localTransportParams;
+ok(clientLocalParams != null, 'client localTransportParams should be available');
+strictEqual(typeof clientLocalParams, 'object');
+strictEqual(Object.getPrototypeOf(clientLocalParams), null);
+
+// Verify client's configured values.
+strictEqual(clientLocalParams.initialMaxStreamsBidi,
+            BigInt(clientTransportParams.initialMaxStreamsBidi));
+strictEqual(clientLocalParams.initialMaxData,
+            BigInt(clientTransportParams.initialMaxData));
+
+const clientRemoteParams = clientSession.remoteTransportParams;
+ok(clientRemoteParams != null,
+   'client remoteTransportParams should be available after handshake');
+strictEqual(typeof clientRemoteParams, 'object');
+strictEqual(Object.getPrototypeOf(clientRemoteParams), null);
+
+// Remote params should reflect the server's configured values.
+strictEqual(clientRemoteParams.initialMaxStreamsBidi,
+            BigInt(serverTransportParams.initialMaxStreamsBidi));
+strictEqual(clientRemoteParams.initialMaxData,
+            BigInt(serverTransportParams.initialMaxData));
+
+// CID fields should be present on the client's view of server params.
+strictEqual(typeof clientRemoteParams.initialSCID, 'string');
+ok(clientRemoteParams.initialSCID.length > 0,
+   'remote initialSCID should be non-empty');
+
+// Cross-validation: server's remote matches client's local and vice versa.
+const stream = await clientSession.createBidirectionalStream();
+stream.writer.endSync();
+
+// eslint-disable-next-line no-unused-vars
+for await (const _ of stream) { /* drain */ }
+await stream.closed;
+await serverDone.promise;
+
+// Cross-validate after both sides have captured params.
+strictEqual(serverRemoteParams.initialMaxStreamsBidi,
+            clientLocalParams.initialMaxStreamsBidi);
+strictEqual(serverRemoteParams.initialMaxData,
+            clientLocalParams.initialMaxData);
+strictEqual(clientRemoteParams.initialMaxStreamsBidi,
+            serverLocalParams.initialMaxStreamsBidi);
+strictEqual(clientRemoteParams.initialMaxData,
+            serverLocalParams.initialMaxData);
+
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-iteration-double.mjs
+++ b/test/parallel/test-quic-stream-iteration-double.mjs
@@ -57,3 +57,4 @@ const stream = await clientSession.createBidirectionalStream({
 for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
 await Promise.all([stream.closed, serverDone.promise]);
 await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-recv-coalescing.mjs
+++ b/test/parallel/test-quic-stream-recv-coalescing.mjs
@@ -1,0 +1,130 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// Test: receive-side coalescing produces reasonably-sized chunks.
+// Sends multiple payloads of varying sizes through a bidi stream and
+// verifies that the received chunks are coalesced rather than
+// delivered as ~1154-byte QUIC frame fragments.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import assert from 'node:assert';
+
+const { ok, strictEqual } = assert;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+const { drainableProtocol: dp } = await import('stream/iter');
+
+// Payloads of varying sizes. Exercises different coalescing paths:
+//   Small (below frame size), medium (a few frames), large (many frames).
+const payloadSizes = [
+  100,       // Small: fits in a single frame
+  5_000,     // Medium: a few frames
+  64_000,    // Large: triggers buffer-full flush
+  1_000,     // Small again after large
+  200_000,   // Very large: well beyond 64 KB buffer
+  500,       // Small tail
+];
+const totalBytes = payloadSizes.reduce((a, b) => a + b, 0);
+
+// Build deterministic payloads for integrity checking.
+function buildPayload(size, seed) {
+  const buf = new Uint8Array(size);
+  for (let i = 0; i < size; i++) {
+    buf[i] = (seed + i) & 0xff;
+  }
+  return buf;
+}
+
+function checksum(data) {
+  let sum = 0;
+  for (let i = 0; i < data.byteLength; i++) {
+    sum = (sum + data[i]) | 0;
+  }
+  return sum;
+}
+
+// Compute expected checksum across all payloads.
+let expectedChecksum = 0;
+for (let i = 0; i < payloadSizes.length; i++) {
+  expectedChecksum = (expectedChecksum +
+    checksum(buildPayload(payloadSizes[i], i))) | 0;
+}
+
+// --- Server side ---
+
+const serverDone = Promise.withResolvers();
+
+const serverEndpoint = await listen(mustCall((serverSession) => {
+  serverSession.onstream = mustCall(async (stream) => {
+    const receivedChunkSizes = [];
+    let receivedBytes = 0;
+    let receivedChecksum = 0;
+
+    for await (const chunks of stream) {
+      for (const chunk of chunks) {
+        receivedChunkSizes.push(chunk.byteLength);
+        receivedBytes += chunk.byteLength;
+        receivedChecksum = (receivedChecksum + checksum(chunk)) | 0;
+      }
+    }
+
+    // Data integrity.
+    strictEqual(receivedBytes, totalBytes);
+    strictEqual(receivedChecksum, expectedChecksum);
+
+    // Coalescing effectiveness: verify that at least some chunks are larger
+    // than the ~1154-byte QUIC frame payload, showing that the accumulator
+    // is combining callbacks. On localhost, round-trip latency is near
+    // zero so coalescing opportunities are limited to I/O bursts where
+    // multiple packets arrive in the same event loop iteration. Under
+    // real network conditions the effect is much more pronounced.
+    const maxChunkSize = Math.max(...receivedChunkSizes);
+    ok(
+      maxChunkSize > 1154,
+      `Expected at least one chunk larger than a single QUIC frame ` +
+      `(1154 bytes), but max was ${maxChunkSize}`
+    );
+
+    // Stats: after full drain, bytes_accumulated should be 0.
+    strictEqual(stream.stats.bytesAccumulated, 0n);
+
+    // max_bytes_accumulated should be nonzero — data passed through
+    // the accumulator.
+    ok(
+      stream.stats.maxBytesAccumulated > 0n,
+      'maxBytesAccumulated should be nonzero'
+    );
+
+    stream.writer.endSync();
+    await stream.closed;
+    serverSession.close();
+    serverDone.resolve();
+  });
+}));
+
+// --- Client side ---
+
+const clientSession = await connect(serverEndpoint.address);
+await clientSession.opened;
+
+const stream = await clientSession.createBidirectionalStream();
+const w = stream.writer;
+
+for (let i = 0; i < payloadSizes.length; i++) {
+  const payload = buildPayload(payloadSizes[i], i);
+  while (!w.writeSync(payload)) {
+    const drainable = w[dp]();
+    if (drainable) await drainable;
+  }
+}
+w.endSync();
+
+// Drain the server's empty response to let the stream close cleanly.
+// eslint-disable-next-line no-unused-vars
+for await (const _ of stream) { /* drain response */ }
+await Promise.all([stream.closed, serverDone.promise]);
+await clientSession.close();
+await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-recv-coalescing.mjs
+++ b/test/parallel/test-quic-stream-recv-coalescing.mjs
@@ -17,15 +17,17 @@ if (!hasQuic) {
 const { listen, connect } = await import('../common/quic.mjs');
 const { drainableProtocol: dp } = await import('stream/iter');
 
-// Payloads of varying sizes. Exercises different coalescing paths:
-//   Small (below frame size), medium (a few frames), large (many frames).
+// Payloads of varying sizes with diverse prime factors to exercise
+// different flow control boundary alignments. Avoids round multiples
+// of 1000 so that frame boundaries, accumulation buffer thresholds,
+// and flow control windows are hit at irregular offsets.
 const payloadSizes = [
-  100,       // Small: fits in a single frame
-  5_000,     // Medium: a few frames
-  64_000,    // Large: triggers buffer-full flush
-  1_000,     // Small again after large
-  200_000,   // Very large: well beyond 64 KB buffer
-  500,       // Small tail
+  97,        // Small prime: fits in a single frame
+  4_999,     // Medium prime: a few frames
+  65_521,    // Largest prime below 64 KB buffer flush threshold
+  1_153,     // Small prime after large
+  196_613,   // Large prime: well beyond 64 KB buffer
+  509,       // Small prime tail
 ];
 const totalBytes = payloadSizes.reduce((a, b) => a + b, 0);
 


### PR DESCRIPTION
A number of planned backend changes and improvements in the packet handling. Yields a net performance improvement of around 10% higher rps. Sets us up to be able to better leverage https://github.com/libuv/libuv/pull/5116 if/when that lands (@santigimeno @saghul fyi) which will provide an even larger perf boost. Fixes a bug while we're at it.

@nodejs/quic 