### PR TITLE
doc: clarify tty raw mode output behavior

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -80,10 +80,11 @@ added: v0.7.7
 Allows configuration of `tty.ReadStream` so that it operates as a raw device.
 
 When in raw mode, input is always available character-by-character, not
-including modifiers. Additionally, all special processing of characters by the
-terminal is disabled, including echoing input
+including modifiers. Additionally, all special processing of input characters
+by the terminal is disabled, including echoing input
 characters. <kbd>Ctrl</kbd>+<kbd>C</kbd> will no longer cause a `SIGINT` when
-in this mode.
+in this mode. This mode does not affect terminal output processing, such as
+newline translation on Unix terminals.
 
 ## Class: `tty.WriteStream`
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/63059

This updates the `tty.ReadStream.setRawMode()` docs to describe raw mode as disabling special processing of input characters, and notes that it does not affect terminal output processing such as newline translation on Unix terminals.

## Testing
- git diff --check