### PR TITLE
doc: clarify createRequire resolution base

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -58,6 +58,9 @@ added: v12.2.0
   string.
 * Returns: {require} Require function
 
+The returned require function resolves relative specifiers as if they were
+loaded from `filename`. The file at `filename` does not need to exist.
+
 ```mjs
 import { createRequire } from 'node:module';
 const require = createRequire(import.meta.url);


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/40567

Clarifies that `module.createRequire(filename)` uses `filename` as the base location for resolving relative specifiers, and that the file named by `filename` does not need to exist.

Validation:
- `node tools/lint-md/lint-md.mjs doc/api/module.md`
- `git diff --check`
- Runtime probe that `createRequire('/tmp/does-not-exist/file.js')` returns a function