### PR TITLE
build,win: add Rust toolchain automated configuration Windows

### DIFF
--- a/.configurations/configuration.dsc.yaml
+++ b/.configurations/configuration.dsc.yaml
@@ -36,6 +36,13 @@ properties:
           - Microsoft.VisualStudio.Component.VC.Llvm.Clang
           - Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
     - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: rustPackage
+      directives:
+        description: Install Rust with MSVC toolchain
+      settings:
+        id: Rustlang.Rust.MSVC
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: gitPackage
       directives:
         description: Install Git
@@ -51,4 +58,4 @@ properties:
       settings:
         id: Nasm.Nasm
         source: winget
-  configurationVersion: 0.1.1
+  configurationVersion: 0.2.0

--- a/.configurations/configuration.vsBuildTools.dsc.yaml
+++ b/.configurations/configuration.vsBuildTools.dsc.yaml
@@ -36,6 +36,13 @@ properties:
           - Microsoft.VisualStudio.Component.VC.Llvm.Clang
           - Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
     - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: rustPackage
+      directives:
+        description: Install Rust with MSVC toolchain
+      settings:
+        id: Rustlang.Rust.MSVC
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: gitPackage
       directives:
         description: Install Git
@@ -51,4 +58,4 @@ properties:
       settings:
         id: Nasm.Nasm
         source: winget
-  configurationVersion: 0.1.1
+  configurationVersion: 0.2.0

--- a/.configurations/configuration.vsEnterprise.dsc.yaml
+++ b/.configurations/configuration.vsEnterprise.dsc.yaml
@@ -36,6 +36,13 @@ properties:
           - Microsoft.VisualStudio.Component.VC.Llvm.Clang
           - Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
     - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: rustPackage
+      directives:
+        description: Install Rust with MSVC toolchain
+      settings:
+        id: Rustlang.Rust.MSVC
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: gitPackage
       directives:
         description: Install Git
@@ -51,4 +58,4 @@ properties:
       settings:
         id: Nasm.Nasm
         source: winget
-  configurationVersion: 0.1.1
+  configurationVersion: 0.2.0

--- a/.configurations/configuration.vsProfessional.dsc.yaml
+++ b/.configurations/configuration.vsProfessional.dsc.yaml
@@ -36,6 +36,13 @@ properties:
           - Microsoft.VisualStudio.Component.VC.Llvm.Clang
           - Microsoft.VisualStudio.Component.VC.Llvm.ClangToolset
     - resource: Microsoft.WinGet.DSC/WinGetPackage
+      id: rustPackage
+      directives:
+        description: Install Rust with MSVC toolchain
+      settings:
+        id: Rustlang.Rust.MSVC
+        source: winget
+    - resource: Microsoft.WinGet.DSC/WinGetPackage
       id: gitPackage
       directives:
         description: Install Git
@@ -51,4 +58,4 @@ properties:
       settings:
         id: Nasm.Nasm
         source: winget
-  configurationVersion: 0.1.1
+  configurationVersion: 0.2.0

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -792,6 +792,7 @@ easily. These files will install the following
 * `Python 3.14`
 * `Visual Studio 2022` (Build Tools, Community, Professional or Enterprise Edition) and
   "Desktop development with C++" workload, Clang and ClangToolset optional components
+* `Rust Toolchain MSVC`
 * `NetWide Assembler`
 
 The following Desired State Configuration (DSC) files are available:


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/63225
Refs: https://github.com/nodejs/node/pull/63367

## Situation

- [Building Node.js with Temporal support](https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-with-temporal-support) now states:

> Temporal support is enabled by default starting in Node.js 26. Building it requires a Rust toolchain.

[Windows prerequisites - Automated install with WinGet](https://github.com/nodejs/node/blob/main/BUILDING.md#option-2-automated-install-with-winget) states:

> WinGet configuration files can be used to install all the required prerequisites for Node.js development easily.

This is no longer true, because a Rust toolchain is required and not automatically installed. The [WinGet configuration files](https://github.com/nodejs/node/tree/main/.configurations) do not install Rust.

## Change

- Add the WinGet package [Rustlang.Rust.MSVC](https://github.com/microsoft/winget-pkgs/tree/master/manifests/r/Rustlang/Rust/MSVC) to the [WinGet configuration files](https://github.com/nodejs/node/tree/main/.configurations)
- Correct the `configurationVersion` to `0.2.0` to match `$schema=https://aka.ms/configuration-dsc-schema/0.2`, which is the latest version.

- Add "Rust Toolchain MSVC" to the list of installed components in [Windows prerequisites - Automated install with WinGet](https://github.com/nodejs/node/blob/main/BUILDING.md#option-2-automated-install-with-winget)

## Verification

On Windows 11 25H2 (amd64)

Uninstall any related previously installed prerequisites from Settings > Apps, such as:

- Rust
- Microsoft Visual Studio Installer
- Python
- Python Install Manager
- Git

Uninstall:

- NASM (delete `C:\Program Files\NASM`)

In a PowerShell terminal, execute each of the following separately. Between each test,
uninstall Microsoft Visual Studio Installer:

```shell
winget configure .\.configurations\configuration.vsBuildTools.dsc.yaml
```

```shell
winget configure .\.configurations\configuration.dsc.yaml # Community Edition
```

```shell
winget configure .\.configurations\configuration.vsProfessional.dsc.yaml
```

```shell
winget configure .\.configurations\configuration.vsEnterprise.dsc.yaml
```

Check installation:

```shell
rustc --version
cargo --version
```

Expect the following versions or above:

```text
rustc 1.95.0 (59807616e 2026-04-14)
cargo 1.95.0 (f2d3ce0bd 2026-03-21)
```

## Backporting

This PR is applicable to Node.js >=26 only and should not be backported to earlier release lines.
