### PR TITLE
watch: cancel pending restart on shutdown

### DIFF
--- a/lib/internal/main/watch_mode.js
+++ b/lib/internal/main/watch_mode.js
@@ -83,10 +83,13 @@ ArrayPrototypeForEach(kWatchedPaths, (p) => watcher.watchPath(p));
 
 let graceTimer;
 let child;
+let childExitPromise;
 let exited;
+let stopping;
 
 function start() {
   exited = false;
+  stopping = false;
   const stdio = kShouldFilterModules ? ['inherit', 'inherit', 'inherit', 'ipc'] : 'inherit';
   child = spawn(process.execPath, argsWithoutWatchOptions, {
     stdio,
@@ -103,29 +106,36 @@ function start() {
     ArrayPrototypeForEach(kOptionalEnvFiles,
                           (file) => watcher.filterFile(resolve(file), undefined, { allowMissing: true }));
   }
-  child.once('exit', (code) => {
+  childExitPromise = once(child, 'exit').then(({ 0: code }) => {
     exited = true;
+    if (stopping) {
+      return code;
+    }
     const waitingForChanges = 'Waiting for file changes before restarting...';
     if (code === 0) {
       process.stdout.write(`${blue}Completed running ${kCommandStr}. ${waitingForChanges}${white}\n`);
     } else {
       process.stdout.write(`${red}Failed running ${kCommandStr}. ${waitingForChanges}${white}\n`);
     }
+    return code;
   });
   return child;
 }
 
 async function killAndWait(signal = kKillSignal, force = false) {
-  child?.removeAllListeners();
-  if (!child) {
+  const processToKill = child;
+  const onExit = childExitPromise;
+  if (!processToKill) {
     return;
   }
-  if ((child.killed || exited) && !force) {
+  if ((processToKill.killed || exited) && !force) {
     return;
   }
-  const onExit = once(child, 'exit');
-  child.kill(signal);
-  const { 0: exitCode } = await onExit;
+  stopping = true;
+  if (!exited && processToKill.exitCode === null && processToKill.signalCode === null) {
+    processToKill.kill(signal);
+  }
+  const exitCode = await onExit;
   return exitCode;
 }
 

--- a/lib/internal/watch_mode/files_watcher.js
+++ b/lib/internal/watch_mode/files_watcher.js
@@ -204,6 +204,9 @@ class FilesWatcher extends EventEmitter {
     this.#filteredFiles.clear();
   }
   clear() {
+    clearTimeout(this.#debounceTimer);
+    this.#debounceTimer = null;
+    this.#debounceOwners.clear();
     this.#watchers.forEach(this.#unwatch);
     this.#watchers.clear();
     this.#filteredFiles.clear();

--- a/test/parallel/test-watch-mode-files_watcher-clear.mjs
+++ b/test/parallel/test-watch-mode-files_watcher-clear.mjs
@@ -1,0 +1,58 @@
+// Flags: --expose-internals
+import * as common from '../common/index.mjs';
+import tmpdir from '../common/tmpdir.js';
+import assert from 'node:assert';
+import { writeFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
+const require = createRequire(import.meta.url);
+const timers = require('node:timers');
+const originalSetTimeout = timers.setTimeout;
+const originalClearTimeout = timers.clearTimeout;
+const { promise, resolve } = Promise.withResolvers();
+let debounceTimer;
+let debounceTimerCleared = false;
+
+timers.setTimeout = function(fn, delay, ...args) {
+  const timer = originalSetTimeout(fn, delay, ...args);
+  if (delay === 1000) {
+    debounceTimer = timer;
+    debounceTimer.ref();
+    resolve();
+  }
+  return timer;
+};
+
+timers.clearTimeout = function(timer) {
+  if (timer === debounceTimer) {
+    debounceTimerCleared = true;
+  }
+  return originalClearTimeout(timer);
+};
+
+try {
+  const { FilesWatcher } = require('internal/watch_mode/files_watcher');
+
+  tmpdir.refresh();
+  const file = tmpdir.resolve('watcher-clear.js');
+  writeFileSync(file, '0');
+
+  const watcher = new FilesWatcher({ debounce: 1000, mode: 'all' });
+  watcher.on('changed', common.mustNotCall());
+  watcher.watchPath(file, false);
+
+  const interval = setInterval(() => writeFileSync(file, `${Date.now()}`), 50);
+  await promise;
+  clearInterval(interval);
+
+  watcher.clear();
+  assert.strictEqual(debounceTimerCleared, true);
+  await sleep(1100);
+} finally {
+  timers.setTimeout = originalSetTimeout;
+  timers.clearTimeout = originalClearTimeout;
+}

--- a/test/parallel/test-watch-mode-files_watcher-clear.mjs
+++ b/test/parallel/test-watch-mode-files_watcher-clear.mjs
@@ -13,12 +13,14 @@ const timers = require('node:timers');
 const originalSetTimeout = timers.setTimeout;
 const originalClearTimeout = timers.clearTimeout;
 const { promise, resolve } = Promise.withResolvers();
+const debounce = 1000;
 let debounceTimer;
 let debounceTimerCallback;
 let debounceTimerCleared = false;
 
 timers.setTimeout = function(fn, delay, ...args) {
-  if (delay === 1000) {
+  // Only intercept the FilesWatcher debounce timer configured below.
+  if (delay === debounce) {
     const timer = {
       __proto__: null,
       ref() { return this; },
@@ -50,7 +52,7 @@ try {
   const file = tmpdir.resolve('watcher-clear.js');
   writeFileSync(file, '0');
 
-  const watcher = new FilesWatcher({ debounce: 1000, mode: 'all' });
+  const watcher = new FilesWatcher({ debounce, mode: 'all' });
   watcher.on('changed', common.mustNotCall());
   watcher.watchPath(file, false);
 

--- a/test/parallel/test-watch-mode-files_watcher-clear.mjs
+++ b/test/parallel/test-watch-mode-files_watcher-clear.mjs
@@ -4,7 +4,6 @@ import tmpdir from '../common/tmpdir.js';
 import assert from 'node:assert';
 import { writeFileSync } from 'node:fs';
 import { createRequire } from 'node:module';
-import { setTimeout as sleep } from 'node:timers/promises';
 
 if (common.isIBMi)
   common.skip('IBMi does not support `fs.watch()`');
@@ -15,16 +14,26 @@ const originalSetTimeout = timers.setTimeout;
 const originalClearTimeout = timers.clearTimeout;
 const { promise, resolve } = Promise.withResolvers();
 let debounceTimer;
+let debounceTimerCallback;
 let debounceTimerCleared = false;
 
 timers.setTimeout = function(fn, delay, ...args) {
-  const timer = originalSetTimeout(fn, delay, ...args);
   if (delay === 1000) {
+    const timer = {
+      __proto__: null,
+      ref() { return this; },
+      unref() { return this; },
+    };
     debounceTimer = timer;
-    debounceTimer.ref();
+    debounceTimerCallback = () => {
+      if (!debounceTimerCleared) {
+        fn(...args);
+      }
+    };
     resolve();
+    return timer;
   }
-  return timer;
+  return originalSetTimeout(fn, delay, ...args);
 };
 
 timers.clearTimeout = function(timer) {
@@ -51,7 +60,7 @@ try {
 
   watcher.clear();
   assert.strictEqual(debounceTimerCleared, true);
-  await sleep(1100);
+  debounceTimerCallback();
 } finally {
   timers.setTimeout = originalSetTimeout;
   timers.clearTimeout = originalClearTimeout;

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -171,6 +171,35 @@ async function failWriteSucceed({ file, watchedFile }) {
 tmpdir.refresh();
 
 describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_000 }, () => {
+  it('should exit when terminated after the watched process has completed', async () => {
+    const file = createTmpFile();
+    const child = spawn(execPath, ['--watch', '--no-warnings', file], {
+      encoding: 'utf8',
+      stdio: 'pipe',
+    });
+
+    for await (const line of createInterface({ input: child.stdout })) {
+      if (line.includes('Completed running')) {
+        break;
+      }
+    }
+
+    child.kill();
+    const timedOut = Promise.withResolvers();
+    const timer = setTimeout(() => {
+      timedOut.reject(new Error('Timed out waiting for watch mode to exit'));
+      if (child.exitCode === null && child.signalCode === null) {
+        child.kill('SIGKILL');
+      }
+    }, common.platformTimeout(5000));
+    timer.unref();
+    try {
+      await Promise.race([once(child, 'exit'), timedOut.promise]);
+    } finally {
+      clearTimeout(timer);
+    }
+  });
+
   it('should watch changes to a file', async () => {
     const file = createTmpFile();
     const { stderr, stdout } = await runWriteSucceed({ file, watchedFile: file, watchFlag: '--watch=true', options: {

--- a/test/sequential/test-watch-mode.mjs
+++ b/test/sequential/test-watch-mode.mjs
@@ -185,19 +185,7 @@ describe('watch mode', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_00
     }
 
     child.kill();
-    const timedOut = Promise.withResolvers();
-    const timer = setTimeout(() => {
-      timedOut.reject(new Error('Timed out waiting for watch mode to exit'));
-      if (child.exitCode === null && child.signalCode === null) {
-        child.kill('SIGKILL');
-      }
-    }, common.platformTimeout(5000));
-    timer.unref();
-    try {
-      await Promise.race([once(child, 'exit'), timedOut.promise]);
-    } finally {
-      clearTimeout(timer);
-    }
+    await once(child, 'exit');
   });
 
   it('should watch changes to a file', async () => {


### PR DESCRIPTION
Fixes a watch mode shutdown race where a pending debounced file change could still emit after `FilesWatcher.clear()` closed the active watchers. That allowed watch mode to restart the child process after shutdown had already started, which could leave `out/Release/node --watch --inspect` processes behind and fail CI’s leftover-process check.

This cancels the pending debounce timer during watcher cleanup and makes watched child exit handling stable across overlapping restart/shutdown paths.

Noticed while examining flaky tests in [ubuntu2404_sharedlibs_shared_x64/56356](https://ci.nodejs.org/job/node-test-commit-linux-containered/nodes=ubuntu2404_sharedlibs_shared_x64/56356/console)
```console
13:35:08 All tests passed.
13:35:08 ps awwx | grep Release/node | grep -v grep | cat
13:35:08 2405720 ?        Sl     0:00 /home/iojs/build/workspace/node-test-commit-linux-containered/out/Release/node --inspect=0 --watch /home/iojs/build/workspace/node-test-commit-linux-containered/test/fixtures/watch-mode/inspect.js
13:35:08 2405726 ?        Sl     0:00 /home/iojs/build/workspace/node-test-commit-linux-containered/out/Release/node --inspect=0 /home/iojs/build/workspace/node-test-commit-linux-containered/test/fixtures/watch-mode/inspect.js
13:35:08 make[1]: *** [Makefile:648: test-ci] Error 1
13:35:08 make: *** [Makefile:674: run-ci] Error 2
13:35:08 Build step 'Conditional steps (multiple)' marked build as failure
```

### Testing

The updated unit tests were run before/after

#### Before

```console
$ python3 tools/test.py -J --mode=release \
  parallel/test-watch-mode-files_watcher-clear \
  sequential/test-watch-mode-inspect \
  parallel/test-watch-mode-files_watcher
=== release test-watch-mode-files_watcher-clear ===
Path: parallel/test-watch-mode-files_watcher-clear
node:assert:173
  throw err;
  ^

AssertionError [ERR_ASSERTION]: function should not have been called at file:///Users/trivikram/workspace/node/test/parallel/test-watch-mode-files_watcher-clear.mjs:45
called with arguments: { owners: SafeSet(0) {}, eventType: 'change' }
    at FilesWatcher.mustNotCall (/Users/trivikram/workspace/node/test/common/index.js:567:12)
    at FilesWatcher.emit (node:events:509:20)
    at Timeout._onTimeout (node:internal/watch_mode/files_watcher:104:12)
    at listOnTimeout (node:internal/timers:605:17)
    at process.processTimers (node:internal/timers:541:7) {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: undefined,
  expected: undefined,
  operator: 'fail',
  diff: 'simple'
}

Node.js v27.0.0-pre
Command: out/Release/node --expose-internals /Users/trivikram/workspace/node/test/parallel/test-watch-mode-files_watcher-clear.mjs


[00:03|% 100|+   2|-   1]: Done

Failed tests:
out/Release/node --expose-internals /Users/trivikram/workspace/node/test/parallel/test-watch-mode-files_watcher-clear.mjs
```

#### After

```console
$ python3 tools/test.py -J --mode=release \
  parallel/test-watch-mode-files_watcher-clear \
  sequential/test-watch-mode-inspect \
  parallel/test-watch-mode-files_watcher
[00:03|% 100|+   3|-   0]: Done

All tests passed.
```

---

Assisted-by: openai:gpt-5.5