### PR TITLE
doc: clarify bare specifier subpath examples

### DIFF
--- a/doc/api/esm.md
+++ b/doc/api/esm.md
@@ -163,10 +163,11 @@ There are three types of specifiers:
   is always necessary for these._
 
 * _Bare specifiers_ like `'some-package'` or `'some-package/shuffle'`. They can
-  refer to the main entry point of a package by the package name, or a
-  specific feature module within a package prefixed by the package name as per
-  the examples respectively. _Including the file extension is only necessary
-  for packages without an [`"exports"`][] field._
+  refer to the main entry point of a package by the package name, or to a
+  package subpath by appending the subpath to the package name. Examples include
+  `'some-package/shuffle'` for a subpath exported by the package, and
+  `'some-package/shuffle.js'` for a file subpath in a package without an
+  [`"exports"`][] field.
 
 * _Absolute specifiers_ like `'file:///opt/nodejs/config.js'`. They refer
   directly and explicitly to a full path.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/53022

Clarify the bare specifier terminology by replacing the ambiguous extension note with explicit examples for package main entries, exported package subpaths, and file subpaths in packages without an `exports` field.

Validation:
- `node tools/lint-md/lint-md.mjs doc/api/esm.md`
- `git diff --check origin/main...HEAD`
- Runtime ESM probe covering `pkg`, `pkg/shuffle.mjs`, `pkg-exports/shuffle`, and failure for `pkg/shuffle` without `exports`.