### PR TITLE
doc: clarify setKeepAlive delay precision

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -773,7 +773,9 @@ changes:
     the socket immediately after the connection is established, similarly on what
     is done in [`socket.setKeepAlive()`][]. **Default:** `false`.
   * `keepAliveInitialDelay` {number} If set to a positive number, it sets the
-    initial delay before the first keepalive probe is sent on an idle socket. **Default:** `0`.
+    initial delay, in milliseconds, before the first keepalive probe is sent on
+    an idle socket. The value is rounded down to whole seconds before use.
+    **Default:** `0`.
   * `noDelay` {boolean} If set to `true`, it disables the use of Nagle's algorithm
     immediately after the socket is established. **Default:** `false`.
   * `onread` {Object} If specified, incoming data is stored in a single `buffer`
@@ -1400,8 +1402,9 @@ Enable/disable keep-alive functionality, and optionally set the initial
 delay before the first keepalive probe is sent on an idle socket.
 
 Set `initialDelay` (in milliseconds) to set the delay between the last
-data packet received and the first keepalive probe. Setting `0` for
-`initialDelay` will leave the value unchanged from the default
+data packet received and the first keepalive probe. The value is rounded down
+to whole seconds before it is passed to the operating system. Values less than
+`1000` ms become `0`, which leaves the value unchanged from the default
 (or previous) setting.
 
 Enabling the keep-alive functionality will set the following socket options:
@@ -1823,7 +1826,8 @@ changes:
     similarly on what is done in [`socket.setKeepAlive()`][]. **Default:**
     `false`.
   * `keepAliveInitialDelay` {number} If set to a positive number, it sets the
-    initial delay before the first keepalive probe is sent on an idle socket.
+    initial delay, in milliseconds, before the first keepalive probe is sent on
+    an idle socket. The value is rounded down to whole seconds before use.
     **Default:** `0`.
   * `noDelay` {boolean} If set to `true`, it disables the use of Nagle's
     algorithm immediately after a new incoming connection is received.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/57712

This updates the `net` docs to clarify that `socket.setKeepAlive()` and the related `keepAliveInitialDelay` options accept milliseconds but are rounded down to whole seconds before use.

It also explicitly calls out that values below `1000` ms become `0`, which leaves the value unchanged from the default or previous setting.

Validation:

- `git diff --check`
- `node tools/lint-md/lint-md.mjs doc/api/net.md`