### PR TITLE
crypto: harden WebCrypto jobs and promise handling

### DIFF
--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -7,7 +7,7 @@ const {
 
 const {
   AESCipherJob,
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
   kKeyVariantAES_CTR_128,
   kKeyVariantAES_CBC_128,
   kKeyVariantAES_GCM_128,
@@ -107,7 +107,7 @@ function getVariant(name, length) {
 
 function asyncAesCtrCipher(mode, key, data, algorithm) {
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobAsync,
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -118,7 +118,7 @@ function asyncAesCtrCipher(mode, key, data, algorithm) {
 
 function asyncAesCbcCipher(mode, key, data, algorithm) {
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobAsync,
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -128,7 +128,7 @@ function asyncAesCbcCipher(mode, key, data, algorithm) {
 
 function asyncAesKwCipher(mode, key, data) {
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobAsync,
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -140,7 +140,7 @@ function asyncAesGcmCipher(mode, key, data, algorithm) {
   const tagByteLength = tagLength / 8;
 
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobAsync,
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -155,7 +155,7 @@ function asyncAesOcbCipher(mode, key, data, algorithm) {
   const tagByteLength = tagLength / 8;
 
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobAsync,
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -175,7 +175,7 @@ function aesCipher(mode, key, data, algorithm) {
   }
 }
 
-async function aesGenerateKey(algorithm, extractable, keyUsages) {
+function aesGenerateKey(algorithm, extractable, keyUsages) {
   const { name, length } = algorithm;
 
   const checkUsages = ['wrapKey', 'unwrapKey'];
@@ -188,14 +188,18 @@ async function aesGenerateKey(algorithm, extractable, keyUsages) {
       'Unsupported key usage for an AES key',
       'SyntaxError');
   }
+  if (usagesSet.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const handle = await jobPromise(() => new SecretKeyGenJob(kCryptoJobAsync, length));
-
-  return new InternalCryptoKey(
-    handle,
+  return jobPromise(() => new SecretKeyGenJob(
+    kCryptoJobWebCrypto,
+    length,
     { name, length },
     getUsagesMask(usagesSet),
-    extractable);
+    extractable));
 }
 
 function aesImportKey(

--- a/lib/internal/crypto/argon2.js
+++ b/lib/internal/crypto/argon2.js
@@ -3,8 +3,6 @@
 const {
   FunctionPrototypeCall,
   MathPow,
-  StringPrototypeToLowerCase,
-  TypedArrayPrototypeGetBuffer,
   Uint8Array,
 } = primordials;
 
@@ -14,6 +12,7 @@ const {
   Argon2Job,
   kCryptoJobAsync,
   kCryptoJobSync,
+  kCryptoJobWebCrypto,
   kTypeArgon2d,
   kTypeArgon2i,
   kTypeArgon2id,
@@ -21,7 +20,6 @@ const {
 
 const {
   lazyDOMException,
-  promisify,
 } = require('internal/util');
 
 const {
@@ -30,6 +28,7 @@ const {
 
 const {
   getArrayBufferOrView,
+  jobPromise,
 } = require('internal/crypto/util');
 
 const {
@@ -143,20 +142,12 @@ function check(algorithm, parameters) {
   validateString(algorithm, 'algorithm');
   validateOneOf(algorithm, 'algorithm', ['argon2d', 'argon2i', 'argon2id']);
 
-  let type;
-  switch (algorithm) {
-    case 'argon2d':
-      type = kTypeArgon2d;
-      break;
-    case 'argon2i':
-      type = kTypeArgon2i;
-      break;
-    case 'argon2id':
-      type = kTypeArgon2id;
-      break;
-    default:  // unreachable
-      throw new ERR_CRYPTO_ARGON2_NOT_SUPPORTED();
-  }
+  const type = {
+    '__proto__': null,
+    'argon2d': kTypeArgon2d,
+    'argon2i': kTypeArgon2i,
+    'argon2id': kTypeArgon2id,
+  }[algorithm];
 
   validateObject(parameters, 'parameters');
 
@@ -193,7 +184,6 @@ function check(algorithm, parameters) {
   return { message, nonce, secret, associatedData, tagLength, passes, parallelism, memory, type };
 }
 
-const argon2Promise = promisify(argon2);
 function validateArgon2DeriveBitsLength(length) {
   if (length === null)
     throw lazyDOMException('length cannot be null', 'OperationError');
@@ -211,32 +201,39 @@ function validateArgon2DeriveBitsLength(length) {
   }
 }
 
-async function argon2DeriveBits(algorithm, baseKey, length) {
+function argon2DeriveBits(algorithm, baseKey, length) {
   validateArgon2DeriveBitsLength(length);
 
-  let result;
+  const type = {
+    '__proto__': null,
+    'Argon2d': kTypeArgon2d,
+    'Argon2i': kTypeArgon2i,
+    'Argon2id': kTypeArgon2id,
+  }[algorithm.name];
+
+  let message;
   try {
-    result = await argon2Promise(
-      StringPrototypeToLowerCase(algorithm.name),
-      {
-        // TODO(panva): call the job directly without needing to re-export the handle
-        message: getCryptoKeyHandle(baseKey).export(),
-        nonce: algorithm.nonce,
-        parallelism: algorithm.parallelism,
-        tagLength: length / 8,
-        memory: algorithm.memory,
-        passes: algorithm.passes,
-        secret: algorithm.secretValue,
-        associatedData: algorithm.associatedData,
-      },
-    );
+    // TODO(panva): call the job directly without needing to re-export the handle
+    message = getCryptoKeyHandle(baseKey).export();
   } catch (err) {
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
       { name: 'OperationError', cause: err });
   }
 
-  return TypedArrayPrototypeGetBuffer(result);
+  const empty = new Uint8Array(0);
+
+  return jobPromise(() => new Argon2Job(
+    kCryptoJobWebCrypto,
+    message,
+    algorithm.nonce,
+    algorithm.parallelism,
+    length / 8,
+    algorithm.memory,
+    algorithm.passes,
+    algorithm.secretValue === undefined ? empty : algorithm.secretValue,
+    algorithm.associatedData === undefined ? empty : algorithm.associatedData,
+    type));
 }
 
 module.exports = {

--- a/lib/internal/crypto/argon2.js
+++ b/lib/internal/crypto/argon2.js
@@ -211,28 +211,16 @@ function argon2DeriveBits(algorithm, baseKey, length) {
     'Argon2id': kTypeArgon2id,
   }[algorithm.name];
 
-  let message;
-  try {
-    // TODO(panva): call the job directly without needing to re-export the handle
-    message = getCryptoKeyHandle(baseKey).export();
-  } catch (err) {
-    throw lazyDOMException(
-      'The operation failed for an operation-specific reason',
-      { name: 'OperationError', cause: err });
-  }
-
-  const empty = new Uint8Array(0);
-
   return jobPromise(() => new Argon2Job(
     kCryptoJobWebCrypto,
-    message,
+    getCryptoKeyHandle(baseKey),
     algorithm.nonce,
     algorithm.parallelism,
     length / 8,
     algorithm.memory,
     algorithm.passes,
-    algorithm.secretValue === undefined ? empty : algorithm.secretValue,
-    algorithm.associatedData === undefined ? empty : algorithm.associatedData,
+    algorithm.secretValue === undefined ? new Uint8Array() : algorithm.secretValue,
+    algorithm.associatedData === undefined ? new Uint8Array() : algorithm.associatedData,
     type));
 }
 

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -8,7 +8,7 @@ const {
 
 const {
   SignJob,
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
   kSignJobModeSign,
@@ -73,7 +73,7 @@ function verifyAcceptableCfrgKeyUse(name, isPublic, usages) {
   }
 }
 
-async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
+function cfrgGenerateKey(algorithm, extractable, keyUsages) {
   const { name } = algorithm;
 
   const usageSet = new SafeSet(keyUsages);
@@ -97,23 +97,13 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
       }
       break;
   }
-  let nid;
-  switch (name) {
-    case 'Ed25519':
-      nid = EVP_PKEY_ED25519;
-      break;
-    case 'Ed448':
-      nid = EVP_PKEY_ED448;
-      break;
-    case 'X25519':
-      nid = EVP_PKEY_X25519;
-      break;
-    case 'X448':
-      nid = EVP_PKEY_X448;
-      break;
-  }
-
-  const handles = await jobPromise(() => new NidKeyPairGenJob(kCryptoJobAsync, nid));
+  const nid = {
+    '__proto__': null,
+    'Ed25519': EVP_PKEY_ED25519,
+    'Ed448': EVP_PKEY_ED448,
+    'X25519': EVP_PKEY_X25519,
+    'X448': EVP_PKEY_X448,
+  }[name];
 
   let publicUsages;
   let privateUsages;
@@ -134,21 +124,19 @@ async function cfrgGenerateKey(algorithm, extractable, keyUsages) {
 
   const keyAlgorithm = { name };
 
-  const publicKey =
-    new InternalCryptoKey(
-      handles[0],
-      keyAlgorithm,
-      getUsagesMask(publicUsages),
-      true);
+  if (privateUsages.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const privateKey =
-    new InternalCryptoKey(
-      handles[1],
-      keyAlgorithm,
-      getUsagesMask(privateUsages),
-      extractable);
-
-  return { __proto__: null, privateKey, publicKey };
+  return jobPromise(() => new NidKeyPairGenJob(
+    kCryptoJobWebCrypto,
+    nid,
+    keyAlgorithm,
+    getUsagesMask(publicUsages),
+    getUsagesMask(privateUsages),
+    extractable));
 }
 
 function cfrgExportKey(key, format) {
@@ -243,15 +231,15 @@ function cfrgImportKey(
     extractable);
 }
 
-async function eddsaSignVerify(key, data, algorithm, signature) {
+function eddsaSignVerify(key, data, algorithm, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   const type = mode === kSignJobModeSign ? 'private' : 'public';
 
   if (getCryptoKeyType(key) !== type)
     throw lazyDOMException(`Key must be a ${type} key`, 'InvalidAccessError');
 
-  return await jobPromise(() => new SignJob(
-    kCryptoJobAsync,
+  return jobPromise(() => new SignJob(
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     undefined,

--- a/lib/internal/crypto/chacha20_poly1305.js
+++ b/lib/internal/crypto/chacha20_poly1305.js
@@ -7,7 +7,7 @@ const {
 const {
   ChaCha20Poly1305CipherJob,
   SecretKeyGenJob,
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
 } = internalBinding('crypto');
 
 const {
@@ -39,7 +39,7 @@ function validateKeyLength(length) {
 
 function c20pCipher(mode, key, data, algorithm) {
   return jobPromise(() => new ChaCha20Poly1305CipherJob(
-    kCryptoJobAsync,
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -47,7 +47,7 @@ function c20pCipher(mode, key, data, algorithm) {
     algorithm.additionalData));
 }
 
-async function c20pGenerateKey(algorithm, extractable, keyUsages) {
+function c20pGenerateKey(algorithm, extractable, keyUsages) {
   const { name } = algorithm;
 
   const checkUsages = ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'];
@@ -58,14 +58,18 @@ async function c20pGenerateKey(algorithm, extractable, keyUsages) {
       `Unsupported key usage for a ${algorithm.name} key`,
       'SyntaxError');
   }
+  if (usagesSet.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const handle = await jobPromise(() => new SecretKeyGenJob(kCryptoJobAsync, 256));
-
-  return new InternalCryptoKey(
-    handle,
+  return jobPromise(() => new SecretKeyGenJob(
+    kCryptoJobWebCrypto,
+    256,
     { name },
     getUsagesMask(usagesSet),
-    extractable);
+    extractable));
 }
 
 function c20pImportKey(

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -5,6 +5,7 @@ const {
   FunctionPrototypeCall,
   MathCeil,
   ObjectDefineProperty,
+  PromisePrototypeThen,
   TypedArrayPrototypeGetBuffer,
   Uint8Array,
 } = primordials;
@@ -19,6 +20,7 @@ const {
   ECDHConvertKey: _ECDHConvertKey,
   kCryptoJobAsync,
   kCryptoJobSync,
+  kCryptoJobWebCrypto,
 } = internalBinding('crypto');
 
 const {
@@ -326,7 +328,7 @@ function diffieHellman(options, callback) {
 let masks;
 // The ecdhDeriveBits function is part of the Web Crypto API and serves both
 // deriveKeys and deriveBits functions.
-async function ecdhDeriveBits(algorithm, baseKey, length) {
+function ecdhDeriveBits(algorithm, baseKey, length) {
   const { 'public': key } = algorithm;
 
   if (getCryptoKeyType(baseKey) !== 'private') {
@@ -349,8 +351,8 @@ async function ecdhDeriveBits(algorithm, baseKey, length) {
     throw lazyDOMException('Named curve mismatch', 'InvalidAccessError');
   }
 
-  const bits = await jobPromise(() => new DHBitsJob(
-    kCryptoJobAsync,
+  const bits = jobPromise(() => new DHBitsJob(
+    kCryptoJobWebCrypto,
     getCryptoKeyHandle(key),
     undefined,
     undefined,
@@ -366,27 +368,29 @@ async function ecdhDeriveBits(algorithm, baseKey, length) {
   if (length === null)
     return bits;
 
-  // If the length is not a multiple of 8 the nearest ceiled
-  // multiple of 8 is sliced.
-  const sliceLength = MathCeil(length / 8);
+  return PromisePrototypeThen(bits, (bits) => {
+    // If the length is not a multiple of 8 the nearest ceiled
+    // multiple of 8 is sliced.
+    const sliceLength = MathCeil(length / 8);
 
-  const { byteLength } = bits;
-  // If the length is larger than the derived secret, throw.
-  if (byteLength < sliceLength)
-    throw lazyDOMException('derived bit length is too small', 'OperationError');
+    const { byteLength } = bits;
+    // If the length is larger than the derived secret, throw.
+    if (byteLength < sliceLength)
+      throw lazyDOMException('derived bit length is too small', 'OperationError');
 
-  const slice = ArrayBufferPrototypeSlice(bits, 0, sliceLength);
+    const slice = ArrayBufferPrototypeSlice(bits, 0, sliceLength);
 
-  const mod = length % 8;
-  if (mod === 0)
-    return slice;
+    const mod = length % 8;
+    if (mod === 0)
+      return slice;
 
-  // eslint-disable-next-line no-sparse-arrays
-  masks ||= [, 0b10000000, 0b11000000, 0b11100000, 0b11110000, 0b11111000, 0b11111100, 0b11111110];
+    // eslint-disable-next-line no-sparse-arrays
+    masks ||= [, 0b10000000, 0b11000000, 0b11100000, 0b11110000, 0b11111000, 0b11111100, 0b11111110];
 
-  const masked = new Uint8Array(slice);
-  masked[sliceLength - 1] = masked[sliceLength - 1] & masks[mod];
-  return TypedArrayPrototypeGetBuffer(masked);
+    const masked = new Uint8Array(slice);
+    masked[sliceLength - 1] = masked[sliceLength - 1] & masks[mod];
+    return TypedArrayPrototypeGetBuffer(masked);
+  });
 }
 
 module.exports = {

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -5,7 +5,6 @@ const {
   FunctionPrototypeCall,
   MathCeil,
   ObjectDefineProperty,
-  PromisePrototypeThen,
   TypedArrayPrototypeGetBuffer,
   Uint8Array,
 } = primordials;
@@ -59,6 +58,7 @@ const {
 const {
   getArrayBufferOrView,
   jobPromise,
+  jobPromiseThen,
   toBuf,
   kHandle,
 } = require('internal/crypto/util');
@@ -368,7 +368,7 @@ function ecdhDeriveBits(algorithm, baseKey, length) {
   if (length === null)
     return bits;
 
-  return PromisePrototypeThen(bits, (bits) => {
+  return jobPromiseThen(bits, (bits) => {
     // If the length is not a multiple of 8 the nearest ceiled
     // multiple of 8 is sliced.
     const sliceLength = MathCeil(length / 8);

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -10,7 +10,7 @@ const {
   EcKeyPairGenJob,
   KeyObjectHandle,
   SignJob,
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
   kKeyTypePublic,
@@ -77,7 +77,7 @@ function verifyAcceptableEcKeyUse(name, isPublic, usages) {
   }
 }
 
-async function ecGenerateKey(algorithm, extractable, keyUsages) {
+function ecGenerateKey(algorithm, extractable, keyUsages) {
   const { name, namedCurve } = algorithm;
 
   const usageSet = new SafeSet(keyUsages);
@@ -98,9 +98,6 @@ async function ecGenerateKey(algorithm, extractable, keyUsages) {
       // Fall through
   }
 
-  const handles = await jobPromise(() => new EcKeyPairGenJob(
-    kCryptoJobAsync, namedCurve));
-
   let publicUsages;
   let privateUsages;
   switch (name) {
@@ -116,21 +113,20 @@ async function ecGenerateKey(algorithm, extractable, keyUsages) {
 
   const keyAlgorithm = { name, namedCurve };
 
-  const publicKey =
-    new InternalCryptoKey(
-      handles[0],
-      keyAlgorithm,
-      getUsagesMask(publicUsages),
-      true);
+  if (privateUsages.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const privateKey =
-    new InternalCryptoKey(
-      handles[1],
-      keyAlgorithm,
-      getUsagesMask(privateUsages),
-      extractable);
-
-  return { __proto__: null, publicKey, privateKey };
+  return jobPromise(() => new EcKeyPairGenJob(
+    kCryptoJobWebCrypto,
+    namedCurve,
+    undefined,
+    keyAlgorithm,
+    getUsagesMask(publicUsages),
+    getUsagesMask(privateUsages),
+    extractable));
 }
 
 function ecExportKey(key, format) {
@@ -264,17 +260,15 @@ function ecImportKey(
     extractable);
 }
 
-async function ecdsaSignVerify(key, data, { name, hash }, signature) {
+function ecdsaSignVerify(key, data, { name, hash }, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   const type = mode === kSignJobModeSign ? 'private' : 'public';
 
   if (getCryptoKeyType(key) !== type)
     throw lazyDOMException(`Key must be a ${type} key`, 'InvalidAccessError');
 
-  const hashname = normalizeHashName(hash.name);
-
-  return await jobPromise(() => new SignJob(
-    kCryptoJobAsync,
+  return jobPromise(() => new SignJob(
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     undefined,
@@ -282,7 +276,7 @@ async function ecdsaSignVerify(key, data, { name, hash }, signature) {
     undefined,
     undefined,
     data,
-    hashname,
+    normalizeHashName(hash.name),
     undefined,  // Salt length, not used with ECDSA
     undefined,  // PSS Padding, not used with ECDSA
     kSigEncP1363,

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -12,7 +12,7 @@ const {
   Hash: _Hash,
   HashJob,
   Hmac: _Hmac,
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
   oneShotDigest,
   TurboShakeJob,
   KangarooTwelveJob,
@@ -200,7 +200,7 @@ Hmac.prototype._transform = Hash.prototype._transform;
 
 // Implementation for WebCrypto subtle.digest()
 
-async function asyncDigest(algorithm, data) {
+function asyncDigest(algorithm, data) {
   validateMaxBufferLength(data, 'data');
 
   switch (algorithm.name) {
@@ -221,16 +221,16 @@ async function asyncDigest(algorithm, data) {
     case 'cSHAKE128':
       // Fall through
     case 'cSHAKE256':
-      return await jobPromise(() => new HashJob(
-        kCryptoJobAsync,
+      return jobPromise(() => new HashJob(
+        kCryptoJobWebCrypto,
         normalizeHashName(algorithm.name),
         data,
         algorithm.outputLength));
     case 'TurboSHAKE128':
       // Fall through
     case 'TurboSHAKE256':
-      return await jobPromise(() => new TurboShakeJob(
-        kCryptoJobAsync,
+      return jobPromise(() => new TurboShakeJob(
+        kCryptoJobWebCrypto,
         algorithm.name,
         algorithm.domainSeparation ?? 0x1f,
         algorithm.outputLength / 8,
@@ -238,8 +238,8 @@ async function asyncDigest(algorithm, data) {
     case 'KT128':
       // Fall through
     case 'KT256':
-      return await jobPromise(() => new KangarooTwelveJob(
-        kCryptoJobAsync,
+      return jobPromise(() => new KangarooTwelveJob(
+        kCryptoJobWebCrypto,
         algorithm.name,
         algorithm.customization,
         algorithm.outputLength / 8,

--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -3,12 +3,14 @@
 const {
   ArrayBuffer,
   FunctionPrototypeCall,
+  PromiseResolve,
 } = primordials;
 
 const {
   HKDFJob,
   kCryptoJobAsync,
   kCryptoJobSync,
+  kCryptoJobWebCrypto,
 } = internalBinding('crypto');
 
 const {
@@ -148,26 +150,29 @@ function validateHkdfDeriveBitsLength(length) {
   }
 }
 
-async function hkdfDeriveBits(algorithm, baseKey, length) {
+function hkdfDeriveBits(algorithm, baseKey, length) {
   validateHkdfDeriveBitsLength(length);
   const { hash, salt, info } = algorithm;
 
   if (length === 0)
-    return new ArrayBuffer(0);
+    return PromiseResolve(new ArrayBuffer(0));
 
+  let normalizedHash;
   try {
-    return await jobPromise(() => new HKDFJob(
-      kCryptoJobAsync,
-      normalizeHashName(hash.name),
-      getCryptoKeyHandle(baseKey),
-      salt,
-      info,
-      length / 8));
+    normalizedHash = normalizeHashName(hash.name);
   } catch (err) {
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
       { name: 'OperationError', cause: err });
   }
+
+  return jobPromise(() => new HKDFJob(
+    kCryptoJobWebCrypto,
+    normalizedHash,
+    getCryptoKeyHandle(baseKey),
+    salt,
+    info,
+    length / 8));
 }
 
 module.exports = {

--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -29,10 +29,9 @@ const {
 } = require('internal/crypto/util');
 
 const {
-  createSecretKey,
   getCryptoKeyHandle,
-  getKeyObjectHandle,
   isKeyObject,
+  prepareSecretKey,
 } = require('internal/crypto/keys');
 
 const {
@@ -78,10 +77,10 @@ const validateParameters = hideStackFrames((hash, key, salt, info, length) => {
 
 function prepareKey(key) {
   if (isKeyObject(key))
-    return getKeyObjectHandle(key);
+    return prepareSecretKey(key);
 
   if (isAnyArrayBuffer(key))
-    return getKeyObjectHandle(createSecretKey(key));
+    return key;
 
   key = toBuf(key);
 
@@ -99,7 +98,7 @@ function prepareKey(key) {
       key);
   }
 
-  return getKeyObjectHandle(createSecretKey(key));
+  return key;
 }
 
 function hkdf(hash, key, salt, info, length, callback) {
@@ -157,18 +156,9 @@ function hkdfDeriveBits(algorithm, baseKey, length) {
   if (length === 0)
     return PromiseResolve(new ArrayBuffer(0));
 
-  let normalizedHash;
-  try {
-    normalizedHash = normalizeHashName(hash.name);
-  } catch (err) {
-    throw lazyDOMException(
-      'The operation failed for an operation-specific reason',
-      { name: 'OperationError', cause: err });
-  }
-
   return jobPromise(() => new HKDFJob(
     kCryptoJobWebCrypto,
-    normalizedHash,
+    normalizeHashName(hash.name),
     getCryptoKeyHandle(baseKey),
     salt,
     info,

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -8,7 +8,7 @@ const {
 const {
   HmacJob,
   KmacJob,
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
   kSignJobModeSign,
   kSignJobModeVerify,
   SecretKeyGenJob,
@@ -40,7 +40,7 @@ const {
   validateJwk,
 } = require('internal/crypto/webcrypto_util');
 
-async function hmacGenerateKey(algorithm, extractable, keyUsages) {
+function hmacGenerateKey(algorithm, extractable, keyUsages) {
   const {
     hash,
     name,
@@ -53,17 +53,21 @@ async function hmacGenerateKey(algorithm, extractable, keyUsages) {
       'Unsupported key usage for an HMAC key',
       'SyntaxError');
   }
+  if (usageSet.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const handle = await jobPromise(() => new SecretKeyGenJob(kCryptoJobAsync, length));
-
-  return new InternalCryptoKey(
-    handle,
+  return jobPromise(() => new SecretKeyGenJob(
+    kCryptoJobWebCrypto,
+    length,
     { name, length, hash },
     getUsagesMask(usageSet),
-    extractable);
+    extractable));
 }
 
-async function kmacGenerateKey(algorithm, extractable, keyUsages) {
+function kmacGenerateKey(algorithm, extractable, keyUsages) {
   const {
     name,
     length = {
@@ -79,14 +83,18 @@ async function kmacGenerateKey(algorithm, extractable, keyUsages) {
       `Unsupported key usage for ${name} key`,
       'SyntaxError');
   }
+  if (usageSet.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const handle = await jobPromise(() => new SecretKeyGenJob(kCryptoJobAsync, length));
-
-  return new InternalCryptoKey(
-    handle,
+  return jobPromise(() => new SecretKeyGenJob(
+    kCryptoJobWebCrypto,
+    length,
     { name, length },
     getUsagesMask(usageSet),
-    extractable);
+    extractable));
 }
 
 function macImportKey(
@@ -168,7 +176,7 @@ function macImportKey(
 function hmacSignVerify(key, data, algorithm, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   return jobPromise(() => new HmacJob(
-    kCryptoJobAsync,
+    kCryptoJobWebCrypto,
     mode,
     normalizeHashName(getCryptoKeyAlgorithm(key).hash.name),
     getCryptoKeyHandle(key),
@@ -179,7 +187,7 @@ function hmacSignVerify(key, data, algorithm, signature) {
 function kmacSignVerify(key, data, algorithm, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   return jobPromise(() => new KmacJob(
-    kCryptoJobAsync,
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     algorithm.name,

--- a/lib/internal/crypto/ml_dsa.js
+++ b/lib/internal/crypto/ml_dsa.js
@@ -9,7 +9,7 @@ const {
 
 const {
   SignJob,
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
   kKeyFormatRawSeed,
@@ -59,7 +59,7 @@ function verifyAcceptableMlDsaKeyUse(name, isPublic, usages) {
   }
 }
 
-async function mlDsaGenerateKey(algorithm, extractable, keyUsages) {
+function mlDsaGenerateKey(algorithm, extractable, keyUsages) {
   const { name } = algorithm;
 
   const usageSet = new SafeSet(keyUsages);
@@ -69,40 +69,31 @@ async function mlDsaGenerateKey(algorithm, extractable, keyUsages) {
       'SyntaxError');
   }
 
-  let nid;
-  switch (name) {
-    case 'ML-DSA-44':
-      nid = EVP_PKEY_ML_DSA_44;
-      break;
-    case 'ML-DSA-65':
-      nid = EVP_PKEY_ML_DSA_65;
-      break;
-    case 'ML-DSA-87':
-      nid = EVP_PKEY_ML_DSA_87;
-      break;
-  }
+  const nid = {
+    '__proto__': null,
+    'ML-DSA-44': EVP_PKEY_ML_DSA_44,
+    'ML-DSA-65': EVP_PKEY_ML_DSA_65,
+    'ML-DSA-87': EVP_PKEY_ML_DSA_87,
+  }[name];
 
-  const handles = await jobPromise(() => new NidKeyPairGenJob(kCryptoJobAsync, nid));
-  const publicUsagesMask = getUsagesMask(getUsagesUnion(usageSet, 'verify'));
-  const privateUsagesMask = getUsagesMask(getUsagesUnion(usageSet, 'sign'));
+  const publicUsages = getUsagesUnion(usageSet, 'verify');
+  const privateUsages = getUsagesUnion(usageSet, 'sign');
 
   const keyAlgorithm = { name };
 
-  const publicKey =
-    new InternalCryptoKey(
-      handles[0],
-      keyAlgorithm,
-      publicUsagesMask,
-      true);
+  if (privateUsages.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const privateKey =
-    new InternalCryptoKey(
-      handles[1],
-      keyAlgorithm,
-      privateUsagesMask,
-      extractable);
-
-  return { __proto__: null, privateKey, publicKey };
+  return jobPromise(() => new NidKeyPairGenJob(
+    kCryptoJobWebCrypto,
+    nid,
+    keyAlgorithm,
+    getUsagesMask(publicUsages),
+    getUsagesMask(privateUsages),
+    extractable));
 }
 
 function mlDsaExportKey(key, format) {
@@ -214,15 +205,15 @@ function mlDsaImportKey(
     extractable);
 }
 
-async function mlDsaSignVerify(key, data, algorithm, signature) {
+function mlDsaSignVerify(key, data, algorithm, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   const type = mode === kSignJobModeSign ? 'private' : 'public';
 
   if (getCryptoKeyType(key) !== type)
     throw lazyDOMException(`Key must be a ${type} key`, 'InvalidAccessError');
 
-  return await jobPromise(() => new SignJob(
-    kCryptoJobAsync,
+  return jobPromise(() => new SignJob(
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     undefined,

--- a/lib/internal/crypto/ml_kem.js
+++ b/lib/internal/crypto/ml_kem.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const {
-  PromiseWithResolvers,
   SafeSet,
   StringPrototypeToLowerCase,
   TypedArrayPrototypeGetBuffer,
@@ -9,7 +8,7 @@ const {
 } = primordials;
 
 const {
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
   KEMDecapsulateJob,
   KEMEncapsulateJob,
   kKeyFormatDER,
@@ -50,7 +49,7 @@ const {
   validateJwk,
 } = require('internal/crypto/webcrypto_util');
 
-async function mlKemGenerateKey(algorithm, extractable, keyUsages) {
+function mlKemGenerateKey(algorithm, extractable, keyUsages) {
   const { name } = algorithm;
 
   const usageSet = new SafeSet(keyUsages);
@@ -67,29 +66,26 @@ async function mlKemGenerateKey(algorithm, extractable, keyUsages) {
     'ML-KEM-1024': EVP_PKEY_ML_KEM_1024,
   }[name];
 
-  const handles = await jobPromise(() => new NidKeyPairGenJob(kCryptoJobAsync, nid));
-  const publicUsagesMask = getUsagesMask(
-    getUsagesUnion(usageSet, 'encapsulateKey', 'encapsulateBits'));
-  const privateUsagesMask = getUsagesMask(
-    getUsagesUnion(usageSet, 'decapsulateKey', 'decapsulateBits'));
+  const publicUsages =
+    getUsagesUnion(usageSet, 'encapsulateKey', 'encapsulateBits');
+  const privateUsages =
+    getUsagesUnion(usageSet, 'decapsulateKey', 'decapsulateBits');
 
   const keyAlgorithm = { name };
 
-  const publicKey =
-    new InternalCryptoKey(
-      handles[0],
-      keyAlgorithm,
-      publicUsagesMask,
-      true);
+  if (privateUsages.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const privateKey =
-    new InternalCryptoKey(
-      handles[1],
-      keyAlgorithm,
-      privateUsagesMask,
-      extractable);
-
-  return { __proto__: null, privateKey, publicKey };
+  return jobPromise(() => new NidKeyPairGenJob(
+    kCryptoJobWebCrypto,
+    nid,
+    keyAlgorithm,
+    getUsagesMask(publicUsages),
+    getUsagesMask(privateUsages),
+    extractable));
 }
 
 function mlKemExportKey(key, format) {
@@ -215,33 +211,13 @@ function mlKemEncapsulate(encapsulationKey) {
     throw lazyDOMException(`Key must be a public key`, 'InvalidAccessError');
   }
 
-  const { promise, resolve, reject } = PromiseWithResolvers();
-
-  const job = new KEMEncapsulateJob(
-    kCryptoJobAsync,
+  return jobPromise(() => new KEMEncapsulateJob(
+    kCryptoJobWebCrypto,
     getCryptoKeyHandle(encapsulationKey),
     undefined,
     undefined,
     undefined,
-    undefined);
-
-  job.ondone = (error, result) => {
-    if (error) {
-      reject(lazyDOMException(
-        'The operation failed for an operation-specific reason',
-        { name: 'OperationError', cause: error }));
-    } else {
-      const { 0: sharedKey, 1: ciphertext } = result;
-
-      resolve({
-        sharedKey: TypedArrayPrototypeGetBuffer(sharedKey),
-        ciphertext: TypedArrayPrototypeGetBuffer(ciphertext),
-      });
-    }
-  };
-  job.run();
-
-  return promise;
+    undefined));
 }
 
 function mlKemDecapsulate(decapsulationKey, ciphertext) {
@@ -249,29 +225,14 @@ function mlKemDecapsulate(decapsulationKey, ciphertext) {
     throw lazyDOMException(`Key must be a private key`, 'InvalidAccessError');
   }
 
-  const { promise, resolve, reject } = PromiseWithResolvers();
-
-  const job = new KEMDecapsulateJob(
-    kCryptoJobAsync,
+  return jobPromise(() => new KEMDecapsulateJob(
+    kCryptoJobWebCrypto,
     getCryptoKeyHandle(decapsulationKey),
     undefined,
     undefined,
     undefined,
     undefined,
-    ciphertext);
-
-  job.ondone = (error, result) => {
-    if (error) {
-      reject(lazyDOMException(
-        'The operation failed for an operation-specific reason',
-        { name: 'OperationError', cause: error }));
-    } else {
-      resolve(TypedArrayPrototypeGetBuffer(result));
-    }
-  };
-  job.run();
-
-  return promise;
+    ciphertext));
 }
 
 module.exports = {

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -3,7 +3,7 @@
 const {
   ArrayBuffer,
   FunctionPrototypeCall,
-  TypedArrayPrototypeGetBuffer,
+  PromiseResolve,
 } = primordials;
 
 const { Buffer } = require('buffer');
@@ -12,6 +12,7 @@ const {
   PBKDF2Job,
   kCryptoJobAsync,
   kCryptoJobSync,
+  kCryptoJobWebCrypto,
 } = internalBinding('crypto');
 
 const {
@@ -23,11 +24,11 @@ const {
 const {
   getArrayBufferOrView,
   normalizeHashName,
+  jobPromise,
 } = require('internal/crypto/util');
 
 const {
   lazyDOMException,
-  promisify,
 } = require('internal/util');
 
 const {
@@ -95,7 +96,6 @@ function check(password, salt, iterations, keylen, digest) {
   return { password, salt, iterations, keylen, digest };
 }
 
-const pbkdf2Promise = promisify(pbkdf2);
 function validatePbkdf2DeriveBitsLength(length) {
   if (length === null)
     throw lazyDOMException('length cannot be null', 'OperationError');
@@ -107,26 +107,32 @@ function validatePbkdf2DeriveBitsLength(length) {
   }
 }
 
-async function pbkdf2DeriveBits(algorithm, baseKey, length) {
+function pbkdf2DeriveBits(algorithm, baseKey, length) {
   validatePbkdf2DeriveBitsLength(length);
   const { iterations, hash, salt } = algorithm;
 
   if (length === 0)
-    return new ArrayBuffer(0);
+    return PromiseResolve(new ArrayBuffer(0));
 
-  let result;
+  let password;
+  let normalizedHash;
   try {
     // TODO(panva): call the job directly without needing to re-export the handle
-    result = await pbkdf2Promise(
-      getCryptoKeyHandle(baseKey).export(), salt, iterations, length / 8, normalizeHashName(hash.name),
-    );
+    password = getCryptoKeyHandle(baseKey).export();
+    normalizedHash = normalizeHashName(hash.name);
   } catch (err) {
     throw lazyDOMException(
       'The operation failed for an operation-specific reason',
       { name: 'OperationError', cause: err });
   }
 
-  return TypedArrayPrototypeGetBuffer(result);
+  return jobPromise(() => new PBKDF2Job(
+    kCryptoJobWebCrypto,
+    password,
+    salt,
+    iterations,
+    length / 8,
+    normalizedHash));
 }
 
 module.exports = {

--- a/lib/internal/crypto/pbkdf2.js
+++ b/lib/internal/crypto/pbkdf2.js
@@ -114,25 +114,13 @@ function pbkdf2DeriveBits(algorithm, baseKey, length) {
   if (length === 0)
     return PromiseResolve(new ArrayBuffer(0));
 
-  let password;
-  let normalizedHash;
-  try {
-    // TODO(panva): call the job directly without needing to re-export the handle
-    password = getCryptoKeyHandle(baseKey).export();
-    normalizedHash = normalizeHashName(hash.name);
-  } catch (err) {
-    throw lazyDOMException(
-      'The operation failed for an operation-specific reason',
-      { name: 'OperationError', cause: err });
-  }
-
   return jobPromise(() => new PBKDF2Job(
     kCryptoJobWebCrypto,
-    password,
+    getCryptoKeyHandle(baseKey),
     salt,
     iterations,
     length / 8,
-    normalizedHash));
+    normalizeHashName(hash.name)));
 }
 
 module.exports = {

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -10,7 +10,7 @@ const {
 const {
   RSACipherJob,
   SignJob,
-  kCryptoJobAsync,
+  kCryptoJobWebCrypto,
   kKeyFormatDER,
   kSignJobModeSign,
   kSignJobModeVerify,
@@ -85,7 +85,7 @@ function validateRsaOaepAlgorithm(algorithm) {
   }
 }
 
-async function rsaOaepCipher(mode, key, data, algorithm) {
+function rsaOaepCipher(mode, key, data, algorithm) {
   validateRsaOaepAlgorithm(algorithm);
 
   const type = mode === kWebCryptoCipherEncrypt ? 'public' : 'private';
@@ -95,8 +95,8 @@ async function rsaOaepCipher(mode, key, data, algorithm) {
       'InvalidAccessError');
   }
 
-  return await jobPromise(() => new RSACipherJob(
-    kCryptoJobAsync,
+  return jobPromise(() => new RSACipherJob(
+    kCryptoJobWebCrypto,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -105,7 +105,7 @@ async function rsaOaepCipher(mode, key, data, algorithm) {
     algorithm.label));
 }
 
-async function rsaKeyGenerate(
+function rsaKeyGenerate(
   algorithm,
   extractable,
   keyUsages,
@@ -142,18 +142,18 @@ async function rsaKeyGenerate(
       }
   }
 
-  const handles = await jobPromise(() => new RsaKeyPairGenJob(
-    kCryptoJobAsync,
-    kKeyVariantRSA_SSA_PKCS1_v1_5,
-    modulusLength,
-    publicExponentConverted));
-
   const keyAlgorithm = {
     name,
     modulusLength,
     publicExponent,
     hash,
   };
+
+  if (publicExponentConverted < 3 || publicExponentConverted % 2 === 0) {
+    throw lazyDOMException(
+      'The operation failed for an operation-specific reason',
+      'OperationError');
+  }
 
   let publicUsages;
   let privateUsages;
@@ -170,21 +170,21 @@ async function rsaKeyGenerate(
     }
   }
 
-  const publicKey =
-    new InternalCryptoKey(
-      handles[0],
-      keyAlgorithm,
-      getUsagesMask(publicUsages),
-      true);
+  if (privateUsages.size === 0) {
+    throw lazyDOMException(
+      'Usages cannot be empty when creating a key.',
+      'SyntaxError');
+  }
 
-  const privateKey =
-    new InternalCryptoKey(
-      handles[1],
-      keyAlgorithm,
-      getUsagesMask(privateUsages),
-      extractable);
-
-  return { __proto__: null, publicKey, privateKey };
+  return jobPromise(() => new RsaKeyPairGenJob(
+    kCryptoJobWebCrypto,
+    kKeyVariantRSA_SSA_PKCS1_v1_5,
+    modulusLength,
+    publicExponentConverted,
+    keyAlgorithm,
+    getUsagesMask(publicUsages),
+    getUsagesMask(privateUsages),
+    extractable));
 }
 
 function rsaExportKey(key, format) {
@@ -276,39 +276,44 @@ function rsaImportKey(
   }, getUsagesMask(usagesSet), extractable);
 }
 
-async function rsaSignVerify(key, data, { saltLength }, signature) {
+function rsaSignVerify(key, data, { saltLength }, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   const type = mode === kSignJobModeSign ? 'private' : 'public';
 
   if (getCryptoKeyType(key) !== type)
     throw lazyDOMException(`Key must be a ${type} key`, 'InvalidAccessError');
 
-  return await jobPromise(() => {
-    const algorithm = getCryptoKeyAlgorithm(key);
-    if (algorithm.name === 'RSA-PSS') {
+  const algorithm = getCryptoKeyAlgorithm(key);
+  if (algorithm.name === 'RSA-PSS') {
+    try {
       validateInt32(
         saltLength,
         'algorithm.saltLength',
         0,
-        MathCeil((algorithm.modulusLength - 1) / 8) - getDigestSizeInBytes(algorithm.hash.name) - 2);
+        MathCeil((algorithm.modulusLength - 1) / 8) -
+          getDigestSizeInBytes(algorithm.hash.name) - 2);
+    } catch (err) {
+      throw lazyDOMException(
+        'The operation failed for an operation-specific reason',
+        { name: 'OperationError', cause: err });
     }
+  }
 
-    return new SignJob(
-      kCryptoJobAsync,
-      signature === undefined ? kSignJobModeSign : kSignJobModeVerify,
-      getCryptoKeyHandle(key),
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      data,
-      normalizeHashName(algorithm.hash.name),
-      saltLength,
-      algorithm.name === 'RSA-PSS' ? RSA_PKCS1_PSS_PADDING : undefined,
-      undefined,
-      undefined,
-      signature);
-  });
+  return jobPromise(() => new SignJob(
+    kCryptoJobWebCrypto,
+    signature === undefined ? kSignJobModeSign : kSignJobModeVerify,
+    getCryptoKeyHandle(key),
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    data,
+    normalizeHashName(algorithm.hash.name),
+    saltLength,
+    algorithm.name === 'RSA-PSS' ? RSA_PKCS1_PSS_PADDING : undefined,
+    undefined,
+    undefined,
+    signature));
 }
 
 

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -14,7 +14,9 @@ const {
   ObjectEntries,
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
+  PromisePrototypeThen,
   PromiseReject,
+  PromiseWithResolvers,
   SafeMap,
   SafeSet,
   StringPrototypeToUpperCase,
@@ -77,6 +79,7 @@ const {
   emitExperimentalWarning,
   filterDuplicateStrings,
   lazyDOMException,
+  setOwnProperty,
 } = require('internal/util');
 
 const {
@@ -90,6 +93,7 @@ const {
   isDataView,
   isArrayBufferView,
   isAnyArrayBuffer,
+  isPromise,
 } = require('internal/util/types');
 
 const kHandle = Symbol('kHandle');
@@ -677,6 +681,69 @@ function jobPromise(getJob) {
   }
 }
 
+// Temporarily shadow inherited then accessors on WebCrypto result objects.
+// Promise resolution reads "then" synchronously for thenable assimilation.
+// Returning an own undefined data property keeps that lookup from reaching
+// user-mutated prototypes.
+function prepareWebCryptoResult(value) {
+  if ((value === null || typeof value !== 'object') &&
+      typeof value !== 'function') {
+    return false;
+  }
+  if (isPromise(value) || ObjectPrototypeHasOwnProperty(value, 'then'))
+    return false;
+  setOwnProperty(value, 'then', undefined);
+  return true;
+}
+
+// Remove the temporary then property installed by prepareWebCryptoResult().
+function cleanupWebCryptoResult(value) {
+  delete value.then;
+}
+
+// Resolve a WebCrypto promise while inherited then accessors are shadowed.
+function resolveWebCryptoResult(resolve, value) {
+  const shouldCleanupResult = prepareWebCryptoResult(value);
+  try {
+    resolve(value);
+  } finally {
+    if (shouldCleanupResult)
+      cleanupWebCryptoResult(value);
+  }
+}
+
+// Run a WebCrypto promise reaction and settle the outer promise.
+function settleJobPromise(handler, resolve, reject, value, isRejected) {
+  try {
+    if (typeof handler === 'function') {
+      resolveWebCryptoResult(resolve, handler(value));
+    } else if (isRejected) {
+      reject(value);
+    } else {
+      resolveWebCryptoResult(resolve, value);
+    }
+  } catch (err) {
+    reject(err);
+  }
+}
+
+// Promise.prototype.then gets promise.constructor to determine the result
+// promise's species. These promises are internal WebCrypto intermediates, so
+// make that lookup stay on the promise itself instead of user-mutated state.
+function jobPromiseThen(promise, onFulfilled, onRejected) {
+  const {
+    promise: resultPromise,
+    resolve,
+    reject,
+  } = PromiseWithResolvers();
+  setOwnProperty(promise, 'constructor', undefined);
+  PromisePrototypeThen(
+    promise,
+    (value) => settleJobPromise(onFulfilled, resolve, reject, value, false),
+    (value) => settleJobPromise(onRejected, resolve, reject, value, true));
+  return resultPromise;
+}
+
 // In WebCrypto, the publicExponent option in RSA is represented as a
 // WebIDL "BigInteger"... that is, a Uint8Array that allows an arbitrary
 // number of leading zero bits. Our conventional APIs for reading
@@ -899,6 +966,9 @@ module.exports = {
   validateByteSource,
   validateKeyOps,
   jobPromise,
+  jobPromiseThen,
+  cleanupWebCryptoResult,
+  prepareWebCryptoResult,
   validateMaxBufferLength,
   bigIntArrayToUnsignedBigInt,
   bigIntArrayToUnsignedInt,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -9,13 +9,12 @@ const {
   DataViewPrototypeGetBuffer,
   DataViewPrototypeGetByteLength,
   DataViewPrototypeGetByteOffset,
-  FunctionPrototypeBind,
   Number,
   ObjectDefineProperty,
   ObjectEntries,
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
-  PromiseWithResolvers,
+  PromiseReject,
   SafeMap,
   SafeSet,
   StringPrototypeToUpperCase,
@@ -665,25 +664,17 @@ const validateByteSource = hideStackFrames((val, name) => {
     val);
 });
 
-function onDone(resolve, reject, err, result) {
-  if (err) {
-    return reject(lazyDOMException(
+// CryptoJob constructors can synchronously throw while running their native
+// AdditionalConfig hook. WebCrypto needs those operation-specific setup
+// failures to reject with an OperationError.
+function jobPromise(getJob) {
+  try {
+    return getJob().run();
+  } catch (err) {
+    return PromiseReject(lazyDOMException(
       'The operation failed for an operation-specific reason',
       { name: 'OperationError', cause: err }));
   }
-  resolve(result);
-}
-
-function jobPromise(getJob) {
-  const { promise, resolve, reject } = PromiseWithResolvers();
-  try {
-    const job = getJob();
-    job.ondone = FunctionPrototypeBind(onDone, job, resolve, reject);
-    job.run();
-  } catch (err) {
-    onDone(resolve, reject, err);
-  }
-  return promise;
 }
 
 // In WebCrypto, the publicExponent option in RSA is represented as a

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -6,6 +6,9 @@ const {
   JSONParse,
   JSONStringify,
   ObjectDefineProperties,
+  PromisePrototypeThen,
+  PromiseReject,
+  PromiseResolve,
   ReflectApply,
   ReflectConstruct,
   StringPrototypeRepeat,
@@ -70,7 +73,21 @@ const {
 
 let webidl;
 
-async function digest(algorithm, data) {
+// WebCrypto methods return promises, including for synchronous validation
+// failures. Keep that conversion in one place so method bodies stay readable.
+function callSubtleCryptoMethod(fn, receiver, args) {
+  try {
+    return PromiseResolve(ReflectApply(fn, receiver, args));
+  } catch (err) {
+    return PromiseReject(err);
+  }
+}
+
+function digest(algorithm, data) {
+  return callSubtleCryptoMethod(digestImpl, this, arguments);
+}
+
+function digestImpl(algorithm, data) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
@@ -87,7 +104,7 @@ async function digest(algorithm, data) {
 
   algorithm = normalizeAlgorithm(algorithm, 'digest');
 
-  return await FunctionPrototypeCall(asyncDigest, this, algorithm, data);
+  return FunctionPrototypeCall(asyncDigest, this, algorithm, data);
 }
 
 function randomUUID() {
@@ -95,7 +112,14 @@ function randomUUID() {
   return _randomUUID();
 }
 
-async function generateKey(
+function generateKey(
+  algorithm,
+  extractable,
+  keyUsages) {
+  return callSubtleCryptoMethod(generateKeyImpl, this, arguments);
+}
+
+function generateKeyImpl(
   algorithm,
   extractable,
   keyUsages) {
@@ -118,18 +142,14 @@ async function generateKey(
   });
 
   algorithm = normalizeAlgorithm(algorithm, 'generateKey');
-  let result;
-  let resultType;
   switch (algorithm.name) {
     case 'RSASSA-PKCS1-v1_5':
       // Fall through
     case 'RSA-PSS':
       // Fall through
     case 'RSA-OAEP':
-      resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/rsa')
+      return require('internal/crypto/rsa')
         .rsaKeyGenerate(algorithm, extractable, keyUsages);
-      break;
     case 'Ed25519':
       // Fall through
     case 'Ed448':
@@ -137,22 +157,16 @@ async function generateKey(
     case 'X25519':
       // Fall through
     case 'X448':
-      resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/cfrg')
+      return require('internal/crypto/cfrg')
         .cfrgGenerateKey(algorithm, extractable, keyUsages);
-      break;
     case 'ECDSA':
       // Fall through
     case 'ECDH':
-      resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/ec')
+      return require('internal/crypto/ec')
         .ecGenerateKey(algorithm, extractable, keyUsages);
-      break;
     case 'HMAC':
-      resultType = 'CryptoKey';
-      result = await require('internal/crypto/mac')
+      return require('internal/crypto/mac')
         .hmacGenerateKey(algorithm, extractable, keyUsages);
-      break;
     case 'AES-CTR':
       // Fall through
     case 'AES-CBC':
@@ -162,62 +176,40 @@ async function generateKey(
     case 'AES-OCB':
       // Fall through
     case 'AES-KW':
-      resultType = 'CryptoKey';
-      result = await require('internal/crypto/aes')
+      return require('internal/crypto/aes')
         .aesGenerateKey(algorithm, extractable, keyUsages);
-      break;
     case 'ChaCha20-Poly1305':
-      resultType = 'CryptoKey';
-      result = await require('internal/crypto/chacha20_poly1305')
+      return require('internal/crypto/chacha20_poly1305')
         .c20pGenerateKey(algorithm, extractable, keyUsages);
-      break;
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
       // Fall through
     case 'ML-DSA-87':
-      resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/ml_dsa')
+      return require('internal/crypto/ml_dsa')
         .mlDsaGenerateKey(algorithm, extractable, keyUsages);
-      break;
     case 'ML-KEM-512':
       // Fall through
     case 'ML-KEM-768':
       // Fall through
     case 'ML-KEM-1024':
-      resultType = 'CryptoKeyPair';
-      result = await require('internal/crypto/ml_kem')
+      return require('internal/crypto/ml_kem')
         .mlKemGenerateKey(algorithm, extractable, keyUsages);
-      break;
     case 'KMAC128':
       // Fall through
     case 'KMAC256':
-      resultType = 'CryptoKey';
-      result = await require('internal/crypto/mac')
+      return require('internal/crypto/mac')
         .kmacGenerateKey(algorithm, extractable, keyUsages);
-      break;
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
-
-  if (resultType === 'CryptoKey') {
-    const type = getCryptoKeyType(result);
-    if ((type === 'secret' || type === 'private') &&
-        getCryptoKeyUsagesMask(result) === 0) {
-      throw lazyDOMException(
-        'Usages cannot be empty when creating a key.',
-        'SyntaxError');
-    }
-  } else if (getCryptoKeyUsagesMask(result.privateKey) === 0) {
-    throw lazyDOMException(
-      'Usages cannot be empty when creating a key.',
-      'SyntaxError');
-  }
-
-  return result;
 }
 
-async function deriveBits(algorithm, baseKey, length = null) {
+function deriveBits(algorithm, baseKey, length = null) {
+  return callSubtleCryptoMethod(deriveBitsImpl, this, arguments);
+}
+
+function deriveBitsImpl(algorithm, baseKey, length = null) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
@@ -252,20 +244,20 @@ async function deriveBits(algorithm, baseKey, length = null) {
     case 'X448':
       // Fall through
     case 'ECDH':
-      return await require('internal/crypto/diffiehellman')
+      return require('internal/crypto/diffiehellman')
         .ecdhDeriveBits(algorithm, baseKey, length);
     case 'HKDF':
-      return await require('internal/crypto/hkdf')
+      return require('internal/crypto/hkdf')
         .hkdfDeriveBits(algorithm, baseKey, length);
     case 'PBKDF2':
-      return await require('internal/crypto/pbkdf2')
+      return require('internal/crypto/pbkdf2')
         .pbkdf2DeriveBits(algorithm, baseKey, length);
     case 'Argon2d':
       // Fall through
     case 'Argon2i':
       // Fall through
     case 'Argon2id':
-      return await require('internal/crypto/argon2')
+      return require('internal/crypto/argon2')
         .argon2DeriveBits(algorithm, baseKey, length);
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
@@ -310,7 +302,16 @@ function getKeyLength({ name, length, hash }) {
   }
 }
 
-async function deriveKey(
+function deriveKey(
+  algorithm,
+  baseKey,
+  derivedKeyAlgorithm,
+  extractable,
+  keyUsages) {
+  return callSubtleCryptoMethod(deriveKeyImpl, this, arguments);
+}
+
+function deriveKeyImpl(
   algorithm,
   baseKey,
   derivedKeyAlgorithm,
@@ -360,15 +361,15 @@ async function deriveKey(
     case 'X448':
       // Fall through
     case 'ECDH':
-      bits = await require('internal/crypto/diffiehellman')
+      bits = require('internal/crypto/diffiehellman')
         .ecdhDeriveBits(algorithm, baseKey, length);
       break;
     case 'HKDF':
-      bits = await require('internal/crypto/hkdf')
+      bits = require('internal/crypto/hkdf')
         .hkdfDeriveBits(algorithm, baseKey, length);
       break;
     case 'PBKDF2':
-      bits = await require('internal/crypto/pbkdf2')
+      bits = require('internal/crypto/pbkdf2')
         .pbkdf2DeriveBits(algorithm, baseKey, length);
       break;
     case 'Argon2d':
@@ -376,21 +377,21 @@ async function deriveKey(
     case 'Argon2i':
       // Fall through
     case 'Argon2id':
-      bits = await require('internal/crypto/argon2')
+      bits = require('internal/crypto/argon2')
         .argon2DeriveBits(algorithm, baseKey, length);
       break;
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  return FunctionPrototypeCall(
+  return PromisePrototypeThen(bits, (bits) => FunctionPrototypeCall(
     importKeySync,
     this,
     'raw-secret', bits, derivedKeyAlgorithm, extractable, keyUsages,
-  );
+  ));
 }
 
-async function exportKeySpki(key) {
+function exportKeySpki(key) {
   switch (getCryptoKeyAlgorithm(key).name) {
     case 'RSASSA-PKCS1-v1_5':
       // Fall through
@@ -432,7 +433,7 @@ async function exportKeySpki(key) {
   }
 }
 
-async function exportKeyPkcs8(key) {
+function exportKeyPkcs8(key) {
   switch (getCryptoKeyAlgorithm(key).name) {
     case 'RSASSA-PKCS1-v1_5':
       // Fall through
@@ -474,7 +475,7 @@ async function exportKeyPkcs8(key) {
   }
 }
 
-async function exportKeyRawPublic(key, format) {
+function exportKeyRawPublic(key, format) {
   switch (getCryptoKeyAlgorithm(key).name) {
     case 'ECDSA':
       // Fall through
@@ -519,7 +520,7 @@ async function exportKeyRawPublic(key, format) {
   }
 }
 
-async function exportKeyRawSeed(key) {
+function exportKeyRawSeed(key) {
   switch (getCryptoKeyAlgorithm(key).name) {
     case 'ML-DSA-44':
       // Fall through
@@ -540,7 +541,7 @@ async function exportKeyRawSeed(key) {
   }
 }
 
-async function exportKeyRawSecret(key, format) {
+function exportKeyRawSecret(key, format) {
   switch (getCryptoKeyAlgorithm(key).name) {
     case 'AES-CTR':
       // Fall through
@@ -568,7 +569,7 @@ async function exportKeyRawSecret(key, format) {
   }
 }
 
-async function exportKeyJWK(key) {
+function exportKeyJWK(key) {
   const algorithm = getCryptoKeyAlgorithm(key);
   const parameters = {
     key_ops: ArrayPrototypeSlice(getCryptoKeyUsages(key), 0),
@@ -657,21 +658,7 @@ async function exportKeyJWK(key) {
   return getCryptoKeyHandle(key).exportJwk(parameters, true);
 }
 
-async function exportKey(format, key) {
-  if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
-
-  webidl ??= require('internal/crypto/webidl');
-  const prefix = "Failed to execute 'exportKey' on 'SubtleCrypto'";
-  webidl.requiredArguments(arguments.length, 2, { prefix });
-  format = webidl.converters.KeyFormat(format, {
-    prefix,
-    context: '1st argument',
-  });
-  key = webidl.converters.CryptoKey(key, {
-    prefix,
-    context: '2nd argument',
-  });
-
+function exportKeySync(format, key) {
   const algorithm = getCryptoKeyAlgorithm(key);
   try {
     normalizeAlgorithm(algorithm, 'exportKey');
@@ -688,43 +675,43 @@ async function exportKey(format, key) {
   switch (format) {
     case 'spki': {
       if (type === 'public') {
-        result = await exportKeySpki(key);
+        result = exportKeySpki(key);
       }
       break;
     }
     case 'pkcs8': {
       if (type === 'private') {
-        result = await exportKeyPkcs8(key);
+        result = exportKeyPkcs8(key);
       }
       break;
     }
     case 'jwk': {
-      result = await exportKeyJWK(key);
+      result = exportKeyJWK(key);
       break;
     }
     case 'raw-secret': {
       if (type === 'secret') {
-        result = await exportKeyRawSecret(key, format);
+        result = exportKeyRawSecret(key, format);
       }
       break;
     }
     case 'raw-public': {
       if (type === 'public') {
-        result = await exportKeyRawPublic(key, format);
+        result = exportKeyRawPublic(key, format);
       }
       break;
     }
     case 'raw-seed': {
       if (type === 'private') {
-        result = await exportKeyRawSeed(key);
+        result = exportKeyRawSeed(key);
       }
       break;
     }
     case 'raw': {
       if (type === 'secret') {
-        result = await exportKeyRawSecret(key, format);
+        result = exportKeyRawSecret(key, format);
       } else if (type === 'public') {
-        result = await exportKeyRawPublic(key, format);
+        result = exportKeyRawPublic(key, format);
       }
       break;
     }
@@ -737,6 +724,28 @@ async function exportKey(format, key) {
   }
 
   return result;
+}
+
+function exportKey(format, key) {
+  return callSubtleCryptoMethod(exportKeyImpl, this, arguments);
+}
+
+function exportKeyImpl(format, key) {
+  if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
+
+  webidl ??= require('internal/crypto/webidl');
+  const prefix = "Failed to execute 'exportKey' on 'SubtleCrypto'";
+  webidl.requiredArguments(arguments.length, 2, { prefix });
+  format = webidl.converters.KeyFormat(format, {
+    prefix,
+    context: '1st argument',
+  });
+  key = webidl.converters.CryptoKey(key, {
+    prefix,
+    context: '2nd argument',
+  });
+
+  return exportKeySync(format, key);
 }
 
 function aliasKeyFormat(format) {
@@ -862,7 +871,16 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
   return result;
 }
 
-async function importKey(
+function importKey(
+  format,
+  keyData,
+  algorithm,
+  extractable,
+  keyUsages) {
+  return callSubtleCryptoMethod(importKeyImpl, this, arguments);
+}
+
+function importKeyImpl(
   format,
   keyData,
   algorithm,
@@ -906,7 +924,11 @@ async function importKey(
 
 // subtle.wrapKey() is essentially a subtle.exportKey() followed
 // by a subtle.encrypt().
-async function wrapKey(format, key, wrappingKey, algorithm) {
+function wrapKey(format, key, wrappingKey, algorithm) {
+  return callSubtleCryptoMethod(wrapKeyImpl, this, arguments);
+}
+
+function wrapKeyImpl(format, key, wrappingKey, algorithm) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
@@ -942,7 +964,7 @@ async function wrapKey(format, key, wrappingKey, algorithm) {
     throw lazyDOMException(
       'Unable to use this key to wrapKey', 'InvalidAccessError');
 
-  let keyData = await FunctionPrototypeCall(exportKey, this, format, key);
+  let keyData = exportKeySync(format, key);
 
   if (format === 'jwk') {
     const ec = new TextEncoder();
@@ -957,7 +979,7 @@ async function wrapKey(format, key, wrappingKey, algorithm) {
     }
   }
 
-  return await cipherOrWrap(
+  return cipherOrWrap(
     kWebCryptoCipherEncrypt,
     algorithm,
     wrappingKey,
@@ -967,7 +989,18 @@ async function wrapKey(format, key, wrappingKey, algorithm) {
 
 // subtle.unwrapKey() is essentially a subtle.decrypt() followed
 // by a subtle.importKey().
-async function unwrapKey(
+function unwrapKey(
+  format,
+  wrappedKey,
+  unwrappingKey,
+  unwrapAlgo,
+  unwrappedKeyAlgo,
+  extractable,
+  keyUsages) {
+  return callSubtleCryptoMethod(unwrapKeyImpl, this, arguments);
+}
+
+function unwrapKeyImpl(
   format,
   wrappedKey,
   unwrappingKey,
@@ -1027,33 +1060,35 @@ async function unwrapKey(
     throw lazyDOMException(
       'Unable to use this key to unwrapKey', 'InvalidAccessError');
 
-  let keyData = await cipherOrWrap(
+  const keyData = cipherOrWrap(
     kWebCryptoCipherDecrypt,
     unwrapAlgo,
     unwrappingKey,
     wrappedKey,
     'unwrapKey');
 
-  if (format === 'jwk') {
-    // The fatal: true option is only supported in builds that have ICU.
-    const options = process.versions.icu !== undefined ?
-      { fatal: true } : undefined;
-    const dec = new TextDecoder('utf-8', options);
-    try {
-      keyData = JSONParse(dec.decode(keyData));
-    } catch {
-      throw lazyDOMException('Invalid wrapped JWK key', 'DataError');
+  return PromisePrototypeThen(keyData, (keyData) => {
+    if (format === 'jwk') {
+      // The fatal: true option is only supported in builds that have ICU.
+      const options = process.versions.icu !== undefined ?
+        { fatal: true } : undefined;
+      const dec = new TextDecoder('utf-8', options);
+      try {
+        keyData = JSONParse(dec.decode(keyData));
+      } catch {
+        throw lazyDOMException('Invalid wrapped JWK key', 'DataError');
+      }
     }
-  }
 
-  return FunctionPrototypeCall(
-    importKeySync,
-    this,
-    format, keyData, unwrappedKeyAlgo, extractable, keyUsages,
-  );
+    return FunctionPrototypeCall(
+      importKeySync,
+      this,
+      format, keyData, unwrappedKeyAlgo, extractable, keyUsages,
+    );
+  });
 }
 
-async function signVerify(algorithm, key, data, signature) {
+function signVerify(algorithm, key, data, signature) {
   const op = signature !== undefined ? 'verify' : 'sign'; // This is also usage
   algorithm = normalizeAlgorithm(algorithm, op);
 
@@ -1068,37 +1103,41 @@ async function signVerify(algorithm, key, data, signature) {
     case 'RSA-PSS':
       // Fall through
     case 'RSASSA-PKCS1-v1_5':
-      return await require('internal/crypto/rsa')
+      return require('internal/crypto/rsa')
         .rsaSignVerify(key, data, algorithm, signature);
     case 'ECDSA':
-      return await require('internal/crypto/ec')
+      return require('internal/crypto/ec')
         .ecdsaSignVerify(key, data, algorithm, signature);
     case 'Ed25519':
       // Fall through
     case 'Ed448':
       // Fall through
-      return await require('internal/crypto/cfrg')
+      return require('internal/crypto/cfrg')
         .eddsaSignVerify(key, data, algorithm, signature);
     case 'HMAC':
-      return await require('internal/crypto/mac')
+      return require('internal/crypto/mac')
         .hmacSignVerify(key, data, algorithm, signature);
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
       // Fall through
     case 'ML-DSA-87':
-      return await require('internal/crypto/ml_dsa')
+      return require('internal/crypto/ml_dsa')
         .mlDsaSignVerify(key, data, algorithm, signature);
     case 'KMAC128':
       // Fall through
     case 'KMAC256':
-      return await require('internal/crypto/mac')
+      return require('internal/crypto/mac')
         .kmacSignVerify(key, data, algorithm, signature);
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
 
-async function sign(algorithm, key, data) {
+function sign(algorithm, key, data) {
+  return callSubtleCryptoMethod(signImpl, this, arguments);
+}
+
+function signImpl(algorithm, key, data) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
@@ -1117,10 +1156,14 @@ async function sign(algorithm, key, data) {
     context: '3rd argument',
   });
 
-  return await signVerify(algorithm, key, data);
+  return signVerify(algorithm, key, data);
 }
 
-async function verify(algorithm, key, signature, data) {
+function verify(algorithm, key, signature, data) {
+  return callSubtleCryptoMethod(verifyImpl, this, arguments);
+}
+
+function verifyImpl(algorithm, key, signature, data) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
@@ -1143,10 +1186,10 @@ async function verify(algorithm, key, signature, data) {
     context: '4th argument',
   });
 
-  return await signVerify(algorithm, key, data, signature);
+  return signVerify(algorithm, key, data, signature);
 }
 
-async function cipherOrWrap(mode, algorithm, key, data, op) {
+function cipherOrWrap(mode, algorithm, key, data, op) {
   // While WebCrypto allows for larger input buffer sizes, we limit
   // those to sizes that can fit within uint32_t because of limitations
   // in the OpenSSL API.
@@ -1154,7 +1197,7 @@ async function cipherOrWrap(mode, algorithm, key, data, op) {
 
   switch (algorithm.name) {
     case 'RSA-OAEP':
-      return await require('internal/crypto/rsa')
+      return require('internal/crypto/rsa')
         .rsaCipher(mode, key, data, algorithm);
     case 'AES-CTR':
       // Fall through
@@ -1163,21 +1206,25 @@ async function cipherOrWrap(mode, algorithm, key, data, op) {
     case 'AES-GCM':
       // Fall through
     case 'AES-OCB':
-      return await require('internal/crypto/aes')
+      return require('internal/crypto/aes')
         .aesCipher(mode, key, data, algorithm);
     case 'ChaCha20-Poly1305':
-      return await require('internal/crypto/chacha20_poly1305')
+      return require('internal/crypto/chacha20_poly1305')
         .c20pCipher(mode, key, data, algorithm);
     case 'AES-KW':
       if (op === 'wrapKey' || op === 'unwrapKey') {
-        return await require('internal/crypto/aes')
+        return require('internal/crypto/aes')
           .aesCipher(mode, key, data, algorithm);
       }
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
 
-async function encrypt(algorithm, key, data) {
+function encrypt(algorithm, key, data) {
+  return callSubtleCryptoMethod(encryptImpl, this, arguments);
+}
+
+function encryptImpl(algorithm, key, data) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
@@ -1205,7 +1252,7 @@ async function encrypt(algorithm, key, data) {
     throw lazyDOMException(
       'Unable to use this key to encrypt', 'InvalidAccessError');
 
-  return await cipherOrWrap(
+  return cipherOrWrap(
     kWebCryptoCipherEncrypt,
     algorithm,
     key,
@@ -1214,7 +1261,11 @@ async function encrypt(algorithm, key, data) {
   );
 }
 
-async function decrypt(algorithm, key, data) {
+function decrypt(algorithm, key, data) {
+  return callSubtleCryptoMethod(decryptImpl, this, arguments);
+}
+
+function decryptImpl(algorithm, key, data) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
@@ -1242,7 +1293,7 @@ async function decrypt(algorithm, key, data) {
     throw lazyDOMException(
       'Unable to use this key to decrypt', 'InvalidAccessError');
 
-  return await cipherOrWrap(
+  return cipherOrWrap(
     kWebCryptoCipherDecrypt,
     algorithm,
     key,
@@ -1252,7 +1303,11 @@ async function decrypt(algorithm, key, data) {
 }
 
 // Implements https://wicg.github.io/webcrypto-modern-algos/#SubtleCrypto-method-getPublicKey
-async function getPublicKey(key, keyUsages) {
+function getPublicKey(key, keyUsages) {
+  return callSubtleCryptoMethod(getPublicKeyImpl, this, arguments);
+}
+
+function getPublicKeyImpl(key, keyUsages) {
   emitExperimentalWarning('The getPublicKey Web Crypto API method');
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
@@ -1273,14 +1328,17 @@ async function getPublicKey(key, keyUsages) {
     throw lazyDOMException('key must be a private key',
                            type === 'secret' ? 'NotSupportedError' : 'InvalidAccessError');
 
-
   // TODO(panva): this is by no means a hot path, but let's still follow up to get
   //              rid of this awkwardness
   const keyObject = createPublicKey(new PrivateKeyObject(getCryptoKeyHandle(key)));
   return keyObject.toCryptoKey(getCryptoKeyAlgorithm(key), true, keyUsages);
 }
 
-async function encapsulateBits(encapsulationAlgorithm, encapsulationKey) {
+function encapsulateBits(encapsulationAlgorithm, encapsulationKey) {
+  return callSubtleCryptoMethod(encapsulateBitsImpl, this, arguments);
+}
+
+function encapsulateBitsImpl(encapsulationAlgorithm, encapsulationKey) {
   emitExperimentalWarning('The encapsulateBits Web Crypto API method');
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
@@ -1296,7 +1354,8 @@ async function encapsulateBits(encapsulationAlgorithm, encapsulationKey) {
     context: '2nd argument',
   });
 
-  const normalizedEncapsulationAlgorithm = normalizeAlgorithm(encapsulationAlgorithm, 'encapsulate');
+  const normalizedEncapsulationAlgorithm =
+    normalizeAlgorithm(encapsulationAlgorithm, 'encapsulate');
   const keyAlgorithm = getCryptoKeyAlgorithm(encapsulationKey);
 
   if (normalizedEncapsulationAlgorithm.name !== keyAlgorithm.name) {
@@ -1315,14 +1374,28 @@ async function encapsulateBits(encapsulationAlgorithm, encapsulationKey) {
     case 'ML-KEM-512':
     case 'ML-KEM-768':
     case 'ML-KEM-1024':
-      return await require('internal/crypto/ml_kem')
+      return require('internal/crypto/ml_kem')
         .mlKemEncapsulate(encapsulationKey);
   }
 
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
 
-async function encapsulateKey(encapsulationAlgorithm, encapsulationKey, sharedKeyAlgorithm, extractable, usages) {
+function encapsulateKey(
+  encapsulationAlgorithm,
+  encapsulationKey,
+  sharedKeyAlgorithm,
+  extractable,
+  usages) {
+  return callSubtleCryptoMethod(encapsulateKeyImpl, this, arguments);
+}
+
+function encapsulateKeyImpl(
+  encapsulationAlgorithm,
+  encapsulationKey,
+  sharedKeyAlgorithm,
+  extractable,
+  usages) {
   emitExperimentalWarning('The encapsulateKey Web Crypto API method');
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
@@ -1350,8 +1423,10 @@ async function encapsulateKey(encapsulationAlgorithm, encapsulationKey, sharedKe
     context: '5th argument',
   });
 
-  const normalizedEncapsulationAlgorithm = normalizeAlgorithm(encapsulationAlgorithm, 'encapsulate');
-  const normalizedSharedKeyAlgorithm = normalizeAlgorithm(sharedKeyAlgorithm, 'importKey');
+  const normalizedEncapsulationAlgorithm =
+    normalizeAlgorithm(encapsulationAlgorithm, 'encapsulate');
+  const normalizedSharedKeyAlgorithm =
+    normalizeAlgorithm(sharedKeyAlgorithm, 'importKey');
   const keyAlgorithm = getCryptoKeyAlgorithm(encapsulationKey);
 
   if (normalizedEncapsulationAlgorithm.name !== keyAlgorithm.name) {
@@ -1371,28 +1446,33 @@ async function encapsulateKey(encapsulationAlgorithm, encapsulationKey, sharedKe
     case 'ML-KEM-512':
     case 'ML-KEM-768':
     case 'ML-KEM-1024':
-      encapsulateBits = await require('internal/crypto/ml_kem')
+      encapsulateBits = require('internal/crypto/ml_kem')
         .mlKemEncapsulate(encapsulationKey);
       break;
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  const sharedKey = FunctionPrototypeCall(
-    importKeySync,
-    this,
-    'raw-secret', encapsulateBits.sharedKey, normalizedSharedKeyAlgorithm, extractable, usages,
-  );
+  return PromisePrototypeThen(encapsulateBits, (encapsulateBits) => {
+    const sharedKey = FunctionPrototypeCall(
+      importKeySync,
+      this,
+      'raw-secret', encapsulateBits.sharedKey, normalizedSharedKeyAlgorithm,
+      extractable, usages,
+    );
 
-  const encapsulatedKey = {
-    ciphertext: encapsulateBits.ciphertext,
-    sharedKey,
-  };
-
-  return encapsulatedKey;
+    return {
+      ciphertext: encapsulateBits.ciphertext,
+      sharedKey,
+    };
+  });
 }
 
-async function decapsulateBits(decapsulationAlgorithm, decapsulationKey, ciphertext) {
+function decapsulateBits(decapsulationAlgorithm, decapsulationKey, ciphertext) {
+  return callSubtleCryptoMethod(decapsulateBitsImpl, this, arguments);
+}
+
+function decapsulateBitsImpl(decapsulationAlgorithm, decapsulationKey, ciphertext) {
   emitExperimentalWarning('The decapsulateBits Web Crypto API method');
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
@@ -1412,7 +1492,8 @@ async function decapsulateBits(decapsulationAlgorithm, decapsulationKey, ciphert
     context: '3rd argument',
   });
 
-  const normalizedDecapsulationAlgorithm = normalizeAlgorithm(decapsulationAlgorithm, 'decapsulate');
+  const normalizedDecapsulationAlgorithm =
+    normalizeAlgorithm(decapsulationAlgorithm, 'decapsulate');
   const keyAlgorithm = getCryptoKeyAlgorithm(decapsulationKey);
 
   if (normalizedDecapsulationAlgorithm.name !== keyAlgorithm.name) {
@@ -1431,16 +1512,26 @@ async function decapsulateBits(decapsulationAlgorithm, decapsulationKey, ciphert
     case 'ML-KEM-512':
     case 'ML-KEM-768':
     case 'ML-KEM-1024':
-      return await require('internal/crypto/ml_kem')
+      return require('internal/crypto/ml_kem')
         .mlKemDecapsulate(decapsulationKey, ciphertext);
   }
 
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
 
-async function decapsulateKey(
+function decapsulateKey(
   decapsulationAlgorithm, decapsulationKey, ciphertext, sharedKeyAlgorithm, extractable, usages,
 ) {
+  return callSubtleCryptoMethod(decapsulateKeyImpl, this, arguments);
+}
+
+function decapsulateKeyImpl(
+  decapsulationAlgorithm,
+  decapsulationKey,
+  ciphertext,
+  sharedKeyAlgorithm,
+  extractable,
+  usages) {
   emitExperimentalWarning('The decapsulateKey Web Crypto API method');
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
@@ -1472,8 +1563,10 @@ async function decapsulateKey(
     context: '6th argument',
   });
 
-  const normalizedDecapsulationAlgorithm = normalizeAlgorithm(decapsulationAlgorithm, 'decapsulate');
-  const normalizedSharedKeyAlgorithm = normalizeAlgorithm(sharedKeyAlgorithm, 'importKey');
+  const normalizedDecapsulationAlgorithm =
+    normalizeAlgorithm(decapsulationAlgorithm, 'decapsulate');
+  const normalizedSharedKeyAlgorithm =
+    normalizeAlgorithm(sharedKeyAlgorithm, 'importKey');
   const keyAlgorithm = getCryptoKeyAlgorithm(decapsulationKey);
 
   if (normalizedDecapsulationAlgorithm.name !== keyAlgorithm.name) {
@@ -1493,18 +1586,19 @@ async function decapsulateKey(
     case 'ML-KEM-512':
     case 'ML-KEM-768':
     case 'ML-KEM-1024':
-      decapsulatedBits = await require('internal/crypto/ml_kem')
+      decapsulatedBits = require('internal/crypto/ml_kem')
         .mlKemDecapsulate(decapsulationKey, ciphertext);
       break;
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  return FunctionPrototypeCall(
+  return PromisePrototypeThen(decapsulatedBits, (decapsulatedBits) => FunctionPrototypeCall(
     importKeySync,
     this,
-    'raw-secret', decapsulatedBits, normalizedSharedKeyAlgorithm, extractable, usages,
-  );
+    'raw-secret', decapsulatedBits, normalizedSharedKeyAlgorithm, extractable,
+    usages,
+  ));
 }
 
 // The SubtleCrypto and Crypto classes are defined as part of the

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -1,19 +1,23 @@
 'use strict';
 
 const {
+  ArrayIsArray,
   ArrayPrototypeSlice,
   FunctionPrototypeCall,
   JSONParse,
   JSONStringify,
   ObjectDefineProperties,
-  PromisePrototypeThen,
+  ObjectKeys,
+  ObjectSetPrototypeOf,
   PromiseReject,
   PromiseResolve,
   ReflectApply,
   ReflectConstruct,
+  SafeArrayIterator,
   StringPrototypeRepeat,
   StringPrototypeSlice,
   StringPrototypeStartsWith,
+  SymbolIterator,
   SymbolToStringTag,
   TypedArrayPrototypeGetBuffer,
 } = primordials;
@@ -26,7 +30,10 @@ const {
   kWebCryptoCipherDecrypt,
 } = internalBinding('crypto');
 
-const { TextDecoder, TextEncoder } = require('internal/encoding');
+const {
+  decodeUTF8,
+  encodeUtf8String,
+} = internalBinding('encoding_binding');
 
 const {
   codes: {
@@ -54,9 +61,12 @@ const {
 } = require('internal/crypto/hash');
 
 const {
+  cleanupWebCryptoResult,
   getBlockSize,
+  jobPromiseThen,
   normalizeAlgorithm,
   normalizeHashName,
+  prepareWebCryptoResult,
   validateMaxBufferLength,
 } = require('internal/crypto/util');
 
@@ -64,6 +74,7 @@ const {
   emitExperimentalWarning,
   kEnumerableProperty,
   lazyDOMException,
+  setOwnProperty,
 } = require('internal/util');
 
 const {
@@ -71,13 +82,28 @@ const {
   randomUUID: _randomUUID,
 } = require('internal/crypto/random');
 
+const {
+  isPromise,
+} = require('internal/util/types');
+
 let webidl;
 
 // WebCrypto methods return promises, including for synchronous validation
 // failures. Keep that conversion in one place so method bodies stay readable.
 function callSubtleCryptoMethod(fn, receiver, args) {
   try {
-    return PromiseResolve(ReflectApply(fn, receiver, args));
+    const result = ReflectApply(fn, receiver, args);
+    if (isPromise(result))
+      return result;
+    // PromiseResolve() performs thenable assimilation for object results.
+    // Shadow inherited then accessors while it resolves synchronous results.
+    const shouldCleanupResult = prepareWebCryptoResult(result);
+    try {
+      return PromiseResolve(result);
+    } finally {
+      if (shouldCleanupResult)
+        cleanupWebCryptoResult(result);
+    }
   } catch (err) {
     return PromiseReject(err);
   }
@@ -384,7 +410,7 @@ function deriveKeyImpl(
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  return PromisePrototypeThen(bits, (bits) => FunctionPrototypeCall(
+  return jobPromiseThen(bits, (bits) => FunctionPrototypeCall(
     importKeySync,
     this,
     'raw-secret', bits, derivedKeyAlgorithm, extractable, keyUsages,
@@ -571,30 +597,24 @@ function exportKeyRawSecret(key, format) {
 
 function exportKeyJWK(key) {
   const algorithm = getCryptoKeyAlgorithm(key);
-  const parameters = {
-    key_ops: ArrayPrototypeSlice(getCryptoKeyUsages(key), 0),
-    ext: getCryptoKeyExtractable(key),
-  };
+  let alg;
   switch (algorithm.name) {
     case 'RSASSA-PKCS1-v1_5': {
-      const alg = normalizeHashName(
+      alg = normalizeHashName(
         algorithm.hash.name,
         normalizeHashName.kContextJwkRsa);
-      if (alg) parameters.alg = alg;
       break;
     }
     case 'RSA-PSS': {
-      const alg = normalizeHashName(
+      alg = normalizeHashName(
         algorithm.hash.name,
         normalizeHashName.kContextJwkRsaPss);
-      if (alg) parameters.alg = alg;
       break;
     }
     case 'RSA-OAEP': {
-      const alg = normalizeHashName(
+      alg = normalizeHashName(
         algorithm.hash.name,
         normalizeHashName.kContextJwkRsaOaep);
-      if (alg) parameters.alg = alg;
       break;
     }
     case 'ECDSA':
@@ -620,7 +640,7 @@ function exportKeyJWK(key) {
     case 'Ed25519':
       // Fall through
     case 'Ed448':
-      parameters.alg = algorithm.name;
+      alg = algorithm.name;
       break;
     case 'AES-CTR':
       // Fall through
@@ -631,29 +651,38 @@ function exportKeyJWK(key) {
     case 'AES-OCB':
       // Fall through
     case 'AES-KW':
-      parameters.alg = require('internal/crypto/aes')
+      alg = require('internal/crypto/aes')
         .getAlgorithmName(algorithm.name, algorithm.length);
       break;
     case 'ChaCha20-Poly1305':
-      parameters.alg = 'C20P';
+      alg = 'C20P';
       break;
     case 'HMAC': {
-      const alg = normalizeHashName(
+      alg = normalizeHashName(
         algorithm.hash.name,
         normalizeHashName.kContextJwkHmac);
-      if (alg) parameters.alg = alg;
       break;
     }
     case 'KMAC128':
-      parameters.alg = 'K128';
+      alg = 'K128';
       break;
     case 'KMAC256': {
-      parameters.alg = 'K256';
+      alg = 'K256';
       break;
     }
     default:
       return undefined;
   }
+
+  // Keep `alg` in the object literal so an inherited setter cannot capture
+  // `parameters` before native export populates key material. Delete it for
+  // algorithms without a JWK alg value to keep the expected shape.
+  const parameters = {
+    key_ops: ArrayPrototypeSlice(getCryptoKeyUsages(key), 0),
+    ext: getCryptoKeyExtractable(key),
+    alg,
+  };
+  if (alg === undefined) delete parameters.alg;
 
   return getCryptoKeyHandle(key).exportJwk(parameters, true);
 }
@@ -746,6 +775,60 @@ function exportKeyImpl(format, key) {
   });
 
   return exportKeySync(format, key);
+}
+
+// Parsed JWK arrays are detached from Array.prototype but still need to pass
+// WebIDL sequence conversion, which reads @@iterator from the value.
+function safeArrayIterator() {
+  return new SafeArrayIterator(this);
+}
+
+// The WebCrypto spec parses and stringifies JWKs in a fresh global object.
+// Detach internal JSON values from the current global's mutable prototypes to
+// approximate those fresh-realm semantics without creating a new realm.
+function detachFromUserPrototypes(value) {
+  if (value === null || typeof value !== 'object')
+    return;
+
+  ObjectSetPrototypeOf(value, null);
+
+  if (ArrayIsArray(value)) {
+    setOwnProperty(value, SymbolIterator, safeArrayIterator);
+    for (let n = 0; n < value.length; n++)
+      detachFromUserPrototypes(value[n]);
+    return;
+  }
+
+  const keys = ObjectKeys(value);
+  for (let n = 0; n < keys.length; n++)
+    detachFromUserPrototypes(value[keys[n]]);
+}
+
+// Parse wrapped JWK bytes according to WebCrypto's "parse a JWK" procedure.
+function parseJwk(keyData) {
+  let key;
+  try {
+    // WebCrypto parses JWKs in a fresh global. Detach parsed JSON values
+    // from user-mutated prototypes before WebIDL dictionary conversion.
+    // Wrapped JWKs may be produced outside WebCrypto, so parse using the
+    // spec-required UTF-8.
+    const json = decodeUTF8(keyData, false, true);
+    const result = JSONParse(json);
+    detachFromUserPrototypes(result);
+    key = webidl.converters.JsonWebKey(result);
+  } catch (err) {
+    throw lazyDOMException(
+      'Invalid wrapped JWK key',
+      { name: 'DataError', cause: err });
+  }
+
+  if (key.kty === undefined) {
+    throw lazyDOMException(
+      'Invalid wrapped JWK key',
+      'DataError');
+  }
+
+  return key;
 }
 
 function aliasKeyFormat(format) {
@@ -967,15 +1050,21 @@ function wrapKeyImpl(format, key, wrappingKey, algorithm) {
   let keyData = exportKeySync(format, key);
 
   if (format === 'jwk') {
-    const ec = new TextEncoder();
-    const raw = JSONStringify(keyData);
+    // The WebCrypto spec stringifies JWKs in a new global object. Rather
+    // than create a new realm here, detach this internally generated JWK from
+    // user-mutated prototypes so JSON.stringify cannot read inherited toJSON
+    // hooks from the current global.
+    detachFromUserPrototypes(keyData);
+    const json = JSONStringify(keyData);
     // As per the NOTE in step 13 https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey
     // we're padding AES-KW wrapped JWK to make sure it is always a multiple of 8 bytes
     // in length
-    if (algorithm.name === 'AES-KW' && raw.length % 8 !== 0) {
-      keyData = ec.encode(raw + StringPrototypeRepeat(' ', 8 - (raw.length % 8)));
+    // The spec then UTF-8 encodes json.
+    if (algorithm.name === 'AES-KW' && json.length % 8 !== 0) {
+      keyData = encodeUtf8String(
+        json + StringPrototypeRepeat(' ', 8 - (json.length % 8)));
     } else {
-      keyData = ec.encode(raw);
+      keyData = encodeUtf8String(json);
     }
   }
 
@@ -1067,17 +1156,9 @@ function unwrapKeyImpl(
     wrappedKey,
     'unwrapKey');
 
-  return PromisePrototypeThen(keyData, (keyData) => {
+  return jobPromiseThen(keyData, (keyData) => {
     if (format === 'jwk') {
-      // The fatal: true option is only supported in builds that have ICU.
-      const options = process.versions.icu !== undefined ?
-        { fatal: true } : undefined;
-      const dec = new TextDecoder('utf-8', options);
-      try {
-        keyData = JSONParse(dec.decode(keyData));
-      } catch {
-        throw lazyDOMException('Invalid wrapped JWK key', 'DataError');
-      }
+      keyData = parseJwk(keyData);
     }
 
     return FunctionPrototypeCall(
@@ -1453,7 +1534,7 @@ function encapsulateKeyImpl(
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  return PromisePrototypeThen(encapsulateBits, (encapsulateBits) => {
+  return jobPromiseThen(encapsulateBits, (encapsulateBits) => {
     const sharedKey = FunctionPrototypeCall(
       importKeySync,
       this,
@@ -1593,7 +1674,7 @@ function decapsulateKeyImpl(
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  return PromisePrototypeThen(decapsulatedBits, (decapsulatedBits) => FunctionPrototypeCall(
+  return jobPromiseThen(decapsulatedBits, (decapsulatedBits) => FunctionPrototypeCall(
     importKeySync,
     this,
     'raw-secret', decapsulatedBits, normalizedSharedKeyAlgorithm, extractable,

--- a/src/crypto/README.md
+++ b/src/crypto/README.md
@@ -186,7 +186,8 @@ All operations that are not either Stream-based or single-use functions
 are built around the `CryptoJob` class.
 
 A `CryptoJob` encapsulates a single crypto operation that can be
-invoked synchronously or asynchronously.
+invoked synchronously, asynchronously, or as a Web Crypto API
+Promise-based job.
 
 The `CryptoJob` class itself is a C++ template that takes a single
 `CryptoJobTraits` struct as a parameter. The `CryptoJobTraits`
@@ -228,14 +229,15 @@ specializations and will either be called synchronously within
 the current thread or from within the libuv threadpool.
 
 Every `CryptoJob` instance exposes a `run()` function to the
-JavaScript layer. When called, `run()` with either dispatch the
-job to the libuv threadpool or invoke the Implementation
-function synchronously. If invoked synchronously, run() will
-return a JavaScript array. The first value in the array is
-either an `Error` or `undefined`. If the operation was successful,
-the second value in the array will contain the result of the
-operation. Typically, the result is an `ArrayBuffer`, but
-certain `CryptoJob` types can alter the output.
+JavaScript layer. When called, `run()` will either dispatch the
+job to the libuv threadpool, invoke the Implementation function
+synchronously, or return a `Promise` for Web Crypto API jobs. If
+invoked synchronously, `run()` will return a JavaScript array.
+The first value in the array is either an `Error` or `undefined`.
+If the operation was successful, the second value in the array
+will contain the result of the operation. Typically, the result
+is an `ArrayBuffer`, but certain `CryptoJob` types can alter the
+output.
 
 If the `CryptoJob` is processed asynchronously, then the job
 must have an `ondone` property whose value is a function that
@@ -244,11 +246,19 @@ be called with two arguments. The first is either an `Error`
 or `undefined`, and the second is the result of the operation
 if successful.
 
+If the `CryptoJob` is processed as a Web Crypto API job, then
+`run()` returns a Promise. Operation-specific failures are
+rejected with an `OperationError`, and successful jobs resolve
+with the Web Crypto API result shape expected by the JavaScript
+implementation.
+
 For `CipherJob` types, the output is always an `ArrayBuffer`.
 
 For `KeyGenJob` types, the output is either a single KeyObject,
 or an array containing a Public/Private key pair represented
-either as a `KeyObjectHandle` object or a `Buffer`.
+either as a `KeyObjectHandle` object or a `Buffer`. Web Crypto
+API key generation jobs return a `CryptoKey` or a `CryptoKeyPair`
+object.
 
 For `DeriveBitsJob` type output is typically an `ArrayBuffer` but
 can be other values (`RandomBytesJob` for instance, fills an
@@ -273,11 +283,12 @@ should be used to throw JavaScript errors when necessary.
 
 ### Operation mode
 
-All crypto functions in Node.js operate in one of three
+All crypto functions in Node.js operate in one of these
 modes:
 
 * Synchronous single-call
 * Asynchronous single-call
+* Web Crypto API Promise-based
 * Stream-oriented
 
 It is often possible to perform various operations across

--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -418,9 +418,7 @@ bool ValidateIV(
     THROW_ERR_OUT_OF_RANGE(env, "iv is too big");
     return false;
   }
-  params->iv = (mode == kCryptoJobAsync)
-      ? iv.ToCopy()
-      : iv.ToByteSource();
+  params->iv = (IsCryptoJobAsync(mode)) ? iv.ToCopy() : iv.ToByteSource();
   return true;
 }
 
@@ -466,9 +464,9 @@ bool ValidateAdditionalData(
       THROW_ERR_OUT_OF_RANGE(env, "additionalData is too big");
       return false;
     }
-    params->additional_data = mode == kCryptoJobAsync
-        ? additional.ToCopy()
-        : additional.ToByteSource();
+    params->additional_data = IsCryptoJobAsync(mode)
+                                  ? additional.ToCopy()
+                                  : additional.ToByteSource();
   }
   return true;
 }
@@ -495,7 +493,7 @@ AESCipherConfig& AESCipherConfig::operator=(AESCipherConfig&& other) noexcept {
 void AESCipherConfig::MemoryInfo(MemoryTracker* tracker) const {
   // If mode is sync, then the data in each of these properties
   // is not owned by the AESCipherConfig, so we ignore it.
-  if (mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(mode)) {
     tracker->TrackFieldWithSize("iv", iv.size());
     tracker->TrackFieldWithSize("additional_data", additional_data.size());
   }

--- a/src/crypto/crypto_argon2.cc
+++ b/src/crypto/crypto_argon2.cc
@@ -36,7 +36,7 @@ Argon2Config& Argon2Config::operator=(Argon2Config&& other) noexcept {
 }
 
 void Argon2Config::MemoryInfo(MemoryTracker* tracker) const {
-  if (mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(mode)) {
     tracker->TrackFieldWithSize("pass", pass.size());
     tracker->TrackFieldWithSize("salt", salt.size());
     tracker->TrackFieldWithSize("secret", secret.size());
@@ -84,7 +84,7 @@ Maybe<void> Argon2Traits::AdditionalConfig(
     return Nothing<void>();
   }
 
-  const bool isAsync = mode == kCryptoJobAsync;
+  const bool isAsync = IsCryptoJobAsync(mode);
   config->pass = isAsync ? pass.ToCopy() : pass.ToByteSource();
   config->salt = isAsync ? salt.ToCopy() : salt.ToByteSource();
   config->secret = isAsync ? secret.ToCopy() : secret.ToByteSource();

--- a/src/crypto/crypto_argon2.cc
+++ b/src/crypto/crypto_argon2.cc
@@ -1,5 +1,8 @@
 #include "crypto/crypto_argon2.h"
 #include "async_wrap-inl.h"
+#include "base_object-inl.h"
+#include "crypto/crypto_keys.h"
+#include "memory_tracker-inl.h"
 #include "threadpoolwork-inl.h"
 
 #if OPENSSL_WITH_ARGON2
@@ -19,6 +22,7 @@ using v8::Value;
 
 Argon2Config::Argon2Config(Argon2Config&& other) noexcept
     : mode{other.mode},
+      key{std::move(other.key)},
       pass{std::move(other.pass)},
       salt{std::move(other.salt)},
       secret{std::move(other.secret)},
@@ -36,8 +40,9 @@ Argon2Config& Argon2Config::operator=(Argon2Config&& other) noexcept {
 }
 
 void Argon2Config::MemoryInfo(MemoryTracker* tracker) const {
+  if (key) tracker->TrackField("key", key);
   if (IsCryptoJobAsync(mode)) {
-    tracker->TrackFieldWithSize("pass", pass.size());
+    if (!key) tracker->TrackFieldWithSize("pass", pass.size());
     tracker->TrackFieldWithSize("salt", salt.size());
     tracker->TrackFieldWithSize("secret", secret.size());
     tracker->TrackFieldWithSize("ad", ad.size());
@@ -59,14 +64,23 @@ Maybe<void> Argon2Traits::AdditionalConfig(
 
   config->mode = mode;
 
-  ArrayBufferOrViewContents<char> pass(args[offset]);
+  CHECK(KeyObjectHandle::HasInstance(env, args[offset]) ||
+        IsAnyBufferSource(args[offset]));  // pass
   ArrayBufferOrViewContents<char> salt(args[offset + 1]);
   ArrayBufferOrViewContents<char> secret(args[offset + 6]);
   ArrayBufferOrViewContents<char> ad(args[offset + 7]);
 
-  if (!pass.CheckSizeInt32()) [[unlikely]] {
-    THROW_ERR_OUT_OF_RANGE(env, "pass is too large");
-    return Nothing<void>();
+  if (KeyObjectHandle::HasInstance(env, args[offset])) {
+    KeyObjectHandle* key;
+    ASSIGN_OR_RETURN_UNWRAP(&key, args[offset], Nothing<void>());
+    config->key = key->Data().addRef();
+  } else {
+    ArrayBufferOrViewContents<char> pass(args[offset]);
+    if (!pass.CheckSizeInt32()) [[unlikely]] {
+      THROW_ERR_OUT_OF_RANGE(env, "pass is too large");
+      return Nothing<void>();
+    }
+    config->pass = IsCryptoJobAsync(mode) ? pass.ToCopy() : pass.ToByteSource();
   }
 
   if (!salt.CheckSizeInt32()) [[unlikely]] {
@@ -85,7 +99,6 @@ Maybe<void> Argon2Traits::AdditionalConfig(
   }
 
   const bool isAsync = IsCryptoJobAsync(mode);
-  config->pass = isAsync ? pass.ToCopy() : pass.ToByteSource();
   config->salt = isAsync ? salt.ToCopy() : salt.ToByteSource();
   config->secret = isAsync ? secret.ToCopy() : secret.ToByteSource();
   config->ad = isAsync ? ad.ToCopy() : ad.ToByteSource();
@@ -119,7 +132,13 @@ bool Argon2Traits::DeriveBits(Environment* env,
   }
 
   // Both the pass and salt may be zero-length at this point
-  auto dp = ncrypto::argon2(config.pass,
+  const ncrypto::Buffer<const char> pass{
+      .data = config.key ? config.key.GetSymmetricKey()
+                         : config.pass.data<const char>(),
+      .len = config.key ? config.key.GetSymmetricKeySize() : config.pass.size(),
+  };
+
+  auto dp = ncrypto::argon2(pass,
                             config.salt,
                             config.lanes,
                             config.keylen,

--- a/src/crypto/crypto_argon2.h
+++ b/src/crypto/crypto_argon2.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "crypto/crypto_keys.h"
 #include "crypto/crypto_util.h"
 
 namespace node::crypto {
@@ -22,6 +23,7 @@ namespace node::crypto {
 
 struct Argon2Config final : public MemoryRetainer {
   CryptoJobMode mode;
+  KeyObjectData key;
   ByteSource pass;
   ByteSource salt;
   ByteSource secret;

--- a/src/crypto/crypto_chacha20_poly1305.cc
+++ b/src/crypto/crypto_chacha20_poly1305.cc
@@ -48,7 +48,7 @@ bool ValidateIV(Environment* env,
     return false;
   }
 
-  if (mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(mode)) {
     params->iv = iv.ToCopy();
   } else {
     params->iv = iv.ToByteSource();
@@ -68,7 +68,7 @@ bool ValidateAdditionalData(Environment* env,
       return false;
     }
 
-    if (mode == kCryptoJobAsync) {
+    if (IsCryptoJobAsync(mode)) {
       params->additional_data = additional_data.ToCopy();
     } else {
       params->additional_data = additional_data.ToByteSource();
@@ -96,7 +96,7 @@ ChaCha20Poly1305CipherConfig& ChaCha20Poly1305CipherConfig::operator=(
 void ChaCha20Poly1305CipherConfig::MemoryInfo(MemoryTracker* tracker) const {
   // If mode is sync, then the data in each of these properties
   // is not owned by the ChaCha20Poly1305CipherConfig, so we ignore it.
-  if (mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(mode)) {
     tracker->TrackFieldWithSize("iv", iv.size());
     tracker->TrackFieldWithSize("additional_data", additional_data.size());
   }

--- a/src/crypto/crypto_cipher.h
+++ b/src/crypto/crypto_cipher.h
@@ -164,13 +164,7 @@ class CipherJob final : public CryptoJob<CipherTraits> {
     }
 
     new CipherJob<CipherTraits>(
-        env,
-        args.This(),
-        mode,
-        key,
-        cipher_mode,
-        data,
-        std::move(params));
+        env, args.This(), mode, key, cipher_mode, data, std::move(params));
   }
 
   static void Initialize(
@@ -197,7 +191,7 @@ class CipherJob final : public CryptoJob<CipherTraits> {
                                 std::move(params)),
         key_(key->Data().addRef()),
         cipher_mode_(cipher_mode),
-        in_(mode == kCryptoJobAsync ? data.ToCopy() : data.ToByteSource()) {}
+        in_(IsCryptoJobAsync(mode) ? data.ToCopy() : data.ToByteSource()) {}
 
   const KeyObjectData& key() const { return key_; }
 
@@ -261,7 +255,7 @@ class CipherJob final : public CryptoJob<CipherTraits> {
 
   SET_SELF_SIZE(CipherJob)
   void MemoryInfo(MemoryTracker* tracker) const override {
-    if (CryptoJob<CipherTraits>::mode() == kCryptoJobAsync)
+    if (IsCryptoJobAsync(CryptoJob<CipherTraits>::mode()))
       tracker->TrackFieldWithSize("in", in_.size());
     tracker->TrackFieldWithSize("out", out_.size());
     CryptoJob<CipherTraits>::MemoryInfo(tracker);

--- a/src/crypto/crypto_ec.cc
+++ b/src/crypto/crypto_ec.cc
@@ -488,10 +488,10 @@ bool ExportJWKEcKey(Environment* env,
     return false;
   }
 
-  if (target->Set(
-          env->context(),
-          env->jwk_kty_string(),
-          env->jwk_ec_string()).IsNothing()) {
+  if (!target
+           ->DefineOwnProperty(
+               env->context(), env->jwk_kty_string(), env->jwk_ec_string())
+           .FromMaybe(false)) {
     return false;
   }
 
@@ -531,10 +531,9 @@ bool ExportJWKEcKey(Environment* env,
       return false;
     }
   }
-  if (target->Set(
-      env->context(),
-      env->jwk_crv_string(),
-      crv_name).IsNothing()) {
+  if (!target
+           ->DefineOwnProperty(env->context(), env->jwk_crv_string(), crv_name)
+           .FromMaybe(false)) {
     return false;
   }
 
@@ -577,20 +576,23 @@ bool ExportJWKEdKey(Environment* env,
     const ncrypto::Buffer<const char> out = data;
     return StringBytes::Encode(env->isolate(), out.data, out.len, BASE64URL)
                .ToLocal(&encoded) &&
-           target->Set(env->context(), key, encoded).IsJust();
+           target->DefineOwnProperty(env->context(), key, encoded)
+               .FromMaybe(false);
   };
 
   return !(
-      target
-          ->Set(env->context(),
-                env->jwk_crv_string(),
-                OneByteString(env->isolate(), curve))
-          .IsNothing() ||
+      !target
+           ->DefineOwnProperty(env->context(),
+                               env->jwk_crv_string(),
+                               OneByteString(env->isolate(), curve))
+           .FromMaybe(false) ||
       (key.GetKeyType() == kKeyTypePrivate &&
        !trySetKey(env, pkey.rawPrivateKey(), target, env->jwk_d_string())) ||
       !trySetKey(env, pkey.rawPublicKey(), target, env->jwk_x_string()) ||
-      target->Set(env->context(), env->jwk_kty_string(), env->jwk_okp_string())
-          .IsNothing());
+      !target
+           ->DefineOwnProperty(
+               env->context(), env->jwk_kty_string(), env->jwk_okp_string())
+           .FromMaybe(false));
 }
 KeyObjectData ImportJWKEdKey(Environment* env, Local<Object> jwk) {
   Local<Value> crv_value;

--- a/src/crypto/crypto_hash.cc
+++ b/src/crypto/crypto_hash.cc
@@ -510,8 +510,7 @@ HashConfig& HashConfig::operator=(HashConfig&& other) noexcept {
 
 void HashConfig::MemoryInfo(MemoryTracker* tracker) const {
   // If the Job is sync, then the HashConfig does not own the data.
-  if (mode == kCryptoJobAsync)
-    tracker->TrackFieldWithSize("in", in.size());
+  if (IsCryptoJobAsync(mode)) tracker->TrackFieldWithSize("in", in.size());
 }
 
 MaybeLocal<Value> HashTraits::EncodeOutput(Environment* env,
@@ -542,9 +541,7 @@ Maybe<void> HashTraits::AdditionalConfig(
     THROW_ERR_OUT_OF_RANGE(env, "data is too big");
     return Nothing<void>();
   }
-  params->in = mode == kCryptoJobAsync
-      ? data.ToCopy()
-      : data.ToByteSource();
+  params->in = IsCryptoJobAsync(mode) ? data.ToCopy() : data.ToByteSource();
 
   unsigned int expected = EVP_MD_size(params->digest);
   params->length = expected;

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -77,13 +77,9 @@ Maybe<void> HKDFTraits::AdditionalConfig(
     return Nothing<void>();
   }
 
-  params->salt = mode == kCryptoJobAsync
-      ? salt.ToCopy()
-      : salt.ToByteSource();
+  params->salt = IsCryptoJobAsync(mode) ? salt.ToCopy() : salt.ToByteSource();
 
-  params->info = mode == kCryptoJobAsync
-      ? info.ToCopy()
-      : info.ToByteSource();
+  params->info = IsCryptoJobAsync(mode) ? info.ToCopy() : info.ToByteSource();
 
   params->length = args[offset + 4].As<Uint32>()->Value();
   // HKDF-Expand computes up to 255 HMAC blocks, each having as many bits as the
@@ -130,7 +126,7 @@ bool HKDFTraits::DeriveBits(Environment* env,
 void HKDFConfig::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("key", key);
   // If the job is sync, then the HKDFConfig does not own the data
-  if (mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(mode)) {
     tracker->TrackFieldWithSize("salt", salt.size());
     tracker->TrackFieldWithSize("info", info.size());
   }

--- a/src/crypto/crypto_hkdf.cc
+++ b/src/crypto/crypto_hkdf.cc
@@ -24,6 +24,7 @@ HKDFConfig::HKDFConfig(HKDFConfig&& other) noexcept
       length(other.length),
       digest(other.digest),
       key(std::move(other.key)),
+      key_data(std::move(other.key_data)),
       salt(std::move(other.salt)),
       info(std::move(other.info)) {}
 
@@ -49,7 +50,8 @@ Maybe<void> HKDFTraits::AdditionalConfig(
   params->mode = mode;
 
   CHECK(args[offset]->IsString());  // Hash
-  CHECK(args[offset + 1]->IsObject());  // Key
+  CHECK(KeyObjectHandle::HasInstance(env, args[offset + 1]) ||
+        IsAnyBufferSource(args[offset + 1]));  // Key
   CHECK(IsAnyBufferSource(args[offset + 2]));  // Salt
   CHECK(IsAnyBufferSource(args[offset + 3]));  // Info
   CHECK(args[offset + 4]->IsUint32());  // Length
@@ -61,9 +63,19 @@ Maybe<void> HKDFTraits::AdditionalConfig(
     return Nothing<void>();
   }
 
-  KeyObjectHandle* key;
-  ASSIGN_OR_RETURN_UNWRAP(&key, args[offset + 1], Nothing<void>());
-  params->key = key->Data().addRef();
+  if (KeyObjectHandle::HasInstance(env, args[offset + 1])) {
+    KeyObjectHandle* key;
+    ASSIGN_OR_RETURN_UNWRAP(&key, args[offset + 1], Nothing<void>());
+    params->key = key->Data().addRef();
+  } else {
+    ArrayBufferOrViewContents<char> key_data(args[offset + 1]);
+    if (!key_data.CheckSizeInt32()) [[unlikely]] {
+      THROW_ERR_OUT_OF_RANGE(env, "key is too big");
+      return Nothing<void>();
+    }
+    params->key_data =
+        IsCryptoJobAsync(mode) ? key_data.ToCopy() : key_data.ToByteSource();
+  }
 
   ArrayBufferOrViewContents<char> salt(args[offset + 2]);
   ArrayBufferOrViewContents<char> info(args[offset + 3]);
@@ -98,12 +110,16 @@ bool HKDFTraits::DeriveBits(Environment* env,
                             ByteSource* out,
                             CryptoJobMode mode,
                             CryptoErrorStore* errors) {
+  const ncrypto::Buffer<const unsigned char> key_data{
+      .data = params.key ? reinterpret_cast<const unsigned char*>(
+                               params.key.GetSymmetricKey())
+                         : params.key_data.data<unsigned char>(),
+      .len = params.key ? params.key.GetSymmetricKeySize()
+                        : params.key_data.size(),
+  };
+
   auto dp = ncrypto::hkdf(params.digest,
-                          ncrypto::Buffer<const unsigned char>{
-                              .data = reinterpret_cast<const unsigned char*>(
-                                  params.key.GetSymmetricKey()),
-                              .len = params.key.GetSymmetricKeySize(),
-                          },
+                          key_data,
                           ncrypto::Buffer<const unsigned char>{
                               .data = params.info.data<const unsigned char>(),
                               .len = params.info.size(),
@@ -124,9 +140,10 @@ bool HKDFTraits::DeriveBits(Environment* env,
 }
 
 void HKDFConfig::MemoryInfo(MemoryTracker* tracker) const {
-  tracker->TrackField("key", key);
+  if (key) tracker->TrackField("key", key);
   // If the job is sync, then the HKDFConfig does not own the data
   if (IsCryptoJobAsync(mode)) {
+    if (!key) tracker->TrackFieldWithSize("key", key_data.size());
     tracker->TrackFieldWithSize("salt", salt.size());
     tracker->TrackFieldWithSize("info", info.size());
   }

--- a/src/crypto/crypto_hkdf.h
+++ b/src/crypto/crypto_hkdf.h
@@ -16,6 +16,7 @@ struct HKDFConfig final : public MemoryRetainer {
   size_t length;
   ncrypto::Digest digest;
   KeyObjectData key;
+  ByteSource key_data;
   ByteSource salt;
   ByteSource info;
 

--- a/src/crypto/crypto_hmac.cc
+++ b/src/crypto/crypto_hmac.cc
@@ -172,7 +172,7 @@ HmacConfig& HmacConfig::operator=(HmacConfig&& other) noexcept {
 void HmacConfig::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("key", key);
   // If the job is sync, then the HmacConfig does not own the data
-  if (job_mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(job_mode)) {
     tracker->TrackFieldWithSize("data", data.size());
     tracker->TrackFieldWithSize("signature", signature.size());
   }
@@ -210,9 +210,7 @@ Maybe<void> HmacTraits::AdditionalConfig(
     THROW_ERR_OUT_OF_RANGE(env, "data is too big");
     return Nothing<void>();
   }
-  params->data = mode == kCryptoJobAsync
-      ? data.ToCopy()
-      : data.ToByteSource();
+  params->data = IsCryptoJobAsync(mode) ? data.ToCopy() : data.ToByteSource();
 
   if (!args[offset + 4]->IsUndefined()) {
     ArrayBufferOrViewContents<char> signature(args[offset + 4]);
@@ -220,9 +218,8 @@ Maybe<void> HmacTraits::AdditionalConfig(
       THROW_ERR_OUT_OF_RANGE(env, "signature is too big");
       return Nothing<void>();
     }
-    params->signature = mode == kCryptoJobAsync
-        ? signature.ToCopy()
-        : signature.ToByteSource();
+    params->signature =
+        IsCryptoJobAsync(mode) ? signature.ToCopy() : signature.ToByteSource();
   }
 
   return JustVoid();

--- a/src/crypto/crypto_kem.cc
+++ b/src/crypto/crypto_kem.cc
@@ -176,16 +176,16 @@ MaybeLocal<Value> KEMEncapsulateTraits::EncodeOutput(
 
   if (params.job_mode == kCryptoJobWebCrypto) {
     Local<Object> result = Object::New(env->isolate());
-    if (result
-            ->Set(env->context(),
-                  OneByteString(env->isolate(), "sharedKey"),
-                  shared_key_obj.As<ArrayBufferView>()->Buffer())
-            .IsNothing() ||
-        result
-            ->Set(env->context(),
-                  OneByteString(env->isolate(), "ciphertext"),
-                  ciphertext_obj.As<ArrayBufferView>()->Buffer())
-            .IsNothing()) {
+    if (!result
+             ->DefineOwnProperty(env->context(),
+                                 OneByteString(env->isolate(), "sharedKey"),
+                                 shared_key_obj.As<ArrayBufferView>()->Buffer())
+             .FromMaybe(false) ||
+        !result
+             ->DefineOwnProperty(env->context(),
+                                 OneByteString(env->isolate(), "ciphertext"),
+                                 ciphertext_obj.As<ArrayBufferView>()->Buffer())
+             .FromMaybe(false)) {
       return MaybeLocal<Value>();
     }
     return result;

--- a/src/crypto/crypto_kem.cc
+++ b/src/crypto/crypto_kem.cc
@@ -16,6 +16,7 @@ namespace node {
 
 using ncrypto::EVPKeyPointer;
 using v8::Array;
+using v8::ArrayBufferView;
 using v8::FunctionCallbackInfo;
 using v8::Local;
 using v8::Maybe;
@@ -41,7 +42,7 @@ KEMConfiguration& KEMConfiguration::operator=(
 
 void KEMConfiguration::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("key", key);
-  if (job_mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(job_mode)) {
     tracker->TrackFieldWithSize("ciphertext", ciphertext.size());
   }
 }
@@ -173,6 +174,23 @@ MaybeLocal<Value> KEMEncapsulateTraits::EncodeOutput(
     return MaybeLocal<Value>();
   }
 
+  if (params.job_mode == kCryptoJobWebCrypto) {
+    Local<Object> result = Object::New(env->isolate());
+    if (result
+            ->Set(env->context(),
+                  OneByteString(env->isolate(), "sharedKey"),
+                  shared_key_obj.As<ArrayBufferView>()->Buffer())
+            .IsNothing() ||
+        result
+            ->Set(env->context(),
+                  OneByteString(env->isolate(), "ciphertext"),
+                  ciphertext_obj.As<ArrayBufferView>()->Buffer())
+            .IsNothing()) {
+      return MaybeLocal<Value>();
+    }
+    return result;
+  }
+
   // Return an array [sharedKey, ciphertext].
   Local<Array> result = Array::New(env->isolate(), 2);
   if (result->Set(env->context(), 0, shared_key_obj).IsNothing() ||
@@ -209,7 +227,7 @@ Maybe<void> KEMDecapsulateTraits::AdditionalConfig(
   }
 
   params->ciphertext =
-      mode == kCryptoJobAsync ? ciphertext.ToCopy() : ciphertext.ToByteSource();
+      IsCryptoJobAsync(mode) ? ciphertext.ToCopy() : ciphertext.ToByteSource();
 
   return v8::JustVoid();
 }

--- a/src/crypto/crypto_keygen.h
+++ b/src/crypto/crypto_keygen.h
@@ -22,6 +22,20 @@ enum class KeyGenJobStatus {
   FAILED
 };
 
+struct WebCryptoKeyGenConfig final {
+  v8::Global<v8::Value> algorithm;
+  uint32_t usages_mask = 0;
+  uint32_t public_usages_mask = 0;
+  uint32_t private_usages_mask = 0;
+  bool extractable = false;
+
+  WebCryptoKeyGenConfig() = default;
+  WebCryptoKeyGenConfig(WebCryptoKeyGenConfig&&) = default;
+  WebCryptoKeyGenConfig& operator=(WebCryptoKeyGenConfig&&) = default;
+  WebCryptoKeyGenConfig(const WebCryptoKeyGenConfig&) = delete;
+  WebCryptoKeyGenConfig& operator=(const WebCryptoKeyGenConfig&) = delete;
+};
+
 // A Base CryptoJob for generating secret keys or key pairs.
 // The KeyGenTraits is largely responsible for the details of
 // the implementation, while KeyGenJob handles the common
@@ -48,7 +62,29 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
       return;
     }
 
-    new KeyGenJob<KeyGenTraits>(env, args.This(), mode, std::move(params));
+    WebCryptoKeyGenConfig config;
+    if (mode == kCryptoJobWebCrypto) {
+      if constexpr (KeyGenTraits::kWebCryptoKeyPair) {
+        CHECK(args[offset]->IsObject());
+        CHECK(args[offset + 1]->IsUint32());
+        CHECK(args[offset + 2]->IsUint32());
+        CHECK(args[offset + 3]->IsBoolean());
+        config.algorithm.Reset(env->isolate(), args[offset]);
+        config.public_usages_mask = args[offset + 1].As<v8::Uint32>()->Value();
+        config.private_usages_mask = args[offset + 2].As<v8::Uint32>()->Value();
+        config.extractable = args[offset + 3]->IsTrue();
+      } else {
+        CHECK(args[offset]->IsObject());
+        CHECK(args[offset + 1]->IsUint32());
+        CHECK(args[offset + 2]->IsBoolean());
+        config.algorithm.Reset(env->isolate(), args[offset]);
+        config.usages_mask = args[offset + 1].As<v8::Uint32>()->Value();
+        config.extractable = args[offset + 2]->IsTrue();
+      }
+    }
+
+    new KeyGenJob<KeyGenTraits>(
+        env, args.This(), mode, std::move(params), std::move(config));
   }
 
   static void Initialize(
@@ -61,17 +97,14 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
     CryptoJob<KeyGenTraits>::RegisterExternalReferences(New, registry);
   }
 
-  KeyGenJob(
-      Environment* env,
-      v8::Local<v8::Object> object,
-      CryptoJobMode mode,
-      AdditionalParams&& params)
+  KeyGenJob(Environment* env,
+            v8::Local<v8::Object> object,
+            CryptoJobMode mode,
+            AdditionalParams&& params,
+            WebCryptoKeyGenConfig&& config)
       : CryptoJob<KeyGenTraits>(
-            env,
-            object,
-            KeyGenTraits::Provider,
-            mode,
-            std::move(params)) {}
+            env, object, KeyGenTraits::Provider, mode, std::move(params)),
+        webcrypto_config_(std::move(config)) {}
 
   void DoThreadPoolWork() override {
     AdditionalParams* params = CryptoJob<KeyGenTraits>::params();
@@ -98,7 +131,11 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
 
     if (status_ == KeyGenJobStatus::OK) {
       v8::TryCatch try_catch(env->isolate());
-      if (KeyGenTraits::EncodeKey(env, params).ToLocal(result)) {
+      v8::MaybeLocal<v8::Value> encoded =
+          CryptoJob<KeyGenTraits>::mode() == kCryptoJobWebCrypto
+              ? EncodeWebCryptoKey(env, params)
+              : KeyGenTraits::EncodeKey(env, params);
+      if (encoded.ToLocal(result)) {
         *err = Undefined(env->isolate());
       } else {
         CHECK(try_catch.HasCaught());
@@ -122,6 +159,53 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
   SET_SELF_SIZE(KeyGenJob)
 
  private:
+  v8::MaybeLocal<v8::Value> EncodeWebCryptoKey(Environment* env,
+                                               AdditionalParams* params) {
+    v8::Isolate* isolate = env->isolate();
+    v8::Local<v8::Value> algorithm =
+        v8::Local<v8::Value>::New(isolate, webcrypto_config_.algorithm);
+
+    if constexpr (KeyGenTraits::kWebCryptoKeyPair) {
+      v8::Local<v8::Value> public_key;
+      v8::Local<v8::Value> private_key;
+      if (!NativeCryptoKey::Create(env,
+                                   params->key.addRefWithType(kKeyTypePublic),
+                                   algorithm,
+                                   webcrypto_config_.public_usages_mask,
+                                   true)
+               .ToLocal(&public_key) ||
+          !NativeCryptoKey::Create(env,
+                                   params->key.addRefWithType(kKeyTypePrivate),
+                                   algorithm,
+                                   webcrypto_config_.private_usages_mask,
+                                   webcrypto_config_.extractable)
+               .ToLocal(&private_key)) {
+        return {};
+      }
+
+      v8::Local<v8::Object> ret = v8::Object::New(isolate);
+      if (ret->Set(env->context(),
+                   OneByteString(isolate, "publicKey"),
+                   public_key)
+              .IsNothing() ||
+          ret->Set(env->context(),
+                   OneByteString(isolate, "privateKey"),
+                   private_key)
+              .IsNothing()) {
+        return {};
+      }
+      return ret;
+    } else {
+      auto data = KeyObjectData::CreateSecret(std::move(params->out));
+      return NativeCryptoKey::Create(env,
+                                     data,
+                                     algorithm,
+                                     webcrypto_config_.usages_mask,
+                                     webcrypto_config_.extractable);
+    }
+  }
+
+  WebCryptoKeyGenConfig webcrypto_config_;
   KeyGenJobStatus status_ = KeyGenJobStatus::FAILED;
 };
 
@@ -130,6 +214,7 @@ template <typename KeyPairAlgorithmTraits>
 struct KeyPairGenTraits final {
   using AdditionalParameters =
       typename KeyPairAlgorithmTraits::AdditionalParameters;
+  static constexpr bool kWebCryptoKeyPair = true;
 
   static const AsyncWrap::ProviderType Provider =
       AsyncWrap::PROVIDER_KEYPAIRGENREQUEST;
@@ -146,8 +231,13 @@ struct KeyPairGenTraits final {
     // process input parameters. This allows each job to have a variable
     // number of input parameters specific to each job type.
     if (KeyPairAlgorithmTraits::AdditionalConfig(mode, args, offset, params)
-            .IsNothing() ||
-        !KeyObjectData::GetPublicKeyEncodingFromJs(
+            .IsNothing()) {
+      return v8::Nothing<void>();
+    }
+
+    if (mode == kCryptoJobWebCrypto) return v8::JustVoid();
+
+    if (!KeyObjectData::GetPublicKeyEncodingFromJs(
              args, offset, kKeyContextGenerate)
              .To(&params->public_key_encoding) ||
         !KeyObjectData::GetPrivateKeyEncodingFromJs(
@@ -204,6 +294,7 @@ struct SecretKeyGenConfig final : public MemoryRetainer {
 
 struct SecretKeyGenTraits final {
   using AdditionalParameters = SecretKeyGenConfig;
+  static constexpr bool kWebCryptoKeyPair = false;
   static const AsyncWrap::ProviderType Provider =
       AsyncWrap::PROVIDER_KEYGENREQUEST;
   static constexpr const char* JobName = "SecretKeyGenJob";
@@ -287,4 +378,3 @@ using SecretKeyGenJob = KeyGenJob<SecretKeyGenTraits>;
 
 #endif  // defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 #endif  // SRC_CRYPTO_CRYPTO_KEYGEN_H_
-

--- a/src/crypto/crypto_keygen.h
+++ b/src/crypto/crypto_keygen.h
@@ -184,14 +184,14 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
       }
 
       v8::Local<v8::Object> ret = v8::Object::New(isolate);
-      if (ret->Set(env->context(),
-                   OneByteString(isolate, "publicKey"),
-                   public_key)
-              .IsNothing() ||
-          ret->Set(env->context(),
-                   OneByteString(isolate, "privateKey"),
-                   private_key)
-              .IsNothing()) {
+      if (!ret->DefineOwnProperty(env->context(),
+                                  OneByteString(isolate, "publicKey"),
+                                  public_key)
+               .FromMaybe(false) ||
+          !ret->DefineOwnProperty(env->context(),
+                                  OneByteString(isolate, "privateKey"),
+                                  private_key)
+               .FromMaybe(false)) {
         return {};
       }
       return ret;

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -156,9 +156,11 @@ bool ExportJWKSecretKey(Environment* env,
                              BASE64URL)
              .ToLocal(&raw) &&
          target
-             ->Set(env->context(), env->jwk_kty_string(), env->jwk_oct_string())
-             .IsJust() &&
-         target->Set(env->context(), env->jwk_k_string(), raw).IsJust();
+             ->DefineOwnProperty(
+                 env->context(), env->jwk_kty_string(), env->jwk_oct_string())
+             .FromMaybe(false) &&
+         target->DefineOwnProperty(env->context(), env->jwk_k_string(), raw)
+             .FromMaybe(false);
 }
 
 KeyObjectData ImportJWKSecretKey(Environment* env, Local<Object> jwk) {

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -27,6 +27,7 @@ using ncrypto::EVPKeyCtxPointer;
 using ncrypto::EVPKeyPointer;
 using ncrypto::MarkPopErrorOnReturn;
 using v8::Array;
+using v8::Boolean;
 using v8::Context;
 using v8::Function;
 using v8::FunctionCallbackInfo;
@@ -1714,6 +1715,38 @@ bool IsNativeCryptoKey(Environment* env, Local<Value> value) {
 
 bool NativeCryptoKey::HasInstance(Environment* env, Local<Value> value) {
   return IsNativeCryptoKey(env, value);
+}
+
+MaybeLocal<Value> NativeCryptoKey::Create(Environment* env,
+                                          const KeyObjectData& data,
+                                          Local<Value> algorithm,
+                                          uint32_t usages_mask,
+                                          bool extractable) {
+  Local<Context> context = env->context();
+  Isolate* isolate = env->isolate();
+  CHECK(algorithm->IsObject());
+
+  Local<Object> handle;
+  if (!KeyObjectHandle::Create(env, data).ToLocal(&handle)) return {};
+
+  if (env->crypto_internal_cryptokey_constructor().IsEmpty()) {
+    Local<Value> arg = FIXED_ONE_BYTE_STRING(isolate, "internal/crypto/keys");
+    if (env->builtin_module_require()
+            ->Call(context, Null(isolate), 1, &arg)
+            .IsEmpty()) {
+      return {};
+    }
+  }
+
+  Local<Function> cryptokey_ctor = env->crypto_internal_cryptokey_constructor();
+  CHECK(!cryptokey_ctor.IsEmpty());
+  Local<Value> ctor_args[] = {
+      handle,
+      algorithm,
+      Uint32::NewFromUnsigned(isolate, usages_mask),
+      Boolean::New(isolate, extractable),
+  };
+  return cryptokey_ctor->NewInstance(context, arraysize(ctor_args), ctor_args);
 }
 
 void NativeCryptoKey::New(const FunctionCallbackInfo<Value>& args) {

--- a/src/crypto/crypto_keys.h
+++ b/src/crypto/crypto_keys.h
@@ -271,6 +271,12 @@ class NativeCryptoKey : public BaseObject {
   static void CreateCryptoKeyClass(
       const v8::FunctionCallbackInfo<v8::Value>& args);
 
+  static v8::MaybeLocal<v8::Value> Create(Environment* env,
+                                          const KeyObjectData& data,
+                                          v8::Local<v8::Value> algorithm,
+                                          uint32_t usages_mask,
+                                          bool extractable);
+
   // True if `value` is a real NativeCryptoKey instance. Uses the
   // FunctionTemplate stored on the Environment as a brand check.
   // Used by `GetSlots` to validate its receiver.

--- a/src/crypto/crypto_kmac.cc
+++ b/src/crypto/crypto_kmac.cc
@@ -45,7 +45,7 @@ KmacConfig& KmacConfig::operator=(KmacConfig&& other) noexcept {
 void KmacConfig::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("key", key);
   // If the job is sync, then the KmacConfig does not own the data.
-  if (job_mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(job_mode)) {
     tracker->TrackFieldWithSize("data", data.size());
     tracker->TrackFieldWithSize("signature", signature.size());
     tracker->TrackFieldWithSize("customization", customization.size());
@@ -90,7 +90,7 @@ Maybe<void> KmacTraits::AdditionalConfig(
       THROW_ERR_OUT_OF_RANGE(env, "customization is too big");
       return Nothing<void>();
     }
-    params->customization = mode == kCryptoJobAsync
+    params->customization = IsCryptoJobAsync(mode)
                                 ? customization.ToCopy()
                                 : customization.ToByteSource();
   }
@@ -104,7 +104,7 @@ Maybe<void> KmacTraits::AdditionalConfig(
     THROW_ERR_OUT_OF_RANGE(env, "data is too big");
     return Nothing<void>();
   }
-  params->data = mode == kCryptoJobAsync ? data.ToCopy() : data.ToByteSource();
+  params->data = IsCryptoJobAsync(mode) ? data.ToCopy() : data.ToByteSource();
 
   if (!args[offset + 6]->IsUndefined()) {
     ArrayBufferOrViewContents<char> signature(args[offset + 6]);
@@ -113,7 +113,7 @@ Maybe<void> KmacTraits::AdditionalConfig(
       return Nothing<void>();
     }
     params->signature =
-        mode == kCryptoJobAsync ? signature.ToCopy() : signature.ToByteSource();
+        IsCryptoJobAsync(mode) ? signature.ToCopy() : signature.ToByteSource();
   }
 
   return JustVoid();

--- a/src/crypto/crypto_pbkdf2.cc
+++ b/src/crypto/crypto_pbkdf2.cc
@@ -1,5 +1,7 @@
 #include "crypto/crypto_pbkdf2.h"
 #include "async_wrap-inl.h"
+#include "base_object-inl.h"
+#include "crypto/crypto_keys.h"
 #include "crypto/crypto_util.h"
 #include "env-inl.h"
 #include "memory_tracker-inl.h"
@@ -21,6 +23,7 @@ using v8::Value;
 namespace crypto {
 PBKDF2Config::PBKDF2Config(PBKDF2Config&& other) noexcept
     : mode(other.mode),
+      key(std::move(other.key)),
       pass(std::move(other.pass)),
       salt(std::move(other.salt)),
       iterations(other.iterations),
@@ -34,9 +37,10 @@ PBKDF2Config& PBKDF2Config::operator=(PBKDF2Config&& other) noexcept {
 }
 
 void PBKDF2Config::MemoryInfo(MemoryTracker* tracker) const {
-  // The job is sync, the PBKDF2Config does not own the data.
+  // If the job is sync, PBKDF2Config does not own the data.
+  if (key) tracker->TrackField("key", key);
   if (IsCryptoJobAsync(mode)) {
-    tracker->TrackFieldWithSize("pass", pass.size());
+    if (!key) tracker->TrackFieldWithSize("pass", pass.size());
     tracker->TrackFieldWithSize("salt", salt.size());
   }
 }
@@ -63,20 +67,27 @@ Maybe<void> PBKDF2Traits::AdditionalConfig(
 
   params->mode = mode;
 
-  ArrayBufferOrViewContents<char> pass(args[offset]);
+  CHECK(KeyObjectHandle::HasInstance(env, args[offset]) ||
+        IsAnyBufferSource(args[offset]));  // pass
   ArrayBufferOrViewContents<char> salt(args[offset + 1]);
 
-  if (!pass.CheckSizeInt32()) [[unlikely]] {
-    THROW_ERR_OUT_OF_RANGE(env, "pass is too large");
-    return Nothing<void>();
+  if (KeyObjectHandle::HasInstance(env, args[offset])) {
+    KeyObjectHandle* key;
+    ASSIGN_OR_RETURN_UNWRAP(&key, args[offset], Nothing<void>());
+    params->key = key->Data().addRef();
+  } else {
+    ArrayBufferOrViewContents<char> pass(args[offset]);
+    if (!pass.CheckSizeInt32()) [[unlikely]] {
+      THROW_ERR_OUT_OF_RANGE(env, "pass is too large");
+      return Nothing<void>();
+    }
+    params->pass = IsCryptoJobAsync(mode) ? pass.ToCopy() : pass.ToByteSource();
   }
 
   if (!salt.CheckSizeInt32()) [[unlikely]] {
     THROW_ERR_OUT_OF_RANGE(env, "salt is too large");
     return Nothing<void>();
   }
-
-  params->pass = IsCryptoJobAsync(mode) ? pass.ToCopy() : pass.ToByteSource();
 
   params->salt = IsCryptoJobAsync(mode) ? salt.ToCopy() : salt.ToByteSource();
 
@@ -112,11 +123,14 @@ bool PBKDF2Traits::DeriveBits(Environment* env,
                               CryptoJobMode mode,
                               CryptoErrorStore* errors) {
   // Both pass and salt may be zero length here.
+  const ncrypto::Buffer<const char> pass{
+      .data = params.key ? params.key.GetSymmetricKey()
+                         : params.pass.data<const char>(),
+      .len = params.key ? params.key.GetSymmetricKeySize() : params.pass.size(),
+  };
+
   auto dp = ncrypto::pbkdf2(params.digest,
-                            ncrypto::Buffer<const char>{
-                                .data = params.pass.data<const char>(),
-                                .len = params.pass.size(),
-                            },
+                            pass,
                             ncrypto::Buffer<const unsigned char>{
                                 .data = params.salt.data<unsigned char>(),
                                 .len = params.salt.size(),

--- a/src/crypto/crypto_pbkdf2.cc
+++ b/src/crypto/crypto_pbkdf2.cc
@@ -35,7 +35,7 @@ PBKDF2Config& PBKDF2Config::operator=(PBKDF2Config&& other) noexcept {
 
 void PBKDF2Config::MemoryInfo(MemoryTracker* tracker) const {
   // The job is sync, the PBKDF2Config does not own the data.
-  if (mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(mode)) {
     tracker->TrackFieldWithSize("pass", pass.size());
     tracker->TrackFieldWithSize("salt", salt.size());
   }
@@ -76,13 +76,9 @@ Maybe<void> PBKDF2Traits::AdditionalConfig(
     return Nothing<void>();
   }
 
-  params->pass = mode == kCryptoJobAsync
-      ? pass.ToCopy()
-      : pass.ToByteSource();
+  params->pass = IsCryptoJobAsync(mode) ? pass.ToCopy() : pass.ToByteSource();
 
-  params->salt = mode == kCryptoJobAsync
-      ? salt.ToCopy()
-      : salt.ToByteSource();
+  params->salt = IsCryptoJobAsync(mode) ? salt.ToCopy() : salt.ToByteSource();
 
   CHECK(args[offset + 2]->IsInt32());  // iteration_count
   CHECK(args[offset + 3]->IsInt32());  // length

--- a/src/crypto/crypto_pbkdf2.h
+++ b/src/crypto/crypto_pbkdf2.h
@@ -3,8 +3,9 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
-#include "crypto/crypto_util.h"
 #include "async_wrap.h"
+#include "crypto/crypto_keys.h"
+#include "crypto/crypto_util.h"
 #include "env.h"
 #include "memory_tracker.h"
 #include "v8.h"
@@ -26,6 +27,7 @@ namespace crypto {
 
 struct PBKDF2Config final : public MemoryRetainer {
   CryptoJobMode mode;
+  KeyObjectData key;
   ByteSource pass;
   ByteSource salt;
   int32_t iterations;

--- a/src/crypto/crypto_pqc.cc
+++ b/src/crypto/crypto_pqc.cc
@@ -145,7 +145,8 @@ bool TrySetEncodedKey(Environment* env,
   const ncrypto::Buffer<const char> out = data;
   return StringBytes::Encode(env->isolate(), out.data, out.len, BASE64URL)
              .ToLocal(&encoded) &&
-         target->Set(env->context(), key, encoded).IsJust();
+         target->DefineOwnProperty(env->context(), key, encoded)
+             .FromMaybe(false);
 }
 }  // namespace
 
@@ -172,16 +173,18 @@ bool ExportJwkPqcKey(Environment* env,
     }
   }
 
-  return !(
-      target->Set(env->context(), env->jwk_kty_string(), env->jwk_akp_string())
-          .IsNothing() ||
-      target
-          ->Set(env->context(),
-                env->jwk_alg_string(),
-                OneByteString(env->isolate(), alg->name))
-          .IsNothing() ||
-      !TrySetEncodedKey(
-          env, pkey.rawPublicKey(), target, env->jwk_pub_string()));
+  return !(!target
+                ->DefineOwnProperty(env->context(),
+                                    env->jwk_kty_string(),
+                                    env->jwk_akp_string())
+                .FromMaybe(false) ||
+           !target
+                ->DefineOwnProperty(env->context(),
+                                    env->jwk_alg_string(),
+                                    OneByteString(env->isolate(), alg->name))
+                .FromMaybe(false) ||
+           !TrySetEncodedKey(
+               env, pkey.rawPublicKey(), target, env->jwk_pub_string()));
 }
 
 KeyObjectData ImportJWKPqcKey(Environment* env, Local<Object> jwk) {

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -295,8 +295,10 @@ bool ExportJWKRsaKey(Environment* env,
 
   const ncrypto::Rsa rsa = m_pkey;
   if (!rsa ||
-      target->Set(env->context(), env->jwk_kty_string(), env->jwk_rsa_string())
-          .IsNothing()) {
+      !target
+           ->DefineOwnProperty(
+               env->context(), env->jwk_kty_string(), env->jwk_rsa_string())
+           .FromMaybe(false)) {
     return false;
   }
 

--- a/src/crypto/crypto_rsa.cc
+++ b/src/crypto/crypto_rsa.cc
@@ -223,7 +223,7 @@ RSACipherConfig::RSACipherConfig(RSACipherConfig&& other) noexcept
       digest(other.digest) {}
 
 void RSACipherConfig::MemoryInfo(MemoryTracker* tracker) const {
-  if (mode == kCryptoJobAsync)
+  if (IsCryptoJobAsync(mode))
     tracker->TrackFieldWithSize("label", label.size());
 }
 

--- a/src/crypto/crypto_scrypt.cc
+++ b/src/crypto/crypto_scrypt.cc
@@ -38,7 +38,7 @@ ScryptConfig& ScryptConfig::operator=(ScryptConfig&& other) noexcept {
 }
 
 void ScryptConfig::MemoryInfo(MemoryTracker* tracker) const {
-  if (mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(mode)) {
     tracker->TrackFieldWithSize("pass", pass.size());
     tracker->TrackFieldWithSize("salt", salt.size());
   }
@@ -72,13 +72,9 @@ Maybe<void> ScryptTraits::AdditionalConfig(
     return Nothing<void>();
   }
 
-  params->pass = mode == kCryptoJobAsync
-      ? pass.ToCopy()
-      : pass.ToByteSource();
+  params->pass = IsCryptoJobAsync(mode) ? pass.ToCopy() : pass.ToByteSource();
 
-  params->salt = mode == kCryptoJobAsync
-      ? salt.ToCopy()
-      : salt.ToByteSource();
+  params->salt = IsCryptoJobAsync(mode) ? salt.ToCopy() : salt.ToByteSource();
 
   CHECK(args[offset + 2]->IsUint32());  // N
   CHECK(args[offset + 3]->IsUint32());  // r

--- a/src/crypto/crypto_sig.cc
+++ b/src/crypto/crypto_sig.cc
@@ -564,7 +564,7 @@ SignConfiguration& SignConfiguration::operator=(
 
 void SignConfiguration::MemoryInfo(MemoryTracker* tracker) const {
   tracker->TrackField("key", key);
-  if (job_mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(job_mode)) {
     tracker->TrackFieldWithSize("data", data.size());
     tracker->TrackFieldWithSize("signature", signature.size());
     tracker->TrackFieldWithSize("context_string", context_string.size());
@@ -603,9 +603,7 @@ Maybe<void> SignTraits::AdditionalConfig(
     THROW_ERR_OUT_OF_RANGE(env, "data is too big");
     return Nothing<void>();
   }
-  params->data = mode == kCryptoJobAsync
-      ? data.ToCopy()
-      : data.ToByteSource();
+  params->data = IsCryptoJobAsync(mode) ? data.ToCopy() : data.ToByteSource();
 
   if (args[offset + 7]->IsString()) {
     Utf8Value digest(env->isolate(), args[offset + 7]);
@@ -642,7 +640,7 @@ Maybe<void> SignTraits::AdditionalConfig(
       return Nothing<void>();
     }
     params->flags |= SignConfiguration::kHasContextString;
-    params->context_string = mode == kCryptoJobAsync
+    params->context_string = IsCryptoJobAsync(mode)
                                  ? context_string.ToCopy()
                                  : context_string.ToByteSource();
   }
@@ -660,9 +658,8 @@ Maybe<void> SignTraits::AdditionalConfig(
     if (UseP1363Encoding(akey, params->dsa_encoding)) {
       params->signature = ConvertSignatureToDER(akey, signature.ToByteSource());
     } else {
-      params->signature = mode == kCryptoJobAsync
-          ? signature.ToCopy()
-          : signature.ToByteSource();
+      params->signature = IsCryptoJobAsync(mode) ? signature.ToCopy()
+                                                 : signature.ToByteSource();
     }
   }
 

--- a/src/crypto/crypto_turboshake.cc
+++ b/src/crypto/crypto_turboshake.cc
@@ -419,7 +419,7 @@ TurboShakeConfig& TurboShakeConfig::operator=(
 }
 
 void TurboShakeConfig::MemoryInfo(MemoryTracker* tracker) const {
-  if (job_mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(job_mode)) {
     // TODO(addaleax): Implement MemoryRetainer protocol for ByteSource
     tracker->TrackFieldWithSize("data", data.size());
   }
@@ -464,7 +464,7 @@ Maybe<void> TurboShakeTraits::AdditionalConfig(
     THROW_ERR_OUT_OF_RANGE(env, "data is too big");
     return Nothing<void>();
   }
-  params->data = mode == kCryptoJobAsync ? data.ToCopy() : data.ToByteSource();
+  params->data = IsCryptoJobAsync(mode) ? data.ToCopy() : data.ToByteSource();
 
   return JustVoid();
 }
@@ -527,7 +527,7 @@ KangarooTwelveConfig& KangarooTwelveConfig::operator=(
 }
 
 void KangarooTwelveConfig::MemoryInfo(MemoryTracker* tracker) const {
-  if (job_mode == kCryptoJobAsync) {
+  if (IsCryptoJobAsync(job_mode)) {
     // TODO(addaleax): Implement MemoryRetainer protocol for ByteSource
     tracker->TrackFieldWithSize("data", data.size());
     tracker->TrackFieldWithSize("customization", customization.size());
@@ -563,7 +563,7 @@ Maybe<void> KangarooTwelveTraits::AdditionalConfig(
       THROW_ERR_OUT_OF_RANGE(env, "customization is too big");
       return Nothing<void>();
     }
-    params->customization = mode == kCryptoJobAsync
+    params->customization = IsCryptoJobAsync(mode)
                                 ? customization.ToCopy()
                                 : customization.ToByteSource();
   }
@@ -578,7 +578,7 @@ Maybe<void> KangarooTwelveTraits::AdditionalConfig(
     THROW_ERR_OUT_OF_RANGE(env, "data is too big");
     return Nothing<void>();
   }
-  params->data = mode == kCryptoJobAsync ? data.ToCopy() : data.ToByteSource();
+  params->data = IsCryptoJobAsync(mode) ? data.ToCopy() : data.ToByteSource();
 
   return JustVoid();
 }

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -705,8 +705,9 @@ Maybe<void> SetEncodedValue(Environment* env,
   if (!EncodeBignum(env, bn, size).ToLocal(&value)) {
     return Nothing<void>();
   }
-  return target->Set(env->context(), name, value).IsJust() ? JustVoid()
-                                                           : Nothing<void>();
+  return target->DefineOwnProperty(env->context(), name, value).FromMaybe(false)
+             ? JustVoid()
+             : Nothing<void>();
 }
 
 CryptoJobMode GetCryptoJobMode(v8::Local<v8::Value> args) {

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -32,7 +32,9 @@ using ncrypto::DataPointer;
 using ncrypto::EnginePointer;
 #endif  // !OPENSSL_NO_ENGINE
 using ncrypto::SSLPointer;
+using v8::Array;
 using v8::ArrayBuffer;
+using v8::ArrayBufferView;
 using v8::BackingStore;
 using v8::BackingStoreInitializationMode;
 using v8::BackingStoreOnFailureMode;
@@ -40,6 +42,7 @@ using v8::BigInt;
 using v8::Context;
 using v8::EscapableHandleScope;
 using v8::Exception;
+using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::HandleScope;
 using v8::Isolate;
@@ -709,8 +712,62 @@ Maybe<void> SetEncodedValue(Environment* env,
 CryptoJobMode GetCryptoJobMode(v8::Local<v8::Value> args) {
   CHECK(args->IsUint32());
   uint32_t mode = args.As<v8::Uint32>()->Value();
-  CHECK_LE(mode, kCryptoJobSync);
+  CHECK_LE(mode, kCryptoJobWebCrypto);
   return static_cast<CryptoJobMode>(mode);
+}
+
+bool IsCryptoJobAsync(CryptoJobMode mode) {
+  return mode == kCryptoJobAsync || mode == kCryptoJobWebCrypto;
+}
+
+MaybeLocal<Value> CreateWebCryptoJobError(Environment* env,
+                                          Local<Value> cause) {
+  Isolate* isolate = env->isolate();
+  Local<Context> context = env->context();
+  Local<Object> per_context_bindings;
+  Local<Value> domexception_ctor;
+  if (!GetPerContextExports(context).ToLocal(&per_context_bindings) ||
+      !per_context_bindings
+           ->Get(context, FIXED_ONE_BYTE_STRING(isolate, "DOMException"))
+           .ToLocal(&domexception_ctor)) {
+    return {};
+  }
+  CHECK(domexception_ctor->IsFunction());
+
+  Local<Object> options = Object::New(isolate);
+  if (options
+          ->Set(context,
+                FIXED_ONE_BYTE_STRING(isolate, "name"),
+                FIXED_ONE_BYTE_STRING(isolate, "OperationError"))
+          .IsNothing() ||
+      options->Set(context, FIXED_ONE_BYTE_STRING(isolate, "cause"), cause)
+          .IsNothing()) {
+    return {};
+  }
+
+  Local<Value> argv[] = {
+      FIXED_ONE_BYTE_STRING(isolate,
+                            "The operation failed for an operation-specific "
+                            "reason"),
+      options,
+  };
+
+  return domexception_ctor.As<Function>()->NewInstance(
+      context, arraysize(argv), argv);
+}
+
+MaybeLocal<Value> ToWebCryptoJobResult(Environment* env, Local<Value> value) {
+  if (value->IsArrayBuffer()) {
+    return value;
+  }
+
+  if (Buffer::HasInstance(value)) {
+    return value.As<ArrayBufferView>()->Buffer();
+  }
+
+  CHECK(value->IsBoolean() || (value->IsObject() && !value->IsArray() &&
+                               !value->IsArrayBufferView()));
+  return value;
 }
 
 namespace {
@@ -780,6 +837,7 @@ void Initialize(Environment* env, Local<Object> target) {
 
   NODE_DEFINE_CONSTANT(target, kCryptoJobAsync);
   NODE_DEFINE_CONSTANT(target, kCryptoJobSync);
+  NODE_DEFINE_CONSTANT(target, kCryptoJobWebCrypto);
 
   SetMethod(context, target, "secureBuffer", SecureBuffer);
   SetMethodNoSideEffect(context, target, "secureHeapUsed", SecureHeapUsed);

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -249,12 +249,16 @@ class ByteSource final {
       : data_(data), allocated_data_(allocated_data), size_(size) {}
 };
 
-enum CryptoJobMode {
-  kCryptoJobAsync,
-  kCryptoJobSync
-};
+enum CryptoJobMode { kCryptoJobAsync, kCryptoJobSync, kCryptoJobWebCrypto };
 
 CryptoJobMode GetCryptoJobMode(v8::Local<v8::Value> args);
+bool IsCryptoJobAsync(CryptoJobMode mode);
+
+v8::MaybeLocal<v8::Value> CreateWebCryptoJobError(Environment* env,
+                                                  v8::Local<v8::Value> cause);
+
+v8::MaybeLocal<v8::Value> ToWebCryptoJobResult(Environment* env,
+                                               v8::Local<v8::Value> value);
 
 template <typename CryptoJobTraits>
 class CryptoJob : public AsyncWrap, public ThreadPoolWork {
@@ -283,9 +287,53 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
 
   void AfterThreadPoolWork(int status) override {
     Environment* env = AsyncWrap::env();
-    CHECK_EQ(mode_, kCryptoJobAsync);
+    CHECK(IsCryptoJobAsync(mode_));
     CHECK(status == 0 || status == UV_ECANCELED);
     std::unique_ptr<CryptoJob> ptr(this);
+    if (mode_ == kCryptoJobWebCrypto) {
+      v8::HandleScope handle_scope(env->isolate());
+      v8::Context::Scope context_scope(env->context());
+      InternalCallbackScope callback_scope(this);
+
+      if (status == UV_ECANCELED) {
+        v8::Local<v8::Value> exception = v8::Exception::Error(
+            OneByteString(env->isolate(), "The operation was canceled"));
+        ptr->RejectWebCrypto(exception);
+        return;
+      }
+
+      v8::Local<v8::Value> err;
+      v8::Local<v8::Value> result;
+      {
+        node::errors::TryCatchScope try_catch(env);
+        if (ptr->ToResult(&err, &result).IsNothing()) {
+          CHECK(try_catch.HasCaught());
+          CHECK(try_catch.CanContinue());
+          err = try_catch.Exception();
+        }
+      }
+
+      if (!err.IsEmpty() && !err->IsUndefined()) {
+        ptr->RejectWebCrypto(err);
+        return;
+      }
+
+      CHECK(!result.IsEmpty());
+      v8::Local<v8::Value> webcrypto_result;
+      {
+        node::errors::TryCatchScope try_catch(env);
+        if (!ToWebCryptoJobResult(env, result).ToLocal(&webcrypto_result)) {
+          CHECK(try_catch.HasCaught());
+          CHECK(try_catch.CanContinue());
+          ptr->RejectWebCrypto(try_catch.Exception());
+          return;
+        }
+      }
+
+      ptr->ResolveWebCrypto(webcrypto_result);
+      return;
+    }
+
     // If the job was canceled do not execute the callback.
     // TODO(@jasnell): We should likely revisit skipping the
     // callback on cancel as that could leave the JS in a pending
@@ -340,6 +388,19 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
 
     CryptoJob<CryptoJobTraits>* job;
     ASSIGN_OR_RETURN_UNWRAP(&job, args.This());
+    if (job->mode() == kCryptoJobWebCrypto) {
+      v8::Local<v8::Promise::Resolver> resolver;
+      if (!v8::Promise::Resolver::New(env->context()).ToLocal(&resolver)) {
+        return;
+      }
+
+      CHECK(job->resolver_.IsEmpty());
+      job->resolver_.Reset(env->isolate(), resolver);
+      args.GetReturnValue().Set(resolver->GetPromise());
+
+      return job->ScheduleWork();
+    }
+
     if (job->mode() == kCryptoJobAsync)
       return job->ScheduleWork();
 
@@ -376,9 +437,45 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
   }
 
  private:
+  void ResolveWebCrypto(v8::Local<v8::Value> value) {
+    Environment* env = AsyncWrap::env();
+    v8::Local<v8::Promise::Resolver> resolver =
+        v8::Local<v8::Promise::Resolver>::New(env->isolate(), resolver_);
+
+    v8::Local<v8::Value> exception;
+    {
+      node::errors::TryCatchScope try_catch(env);
+      if (resolver->Resolve(env->context(), value).IsJust()) {
+        resolver_.Reset();
+        return;
+      }
+      if (try_catch.HasCaught() && try_catch.CanContinue()) {
+        exception = try_catch.Exception();
+      }
+    }
+
+    if (!exception.IsEmpty()) {
+      USE(resolver->Reject(env->context(), exception));
+    }
+    resolver_.Reset();
+  }
+
+  void RejectWebCrypto(v8::Local<v8::Value> cause) {
+    Environment* env = AsyncWrap::env();
+    v8::Local<v8::Value> exception;
+    if (!CreateWebCryptoJobError(env, cause).ToLocal(&exception)) {
+      exception = cause;
+    }
+    v8::Local<v8::Promise::Resolver> resolver =
+        v8::Local<v8::Promise::Resolver>::New(env->isolate(), resolver_);
+    USE(resolver->Reject(env->context(), exception));
+    resolver_.Reset();
+  }
+
   const CryptoJobMode mode_;
   CryptoErrorStore errors_;
   AdditionalParams params_;
+  v8::Global<v8::Promise::Resolver> resolver_;
 };
 
 template <typename DeriveBitsTraits>
@@ -413,17 +510,12 @@ class DeriveBitsJob final : public CryptoJob<DeriveBitsTraits> {
     CryptoJob<DeriveBitsTraits>::RegisterExternalReferences(New, registry);
   }
 
-  DeriveBitsJob(
-      Environment* env,
-      v8::Local<v8::Object> object,
-      CryptoJobMode mode,
-      AdditionalParams&& params)
+  DeriveBitsJob(Environment* env,
+                v8::Local<v8::Object> object,
+                CryptoJobMode mode,
+                AdditionalParams&& params)
       : CryptoJob<DeriveBitsTraits>(
-            env,
-            object,
-            DeriveBitsTraits::Provider,
-            mode,
-            std::move(params)) {}
+            env, object, DeriveBitsTraits::Provider, mode, std::move(params)) {}
 
   void DoThreadPoolWork() override {
     ncrypto::ClearErrorOnReturn clear_error_on_return;

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -439,13 +439,45 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
  private:
   void ResolveWebCrypto(v8::Local<v8::Value> value) {
     Environment* env = AsyncWrap::env();
+    v8::Local<v8::Context> context = env->context();
     v8::Local<v8::Promise::Resolver> resolver =
         v8::Local<v8::Promise::Resolver>::New(env->isolate(), resolver_);
 
+    bool should_delete_then = false;
+    v8::Local<v8::String> then_key;
     v8::Local<v8::Value> exception;
     {
       node::errors::TryCatchScope try_catch(env);
-      if (resolver->Resolve(env->context(), value).IsJust()) {
+      if (value->IsObject()) {
+        then_key = FIXED_ONE_BYTE_STRING(env->isolate(), "then");
+        v8::Local<v8::Object> object = value.As<v8::Object>();
+        v8::Maybe<bool> has_own_then =
+            object->HasOwnProperty(context, then_key);
+        if (has_own_then.IsNothing()) {
+          if (try_catch.HasCaught() && try_catch.CanContinue()) {
+            exception = try_catch.Exception();
+          }
+        } else if (!has_own_then.FromJust()) {
+          if (object
+                  ->DefineOwnProperty(context,
+                                      then_key,
+                                      v8::Undefined(env->isolate()),
+                                      v8::DontEnum)
+                  .FromMaybe(false)) {
+            should_delete_then = true;
+          } else if (try_catch.HasCaught() && try_catch.CanContinue()) {
+            exception = try_catch.Exception();
+          } else {
+            exception = v8::Exception::Error(OneByteString(
+                env->isolate(), "Failed to prepare WebCrypto job result"));
+          }
+        }
+      }
+
+      if (exception.IsEmpty() && resolver->Resolve(context, value).IsJust()) {
+        if (should_delete_then) {
+          USE(value.As<v8::Object>()->Delete(context, then_key));
+        }
         resolver_.Reset();
         return;
       }
@@ -454,8 +486,11 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
       }
     }
 
+    if (should_delete_then) {
+      USE(value.As<v8::Object>()->Delete(context, then_key));
+    }
     if (!exception.IsEmpty()) {
-      USE(resolver->Reject(env->context(), exception));
+      USE(resolver->Reject(context, exception));
     }
     resolver_.Reset();
   }

--- a/test/parallel/test-crypto-argon2.js
+++ b/test/parallel/test-crypto-argon2.js
@@ -95,13 +95,23 @@ const bad = [
   ['argon2id', { nonce: nonce.subarray(0, 7) }, 'parameters.nonce.byteLength'], // nonce.byteLength < 8
   ['argon2id', { tagLength: 3 }, 'parameters.tagLength'], // tagLength < 4
   ['argon2id', { tagLength: 2 ** 32 }, 'parameters.tagLength'], // tagLength > 2^(32)-1
-  ['argon2id', { passes: 0 }, 'parameters.passes'], // passes < 2
+  ['argon2id', { passes: 0 }, 'parameters.passes'], // passes < 1
   ['argon2id', { passes: 2 ** 32 }, 'parameters.passes'], // passes > 2^(32)-1
   ['argon2id', { parallelism: 0 }, 'parameters.parallelism'], // parallelism < 1
   ['argon2id', { parallelism: 2 ** 24 }, 'parameters.parallelism'], // Parallelism > 2^(24)-1
   ['argon2id', { parallelism: 4, memory: 16 }, 'parameters.memory'], // Memory < 8 * parallelism
   ['argon2id', { memory: 2 ** 32 }, 'parameters.memory'], // memory > 2^(32)-1
 ];
+
+{
+  const omitted = runArgon2('argon2id', defaults);
+  const explicitEmpty = runArgon2('argon2id', {
+    ...defaults,
+    secret: Buffer.alloc(0),
+    associatedData: Buffer.alloc(0),
+  });
+  assert.deepStrictEqual(omitted, explicitEmpty);
+}
 
 for (const [algorithm, overrides, expected] of good) {
   const parameters = { ...defaults, ...overrides };

--- a/test/parallel/test-webcrypto-crypto-job-mode.js
+++ b/test/parallel/test-webcrypto-crypto-job-mode.js
@@ -1,0 +1,154 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { types: { isCryptoKey } } = require('util');
+const { internalBinding } = require('internal/test/binding');
+const {
+  getCryptoKeyHandle,
+} = require('internal/crypto/keys');
+const {
+  getUsagesMask,
+} = require('internal/crypto/util');
+const {
+  aesCipher,
+} = require('internal/crypto/aes');
+
+const {
+  AESCipherJob,
+  EcKeyPairGenJob,
+  HashJob,
+  SecretKeyGenJob,
+  kCryptoJobWebCrypto,
+  kKeyVariantAES_CBC_128,
+  kWebCryptoCipherEncrypt,
+} = internalBinding('crypto');
+
+const { subtle } = globalThis.crypto;
+
+(async function() {
+  {
+    const promise = new HashJob(
+      kCryptoJobWebCrypto,
+      'sha256',
+      Buffer.from('hello'),
+      undefined).run();
+
+    assert.strictEqual(Object.getPrototypeOf(promise), Promise.prototype);
+
+    let settled = false;
+    promise.then(common.mustCall(() => { settled = true; }));
+    await Promise.resolve();
+    assert.strictEqual(settled, false);
+
+    const digest = await promise;
+    assert(digest instanceof ArrayBuffer);
+    assert.strictEqual(digest.byteLength, 32);
+  }
+
+  {
+    const key = await new SecretKeyGenJob(
+      kCryptoJobWebCrypto,
+      128,
+      { name: 'AES-CBC', length: 128 },
+      getUsagesMask(new Set(['encrypt'])),
+      true).run();
+
+    assert(isCryptoKey(key));
+    assert(key instanceof CryptoKey);
+    assert.strictEqual(key.type, 'secret');
+    assert.strictEqual(key.extractable, true);
+    assert.deepStrictEqual(key.usages, ['encrypt']);
+  }
+
+  {
+    const pair = await new EcKeyPairGenJob(
+      kCryptoJobWebCrypto,
+      'P-256',
+      undefined,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      getUsagesMask(new Set(['verify'])),
+      getUsagesMask(new Set(['sign'])),
+      true).run();
+
+    assert.strictEqual(Object.getPrototypeOf(pair), Object.prototype);
+    assert(isCryptoKey(pair.publicKey));
+    assert(isCryptoKey(pair.privateKey));
+    assert(pair.publicKey instanceof CryptoKey);
+    assert(pair.privateKey instanceof CryptoKey);
+    assert.strictEqual(pair.publicKey.type, 'public');
+    assert.strictEqual(pair.privateKey.type, 'private');
+    assert.deepStrictEqual(pair.publicKey.usages, ['verify']);
+    assert.deepStrictEqual(pair.privateKey.usages, ['sign']);
+  }
+
+  {
+    const key = await subtle.generateKey(
+      { name: 'AES-CBC', length: 128 },
+      false,
+      ['encrypt']);
+    assert.throws(
+      () => new AESCipherJob(
+        kCryptoJobWebCrypto,
+        kWebCryptoCipherEncrypt,
+        getCryptoKeyHandle(key),
+        Buffer.alloc(16),
+        kKeyVariantAES_CBC_128,
+        Buffer.alloc(15)),
+      /Invalid initialization vector/);
+
+    const promise = aesCipher(
+      kWebCryptoCipherEncrypt,
+      key,
+      Buffer.alloc(16),
+      { name: 'AES-CBC', iv: Buffer.alloc(15) });
+
+    assert.strictEqual(Object.getPrototypeOf(promise), Promise.prototype);
+    await assert.rejects(promise, (err) => {
+      assert.strictEqual(err.name, 'OperationError');
+      assert.strictEqual(
+        err.message,
+        'The operation failed for an operation-specific reason');
+      assert(err.cause);
+      assert.match(err.cause.message, /Invalid initialization vector/);
+      return true;
+    });
+  }
+
+  {
+    const key = await subtle.generateKey(
+      { name: 'HMAC', hash: 'SHA-256' },
+      false,
+      ['sign', 'verify']);
+    const data = Buffer.from('hello');
+    const signature = await subtle.sign('HMAC', key, data);
+    assert(signature instanceof ArrayBuffer);
+    assert.strictEqual(
+      typeof await subtle.verify('HMAC', key, signature, data),
+      'boolean');
+  }
+
+  {
+    Object.defineProperty(CryptoKey.prototype, 'then', {
+      __proto__: null,
+      configurable: true,
+      get() { throw new Error('resolve then getter'); },
+    });
+
+    try {
+      await assert.rejects(
+        subtle.generateKey(
+          { name: 'AES-CBC', length: 128 },
+          true,
+          ['encrypt']),
+        /resolve then getter/);
+    } finally {
+      delete CryptoKey.prototype.then;
+    }
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-webcrypto-crypto-job-mode.js
+++ b/test/parallel/test-webcrypto-crypto-job-mode.js
@@ -7,6 +7,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 
 const assert = require('assert');
+const { hasOpenSSL } = require('../common/crypto');
 const { types: { isCryptoKey } } = require('util');
 const { internalBinding } = require('internal/test/binding');
 const {
@@ -31,6 +32,34 @@ const {
 
 const { subtle } = globalThis.crypto;
 
+// Defines Object.prototype setters that fail the test if native result objects
+// carrying key or shared secret material use [[Set]].
+async function withObjectPrototypeSetters(names, fn) {
+  const descriptors = new Map();
+  for (const name of names) {
+    descriptors.set(name, Object.getOwnPropertyDescriptor(Object.prototype, name));
+    Object.defineProperty(Object.prototype, name, {
+      __proto__: null,
+      configurable: true,
+      get: common.mustNotCall(`Object.prototype.${name} getter`),
+      set: common.mustNotCall(`Object.prototype.${name} setter`),
+    });
+  }
+
+  try {
+    return await fn();
+  } finally {
+    for (const name of names) {
+      const descriptor = descriptors.get(name);
+      if (descriptor === undefined) {
+        delete Object.prototype[name];
+      } else {
+        Object.defineProperty(Object.prototype, name, descriptor);
+      }
+    }
+  }
+}
+
 (async function() {
   {
     const promise = new HashJob(
@@ -49,6 +78,7 @@ const { subtle } = globalThis.crypto;
     const digest = await promise;
     assert(digest instanceof ArrayBuffer);
     assert.strictEqual(digest.byteLength, 32);
+    assert.strictEqual(Object.hasOwn(digest, 'then'), false);
   }
 
   {
@@ -67,16 +97,19 @@ const { subtle } = globalThis.crypto;
   }
 
   {
-    const pair = await new EcKeyPairGenJob(
-      kCryptoJobWebCrypto,
-      'P-256',
-      undefined,
-      { name: 'ECDSA', namedCurve: 'P-256' },
-      getUsagesMask(new Set(['verify'])),
-      getUsagesMask(new Set(['sign'])),
-      true).run();
+    const pair = await withObjectPrototypeSetters(
+      ['publicKey', 'privateKey'],
+      () => new EcKeyPairGenJob(
+        kCryptoJobWebCrypto,
+        'P-256',
+        undefined,
+        { name: 'ECDSA', namedCurve: 'P-256' },
+        getUsagesMask(new Set(['verify'])),
+        getUsagesMask(new Set(['sign'])),
+        true).run());
 
     assert.strictEqual(Object.getPrototypeOf(pair), Object.prototype);
+    assert.strictEqual(Object.hasOwn(pair, 'then'), false);
     assert(isCryptoKey(pair.publicKey));
     assert(isCryptoKey(pair.privateKey));
     assert(pair.publicKey instanceof CryptoKey);
@@ -122,6 +155,32 @@ const { subtle } = globalThis.crypto;
 
   {
     const key = await subtle.generateKey(
+      { name: 'AES-CBC', length: 128 },
+      false,
+      ['encrypt', 'decrypt']);
+    const iv = crypto.getRandomValues(new Uint8Array(16));
+    const ciphertext = new Uint8Array(await subtle.encrypt(
+      { name: 'AES-CBC', iv },
+      key,
+      Buffer.alloc(16)));
+    ciphertext[ciphertext.length - 1] ^= 0xff;
+
+    await assert.rejects(
+      subtle.decrypt({ name: 'AES-CBC', iv }, key, ciphertext),
+      (err) => {
+        assert.strictEqual(err.name, 'OperationError');
+        assert.strictEqual(
+          err.message,
+          'The operation failed for an operation-specific reason');
+        assert(err.cause);
+        assert.strictEqual(typeof err.cause.message, 'string');
+        assert.notStrictEqual(err.cause.message, '');
+        return true;
+      });
+  }
+
+  {
+    const key = await subtle.generateKey(
       { name: 'HMAC', hash: 'SHA-256' },
       false,
       ['sign', 'verify']);
@@ -137,18 +196,33 @@ const { subtle } = globalThis.crypto;
     Object.defineProperty(CryptoKey.prototype, 'then', {
       __proto__: null,
       configurable: true,
-      get() { throw new Error('resolve then getter'); },
+      get: common.mustNotCall('CryptoKey.prototype.then getter'),
     });
 
     try {
-      await assert.rejects(
-        subtle.generateKey(
-          { name: 'AES-CBC', length: 128 },
-          true,
-          ['encrypt']),
-        /resolve then getter/);
+      const key = await subtle.generateKey(
+        { name: 'AES-CBC', length: 128 },
+        true,
+        ['encrypt']);
+      assert(isCryptoKey(key));
+      assert.strictEqual(Object.hasOwn(key, 'then'), false);
     } finally {
       delete CryptoKey.prototype.then;
     }
+  }
+
+  if (hasOpenSSL(3, 5) || process.features.openssl_is_boringssl) {
+    const pair = await subtle.generateKey(
+      { name: 'ML-KEM-768' },
+      true,
+      ['encapsulateBits', 'decapsulateBits']);
+    const result = await withObjectPrototypeSetters(
+      ['sharedKey', 'ciphertext'],
+      () => subtle.encapsulateBits({ name: 'ML-KEM-768' }, pair.publicKey));
+
+    assert.strictEqual(Object.getPrototypeOf(result), Object.prototype);
+    assert.strictEqual(Object.hasOwn(result, 'then'), false);
+    assert(result.sharedKey instanceof ArrayBuffer);
+    assert(result.ciphertext instanceof ArrayBuffer);
   }
 })().then(common.mustCall());

--- a/test/parallel/test-webcrypto-derivebits-argon2.js
+++ b/test/parallel/test-webcrypto-derivebits-argon2.js
@@ -90,3 +90,36 @@ for (const { algorithm, length, password, params, tag } of vectors) {
     }
   })().then(common.mustCall());
 }
+
+{
+  (async () => {
+    const algorithm = {
+      name: 'Argon2id',
+      memory: 32,
+      passes: 3,
+      parallelism: 4,
+      nonce: Buffer.alloc(16, 0x02),
+    };
+    const key = await subtle.importKey(
+      'raw-secret',
+      Buffer.alloc(32, 0x01),
+      algorithm.name,
+      false,
+      ['deriveBits']);
+
+    const omitted = await subtle.deriveBits(algorithm, key, 256);
+    const explicitEmpty = await subtle.deriveBits({
+      ...algorithm,
+      secretValue: Buffer.alloc(0),
+      associatedData: Buffer.alloc(0),
+    }, key, 256);
+    assert.deepStrictEqual(omitted, explicitEmpty);
+
+    await assert.rejects(
+      subtle.deriveBits({ ...algorithm, passes: 0 }, key, 256),
+      {
+        name: 'OperationError',
+        message: 'passes must be > 0',
+      });
+  })().then(common.mustCall());
+}

--- a/test/parallel/test-webcrypto-derivekey.js
+++ b/test/parallel/test-webcrypto-derivekey.js
@@ -265,6 +265,36 @@ const { KeyObject } = require('crypto');
   })().then(common.mustCall());
 }
 
+if (hasOpenSSL(3)) {
+  (async () => {
+    const derivedKeyAlgorithm = { name: 'KMAC128', length: 0 };
+    const usages = ['sign'];
+    for (const [algorithm, baseKeyAlgorithm] of [
+      [
+        { name: 'HKDF', salt: new Uint8Array(), info: new Uint8Array(), hash: 'SHA-256' },
+        { name: 'HKDF' },
+      ],
+      [
+        { name: 'PBKDF2', salt: new Uint8Array(), hash: 'SHA-256', iterations: 20 },
+        { name: 'PBKDF2' },
+      ],
+    ]) {
+      const baseKey = await subtle.importKey(
+        'raw',
+        new Uint8Array(),
+        baseKeyAlgorithm,
+        false,
+        ['deriveKey']);
+      await assert.rejects(
+        subtle.deriveKey(algorithm, baseKey, derivedKeyAlgorithm, false, usages),
+        {
+          name: 'DataError',
+          message: /KmacImportParams\.length cannot be 0/,
+        });
+    }
+  })().then(common.mustCall());
+}
+
 // Test X25519 and X448 key derivation
 {
   async function test(name) {

--- a/test/parallel/test-webcrypto-encap-decap-ml-kem.js
+++ b/test/parallel/test-webcrypto-encap-decap-ml-kem.js
@@ -40,6 +40,7 @@ async function testEncapsulateKey({ name, publicKeyPem, privateKeyPem, results }
     ['deriveBits']
   );
 
+  assert.strictEqual(Object.getPrototypeOf(encapsulated), Object.prototype);
   assert(encapsulated.sharedKey instanceof CryptoKey);
   assert(encapsulated.ciphertext instanceof ArrayBuffer);
   assert.strictEqual(encapsulated.sharedKey.type, 'secret');
@@ -59,6 +60,7 @@ async function testEncapsulateKey({ name, publicKeyPem, privateKeyPem, results }
     ['sign', 'verify']
   );
 
+  assert.strictEqual(Object.getPrototypeOf(encapsulated2), Object.prototype);
   assert(encapsulated2.sharedKey instanceof CryptoKey);
   assert.strictEqual(encapsulated2.sharedKey.algorithm.name, 'HMAC');
   assert.strictEqual(encapsulated2.sharedKey.extractable, false);
@@ -93,6 +95,7 @@ async function testEncapsulateBits({ name, publicKeyPem, privateKeyPem, results 
   // Test successful encapsulation
   const encapsulated = await subtle.encapsulateBits({ name }, publicKey);
 
+  assert.strictEqual(Object.getPrototypeOf(encapsulated), Object.prototype);
   assert(encapsulated.sharedKey instanceof ArrayBuffer);
   assert(encapsulated.ciphertext instanceof ArrayBuffer);
   assert.strictEqual(encapsulated.sharedKey.byteLength, 32); // ML-KEM shared secret is 32 bytes

--- a/test/parallel/test-webcrypto-keygen.js
+++ b/test/parallel/test-webcrypto-keygen.js
@@ -297,6 +297,17 @@ if (hasOpenSSL(3, 5) || process.features.openssl_is_boringssl) {
   Promise.all(tests).then(common.mustCall());
 }
 
+// Test CryptoKeyPair prototype
+{
+  subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify'])
+    .then(common.mustCall((pair) => {
+      assert.strictEqual(Object.getPrototypeOf(pair), Object.prototype);
+    }));
+}
+
 // Test RSA key generation
 {
   async function test(

--- a/test/parallel/test-webcrypto-methods-not-async.js
+++ b/test/parallel/test-webcrypto-methods-not-async.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const assert = require('assert');
+const { subtle } = globalThis.crypto;
+
+const AsyncFunction = async function() {}.constructor;
+
+const methods = [
+  'decrypt',
+  'decapsulateBits',
+  'decapsulateKey',
+  'deriveBits',
+  'deriveKey',
+  'digest',
+  'encapsulateBits',
+  'encapsulateKey',
+  'encrypt',
+  'exportKey',
+  'generateKey',
+  'getPublicKey',
+  'importKey',
+  'sign',
+  'unwrapKey',
+  'verify',
+  'wrapKey',
+];
+
+(async function() {
+  for (const name of methods) {
+    assert.notStrictEqual(subtle[name].constructor, AsyncFunction);
+
+    const promise = subtle[name].call({});
+    assert.strictEqual(Object.getPrototypeOf(promise), Promise.prototype);
+    await assert.rejects(promise, {
+      code: 'ERR_INVALID_THIS',
+    });
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-webcrypto-promise-prototype-pollution.mjs
+++ b/test/parallel/test-webcrypto-promise-prototype-pollution.mjs
@@ -1,9 +1,10 @@
 import * as common from '../common/index.mjs';
+import assert from 'node:assert';
 
 if (!common.hasCrypto) common.skip('missing crypto');
 
 // WebCrypto subtle methods must not leak intermediate values
-// through Promise.prototype.then pollution.
+// through Promise.prototype.then or constructor pollution.
 // Regression test for https://github.com/nodejs/node/pull/61492
 // and https://github.com/nodejs/node/issues/59699.
 
@@ -13,51 +14,442 @@ const { subtle } = globalThis.crypto;
 
 Promise.prototype.then = common.mustNotCall('Promise.prototype.then');
 
-await subtle.digest('SHA-256', new Uint8Array([1, 2, 3]));
+// WebCrypto methods return native promises. Re-wrapping a promise with
+// PromiseResolve() or chaining it with Promise.prototype.then can read
+// user-mutated constructor/species accessors.
+async function assertNoPromiseConstructorAccess(name, fn) {
+  const constructorDescriptor =
+    Object.getOwnPropertyDescriptor(Promise.prototype, 'constructor');
+  const speciesDescriptor =
+    Object.getOwnPropertyDescriptor(Promise, Symbol.species);
+  let promise;
+  Object.defineProperty(Promise.prototype, 'constructor', {
+    __proto__: null,
+    configurable: true,
+    get: common.mustNotCall(
+      `${name} Promise.prototype.constructor getter`),
+  });
+  Object.defineProperty(Promise, Symbol.species, {
+    __proto__: null,
+    configurable: true,
+    get: common.mustNotCall(`${name} Promise[Symbol.species] getter`),
+  });
+  try {
+    promise = fn();
+  } finally {
+    Object.defineProperty(
+      Promise.prototype,
+      'constructor',
+      constructorDescriptor);
+    Object.defineProperty(Promise, Symbol.species, speciesDescriptor);
+  }
+  return await promise;
+}
 
-await subtle.generateKey({ name: 'AES-CBC', length: 256 }, true, ['encrypt', 'decrypt']);
+// Exercise each export format through the same promise-constructor guard.
+function assertExportKeyNoPromiseConstructorAccess(name, format, key) {
+  return assertNoPromiseConstructorAccess(`exportKey ${name}`, () =>
+    subtle.exportKey(format, key));
+}
 
-await subtle.generateKey({ name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+// Non-promise object results must be fulfilled without thenable assimilation
+// observing inherited then accessors on the returned object.
+async function assertNoInheritedThenAccess(name, prototype, prototypeName, fn) {
+  const descriptor = Object.getOwnPropertyDescriptor(prototype, 'then');
+  Object.defineProperty(prototype, 'then', {
+    __proto__: null,
+    configurable: true,
+    get: common.mustNotCall(`${name} ${prototypeName}.prototype.then`),
+  });
+  try {
+    return await fn();
+  } finally {
+    if (descriptor === undefined) {
+      delete prototype.then;
+    } else {
+      Object.defineProperty(prototype, 'then', descriptor);
+    }
+  }
+}
+
+function assertNoInheritedArrayBufferThenAccess(name, fn) {
+  return assertNoInheritedThenAccess(
+    name,
+    ArrayBuffer.prototype,
+    'ArrayBuffer',
+    fn);
+}
+
+function assertNoInheritedCryptoKeyThenAccess(name, fn) {
+  return assertNoInheritedThenAccess(
+    name,
+    CryptoKey.prototype,
+    'CryptoKey',
+    fn);
+}
+
+function assertNoInheritedObjectThenAccess(name, fn) {
+  return assertNoInheritedThenAccess(
+    name,
+    Object.prototype,
+    'Object',
+    fn);
+}
+
+// wrapKey('jwk') stringifies an internally exported JWK. The spec does this
+// in a fresh global, so inherited toJSON hooks from the current global must
+// not observe or replace key material.
+async function assertNoInheritedToJSONAccess(name, fn) {
+  const objectDescriptor =
+    Object.getOwnPropertyDescriptor(Object.prototype, 'toJSON');
+  const arrayDescriptor =
+    Object.getOwnPropertyDescriptor(Array.prototype, 'toJSON');
+  Object.defineProperty(Object.prototype, 'toJSON', {
+    __proto__: null,
+    configurable: true,
+    value: common.mustNotCall(`${name} Object.prototype.toJSON`),
+  });
+  Object.defineProperty(Array.prototype, 'toJSON', {
+    __proto__: null,
+    configurable: true,
+    value: common.mustNotCall(`${name} Array.prototype.toJSON`),
+  });
+  try {
+    return await fn();
+  } finally {
+    if (objectDescriptor === undefined) {
+      delete Object.prototype.toJSON;
+    } else {
+      Object.defineProperty(Object.prototype, 'toJSON', objectDescriptor);
+    }
+    if (arrayDescriptor === undefined) {
+      delete Array.prototype.toJSON;
+    } else {
+      Object.defineProperty(Array.prototype, 'toJSON', arrayDescriptor);
+    }
+  }
+}
+
+// JWK export creates and fills a result object. The exported members must be
+// own data properties, not writes that can observe inherited accessors.
+async function assertNoInheritedJwkPropertyAccess(name, fn) {
+  const properties = [
+    'alg',
+    'crv',
+    'd',
+    'dp',
+    'dq',
+    'e',
+    'ext',
+    'k',
+    'key_ops',
+    'kty',
+    'n',
+    'p',
+    'priv',
+    'pub',
+    'q',
+    'qi',
+    'x',
+    'y',
+  ];
+  const descriptors = new Map();
+  for (const property of properties) {
+    descriptors.set(
+      property,
+      Object.getOwnPropertyDescriptor(Object.prototype, property));
+    Object.defineProperty(Object.prototype, property, {
+      __proto__: null,
+      configurable: true,
+      get: common.mustNotCall(`${name} Object.prototype.${property} getter`),
+      set: common.mustNotCall(`${name} Object.prototype.${property} setter`),
+    });
+  }
+  try {
+    return await fn();
+  } finally {
+    for (const property of properties) {
+      const descriptor = descriptors.get(property);
+      if (descriptor === undefined) {
+        delete Object.prototype[property];
+      } else {
+        Object.defineProperty(Object.prototype, property, descriptor);
+      }
+    }
+  }
+}
+
+// unwrapKey('jwk') parses a JWK and then converts it to the JsonWebKey IDL
+// dictionary. The parsed JWK must provide its own kty member; an inherited
+// Object.prototype.kty must not satisfy that required WebCrypto step.
+async function assertMissingJwkKtyIgnoresPrototype(fn) {
+  const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'kty');
+  Object.defineProperty(Object.prototype, 'kty', {
+    __proto__: null,
+    configurable: true,
+    value: 'oct',
+  });
+  try {
+    await assert.rejects(fn(), { name: 'DataError' });
+  } finally {
+    if (descriptor === undefined) {
+      delete Object.prototype.kty;
+    } else {
+      Object.defineProperty(Object.prototype, 'kty', descriptor);
+    }
+  }
+}
+
+// wrapKey('jwk') UTF-8 encodes the JSON string. That step must not rely on
+// user-mutable encoding APIs such as TextEncoder or Buffer.
+async function assertNoUserMutableEncodeAccess(name, fn) {
+  const textEncoderDescriptor =
+    Object.getOwnPropertyDescriptor(TextEncoder.prototype, 'encode');
+  const bufferFromDescriptor = Object.getOwnPropertyDescriptor(Buffer, 'from');
+  Object.defineProperty(TextEncoder.prototype, 'encode', {
+    __proto__: null,
+    configurable: true,
+    value: common.mustNotCall(`${name} TextEncoder.prototype.encode`),
+  });
+  Object.defineProperty(Buffer, 'from', {
+    __proto__: null,
+    configurable: true,
+    value: common.mustNotCall(`${name} Buffer.from`),
+  });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(
+      TextEncoder.prototype,
+      'encode',
+      textEncoderDescriptor);
+    Object.defineProperty(Buffer, 'from', bufferFromDescriptor);
+  }
+}
+
+// unwrapKey('jwk') decodes the wrapped bytes as UTF-8. That step must not
+// rely on user-mutable encoding APIs such as TextDecoder or Buffer.
+async function assertNoUserMutableDecodeAccess(name, fn) {
+  const textDecoderDescriptor =
+    Object.getOwnPropertyDescriptor(TextDecoder.prototype, 'decode');
+  const bufferFromDescriptor = Object.getOwnPropertyDescriptor(Buffer, 'from');
+  const bufferToStringDescriptor =
+    Object.getOwnPropertyDescriptor(Buffer.prototype, 'toString');
+  Object.defineProperty(TextDecoder.prototype, 'decode', {
+    __proto__: null,
+    configurable: true,
+    value: common.mustNotCall(`${name} TextDecoder.prototype.decode`),
+  });
+  Object.defineProperty(Buffer, 'from', {
+    __proto__: null,
+    configurable: true,
+    value: common.mustNotCall(`${name} Buffer.from`),
+  });
+  Object.defineProperty(Buffer.prototype, 'toString', {
+    __proto__: null,
+    configurable: true,
+    value: common.mustNotCall(`${name} Buffer.prototype.toString`),
+  });
+  try {
+    return await fn();
+  } finally {
+    Object.defineProperty(
+      TextDecoder.prototype,
+      'decode',
+      textDecoderDescriptor);
+    Object.defineProperty(Buffer, 'from', bufferFromDescriptor);
+    Object.defineProperty(
+      Buffer.prototype,
+      'toString',
+      bufferToStringDescriptor);
+  }
+}
+
+// encapsulateKey() first resolves an internal encapsulateBits job whose result
+// object contains a raw sharedKey. The final method result is also an object,
+// but its sharedKey is a CryptoKey and is intentionally returned to the caller.
+async function assertNoRawSharedKeyObjectThenAccess(name, fn) {
+  const descriptor = Object.getOwnPropertyDescriptor(Object.prototype, 'then');
+  Object.defineProperty(Object.prototype, 'then', {
+    __proto__: null,
+    configurable: true,
+    get() {
+      if (Object.hasOwn(this, 'sharedKey') &&
+          this.sharedKey instanceof ArrayBuffer) {
+        assert.fail(`${name} Object.prototype.then observed raw sharedKey`);
+      }
+      return undefined;
+    },
+  });
+  try {
+    return await fn();
+  } finally {
+    if (descriptor === undefined) {
+      delete Object.prototype.then;
+    } else {
+      Object.defineProperty(Object.prototype, 'then', descriptor);
+    }
+  }
+}
+
+await assertNoPromiseConstructorAccess('digest', () =>
+  subtle.digest('SHA-256', new Uint8Array([1, 2, 3])));
+
+const secretKey = await assertNoPromiseConstructorAccess(
+  'generateKey secret',
+  () => subtle.generateKey(
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
+
+const extractableKeyPair = await assertNoPromiseConstructorAccess('generateKey pair', () =>
+  subtle.generateKey(
+    { name: 'ECDSA', namedCurve: 'P-256' },
+    true,
+    ['sign', 'verify']));
 
 const rawKey = globalThis.crypto.getRandomValues(new Uint8Array(32));
 
-const importedKey = await subtle.importKey(
-  'raw', rawKey, { name: 'AES-CBC', length: 256 }, false, ['encrypt', 'decrypt']);
+const importedKey = await assertNoPromiseConstructorAccess('importKey', () =>
+  subtle.importKey(
+    'raw',
+    rawKey,
+    { name: 'AES-CBC', length: 256 },
+    false,
+    ['encrypt', 'decrypt']));
 
-const exportableKey = await subtle.importKey(
-  'raw', rawKey, { name: 'AES-CBC', length: 256 }, true, ['encrypt', 'decrypt']);
+await assertNoInheritedCryptoKeyThenAccess('importKey', () =>
+  subtle.importKey(
+    'raw',
+    rawKey,
+    { name: 'AES-CBC', length: 256 },
+    false,
+    ['encrypt', 'decrypt']));
 
-await subtle.exportKey('raw', exportableKey);
+await assertNoInheritedJwkPropertyAccess('exportKey jwk secret', () =>
+  assertExportKeyNoPromiseConstructorAccess(
+    'jwk secret',
+    'jwk',
+    secretKey));
+await assertNoInheritedObjectThenAccess('exportKey jwk secret', () =>
+  subtle.exportKey('jwk', secretKey));
+await assertNoInheritedJwkPropertyAccess('exportKey jwk public', () =>
+  assertExportKeyNoPromiseConstructorAccess(
+    'jwk public',
+    'jwk',
+    extractableKeyPair.publicKey));
+await assertNoInheritedObjectThenAccess('exportKey jwk public', () =>
+  subtle.exportKey('jwk', extractableKeyPair.publicKey));
+await assertNoInheritedJwkPropertyAccess('exportKey jwk private', () =>
+  assertExportKeyNoPromiseConstructorAccess(
+    'jwk private',
+    'jwk',
+    extractableKeyPair.privateKey));
+await assertNoInheritedObjectThenAccess('exportKey jwk private', () =>
+  subtle.exportKey('jwk', extractableKeyPair.privateKey));
+await assertNoInheritedArrayBufferThenAccess('exportKey raw secret', () =>
+  subtle.exportKey('raw', secretKey));
+await assertExportKeyNoPromiseConstructorAccess(
+  'raw secret',
+  'raw',
+  secretKey);
+await assertNoInheritedArrayBufferThenAccess('exportKey spki', () =>
+  subtle.exportKey('spki', extractableKeyPair.publicKey));
+await assertExportKeyNoPromiseConstructorAccess(
+  'spki',
+  'spki',
+  extractableKeyPair.publicKey);
+await assertNoInheritedArrayBufferThenAccess('exportKey pkcs8', () =>
+  subtle.exportKey('pkcs8', extractableKeyPair.privateKey));
+await assertExportKeyNoPromiseConstructorAccess(
+  'pkcs8',
+  'pkcs8',
+  extractableKeyPair.privateKey);
+await assertNoInheritedArrayBufferThenAccess('exportKey raw-public', () =>
+  subtle.exportKey('raw-public', extractableKeyPair.publicKey));
+await assertExportKeyNoPromiseConstructorAccess(
+  'raw-public',
+  'raw-public',
+  extractableKeyPair.publicKey);
 
 const iv = globalThis.crypto.getRandomValues(new Uint8Array(16));
 const plaintext = new TextEncoder().encode('Hello, world!');
 
-const ciphertext = await subtle.encrypt({ name: 'AES-CBC', iv }, importedKey, plaintext);
+const ciphertext = await assertNoPromiseConstructorAccess('encrypt', () =>
+  subtle.encrypt({ name: 'AES-CBC', iv }, importedKey, plaintext));
 
-await subtle.decrypt({ name: 'AES-CBC', iv }, importedKey, ciphertext);
+await assertNoPromiseConstructorAccess('decrypt', () =>
+  subtle.decrypt({ name: 'AES-CBC', iv }, importedKey, ciphertext));
 
 const signingKey = await subtle.generateKey(
-  { name: 'HMAC', hash: 'SHA-256' }, false, ['sign', 'verify']);
+  { name: 'HMAC', hash: 'SHA-256' },
+  false,
+  ['sign', 'verify']);
 
 const data = new TextEncoder().encode('test data');
 
-const signature = await subtle.sign('HMAC', signingKey, data);
+const signature = await assertNoPromiseConstructorAccess('sign', () =>
+  subtle.sign('HMAC', signingKey, data));
 
-await subtle.verify('HMAC', signingKey, signature, data);
+await assertNoPromiseConstructorAccess('verify', () =>
+  subtle.verify('HMAC', signingKey, signature, data));
 
 const pbkdf2Key = await subtle.importKey(
   'raw', rawKey, 'PBKDF2', false, ['deriveBits', 'deriveKey']);
 
-await subtle.deriveBits(
-  { name: 'PBKDF2', salt: rawKey, iterations: 1000, hash: 'SHA-256' },
-  pbkdf2Key, 256);
+await assertNoPromiseConstructorAccess('deriveBits', () =>
+  subtle.deriveBits(
+    { name: 'PBKDF2', salt: rawKey, iterations: 1000, hash: 'SHA-256' },
+    pbkdf2Key,
+    256));
 
-await subtle.deriveKey(
-  { name: 'PBKDF2', salt: rawKey, iterations: 1000, hash: 'SHA-256' },
-  pbkdf2Key,
-  { name: 'AES-CBC', length: 256 },
-  true,
-  ['encrypt', 'decrypt']);
+await assertNoPromiseConstructorAccess('deriveBits PBKDF2 zero-length', () =>
+  subtle.deriveBits(
+    { name: 'PBKDF2', salt: rawKey, iterations: 1000, hash: 'SHA-256' },
+    pbkdf2Key,
+    0));
+
+const hkdfKey = await subtle.importKey(
+  'raw', rawKey, 'HKDF', false, ['deriveBits']);
+
+await assertNoPromiseConstructorAccess('deriveBits HKDF zero-length', () =>
+  subtle.deriveBits(
+    { name: 'HKDF', hash: 'SHA-256', salt: rawKey, info: rawKey },
+    hkdfKey,
+    0));
+
+const ecdhKeyPair = await subtle.generateKey(
+  { name: 'ECDH', namedCurve: 'P-256' },
+  false,
+  ['deriveBits']);
+
+await assertNoPromiseConstructorAccess('deriveBits ECDH', () =>
+  subtle.deriveBits(
+    { name: 'ECDH', public: ecdhKeyPair.publicKey },
+    ecdhKeyPair.privateKey,
+    256));
+
+await assertNoPromiseConstructorAccess('deriveKey', () =>
+  subtle.deriveKey(
+    { name: 'PBKDF2', salt: rawKey, iterations: 1000, hash: 'SHA-256' },
+    pbkdf2Key,
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
+await assertNoInheritedArrayBufferThenAccess('deriveKey', () =>
+  subtle.deriveKey(
+    { name: 'PBKDF2', salt: rawKey, iterations: 1000, hash: 'SHA-256' },
+    pbkdf2Key,
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
+await assertNoInheritedCryptoKeyThenAccess('deriveKey result', () =>
+  subtle.deriveKey(
+    { name: 'PBKDF2', salt: rawKey, iterations: 1000, hash: 'SHA-256' },
+    pbkdf2Key,
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
 
 const wrappingKey = await subtle.generateKey(
   { name: 'AES-KW', length: 256 }, true, ['wrapKey', 'unwrapKey']);
@@ -65,31 +457,224 @@ const wrappingKey = await subtle.generateKey(
 const keyToWrap = await subtle.generateKey(
   { name: 'AES-CBC', length: 256 }, true, ['encrypt', 'decrypt']);
 
-const wrapped = await subtle.wrapKey('raw', keyToWrap, wrappingKey, 'AES-KW');
+const wrapped = await assertNoPromiseConstructorAccess('wrapKey', () =>
+  subtle.wrapKey('raw', keyToWrap, wrappingKey, 'AES-KW'));
 
-await subtle.unwrapKey(
-  'raw', wrapped, wrappingKey, 'AES-KW',
-  { name: 'AES-CBC', length: 256 }, true, ['encrypt', 'decrypt']);
+const wrappedJwk = await assertNoInheritedJwkPropertyAccess('wrapKey jwk', () =>
+  assertNoInheritedToJSONAccess('wrapKey jwk', () =>
+    assertNoUserMutableEncodeAccess('wrapKey jwk', () =>
+      assertNoPromiseConstructorAccess('wrapKey jwk', () =>
+        subtle.wrapKey('jwk', keyToWrap, wrappingKey, 'AES-KW')))));
 
-const { privateKey } = await subtle.generateKey(
-  { name: 'ECDSA', namedCurve: 'P-256' }, true, ['sign', 'verify']);
+await assertNoPromiseConstructorAccess('unwrapKey', () =>
+  subtle.unwrapKey(
+    'raw',
+    wrapped,
+    wrappingKey,
+    'AES-KW',
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
+await assertNoInheritedArrayBufferThenAccess('unwrapKey', () =>
+  subtle.unwrapKey(
+    'raw',
+    wrapped,
+    wrappingKey,
+    'AES-KW',
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
+await assertNoInheritedCryptoKeyThenAccess('unwrapKey result', () =>
+  subtle.unwrapKey(
+    'raw',
+    wrapped,
+    wrappingKey,
+    'AES-KW',
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
 
-await subtle.getPublicKey(privateKey, ['verify']);
+await assertNoUserMutableDecodeAccess('unwrapKey jwk', () =>
+  assertNoPromiseConstructorAccess('unwrapKey jwk', () =>
+    subtle.unwrapKey(
+      'jwk',
+      wrappedJwk,
+      wrappingKey,
+      'AES-KW',
+      { name: 'AES-CBC', length: 256 },
+      true,
+      ['encrypt', 'decrypt'])));
+await assertNoInheritedArrayBufferThenAccess('unwrapKey jwk', () =>
+  subtle.unwrapKey(
+    'jwk',
+    wrappedJwk,
+    wrappingKey,
+    'AES-KW',
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
+await assertNoInheritedCryptoKeyThenAccess('unwrapKey jwk result', () =>
+  subtle.unwrapKey(
+    'jwk',
+    wrappedJwk,
+    wrappingKey,
+    'AES-KW',
+    { name: 'AES-CBC', length: 256 },
+    true,
+    ['encrypt', 'decrypt']));
+
+{
+  const jwkUnwrappingKey = await subtle.generateKey(
+    { name: 'AES-CBC', length: 128 },
+    true,
+    ['encrypt', 'unwrapKey']);
+
+  {
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(16));
+    const validWrappedJwk = await subtle.encrypt(
+      { name: 'AES-CBC', iv },
+      jwkUnwrappingKey,
+      Buffer.from('{"kty":"oct","k":"AAAAAAAAAAAAAAAAAAAAAA"}'));
+
+    await assertNoUserMutableDecodeAccess('unwrapKey jwk AES-CBC', () =>
+      assertNoPromiseConstructorAccess('unwrapKey jwk AES-CBC', () =>
+        subtle.unwrapKey(
+          'jwk',
+          validWrappedJwk,
+          jwkUnwrappingKey,
+          { name: 'AES-CBC', iv },
+          { name: 'AES-CBC', length: 128 },
+          true,
+          ['encrypt'])));
+    await assertNoInheritedCryptoKeyThenAccess(
+      'unwrapKey jwk AES-CBC result',
+      () => subtle.unwrapKey(
+        'jwk',
+        validWrappedJwk,
+        jwkUnwrappingKey,
+        { name: 'AES-CBC', iv },
+        { name: 'AES-CBC', length: 128 },
+        true,
+        ['encrypt']));
+  }
+
+  {
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(16));
+    const wrappedRawKey = await subtle.encrypt(
+      { name: 'AES-CBC', iv },
+      jwkUnwrappingKey,
+      rawKey);
+
+    await assertNoPromiseConstructorAccess('unwrapKey raw AES-CBC', () =>
+      subtle.unwrapKey(
+        'raw',
+        wrappedRawKey,
+        jwkUnwrappingKey,
+        { name: 'AES-CBC', iv },
+        { name: 'AES-CBC', length: 256 },
+        true,
+        ['encrypt']));
+    await assertNoInheritedArrayBufferThenAccess('unwrapKey raw AES-CBC', () =>
+      subtle.unwrapKey(
+        'raw',
+        wrappedRawKey,
+        jwkUnwrappingKey,
+        { name: 'AES-CBC', iv },
+        { name: 'AES-CBC', length: 256 },
+        true,
+        ['encrypt']));
+    await assertNoInheritedCryptoKeyThenAccess(
+      'unwrapKey raw AES-CBC result',
+      () => subtle.unwrapKey(
+        'raw',
+        wrappedRawKey,
+        jwkUnwrappingKey,
+        { name: 'AES-CBC', iv },
+        { name: 'AES-CBC', length: 256 },
+        true,
+        ['encrypt']));
+  }
+
+  {
+    const iv = globalThis.crypto.getRandomValues(new Uint8Array(16));
+    const missingKtyWrappedJwk = await subtle.encrypt(
+      { name: 'AES-CBC', iv },
+      jwkUnwrappingKey,
+      Buffer.from('{"k":"AAAAAAAAAAAAAAAAAAAAAA"}'));
+
+    await assertMissingJwkKtyIgnoresPrototype(() =>
+      subtle.unwrapKey(
+        'jwk',
+        missingKtyWrappedJwk,
+        jwkUnwrappingKey,
+        { name: 'AES-CBC', iv },
+        { name: 'AES-CBC', length: 128 },
+        true,
+        ['encrypt']));
+  }
+}
+
+await assertNoPromiseConstructorAccess('getPublicKey', () =>
+  subtle.getPublicKey(extractableKeyPair.privateKey, ['verify']));
+await assertNoInheritedCryptoKeyThenAccess('getPublicKey', () =>
+  subtle.getPublicKey(extractableKeyPair.privateKey, ['verify']));
 
 if (hasOpenSSL(3, 5) || process.features.openssl_is_boringssl) {
   const kemPair = await subtle.generateKey(
-    { name: 'ML-KEM-768' }, false,
+    { name: 'ML-KEM-768' }, true,
     ['encapsulateKey', 'encapsulateBits', 'decapsulateKey', 'decapsulateBits']);
 
-  const { ciphertext: ct1 } = await subtle.encapsulateKey(
-    { name: 'ML-KEM-768' }, kemPair.publicKey, 'HKDF', false, ['deriveBits']);
+  await assertNoInheritedArrayBufferThenAccess('exportKey raw-seed', () =>
+    subtle.exportKey('raw-seed', kemPair.privateKey));
+  await assertExportKeyNoPromiseConstructorAccess(
+    'raw-seed',
+    'raw-seed',
+    kemPair.privateKey);
 
-  await subtle.decapsulateKey(
-    { name: 'ML-KEM-768' }, kemPair.privateKey, ct1, 'HKDF', false, ['deriveBits']);
+  const { ciphertext: ct1 } =
+    await assertNoRawSharedKeyObjectThenAccess('encapsulateKey', () =>
+      assertNoPromiseConstructorAccess('encapsulateKey', () =>
+        subtle.encapsulateKey(
+          { name: 'ML-KEM-768' },
+          kemPair.publicKey,
+          'HKDF',
+          false,
+          ['deriveBits'])));
 
-  const { ciphertext: ct2 } = await subtle.encapsulateBits(
-    { name: 'ML-KEM-768' }, kemPair.publicKey);
+  await assertNoPromiseConstructorAccess('decapsulateKey', () =>
+    subtle.decapsulateKey(
+      { name: 'ML-KEM-768' },
+      kemPair.privateKey,
+      ct1,
+      'HKDF',
+      false,
+      ['deriveBits']));
+  await assertNoInheritedArrayBufferThenAccess('decapsulateKey', () =>
+    subtle.decapsulateKey(
+      { name: 'ML-KEM-768' },
+      kemPair.privateKey,
+      ct1,
+      'HKDF',
+      false,
+      ['deriveBits']));
+  await assertNoInheritedCryptoKeyThenAccess('decapsulateKey result', () =>
+    subtle.decapsulateKey(
+      { name: 'ML-KEM-768' },
+      kemPair.privateKey,
+      ct1,
+      'HKDF',
+      false,
+      ['deriveBits']));
 
-  await subtle.decapsulateBits(
-    { name: 'ML-KEM-768' }, kemPair.privateKey, ct2);
+  const { ciphertext: ct2 } =
+    await assertNoPromiseConstructorAccess('encapsulateBits', () =>
+      subtle.encapsulateBits(
+        { name: 'ML-KEM-768' },
+        kemPair.publicKey));
+
+  await assertNoPromiseConstructorAccess('decapsulateBits', () =>
+    subtle.decapsulateBits(
+      { name: 'ML-KEM-768' },
+      kemPair.privateKey,
+      ct2));
 }

--- a/test/parallel/test-webcrypto-webidl.js
+++ b/test/parallel/test-webcrypto-webidl.js
@@ -519,6 +519,44 @@ function assertJsonWebKey(actual, expected) {
   }
 }
 
+// Argon2Params
+{
+  const good = {
+    name: 'Argon2id',
+    memory: 8,
+    nonce: Buffer.alloc(8),
+    parallelism: 1,
+    passes: 1,
+  };
+
+  assertIdlDictionary(converters.Argon2Params({ ...good, filtered: 'out' }, opts), good);
+
+  assertIdlDictionary(
+    converters.Argon2Params({
+      ...good,
+      associatedData: Buffer.alloc(0),
+      secretValue: Buffer.alloc(0),
+    }, opts),
+    {
+      ...good,
+      associatedData: Buffer.alloc(0),
+      secretValue: Buffer.alloc(0),
+    });
+
+  for (const required of ['memory', 'nonce', 'parallelism', 'passes']) {
+    assert.throws(() => converters.Argon2Params({ ...good, [required]: undefined }, opts), {
+      name: 'TypeError',
+      code: 'ERR_MISSING_OPTION',
+      message: `${prefix}: ${context} cannot be converted to 'Argon2Params' because '${required}' is required in 'Argon2Params'.`,
+    });
+  }
+
+  assert.throws(() => converters.Argon2Params({ ...good, passes: 0 }, opts), {
+    name: 'OperationError',
+    message: 'passes must be > 0',
+  });
+}
+
 // AesCbcParams
 {
   const good = { name: 'AES-CBC', iv: Buffer.alloc(16) };


### PR DESCRIPTION
After quite the BoringSSL detour I'm coming back to Web Cryptography hardening related to https://github.com/nodejs/node/issues/59699#issuecomment-3286040276 and https://github.com/nodejs/node/issues/59699#issuecomment-3286140858 in hopes that we can eventually mark #59699 as resolved.

---

**crypto: add WebCrypto CryptoJob mode**

Add a WebCrypto-specific CryptoJob mode that returns a promise from run() and resolves it when native work is finished.

Encode job output directly as Web Crypto values, including CryptoKey instances and CryptoKeyPair dictionaries. Convert operation-specific setup failures from AdditionalConfig into OperationError rejections.

---

**crypto: remove async from WebCrypto methods**

Remove async function wrappers from SubtleCrypto methods while keeping their public promise-returning behaviour.

Route method entry points through a shared helper that converts synchronous validation errors into rejected promises. Let the internal implementations return native job promises directly.

---

**crypto: pass CryptoKey handles to KDF jobs**

Pass CryptoKey handles directly into KDF jobs instead of exporting secret bytes in lib.

Normalize HKDF, PBKDF2, and Argon2 around the same job construction pattern so WebCrypto derivation paths avoid extra key material copies and keep operation failures in native job handling.

---

**crypto: harden WebCrypto against prototype pollution**

Avoid re-wrapping native WebCrypto promises with PromiseResolve(), since resolving a promise can read its user-mutated constructor.

Add a helper for chaining internal WebCrypto job promises without consulting Promise species state, and use it for intermediate job results.

Also align JWK wrapping and unwrapping with the spec's fresh-global JSON handling by detaching internal JWK values from user prototypes. Use the internal UTF-8 encoder/decoder bindings instead of shared TextEncoder/TextDecoder prototype methods.

Expand the WebCrypto prototype pollution regression test to cover SubtleCrypto methods, export formats, zero-length KDF results, JWK toJSON/kty pollution, and encoder/decoder prototype poisoning.