### PR TITLE
doc: fix worker URL clone example

### DIFF
--- a/doc/api/worker_threads.md
+++ b/doc/api/worker_threads.md
@@ -1369,17 +1369,18 @@ port2.postMessage(new Foo());
 // Prints: { c: 3 }
 ```
 
-This limitation extends to many built-in objects, such as the global `URL`
-object:
+Some built-in objects are not supported by the cloning algorithm used by
+[`port.postMessage()`][], such as `URL` objects:
 
 ```js
-const { port1, port2 } = new MessageChannel();
+const { port2 } = new MessageChannel();
 
-port1.onmessage = ({ data }) => console.log(data);
-
-port2.postMessage(new URL('https://example.org'));
-
-// Prints: { }
+try {
+  port2.postMessage(new URL('https://example.org'));
+} catch (error) {
+  console.log(error.name);
+  // Prints: DataCloneError
+}
 ```
 
 ### `port.hasRef()`


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/60504

This updates the `worker_threads` cloning example for `URL` objects. The previous example said posting a `URL` would print `{}`, but `port.postMessage(new URL(...))` throws `DataCloneError`.

The docs now show that `URL` is not supported by the cloning algorithm used by `port.postMessage()` and catches the actual error name.

Validation:

- `git diff --check`
- `node tools/lint-md/lint-md.mjs doc/api/worker_threads.md`
- runtime probe: `port2.postMessage(new URL('https://example.org'))` prints `DataCloneError` when caught