### PR TITLE
doc: clarify tty raw mode scope

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -80,10 +80,11 @@ added: v0.7.7
 Allows configuration of `tty.ReadStream` so that it operates as a raw device.
 
 When in raw mode, input is always available character-by-character, not
-including modifiers. Additionally, all special processing of characters by the
-terminal is disabled, including echoing input
+including modifiers. Additionally, all special processing of input characters by
+the terminal is disabled, including echoing input
 characters. <kbd>Ctrl</kbd>+<kbd>C</kbd> will no longer cause a `SIGINT` when
-in this mode.
+in this mode. This mode does not affect output written to TTY streams, such as
+terminal newline translation.
 
 ## Class: `tty.WriteStream`
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63059

This updates the `tty.ReadStream.setRawMode()` docs to clarify that raw mode disables special processing for input characters, but does not affect output written to TTY streams, such as terminal newline translation.

Validation:

- `git diff --check`
- `node tools/lint-md/lint-md.mjs doc/api/tty.md`