### PR TITLE
crypto: align verifyOneShot accepted types

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -6132,7 +6132,7 @@ changes:
 <!--lint disable maximum-line-length remark-lint-->
 
 * `algorithm` {string | null | undefined}
-* `data` {ArrayBuffer|Buffer|TypedArray|DataView}
+* `data` {ArrayBuffer|Buffer|SharedArrayBuffer|TypedArray|DataView|string}
 * `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
 * `callback` {Function}
   * `err` {Error}
@@ -6264,9 +6264,9 @@ changes:
 <!--lint disable maximum-line-length remark-lint-->
 
 * `algorithm` {string|null|undefined}
-* `data` {ArrayBuffer| Buffer|TypedArray|DataView}
+* `data` {ArrayBuffer|Buffer|SharedArrayBuffer|TypedArray|DataView|string}
 * `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject|CryptoKey}
-* `signature` {ArrayBuffer|Buffer|TypedArray|DataView}
+* `signature` {ArrayBuffer|Buffer|SharedArrayBuffer|TypedArray|DataView}
 * `callback` {Function}
   * `err` {Error}
   * `result` {boolean}

--- a/lib/internal/crypto/sig.js
+++ b/lib/internal/crypto/sig.js
@@ -265,14 +265,6 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
 
   data = getArrayBufferOrView(data, 'data');
 
-  if (!isArrayBufferView(data)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'data',
-      ['Buffer', 'TypedArray', 'DataView'],
-      data,
-    );
-  }
-
   // Options specific to RSA
   const rsaPadding = getPadding(key);
   const pssSaltLength = getSaltLength(key);
@@ -283,13 +275,7 @@ function verifyOneShot(algorithm, data, key, signature, callback) {
   // Options specific to Ed448 and ML-DSA
   const context = getContext(key);
 
-  if (!isArrayBufferView(signature)) {
-    throw new ERR_INVALID_ARG_TYPE(
-      'signature',
-      ['Buffer', 'TypedArray', 'DataView'],
-      signature,
-    );
-  }
+  signature = getArrayBufferOrView(signature, 'signature');
 
   const {
     data: keyData,

--- a/test/parallel/test-crypto-sign-verify.js
+++ b/test/parallel/test-crypto-sign-verify.js
@@ -619,8 +619,8 @@ if (hasOpenSSL(3, 2)) {
   assert.throws(() => crypto.sign(null, data, input), errObj);
   assert.throws(() => crypto.verify(null, data, input, sig), errObj);
 
-  errObj.message = 'The "signature" argument must be an instance of ' +
-                   'Buffer, TypedArray, or DataView.' +
+  errObj.message = 'The "signature" argument must be of type string or an instance of ' +
+                   'ArrayBuffer, Buffer, TypedArray, or DataView.' +
                    common.invalidArgTypeHelper(input);
   assert.throws(() => crypto.verify(null, data, 'test', input), errObj);
 });
@@ -1018,4 +1018,40 @@ if (!process.features.openssl_is_boringssl) {
     code: 'ERR_INVALID_ARG_VALUE',
     message: /key\.format/,
   });
+}
+
+// crypto.verify accepts ArrayBuffer and SharedArrayBuffer for data and signature
+{
+  const { privateKey, publicKey } = crypto.generateKeyPairSync('rsa', { modulusLength: 2048 });
+  const dataBuffer = Buffer.from('Hello world');
+
+  // Data as ArrayBuffer
+  {
+    const ab = dataBuffer.buffer.slice(dataBuffer.byteOffset, dataBuffer.byteOffset + dataBuffer.byteLength);
+    const sig = crypto.sign('SHA256', dataBuffer, privateKey);
+    assert.strictEqual(crypto.verify('SHA256', ab, publicKey, sig), true);
+  }
+
+  // Data as SharedArrayBuffer
+  {
+    const sab = new SharedArrayBuffer(dataBuffer.length);
+    new Uint8Array(sab).set(dataBuffer);
+    const sig = crypto.sign('SHA256', dataBuffer, privateKey);
+    assert.strictEqual(crypto.verify('SHA256', sab, publicKey, sig), true);
+  }
+
+  // Signature as ArrayBuffer
+  {
+    const sig = crypto.sign('SHA256', dataBuffer, privateKey);
+    const sigAB = sig.buffer.slice(sig.byteOffset, sig.byteOffset + sig.byteLength);
+    assert.strictEqual(crypto.verify('SHA256', dataBuffer, publicKey, sigAB), true);
+  }
+
+  // Signature as SharedArrayBuffer
+  {
+    const sig = crypto.sign('SHA256', dataBuffer, privateKey);
+    const sigSAB = new SharedArrayBuffer(sig.length);
+    new Uint8Array(sigSAB).set(sig);
+    assert.strictEqual(crypto.verify('SHA256', dataBuffer, publicKey, sigSAB), true);
+  }
 }


### PR DESCRIPTION
Align crypto.verify() accepted types with crypto.sign()

crypto.sign() accepts ArrayBuffer and SharedArrayBuffer for `data`, but crypto.verify() rejected them with ERR_INVALID_ARG_TYPE. Two issues in verifyOneShot():

1. A redundant isArrayBufferView(data) check after getArrayBufferOrView() was incorrectly rejecting ArrayBuffer and SharedArrayBuffer — getArrayBufferOrView() already handles validation and normalization.

2. `signature` had only an isArrayBufferView() check with no prior getArrayBufferOrView() call, so ArrayBuffer and    SharedArrayBuffer were rejected there too.

Fix both by aligning verifyOneShot() with the signOneShot() pattern. Update docs and add test coverage for the affected types.

Fixes: https://github.com/nodejs/node/issues/62903