### PR TITLE
doc: add Rust toolchain manual installation instructions Windows

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -755,6 +755,10 @@ Refs:
 * As an alternative to Visual Studio 2026, download Visual Studio 2022 Current channel Version 17.14 from the
   [Evergreen bootstrappers](https://learn.microsoft.com/en-us/visualstudio/releases/2022/release-history#evergreen-bootstrappers)
   table and install using the same workload and optional component selection as described above.
+* To install the Rust toolchain, required for Temporal support introduced in Node.js 26,
+  ensure Visual Studio is already installed, then run `rustup-init.exe` downloaded from
+  [Install Rust](https://rust-lang.org/tools/install/),
+  choosing the default: "Proceed with standard installation".
 * Basic Unix tools required for some tests,
   [Git for Windows](https://git-scm.com/download/win) includes Git Bash
   and tools which can be included in the global `PATH`.


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/63225

## Situation

- [Building Node.js with Temporal support](https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-with-temporal-support) now states:

> Temporal support is enabled by default starting in Node.js 26. Building it requires a Rust toolchain.

[Windows prerequisites](https://github.com/nodejs/node/blob/main/BUILDING.md#windows-prerequisites) describe both manual install and WinGet install. These instructions do not cover Rust toolchain installation.

## Change

Add `rustup-init.exe` to the manual installation instructions with advice to select the standard (default) installation.

Add this to [Windows prerequisites - Manual install](https://github.com/nodejs/node/blob/main/BUILDING.md#option-1-manual-install)

Reference: https://rust-lang.github.io/rustup/index.html

## Verification

On Windows 11 25H2 (amd64)

Install Visual Studio Build Tools 2022 (17.14.32) and follow other instructions in [Windows prerequisites](https://github.com/nodejs/node/blob/main/BUILDING.md#windows-prerequisites).

Download and run `rustup-init.exe` from https://rust-lang.org/tools/install/ and select default.

Re-open terminal windows and check installation:

```shell
rustc --version
cargo --version
rustup show
```

## rustup logs

https://github.com/rust-lang/rustup/issues/4744 is a known `rustup` issue regarding spurious reporting of an existing config, even on a clean install.

```text
rustup-init.exe
warn: It looks like you have an existing rustup settings file at:
warn: C:\Users\mikem\.rustup\settings.toml
warn: Rustup will install the default toolchain as specified in the settings file,
warn: instead of the one inferred from the default host triple.

Welcome to Rust!

This will download and install the official compiler for the Rust
programming language, and its package manager, Cargo.

Rustup metadata and toolchains will be installed into the Rustup
home directory, located at:

  C:\Users\mikem\.rustup

This can be modified with the RUSTUP_HOME environment variable.

The Cargo home directory is located at:

  C:\Users\mikem\.cargo

This can be modified with the CARGO_HOME environment variable.

The cargo, rustc, rustup and other commands will be added to
Cargo's bin directory, located at:

  C:\Users\mikem\.cargo\bin

This path will then be added to your PATH environment variable by
modifying the PATH registry key at HKEY_CURRENT_USER\Environment.

You can uninstall at any time with rustup self uninstall and
these changes will be reverted.

Current installation options:


   default host triple: x86_64-pc-windows-msvc
     default toolchain: stable (default)
               profile: default
  modify PATH variable: yes

1) Proceed with standard installation (default - just press enter)
2) Customize installation
3) Cancel installation
>

info: profile set to default
info: default host triple is x86_64-pc-windows-msvc
info: syncing channel updates for stable-x86_64-pc-windows-msvc
info: latest update on 2026-04-16 for version 1.95.0 (59807616e 2026-04-14)
info: downloading 6 components
        cargo installed                        9.54 MiB
       clippy installed                        3.80 MiB
    rust-docs installed                       21.19 MiB
     rust-std installed                       21.05 MiB
        rustc installed                       68.26 MiB
      rustfmt installed                        2.47 MiB                                                                                                                                    info: default toolchain set to stable-x86_64-pc-windows-msvc

  stable-x86_64-pc-windows-msvc installed - rustc 1.95.0 (59807616e 2026-04-14)


Rust is installed now. Great!

To get started you may need to restart your current shell.
This would reload its PATH environment variable to include
Cargo's bin directory (%USERPROFILE%\.cargo\bin).

Press the Enter key to continue.
```
