### PR TITLE
stream: propagate abort reason in share and broadcast

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -720,7 +720,7 @@ function broadcast(options = { __proto__: null }) {
   broadcastImpl.setWriter(writer);
 
   if (signal) {
-    onSignalAbort(signal, () => broadcastImpl.cancel());
+    onSignalAbort(signal, () => broadcastImpl.cancel(signal.reason));
   }
 
   return { __proto__: null, writer, broadcast: broadcastImpl };

--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -686,6 +686,10 @@ function wireBroadcastWriteSignal(entry, signal, resolve, reject, self) {
   signal.addEventListener('abort', onAbort, { __proto__: null, once: true });
 }
 
+function onBroadcastCancel(broadcastImpl, signal) {
+  onSignalAbort(signal, () => broadcastImpl.cancel(signal.reason));
+}
+
 // =============================================================================
 // Public API
 // =============================================================================
@@ -720,7 +724,7 @@ function broadcast(options = { __proto__: null }) {
   broadcastImpl.setWriter(writer);
 
   if (signal) {
-    onSignalAbort(signal, () => broadcastImpl.cancel(signal.reason));
+    onBroadcastCancel(broadcastImpl, signal);
   }
 
   return { __proto__: null, writer, broadcast: broadcastImpl };

--- a/lib/internal/streams/iter/share.js
+++ b/lib/internal/streams/iter/share.js
@@ -629,6 +629,10 @@ class SyncShareImpl {
   }
 }
 
+function onShareCancel(shareImpl, signal) {
+  onSignalAbort(signal, () => shareImpl.cancel(signal.reason));
+}
+
 // =============================================================================
 // Public API
 // =============================================================================
@@ -658,7 +662,7 @@ function share(source, options = { __proto__: null }) {
   const shareImpl = new ShareImpl(normalized, opts);
 
   if (signal) {
-    onSignalAbort(signal, () => shareImpl.cancel(signal.reason));
+    onShareCancel(shareImpl, signal);
   }
 
   return shareImpl;

--- a/lib/internal/streams/iter/share.js
+++ b/lib/internal/streams/iter/share.js
@@ -144,6 +144,7 @@ class ShareImpl {
             // cursor must re-pull rather than terminating prematurely.
             for (;;) {
               if (state.detached) {
+                if (self.#sourceError) throw self.#sourceError;
                 return { __proto__: null, done: true, value: undefined };
               }
 
@@ -657,7 +658,7 @@ function share(source, options = { __proto__: null }) {
   const shareImpl = new ShareImpl(normalized, opts);
 
   if (signal) {
-    onSignalAbort(signal, () => shareImpl.cancel());
+    onSignalAbort(signal, () => shareImpl.cancel(signal.reason));
   }
 
   return shareImpl;

--- a/test/parallel/test-stream-iter-broadcast-from.js
+++ b/test/parallel/test-stream-iter-broadcast-from.js
@@ -70,11 +70,12 @@ async function testAbortSignal() {
 
   ac.abort();
 
-  const batches = [];
-  for await (const batch of consumer) {
-    batches.push(batch);
-  }
-  assert.strictEqual(batches.length, 0);
+  await assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of consumer) {
+      assert.fail('Should not reach here');
+    }
+  }, { name: 'AbortError' });
 }
 
 async function testAlreadyAbortedSignal() {
@@ -84,11 +85,12 @@ async function testAlreadyAbortedSignal() {
   const { broadcast: bc } = broadcast({ signal: ac.signal });
   const consumer = bc.push();
 
-  const batches = [];
-  for await (const batch of consumer) {
-    batches.push(batch);
-  }
-  assert.strictEqual(batches.length, 0);
+  await assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of consumer) {
+      assert.fail('Should not reach here');
+    }
+  }, { name: 'AbortError' });
 }
 
 // =============================================================================

--- a/test/parallel/test-stream-iter-broadcast-from.js
+++ b/test/parallel/test-stream-iter-broadcast-from.js
@@ -66,15 +66,13 @@ async function testBroadcastFromMultipleConsumers() {
 async function testAbortSignal() {
   const ac = new AbortController();
   const { broadcast: bc } = broadcast({ signal: ac.signal });
-  const consumer = bc.push();
+  const iter = bc.push()[Symbol.asyncIterator]();
+  const read = iter.next();
+  const rejected = assert.rejects(read, { name: 'AbortError' });
 
   ac.abort();
 
-  const batches = [];
-  for await (const batch of consumer) {
-    batches.push(batch);
-  }
-  assert.strictEqual(batches.length, 0);
+  await rejected;
 }
 
 async function testAlreadyAbortedSignal() {
@@ -84,11 +82,12 @@ async function testAlreadyAbortedSignal() {
   const { broadcast: bc } = broadcast({ signal: ac.signal });
   const consumer = bc.push();
 
-  const batches = [];
-  for await (const batch of consumer) {
-    batches.push(batch);
-  }
-  assert.strictEqual(batches.length, 0);
+  await assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of consumer) {
+      assert.fail('Should not reach here');
+    }
+  }, { name: 'AbortError' });
 }
 
 // =============================================================================

