### PR TITLE
stream: cache minimum cursor count in broadcast

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -92,7 +92,7 @@ class BroadcastImpl {
   #options;
   #writer = null;
   #cachedMinCursor = 0;
-  #minCursorDirty = false;
+  #cachedMinCursorConsumers = 0;
 
   constructor(options) {
     this.#options = options;
@@ -150,13 +150,13 @@ class BroadcastImpl {
     };
 
     this.#consumers.add(state);
-    // New consumer starts at buffer start; recalculate min cursor
-    // since this consumer may now be the slowest.
     if (this.#consumers.size === 1) {
       this.#cachedMinCursor = state.cursor;
-      this.#minCursorDirty = false;
+      this.#cachedMinCursorConsumers = 1;
+    } else if (state.cursor === this.#cachedMinCursor) {
+      this.#cachedMinCursorConsumers++;
     } else {
-      this.#minCursorDirty = true;
+      this.#recomputeMinCursor();
     }
     const self = this;
 
@@ -167,9 +167,9 @@ class BroadcastImpl {
       state.detached = true;
       state.resolve = null;
       state.reject = null;
-      self.#consumers.delete(state);
-      self.#minCursorDirty = true;
-      self.#tryTrimBuffer();
+      if (self.#deleteConsumer(state)) {
+        self.#tryTrimBuffer();
+      }
     }
 
     return {
@@ -186,19 +186,19 @@ class BroadcastImpl {
             const bufferIndex = state.cursor - self.#bufferStart;
             if (bufferIndex < self.#buffer.length) {
               const chunk = self.#buffer.get(bufferIndex);
-              // If this consumer was at the min cursor, mark dirty
-              if (state.cursor <= self.#cachedMinCursor) {
-                self.#minCursorDirty = true;
-              }
+              const cursor = state.cursor;
               state.cursor++;
-              self.#tryTrimBuffer();
+              if (cursor === self.#cachedMinCursor &&
+                  --self.#cachedMinCursorConsumers === 0) {
+                self.#tryTrimBuffer();
+              }
               return PromiseResolve(
                 { __proto__: null, done: false, value: chunk });
             }
 
             if (self.#error) {
               state.detached = true;
-              self.#consumers.delete(state);
+              self.#deleteConsumer(state);
               return PromiseReject(self.#error);
             }
 
@@ -253,6 +253,7 @@ class BroadcastImpl {
       consumer.detached = true;
     }
     this.#consumers.clear();
+    this.#cachedMinCursorConsumers = 0;
   }
 
   [SymbolDispose]() {
@@ -274,9 +275,11 @@ class BroadcastImpl {
           this.#bufferStart++;
           for (const consumer of this.#consumers) {
             if (consumer.cursor < this.#bufferStart) {
+              this.#deleteConsumerFromMin(consumer);
               consumer.cursor = this.#bufferStart;
             }
           }
+          this.#recomputeMinCursor();
           break;
         case 'drop-newest':
           return true;
@@ -297,7 +300,12 @@ class BroadcastImpl {
         const bufferIndex = consumer.cursor - this.#bufferStart;
         if (bufferIndex < this.#buffer.length) {
           const chunk = this.#buffer.get(bufferIndex);
+          const cursor = consumer.cursor;
           consumer.cursor++;
+          if (cursor === this.#cachedMinCursor &&
+              --this.#cachedMinCursorConsumers === 0) {
+            this.#tryTrimBuffer();
+          }
           consumer.resolve({ __proto__: null, done: false, value: chunk });
         } else {
           consumer.resolve({ __proto__: null, done: true, value: undefined });
@@ -323,6 +331,7 @@ class BroadcastImpl {
       consumer.detached = true;
     }
     this.#consumers.clear();
+    this.#cachedMinCursorConsumers = 0;
   }
 
   [kGetDesiredSize]() {
@@ -343,14 +352,14 @@ class BroadcastImpl {
   // Private methods
 
   #recomputeMinCursor() {
-    const { minCursor } = getMinCursor(
+    const { minCursor, minCursorConsumers } = getMinCursor(
       this.#consumers, this.#bufferStart + this.#buffer.length);
     this.#cachedMinCursor = minCursor;
-    this.#minCursorDirty = false;
+    this.#cachedMinCursorConsumers = minCursorConsumers;
   }
 
   #tryTrimBuffer() {
-    if (this.#minCursorDirty) {
+    if (this.#cachedMinCursorConsumers === 0) {
       this.#recomputeMinCursor();
     }
     const trimCount = this.#cachedMinCursor - this.#bufferStart;
@@ -377,10 +386,12 @@ class BroadcastImpl {
         const bufferIndex = consumer.cursor - this.#bufferStart;
         if (bufferIndex < this.#buffer.length) {
           const chunk = this.#buffer.get(bufferIndex);
-          if (consumer.cursor <= this.#cachedMinCursor) {
-            this.#minCursorDirty = true;
-          }
+          const cursor = consumer.cursor;
           consumer.cursor++;
+          if (cursor === this.#cachedMinCursor &&
+              --this.#cachedMinCursorConsumers === 0) {
+            this.#tryTrimBuffer();
+          }
           const resolve = consumer.resolve;
           consumer.resolve = null;
           consumer.reject = null;
@@ -391,6 +402,21 @@ class BroadcastImpl {
         }
       }
     }
+  }
+
+  #deleteConsumerFromMin(consumer) {
+    if (consumer.cursor === this.#cachedMinCursor) {
+      this.#cachedMinCursorConsumers--;
+      return this.#cachedMinCursorConsumers === 0;
+    }
+    return false;
+  }
+
+  #deleteConsumer(consumer) {
+    if (this.#consumers.delete(consumer)) {
+      return this.#deleteConsumerFromMin(consumer);
+    }
+    return false;
   }
 }
 

--- a/test/parallel/test-stream-iter-broadcast-coverage.js
+++ b/test/parallel/test-stream-iter-broadcast-coverage.js
@@ -96,6 +96,33 @@ async function testRingbufferGrow() {
   }
 }
 
+// Multiple consumers at the minimum cursor should trim only after the last
+// one advances or detaches.
+async function testFanOutMinCursorTrimming() {
+  const { writer, broadcast: bc } = broadcast({ highWaterMark: 4 });
+  const iter1 = bc.push()[Symbol.asyncIterator]();
+  const iter2 = bc.push()[Symbol.asyncIterator]();
+
+  writer.writeSync(new Uint8Array([1]));
+  writer.writeSync(new Uint8Array([2]));
+  assert.strictEqual(bc.bufferSize, 2);
+
+  assert.strictEqual((await iter1.next()).done, false);
+  assert.strictEqual(bc.bufferSize, 2);
+
+  assert.strictEqual((await iter2.next()).done, false);
+  assert.strictEqual(bc.bufferSize, 1);
+
+  await iter1.return();
+  assert.strictEqual(bc.bufferSize, 1);
+
+  assert.strictEqual((await iter2.next()).done, false);
+  assert.strictEqual(bc.bufferSize, 0);
+
+  writer.endSync();
+  assert.strictEqual((await iter2.next()).done, true);
+}
+
 // Broadcast drainableProtocol after close returns null
 async function testDrainableAfterClose() {
   const { drainableProtocol } = require('stream/iter');
@@ -111,5 +138,6 @@ Promise.all([
   testBroadcastFromSyncIterable(),
   testBroadcastFromSyncIterableStrings(),
   testRingbufferGrow(),
+  testFanOutMinCursorTrimming(),
   testDrainableAfterClose(),
 ]).then(common.mustCall());


### PR DESCRIPTION
### Description

This ports the cached minimum-cursor consumer count used by `share` to
`broadcast`.

`broadcast` previously used a dirty min-cursor flag, causing trimming to call
`getMinCursor()` and scan all consumers whenever the cached minimum might have
changed. Under high fan-out, that can make normal consumer advancement pay an
O(consumers) cost.

This change tracks how many consumers are currently at the cached minimum
cursor. `broadcast` now only recomputes the minimum when the last such consumer
advances or detaches. The `drop-oldest` path still recomputes after forcing
lagging cursors forward.

### Benchmark

```console
                                                                                       confidence improvement accuracy (*)    (**)   (***)
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=1 api='classic'             *     10.81 %       ±9.94% ±13.96% ±19.78%
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=1 api='iter'               **     19.27 %      ±11.61% ±16.16% ±22.56%
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=1 api='webstream'         ***     67.64 %       ±9.73% ±13.67% ±19.40%
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=2 api='classic'                    5.67 %       ±5.87%  ±8.09% ±11.11%
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=2 api='iter'              ***     17.14 %       ±5.43%  ±7.56% ±10.56%
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=2 api='webstream'         ***     46.36 %       ±5.99%  ±8.24% ±11.30%
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=4 api='classic'             *     12.86 %      ±10.57% ±14.82% ±20.97%
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=4 api='iter'              ***     15.57 %       ±4.32%  ±5.96%  ±8.21%
streams/iter-throughput-broadcast.js n=5 datasize=1048576 consumers=4 api='webstream'         ***     43.94 %       ±3.79%  ±5.23%  ±7.23%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=1 api='classic'                   4.88 %       ±6.51%  ±8.92% ±12.16%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=1 api='iter'             ***     14.77 %       ±5.67%  ±7.88% ±10.96%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=1 api='webstream'        ***     45.84 %      ±16.70% ±23.78% ±34.49%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=2 api='classic'                   2.65 %       ±4.17%  ±5.74%  ±7.87%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=2 api='iter'              **     26.89 %      ±18.15% ±25.98% ±37.98%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=2 api='webstream'        ***     21.67 %       ±7.80% ±10.93% ±15.42%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=4 api='classic'                   3.63 %       ±3.64%  ±5.02%  ±6.91%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=4 api='iter'              **      6.26 %       ±4.46%  ±6.15%  ±8.44%
streams/iter-throughput-broadcast.js n=5 datasize=16777216 consumers=4 api='webstream'        ***     18.26 %       ±5.36%  ±7.60% ±10.93%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 18 comparisons, you can thus
expect the following amount of false-positive results:
  0.90 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.18 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
```

---

Assisted-by: openai:gpt-5.5