### PR TITLE
doc: clarify server keep-alive options

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2016,10 +2016,9 @@ socketTimeout = keepAliveTimeout + keepAliveTimeoutBuffer
 If the server receives new data before the keep-alive timeout has fired, it
 will reset the regular inactivity timeout, i.e., [`server.timeout`][].
 
-A value of `0` will disable the keep-alive timeout behavior on incoming
-connections.
-A value of `0` makes the HTTP server behave similarly to Node.js versions prior
-to 8.0.0, which did not have a keep-alive timeout.
+A value of `0` disables only this idle keep-alive timeout. HTTP keep-alive
+connections may remain open until the client closes them, the server closes
+them, or another timeout applies.
 
 The socket timeout logic is set up on connection, so changing this value only
 affects new connections to the server, not any existing connections.
@@ -3717,10 +3716,13 @@ changes:
     a comma (`, `) instead of discarding the duplicates.
     For more information, refer to [`message.headers`][].
     **Default:** `false`.
-  * `keepAlive` {boolean} If set to `true`, it enables keep-alive functionality
-    on the socket immediately after a new incoming connection is received,
-    similarly on what is done in \[`socket.setKeepAlive([enable][, initialDelay])`]\[`socket.setKeepAlive(enable, initialDelay)`].
-    **Default:** `false`.
+  * `keepAlive` {boolean} If set to `true`, enables TCP keep-alive on the
+    socket immediately after a new incoming connection is received, similarly
+    to what is done in \[`socket.setKeepAlive([enable][, initialDelay])`]\[`socket.setKeepAlive(enable, initialDelay)`].
+    If `false`, no call to
+    \[`socket.setKeepAlive([enable][, initialDelay])`]\[`socket.setKeepAlive(enable, initialDelay)`]
+    is made. This does not disable HTTP persistent connections. **Default:**
+    `false`.
   * `keepAliveInitialDelay` {number} If set to a positive number, it sets the
     initial delay before the first keepalive probe is sent on an idle socket.
     **Default:** `0`.

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1818,10 +1818,10 @@ changes:
   * `highWaterMark` {number} Optionally overrides all [`net.Socket`][]s'
     `readableHighWaterMark` and `writableHighWaterMark`.
     **Default:** See [`stream.getDefaultHighWaterMark()`][].
-  * `keepAlive` {boolean} If set to `true`, it enables keep-alive functionality
-    on the socket immediately after a new incoming connection is received,
-    similarly on what is done in [`socket.setKeepAlive()`][]. **Default:**
-    `false`.
+  * `keepAlive` {boolean} If set to `true`, enables TCP keep-alive on the
+    socket immediately after a new incoming connection is received, similarly
+    to what is done in [`socket.setKeepAlive()`][]. If `false`, no call to
+    [`socket.setKeepAlive()`][] is made. **Default:** `false`.
   * `keepAliveInitialDelay` {number} If set to a positive number, it sets the
     initial delay before the first keepalive probe is sent on an idle socket.
     **Default:** `0`.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/61850

This clarifies two server keep-alive docs points:

- `keepAlive` on `net.createServer()` and `http.createServer()` enables TCP keep-alive by calling `socket.setKeepAlive()` for accepted sockets.
- `server.keepAliveTimeout = 0` disables only the idle keep-alive timeout; it does not mean HTTP keep-alive itself is disabled.

Validation:

- `git diff --check`
- `node tools/lint-md/lint-md.mjs doc/api/http.md doc/api/net.md`