### PR TITLE
Skip commit-lint on backport pull requests

### DIFF
--- a/.github/workflows/commit-lint.yml
+++ b/.github/workflows/commit-lint.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - v[0-9]+.x-staging
 
 env:
   NODE_VERSION: lts/*


### PR DESCRIPTION
The `commit-lint` workflow runs on PRs to `main` and `v[0-9]+.x-staging`. 
For PRs to staging (typically backports), `core-validate-commit` unconditionally fails the `signed-off-by` check, even though    https://github.com/nodejs/node/blob/main/doc/contributing/pull-requests.md#step-4-commit exempts backport commits from it.

Fix: Limit the trigger to PRs targeting `main`.
**I assumed the contributing doc is the source of truth. The alternative would be removing the exemption from the doc instead — happy to switch if preferred.**

Fixes: https://github.com/nodejs/node/issues/63192