### PR TITLE
doc: clarify fs string paths are not URLs

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -8707,8 +8707,11 @@ a string, a {Buffer}, or a {URL} object using the `file:` protocol.
 #### String paths
 
 String paths are interpreted as UTF-8 character sequences identifying
-the absolute or relative filename. Relative paths will be resolved relative
-to the current working directory as determined by calling `process.cwd()`.
+an absolute or relative path. Relative paths will be resolved relative to the
+current working directory as determined by calling `process.cwd()`.
+
+A string path is not interpreted as a URL, even if it starts with `file:`.
+To pass a `file:` URL, use a {URL} object.
 
 Example using an absolute path on POSIX:
 


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/36585

Clarifies that `node:fs` string paths are interpreted as file-system paths, not URL strings, and that callers should pass a `URL` object when they intend to use a `file:` URL.

Validation:
- `node tools/lint-md/lint-md.mjs doc/api/fs.md`
- `git diff --check`