### PR TITLE
doc: clarify Dirent parentPath

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -7291,6 +7291,11 @@ changes:
 * Type: {string}
 
 The path to the parent directory of the file this {fs.Dirent} object refers to.
+This value does not include `dirent.name`. For example, if
+`fs.readdirSync('project', { withFileTypes: true, recursive: true })` returns
+a {fs.Dirent} object for `project/src/index.js`, its `parentPath` is
+`'project/src'` and its `name` is `'index.js'`. Use
+`dirent.parentPath` and `dirent.name` together to build the full path.
 
 ### Class: `fs.FSWatcher`
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/51955

Clarify that `dirent.parentPath` identifies the parent directory and does not include `dirent.name`. The added example shows how recursive `readdirSync()` exposes `parentPath` and `name` together for a nested entry.

Validation:
- `node tools/lint-md/lint-md.mjs doc/api/fs.md`
- `git diff --check origin/main...HEAD`
- Runtime probe confirming a recursive `readdirSync()` result for `project/src/index.js` exposes `parentPath` as `project/src` and `name` as `index.js`.