### PR TITLE
doc: add worker_threads history

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -2,6 +2,15 @@
 
 <!--introduced_in=v10.5.0-->
 
+<!-- YAML
+changes:
+  - version: v12.11.0
+    pr-url: https://github.com/nodejs/node/pull/29512
+    description: The module is no longer experimental.
+  - version: v11.7.0
+    description: The module no longer requires the `--experimental-worker` flag.
+-->
+
 > Stability: 2 - Stable
 
 <!-- source_link=lib/worker_threads.js -->


### PR DESCRIPTION
Add history metadata for the `node:worker_threads` module documenting when it stopped requiring `--experimental-worker` and when it became stable.

Fixes: https://github.com/nodejs/node/issues/55794

Refs: https://nodejs.org/zh-tw/blog/release/v12.11.0

Validation: `git diff --check`

Note: this checkout is sparse and does not include `tools/lint-md`, so I could not run the full markdown linter locally.