### PR TITLE
doc: clarify SEA support on Intel macOS

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -630,8 +630,8 @@ Single-executable support is tested regularly on CI only on the following
 platforms:
 
 * Windows
-* macOS (arm64 only; x64 is not currently supported and is skipped in the
-  tests)
+* macOS (arm64 only; x64 (Intel) is not currently supported and is skipped in
+  the tests)
 * Linux (all distributions [supported by Node.js][] except Alpine and all
   architectures [supported by Node.js][] except s390x)
 


### PR DESCRIPTION
Fixes #62893.

The SEA platform support section already notes that macOS support is limited to arm64. This clarifies that the unsupported x64 macOS target is the Intel macOS case reported in the issue.

Verification:
- `git diff --check`
- Documentation-only change.