### PR TITLE
doc: document net Socket server property

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1347,6 +1347,17 @@ added: v0.5.10
 The numeric representation of the remote port. For example, `80` or `21`. Value may be `undefined` if
 the socket is destroyed (for example, if the client disconnected).
 
+### `socket.server`
+
+<!-- YAML
+added: v0.3.4
+-->
+
+* Type: {net.Server|null}
+
+Reference to the server that accepted the socket. This property is `null` for
+sockets that were not created by a [`net.Server`][].
+
 ### `socket.resetAndDestroy()`
 
 <!-- YAML


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/47148

Document the `net.Socket#server` property for sockets accepted by a `net.Server`, and note that it remains `null` for sockets not created by a server. This also covers the `response.socket.server` access pattern because HTTP server sockets are accepted through the same net server path.

Validation:
- `node tools/lint-md/lint-md.mjs doc/api/net.md`
- `git diff --check origin/main...HEAD`
- Runtime probe confirming `new net.Socket().server === null` and accepted sockets reference their server.