### PR TITLE
test: fix flaky test-watch-mode-inspect timeout

### DIFF
--- a/test/sequential/test-watch-mode-inspect.mjs
+++ b/test/sequential/test-watch-mode-inspect.mjs
@@ -3,7 +3,6 @@ import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 import { describe, it } from 'node:test';
 import { writeFileSync, readFileSync } from 'node:fs';
-import { setTimeout } from 'node:timers/promises';
 import { NodeInstance } from '../common/inspector-helper.js';
 
 
@@ -12,10 +11,7 @@ if (common.isIBMi)
 
 common.skipIfInspectorDisabled();
 
-let gettingDebuggedPid = false;
-
 async function getDebuggedPid(instance, waitForLog = true) {
-  gettingDebuggedPid = true;
   const session = await instance.connectInspectorSession();
   await session.send({ method: 'Runtime.enable' });
   if (waitForLog) {
@@ -25,19 +21,22 @@ async function getDebuggedPid(instance, waitForLog = true) {
     'method': 'Runtime.evaluate', 'params': { 'expression': 'process.pid' },
   })).result;
   session.disconnect();
-  gettingDebuggedPid = false;
   return innerPid;
 }
 
-function restart(file) {
+// Triggers a single restart and resolves when the restarted child prints "safe to debug now".
+function restartAndWaitForReady(file, instance) {
+  const ready = new Promise((resolve) => {
+    instance.on('stdout', (data) => {
+      if (data?.includes('safe to debug now')) {
+        resolve();
+      }
+    });
+  });
   writeFileSync(file, readFileSync(file));
-  const interval = setInterval(() => {
-    if (!gettingDebuggedPid) {
-      writeFileSync(file, readFileSync(file));
-    }
-  }, common.platformTimeout(500));
-  return () => clearInterval(interval);
+  return ready;
 }
+
 
 describe('watch mode - inspect', () => {
   it('should start debugger on inner process', async () => {
@@ -51,11 +50,9 @@ describe('watch mode - inspect', () => {
     const pids = [instance.pid];
     pids.push(await getDebuggedPid(instance));
     instance.resetPort();
-    const stopRestarting = restart(file);
+    await restartAndWaitForReady(file, instance);
     pids.push(await getDebuggedPid(instance));
-    stopRestarting();
 
-    await setTimeout(common.platformTimeout(500));
     await instance.kill();
 
     // There should be a process per restart and one per parent process.


### PR DESCRIPTION
### Description

This PR fixes a persistent flaky timeout in `test-watch-mode-inspect` (marked FLAKY in , issue #44898).

### Root Cause

A race condition between child-process restart and inspector-session connection:

1. The test spawns a parent process with `--inspect=0` and `--watch`
2. It connects an inspector session and retrieves the child pid
3. It **touches** the watched file → the child restarts
4. It tries to connect a **second** inspector session immediately after `resetPort()`
5. The WebSocket upgrade via `/json/list` + upgrade races against the restart:
   - `/json/list` may return an **empty** array (no targets yet) → `response[0]` throws → promise hangs
   - Or it gets the **old** (dying) target → WebSocket connects to a session that immediately ends → hangs
6. Test runner kills after 120s → TIMEOUT

### Fix

Replace the interval-based restart (write every 500ms, paused by a `gettingDebuggedPid` flag) with a **single write + readiness gate**:

- `restartAndWaitForReady(file, instance)` writes the file once and returns a promise that resolves when the restarted child prints `safe to debug now` on stdout
- The second `getDebuggedPid` call only fires **after** that promise resolves — guaranteeing the new child and its inspector session are fully ready

Removes the now-unused `gettingDebuggedPid` flag and the `setTimeout` backstop.

### Validation

Both tests pass locally with the fix. The ordering is now deterministic:



Closes: #44898