### PR TITLE
benchmark: respect stream/iter broadcast backpressure

### DIFF
--- a/benchmark/streams/iter-throughput-broadcast.js
+++ b/benchmark/streams/iter-throughput-broadcast.js
@@ -128,9 +128,11 @@ function benchIter(chunk, numConsumers, datasize, n, totalOps) {
     let remaining = datasize;
     while (remaining > 0) {
       const size = Math.min(remaining, chunk.length);
-      remaining -= size;
       const buf = size === chunk.length ? chunk : chunk.subarray(0, size);
-      writer.writeSync(buf);
+      if (!writer.writeSync(buf)) {
+        await writer.write(buf);
+      }
+      remaining -= size;
     }
     writer.endSync();
 


### PR DESCRIPTION
This updates the `stream/iter` broadcast throughput benchmark to respect
backpressure from `writer.writeSync()`.

Previously, the benchmark decremented `remaining` before checking whether
`writeSync()` accepted the chunk. Under default strict backpressure, rejected
writes could still be counted toward the benchmarked byte total. The iter path
now falls back to `await writer.write(buf)` for the same chunk and only counts it
after the write is accepted.

---

Assisted-by: openai:gpt-5.5