### PR TITLE
doc: mention constructors in deepStrictEqual

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -611,6 +611,7 @@ are recursively evaluated also by the following rules.
 * [Type tags][Object.prototype.toString()] of objects should be the same.
 * [`[[Prototype]]`][prototype-spec] of objects are compared using
   the [`===` operator][].
+* Object constructors are compared when available.
 * Only [enumerable "own" properties][] are considered.
 * {Error} names, messages, causes, and errors are always compared,
   even if these are not enumerable properties.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60239

This updates the `assert.deepStrictEqual()` comparison details to explicitly mention that object constructors are compared when available.

The behavior was already documented for `Assert`'s `skipPrototype` option and `util.isDeepStrictEqual()`, but the `assert.deepStrictEqual()` comparison list omitted it.

Validation:

- `git diff --check`
- `node tools/lint-md/lint-md.mjs doc/api/assert.md`