### PR TITLE
stream: optimize single-slot push queue drain

### DIFF
--- a/lib/internal/streams/iter/push.js
+++ b/lib/internal/streams/iter/push.js
@@ -448,6 +448,10 @@ class PushQueue {
   // ===========================================================================
 
   #drain() {
+    if (this.#slots.length === 1) {
+      return this.#slots.shift();
+    }
+
     const result = [];
     for (let i = 0; i < this.#slots.length; i++) {
       const slot = this.#slots.get(i);


### PR DESCRIPTION
Optimize `PushQueue.#drain()` for the common single-slot case.

When only one slot is queued, return that slot directly instead of allocating a
new result array and copying every chunk into it. The existing flattening path is
kept for multi-slot drains.

---

Assisted-by: openai:gpt-5.5