### PR TITLE
dns: return `localhost` IP directly

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -213,6 +213,21 @@ function lookup(hostname, options, callback) {
     return {};
   }
 
+  if (hostname === 'localhost') {
+    const local4 = { address: '127.0.0.1', family: 4 };
+    const local6 = { address: '::1', family: 6 };
+
+    if (all) {
+      const addresses = family === 4 ? [ local4 ] : family === 6 ? [ local6 ] :
+        dnsOrder === 'ipv6first' ? [ local6, local4 ] : [ local4, local6 ];
+      process.nextTick(callback, null, addresses);
+    } else {
+      const { address, family: localFamily } = family === 6 || dnsOrder === 'ipv6first' ? local6 : local4;
+      process.nextTick(callback, null, address, localFamily);
+    }
+    return {};
+  }
+
   const req = new GetAddrInfoReqWrap();
   req.callback = callback;
   req.family = family;

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -147,6 +147,16 @@ function createLookupPromise(family, hostname, all, hints, dnsOrder) {
       return;
     }
 
+    if (hostname === 'localhost') {
+      const local4 = { address: '127.0.0.1', family: 4 };
+      const local6 = { address: '::1', family: 6 };
+      const addresses = family === 4 ? [ local4 ] : family === 6 ? [ local6 ] :
+        dnsOrder === 'ipv6first' ? [ local6, local4 ] : [ local4, local6 ];
+
+      resolve(all ? addresses : addresses[0]);
+      return;
+    }
+
     const req = new GetAddrInfoReqWrap();
 
     req.family = family;

--- a/test/async-hooks/test-graph.shutdown.js
+++ b/test/async-hooks/test-graph.shutdown.js
@@ -36,8 +36,6 @@ function onexit() {
     hooks,
     [ { type: 'TCPSERVERWRAP', id: 'tcpserver:1', triggerAsyncId: null },
       { type: 'TCPWRAP', id: 'tcp:1', triggerAsyncId: 'tcpserver:1' },
-      { type: 'GETADDRINFOREQWRAP',
-        id: 'getaddrinforeq:1', triggerAsyncId: 'tcp:1' },
       { type: 'TCPCONNECTWRAP',
         id: 'tcpconnect:1', triggerAsyncId: 'tcp:1' },
       { type: 'TCPWRAP', id: 'tcp:2', triggerAsyncId: 'tcpserver:1' },

--- a/test/async-hooks/test-graph.tls-write.js
+++ b/test/async-hooks/test-graph.tls-write.js
@@ -60,8 +60,6 @@ function onexit() {
     [ { type: 'TCPSERVERWRAP', id: 'tcpserver:1', triggerAsyncId: null },
       { type: 'TCPWRAP', id: 'tcp:1', triggerAsyncId: 'tcpserver:1' },
       { type: 'TLSWRAP', id: 'tls:1', triggerAsyncId: 'tcpserver:1' },
-      { type: 'GETADDRINFOREQWRAP',
-        id: 'getaddrinforeq:1', triggerAsyncId: 'tls:1' },
       { type: 'TCPCONNECTWRAP',
         id: 'tcpconnect:1', triggerAsyncId: 'tcp:1' },
       { type: 'TCPWRAP', id: 'tcp:2', triggerAsyncId: 'tcpserver:1' },

--- a/test/parallel/test-dns-perf_hooks.js
+++ b/test/parallel/test-dns-perf_hooks.js
@@ -20,13 +20,13 @@ function inc() {
 
 // If DNS resolution fails, skip it
 // https://github.com/nodejs/node/issues/44003
-dns.lookup('localhost', common.mustCall((err) => { !err && inc(); }));
+dns.lookup('nodejs.org', common.mustCall((err) => { !err && inc(); }));
 dns.lookupService('127.0.0.1', 80, common.mustCall((err) => { !err && inc(); }));
-dns.resolveAny('localhost', common.mustCall((err) => { !err && inc(); }));
+dns.resolveAny('nodejs.org', common.mustCall((err) => { !err && inc(); }));
 
-dns.promises.lookup('localhost').then(inc).catch(() => {});
+dns.promises.lookup('nodejs.org').then(inc).catch(() => {});
 dns.promises.lookupService('127.0.0.1', 80).then(inc).catch(() => {});
-dns.promises.resolveAny('localhost').then(inc).catch(() => {});
+dns.promises.resolveAny('nodejs.org').then(inc).catch(() => {});
 
 process.on('exit', () => {
   assert.strictEqual(entries.length, count);

--- a/test/parallel/test-http2-goaway-delayed-request.js
+++ b/test/parallel/test-http2-goaway-delayed-request.js
@@ -18,5 +18,5 @@ server.listen(0, common.mustCall(() => {
   const stream = client.request();
   stream.on('error', common.expectsError({ code: 'ERR_HTTP2_GOAWAY_SESSION' }));
 
-  setImmediate(() => client.close());
+  client.close();
 }));

--- a/test/parallel/test-permission-net-dns.js
+++ b/test/parallel/test-permission-net-dns.js
@@ -7,10 +7,10 @@ const dns = require('dns');
 const { Resolver } = dns.promises;
 
 {
-  dns.lookup('localhost', common.mustCall((err) => {
+  dns.lookup('nodejs.org', common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_ACCESS_DENIED');
   }));
-  dns.promises.lookup('localhost').catch(common.mustCall((err) => {
+  dns.promises.lookup('nodejs.org').catch(common.mustCall((err) => {
     assert.strictEqual(err.code, 'ERR_ACCESS_DENIED');
   }));
 }

--- a/test/report/test-report-exclude-network.js
+++ b/test/report/test-report-exclude-network.js
@@ -64,19 +64,8 @@ describe('report exclude network option', () => {
           (ep[ip4 ? 'ip4' : 'ip6'] === (ip4 ? '127.0.0.1' : '::1')),
       )?.[local ? 'localEndpoint' : 'remoteEndpoint'];
     };
-    try {
-      // The reverse DNS of 127.0.0.1 can be a lot of things other than localhost
-      // it could resolve to the server name for instance
-      assert.notStrictEqual(findHandle(true)?.host, '127.0.0.1');
-      assert.notStrictEqual(findHandle(false)?.host, '127.0.0.1');
 
-      if (ipv6Available) {
-        assert.notStrictEqual(findHandle(true, false)?.host, '::1');
-        assert.notStrictEqual(findHandle(false, false)?.host, '::1');
-      }
-    } catch (e) {
-      throw new Error(e?.message + ' in ' + JSON.stringify(tcp, null, 2), { cause: e });
-    }
+    // Lookup for 'localhost' does not require DNS queries, hence not tested
 
     process.report.excludeNetwork = true;
     report = process.report.getReport();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/44804
Fixes: https://github.com/nodejs/node/issues/54111
Not fully fixes yet: https://github.com/nodejs/node/issues/50871
Partially related to: https://github.com/nodejs/node/issues/44003

As per [RFC 6761 6.3](https://datatracker.ietf.org/doc/html/rfc6761#section-6.3),
>    2.  Application software MAY recognize localhost names as special, or
       MAY pass them to name resolution APIs as they would for other
       domain names.

>   3.  Name resolution APIs and libraries SHOULD recognize localhost
       names as special and SHOULD always return the IP loopback address
       for address queries and negative responses for all other query
       types.  Name resolution APIs SHOULD NOT send queries for
       localhost names to their configured caching DNS server(s).

I think we should recognize `localhost.` zone as special and return immediately, without relying on `getaddrinfo(3)`, `/etc/hosts`, etc..