### PR TITLE
doc: fix crypto.sign and crypto.verify accepted types

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -6132,7 +6132,7 @@ changes:
 <!--lint disable maximum-line-length remark-lint-->
 
 * `algorithm` {string | null | undefined}
-* `data` {ArrayBuffer|Buffer|TypedArray|DataView}
+* `data` {ArrayBuffer|Buffer|SharedArrayBuffer|TypedArray|DataView|string}
 * `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
 * `callback` {Function}
   * `err` {Error}
@@ -6264,9 +6264,9 @@ changes:
 <!--lint disable maximum-line-length remark-lint-->
 
 * `algorithm` {string|null|undefined}
-* `data` {ArrayBuffer| Buffer|TypedArray|DataView}
+* `data` {Buffer|TypedArray|DataView|string}
 * `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
-* `signature` {ArrayBuffer|Buffer|TypedArray|DataView}
+* `signature` {Buffer|TypedArray|DataView}
 * `callback` {Function}
   * `err` {Error}
   * `result` {boolean}


### PR DESCRIPTION
Updates the documented accepted parameter types for `crypto.sign()` and `crypto.verify()` to match the current runtime behavior.

Runtime testing confirmed that:

* `crypto.sign()` accepts `ArrayBuffer`, `SharedArrayBuffer`, and `string` for `data`
* `crypto.verify()` accepts `string` for `data`
* `crypto.verify()` rejects `ArrayBuffer` and `SharedArrayBuffer` for both `data` and `signature`

The existing v15.0.0 changelog entry for `crypto.verify()` mentions `ArrayBuffer` support for `data` and `signature`, but current runtime behavior does not reflect that. A follow-up PR can address the runtime inconsistency in `verifyOneShot()`.

Fixes: #62903
