### PR TITLE
doc: clarify SEA macOS x64 support

### DIFF
--- a/doc/api/single-executable-applications.md
+++ b/doc/api/single-executable-applications.md
@@ -631,7 +631,8 @@ platforms:
 
 * Windows
 * macOS (arm64 only; x64 is not currently supported and is skipped in the
-  tests)
+  tests). Single-executable applications built on or for Intel macOS are not
+  expected to work.
 * Linux (all distributions [supported by Node.js][] except Alpine and all
   architectures [supported by Node.js][] except s390x)
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/62893

This clarifies that single-executable applications built on or for Intel macOS are not expected to work. The platform support table already noted that SEA is only tested on macOS arm64, but this makes the unsupported x64 case more explicit for users following the SEA build steps.

## Testing
- git diff --check