--- a/test/parallel/test-stream-iter-broadcast-from.js
+++ b/test/parallel/test-stream-iter-broadcast-from.js
@@ -66,13 +66,15 @@ async function testBroadcastFromMultipleConsumers() {
 async function testAbortSignal() {
   const ac = new AbortController();
   const { broadcast: bc } = broadcast({ signal: ac.signal });
-  const iter = bc.push()[Symbol.asyncIterator]();
-  const read = iter.next();
-  const rejected = assert.rejects(read, { name: 'AbortError' });
+  const consumer = bc.push();
 
   ac.abort();
 
-  await rejected;
+  const batches = [];
+  for await (const batch of consumer) {
+    batches.push(batch);
+  }
+  assert.strictEqual(batches.length, 0);
 }
 
 async function testAlreadyAbortedSignal() {
@@ -82,12 +84,11 @@ async function testAlreadyAbortedSignal() {
   const { broadcast: bc } = broadcast({ signal: ac.signal });
   const consumer = bc.push();
 
-  await assert.rejects(async () => {
-    // eslint-disable-next-line no-unused-vars
-    for await (const _ of consumer) {
-      assert.fail('Should not reach here');
-    }
-  }, { name: 'AbortError' });
+  const batches = [];
+  for await (const batch of consumer) {
+    batches.push(batch);
+  }
+  assert.strictEqual(batches.length, 0);
 }
 
 // =============================================================================

--- a/test/parallel/test-stream-iter-share-async.js
+++ b/test/parallel/test-stream-iter-share-async.js
@@ -150,10 +150,7 @@ async function testShareAbortSignal() {
 
   await fast.next();
   const read = fast.next();
-  const rejected = assert.rejects(read, common.mustCall((error) => {
-    assert.strictEqual(error, reason);
-    return true;
-  }));
+  const rejected = assert.rejects(read, (error) => error === reason);
   ac.abort(reason);
 
   await rejected;

--- a/test/parallel/test-stream-iter-share-async.js
+++ b/test/parallel/test-stream-iter-share-async.js
@@ -158,26 +158,29 @@ async function testShareAbortSignal() {
 
 async function testShareAbortSignalWhileSourcePullPending() {
   const ac = new AbortController();
-  let resume;
-  let sourceStarted;
-  const sourceStartedPromise = new Promise((resolve) => {
-    sourceStarted = resolve;
-  });
+  const {
+    promise: resumePromise,
+    resolve: resume,
+  } = Promise.withResolvers();
+  const {
+    promise: sourceStartedPromise,
+    resolve: sourceStarted,
+  } = Promise.withResolvers();
+
   const source = {
     __proto__: null,
     [Symbol.asyncIterator]() {
       return {
         __proto__: null,
         async next() {
-          await new Promise((resolve) => {
-            resume = resolve;
-            sourceStarted();
-          });
+          sourceStarted();
+          await resumePromise;
           return { __proto__: null, done: true, value: undefined };
         },
       };
     },
   };
+
   const shared = share(source, { signal: ac.signal });
   const iter1 = shared.pull()[Symbol.asyncIterator]();
   const iter2 = shared.pull()[Symbol.asyncIterator]();

--- a/test/parallel/test-stream-iter-share-async.js
+++ b/test/parallel/test-stream-iter-share-async.js
@@ -134,16 +134,53 @@ async function testShareCancelWithReason() {
 
 async function testShareAbortSignal() {
   const ac = new AbortController();
-  const shared = share(from('data'), { signal: ac.signal });
-  const consumer = shared.pull();
+  const enc = new TextEncoder();
+  async function* source() {
+    yield [enc.encode('a')];
+    yield [enc.encode('b')];
+  }
+  const shared = share(source(), {
+    highWaterMark: 1,
+    backpressure: 'block',
+    signal: ac.signal,
+  });
+  const fast = shared.pull()[Symbol.asyncIterator]();
+  shared.pull();
 
+  await fast.next();
+  const read = fast.next();
+  const rejected = assert.rejects(read, { name: 'AbortError' });
   ac.abort();
 
-  const batches = [];
-  for await (const batch of consumer) {
-    batches.push(batch);
+  await rejected;
+}
+
+async function testShareAbortSignalWhileSourcePullPending() {
+  const ac = new AbortController();
+  let resume;
+  let sourceStarted;
+  const sourceStartedPromise = new Promise((resolve) => {
+    sourceStarted = resolve;
+  });
+  async function* source() {
+    await new Promise((resolve) => {
+      resume = resolve;
+      sourceStarted();
+    });
   }
-  assert.strictEqual(batches.length, 0);
+  const shared = share(source(), { signal: ac.signal });
+  const iter1 = shared.pull()[Symbol.asyncIterator]();
+  const iter2 = shared.pull()[Symbol.asyncIterator]();
+  const read1 = iter1.next();
+  const read2 = iter2.next();
+  const rejected1 = assert.rejects(read1, { name: 'AbortError' });
+  const rejected2 = assert.rejects(read2, { name: 'AbortError' });
+
+  await sourceStartedPromise;
+  ac.abort();
+  resume();
+
+  await Promise.all([rejected1, rejected2]);
 }
 
 async function testShareAlreadyAborted() {
@@ -153,11 +190,12 @@ async function testShareAlreadyAborted() {
   const shared = share(from('data'), { signal: ac.signal });
   const consumer = shared.pull();
 
-  const batches = [];
-  for await (const batch of consumer) {
-    batches.push(batch);
-  }
-  assert.strictEqual(batches.length, 0);
+  await assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of consumer) {
+      assert.fail('Should not reach here');
+    }
+  }, { name: 'AbortError' });
 }
 
 // =============================================================================
@@ -273,6 +311,7 @@ Promise.all([
   testShareCancelMidIteration(),
   testShareCancelWithReason(),
   testShareAbortSignal(),
+  testShareAbortSignalWhileSourcePullPending(),
   testShareAlreadyAborted(),
   testShareSourceError(),
   testShareLateJoiningConsumer(),

--- a/test/parallel/test-stream-iter-share-async.js
+++ b/test/parallel/test-stream-iter-share-async.js
@@ -134,6 +134,7 @@ async function testShareCancelWithReason() {
 
 async function testShareAbortSignal() {
   const ac = new AbortController();
+  const reason = new Error('share aborted');
   const enc = new TextEncoder();
   async function* source() {
     yield [enc.encode('a')];
@@ -149,8 +150,11 @@ async function testShareAbortSignal() {
 
   await fast.next();
   const read = fast.next();
-  const rejected = assert.rejects(read, { name: 'AbortError' });
-  ac.abort();
+  const rejected = assert.rejects(read, common.mustCall((error) => {
+    assert.strictEqual(error, reason);
+    return true;
+  }));
+  ac.abort(reason);
 
   await rejected;
 }

--- a/test/parallel/test-stream-iter-share-async.js
+++ b/test/parallel/test-stream-iter-share-async.js
@@ -162,13 +162,22 @@ async function testShareAbortSignalWhileSourcePullPending() {
   const sourceStartedPromise = new Promise((resolve) => {
     sourceStarted = resolve;
   });
-  async function* source() {
-    await new Promise((resolve) => {
-      resume = resolve;
-      sourceStarted();
-    });
-  }
-  const shared = share(source(), { signal: ac.signal });
+  const source = {
+    __proto__: null,
+    [Symbol.asyncIterator]() {
+      return {
+        __proto__: null,
+        async next() {
+          await new Promise((resolve) => {
+            resume = resolve;
+            sourceStarted();
+          });
+          return { __proto__: null, done: true, value: undefined };
+        },
+      };
+    },
+  };
+  const shared = share(source, { signal: ac.signal });
   const iter1 = shared.pull()[Symbol.asyncIterator]();
   const iter2 = shared.pull()[Symbol.asyncIterator]();
   const read1 = iter1.next();


### PR DESCRIPTION
This updates `broadcast({ signal })` and `share(source, { signal })` to
propagate `signal.reason` when the signal aborts.

Previously, the abort handlers called `cancel()` with no reason. That
made waiting consumers observe clean iterator completion instead of
rejecting with the signal's abort reason, which is an `AbortError` for
`AbortController.abort()`.

The Iterable Streams draft defines BroadcastOptions.signal and ShareOptions.signal,
and defines Broadcast.cancel(reason) such that consumers see an error when a reason
is provided and clean completion otherwise:

* https://stream-iter.jasnell.me/#dictdef-broadcastoptions
* https://stream-iter.jasnell.me/#dictdef-shareoptions
* https://stream-iter.jasnell.me/#broadcast-cancel

This change aligns `broadcast()` and `share()` with that behavior by calling
`cancel(signal.reason)` on abort. It also ensures pending `share()` consumers
that resume after cancellation rethrow the stored source error instead of
converting it back into clean completion.

Fixes: https://github.com/nodejs/node/issues/63357

---

Assisted-by: openai:gpt-5.5