### PR TITLE
tools: fix test426 updater

### DIFF
--- a/tools/dep_updaters/update-test426-fixtures.sh
+++ b/tools/dep_updaters/update-test426-fixtures.sh
@@ -17,10 +17,10 @@ fi
 TARBALL_URL=$(curl -fsIo /dev/null -w '%header{Location}' https://github.com/tc39/source-map-tests/archive/HEAD.tar.gz)
 SHA=$(basename "$TARBALL_URL")
 
-if [ "$CURRENT_SHA" = "$SHA" ]; then
-  echo "Already up-to-date"
-  exit 0
-fi
+# shellcheck disable=SC1091
+. "$BASE_DIR/tools/dep_updaters/utils.sh"
+
+compare_dependency_version "test426-fixtures" "$CURRENT_SHA" "$SHA"
 
 rm -rf "$TARGET_DIR"
 mkdir "$TARGET_DIR"
@@ -32,4 +32,4 @@ mv "$TMP_FILE" "$README"
 
 # The last line of the script should always print the new version,
 # as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$SHA"
+echo "NEW_VERSION=$(echo "$SHA" | head -c 39)"

--- a/tools/dep_updaters/update-test426-fixtures.sh
+++ b/tools/dep_updaters/update-test426-fixtures.sh
@@ -32,4 +32,5 @@ mv "$TMP_FILE" "$README"
 
 # The last line of the script should always print the new version,
 # as we need to add it to $GITHUB_ENV variable.
-echo "NEW_VERSION=$(echo "$SHA" | head -c 39)"
+NEW_VERSION=$(echo "$SHA" | head -c 39)
+echo "NEW_VERSION=$NEW_VERSION"


### PR DESCRIPTION
The previous version produces a commit that does pass the linter because of a too-long commit title (e.g. https://github.com/nodejs/node/pull/61926).

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
