### PR TITLE
stream: validate broadcast writer writev chunks

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -462,6 +462,9 @@ class BroadcastWriter {
   }
 
   writev(chunks, options) {
+    if (!ArrayIsArray(chunks)) {
+      throw new ERR_INVALID_ARG_TYPE('chunks', 'Array', chunks);
+    }
     // Fast path: no signal, writer open, buffer has space
     if (this.#canUseWriteFastPath(options)) {
       const converted = convertChunks(chunks);
@@ -522,6 +525,9 @@ class BroadcastWriter {
   }
 
   writevSync(chunks) {
+    if (!ArrayIsArray(chunks)) {
+      throw new ERR_INVALID_ARG_TYPE('chunks', 'Array', chunks);
+    }
     if (this.#isClosedOrAborted()) return false;
     if (!this.#broadcast[kCanWrite]()) return false;
     const converted = convertChunks(chunks);

--- a/test/parallel/test-stream-iter-validation.js
+++ b/test/parallel/test-stream-iter-validation.js
@@ -147,6 +147,16 @@ assert.throws(() => broadcast({ highWaterMark: Number.MAX_SAFE_INTEGER + 1 }),
 assert.throws(() => broadcast({ signal: {} }), { code: 'ERR_INVALID_ARG_TYPE' });
 assert.throws(() => broadcast({ backpressure: 'bad' }), { code: 'ERR_INVALID_ARG_VALUE' });
 
+// BroadcastWriter.writev requires array
+{
+  const { writer } = broadcast();
+  assert.throws(() => writer.writev('bad'), { code: 'ERR_INVALID_ARG_TYPE' });
+  assert.throws(() => writer.writev(42), { code: 'ERR_INVALID_ARG_TYPE' });
+  assert.throws(() => writer.writevSync('bad'), { code: 'ERR_INVALID_ARG_TYPE' });
+  assert.throws(() => writer.writevSync(42), { code: 'ERR_INVALID_ARG_TYPE' });
+  writer.endSync();
+}
+
 // Broadcast.from rejects non-iterable input
 assert.throws(() => Broadcast.from(42), { code: 'ERR_INVALID_ARG_TYPE' });
 assert.throws(() => Broadcast.from('bad'), { code: 'ERR_INVALID_ARG_TYPE' });


### PR DESCRIPTION
Fixes BroadcastWriter `writev()` and `writevSync()` input validation so
non-array `chunks` values throw `ERR_INVALID_ARG_TYPE` before reaching
`convertChunks()`.

Previously, `writer.writev('abc')` treated the string as array-like and wrote
`abc`, while `writer.writev(42)` resolved as an empty batch.


Fixes: https://github.com/nodejs/node/issues/63299

---

Assisted-by: openai:gpt-5.5
