### PR TITLE
stream: uncork fromWritable writev on chunk error

### DIFF
--- a/lib/internal/streams/iter/classic.js
+++ b/lib/internal/streams/iter/classic.js
@@ -608,14 +608,26 @@ function fromWritable(writable, options = kNullPrototype) {
         return PromiseResolve();
       }
 
-      if (typeof writable.cork === 'function') writable.cork();
       let ok = true;
-      for (let i = 0; i < chunks.length; i++) {
-        const bytes = toUint8Array(chunks[i]);
-        totalBytes += TypedArrayPrototypeGetByteLength(bytes);
-        ok = writable.write(bytes);
+      if (typeof writable.cork === 'function' &&
+          typeof writable.uncork === 'function') {
+        writable.cork();
+        try {
+          for (let i = 0; i < chunks.length; i++) {
+            const bytes = toUint8Array(chunks[i]);
+            totalBytes += TypedArrayPrototypeGetByteLength(bytes);
+            ok = writable.write(bytes);
+          }
+        } finally {
+          writable.uncork();
+        }
+      } else {
+        for (let i = 0; i < chunks.length; i++) {
+          const bytes = toUint8Array(chunks[i]);
+          totalBytes += TypedArrayPrototypeGetByteLength(bytes);
+          ok = writable.write(bytes);
+        }
       }
-      if (typeof writable.uncork === 'function') writable.uncork();
 
       if (ok) return PromiseResolve();
 

--- a/lib/internal/streams/iter/classic.js
+++ b/lib/internal/streams/iter/classic.js
@@ -513,6 +513,16 @@ function fromWritable(writable, options = kNullPrototype) {
     return (writable.writableLength ?? 0) >= hwm;
   }
 
+  function writeChunks(chunks) {
+    let ok = true;
+    for (let i = 0; i < chunks.length; i++) {
+      const bytes = toUint8Array(chunks[i]);
+      totalBytes += TypedArrayPrototypeGetByteLength(bytes);
+      ok = writable.write(bytes);
+    }
+    return ok;
+  }
+
   const writer = {
     __proto__: null,
 
@@ -613,20 +623,12 @@ function fromWritable(writable, options = kNullPrototype) {
           typeof writable.uncork === 'function') {
         writable.cork();
         try {
-          for (let i = 0; i < chunks.length; i++) {
-            const bytes = toUint8Array(chunks[i]);
-            totalBytes += TypedArrayPrototypeGetByteLength(bytes);
-            ok = writable.write(bytes);
-          }
+          ok = writeChunks(chunks);
         } finally {
           writable.uncork();
         }
       } else {
-        for (let i = 0; i < chunks.length; i++) {
-          const bytes = toUint8Array(chunks[i]);
-          totalBytes += TypedArrayPrototypeGetByteLength(bytes);
-          ok = writable.write(bytes);
-        }
+        ok = writeChunks(chunks);
       }
 
       if (ok) return PromiseResolve();

--- a/test/parallel/test-stream-iter-writable-interop.js
+++ b/test/parallel/test-stream-iter-writable-interop.js
@@ -551,6 +551,21 @@ function testWritevInvalidChunksType() {
 }
 
 // =============================================================================
+// writev() uncorks when chunk validation throws
+// =============================================================================
+
+function testWritevInvalidChunkUncorks() {
+  const writable = new Writable({ write(chunk, enc, cb) { cb(); } });
+  const writer = fromWritable(writable);
+
+  assert.throws(
+    () => writer.writev([new Uint8Array([1]), 42]),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+  assert.strictEqual(writable.writableCorked, 0);
+}
+
+// =============================================================================
 // Cached writer: second call returns same instance
 // =============================================================================
 
@@ -638,6 +653,7 @@ testDrainableNull();
 testDropOldestThrows();
 testInvalidBackpressureThrows();
 testWritevInvalidChunksType();
+testWritevInvalidChunkUncorks();
 testCachedWriter();
 testObjectModeThrows();
 


### PR DESCRIPTION
Fixes `fromWritable().writev()` leaving the wrapped classic `Writable`
corked when conversion of a later chunk throws.

Previously, `writev()` called `writable.cork()` before converting all
chunks. If `toUint8Array()` threw, for example with
`writer.writev([new Uint8Array([1]), 42])`, execution skipped
`writable.uncork()` and left `writable.writableCorked === 1`.

This wraps the corked batch write in `try`/`finally` so the internal cork
is always released, and adds a regression test for the invalid later
chunk case.

Fixes: https://github.com/nodejs/node/issues/63294

---

Assisted-by: openai:gpt-5.5