### PR TITLE
src: add Latin1 fast path in StringBytes::Encode utf8

### DIFF
--- a/benchmark/buffers/buffer-tostring-utf8-latin1.js
+++ b/benchmark/buffers/buffer-tostring-utf8-latin1.js
@@ -1,0 +1,53 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  size: [64, 1024, 16384, 262144, 4194304],
+  content: ['ascii', 'latin1', 'utf8_mixed', 'latin1_then_cjk'],
+  n: [1e4],
+});
+
+function buildBuffer(kind, size) {
+  if (kind === 'ascii') {
+    return Buffer.alloc(size, 0x61);
+  }
+  if (kind === 'latin1') {
+    const pair = Buffer.from([0xC3, 0xA9]);
+    const buf = Buffer.alloc(size);
+    for (let i = 0; i + 2 <= size; i += 2) pair.copy(buf, i);
+    return buf;
+  }
+  if (kind === 'utf8_mixed') {
+    const cjk = Buffer.from([0xE4, 0xB8, 0xAD]);
+    const buf = Buffer.alloc(size);
+    let i = 0;
+    while (i + 4 <= size) {
+      buf[i++] = 0x61;
+      cjk.copy(buf, i);
+      i += 3;
+    }
+    return buf;
+  }
+  if (kind === 'latin1_then_cjk') {
+    const pair = Buffer.from([0xC3, 0xA9]);
+    const cjk = Buffer.from([0xE4, 0xB8, 0xAD]);
+    const buf = Buffer.alloc(size);
+    const mid = (size >> 1) & ~1;
+    for (let i = 0; i + 2 <= mid; i += 2) pair.copy(buf, i);
+    cjk.copy(buf, mid);
+    for (let i = mid + 3; i + 2 <= size; i += 2) pair.copy(buf, i);
+    return buf;
+  }
+  throw new Error('unknown content: ' + kind);
+}
+
+function main({ n, size, content }) {
+  const buf = buildBuffer(content, size);
+
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    buf.toString('utf8');
+  }
+  bench.end(n);
+}

--- a/src/string_bytes.cc
+++ b/src/string_bytes.cc
@@ -582,21 +582,86 @@ MaybeLocal<Value> StringBytes::Encode(Isolate* isolate,
         return ExternOneByteString::NewFromCopy(isolate, buf, buflen);
       }
 
-      if (buflen >= 32 && simdutf::validate_utf8(buf, buflen)) {
-        // We know that we are non-ASCII (and are unlikely Latin1), use 2-byte
-        // In the most likely case of valid UTF-8, we can use this fast impl
-        // For very short input, it is slower, so we limit min size
-        size_t u16size = simdutf::utf16_length_from_utf8(buf, buflen);
-        if (u16size > static_cast<size_t>(v8::String::kMaxLength)) {
-          isolate->ThrowException(ERR_STRING_TOO_LONG(isolate));
-          return MaybeLocal<Value>();
+      // Latin1-fits fast path: one-byte V8 string, half the heap of UTF-16.
+      // Capped at 1 MiB (above that the prescan cost erases the win).
+      constexpr size_t kLatin1Max = 1u << 20;
+      if (buflen >= 256 && buflen <= kLatin1Max) {
+        // Skip the allocation when any byte >= 0xC4 (UTF-8 lead for a
+        // codepoint > U+FF). Inner loop has no early exit so clang
+        // vectorizes it.
+        constexpr size_t kChunk = 64;
+        bool maybe_latin1 = true;
+        size_t i = 0;
+        for (; i + kChunk <= buflen; i += kChunk) {
+          uint8_t acc = 0;
+          for (size_t j = 0; j < kChunk; j++) {
+            acc |= static_cast<uint8_t>(buf[i + j]) >= 0xC4 ? 1 : 0;
+          }
+          if (acc) {
+            maybe_latin1 = false;
+            break;
+          }
         }
-        return EncodeTwoByteString(
-            isolate, u16size, [buf, buflen, u16size](uint16_t* dst) {
-              size_t written = simdutf::convert_valid_utf8_to_utf16(
-                  buf, buflen, reinterpret_cast<char16_t*>(dst));
-              CHECK_EQ(written, u16size);
-            });
+        if (maybe_latin1) {
+          for (; i < buflen; i++) {
+            if (static_cast<uint8_t>(buf[i]) >= 0xC4) {
+              maybe_latin1 = false;
+              break;
+            }
+          }
+        }
+        if (maybe_latin1) {
+          MaybeStackBuffer<char, 4096> latin1;
+          latin1.AllocateSufficientStorage(buflen);
+          simdutf::result l1 = simdutf::convert_utf8_to_latin1_with_errors(
+              buf, buflen, latin1.out());
+          if (l1.error == simdutf::error_code::SUCCESS) {
+            return ExternOneByteString::NewFromCopy(
+                isolate, latin1.out(), l1.count);
+          }
+        }
+      }
+
+      if (buflen >= 32) {
+        // Single-pass UTF-16: over-allocate (1 char16_t per byte), then
+        // shrink. Above 1 MiB the exact-size 3-pass below is cheaper.
+        constexpr size_t kSinglePassMax = 1u << 20;
+        if (buflen <= kSinglePassMax) {
+          MaybeStackBuffer<uint16_t, 256> u16;
+          u16.AllocateSufficientStorage(buflen);
+          simdutf::result r = simdutf::convert_utf8_to_utf16_with_errors(
+              buf, buflen, reinterpret_cast<char16_t*>(u16.out()));
+          if (r.error == simdutf::error_code::SUCCESS) {
+            if (r.count > static_cast<size_t>(v8::String::kMaxLength)) {
+              isolate->ThrowException(ERR_STRING_TOO_LONG(isolate));
+              return MaybeLocal<Value>();
+            }
+            if (u16.IsAllocated()) {
+              uint16_t* data = u16.out();
+              u16.Release();
+              uint16_t* shrunk = static_cast<uint16_t*>(
+                  realloc(data, r.count * sizeof(uint16_t)));
+              if (shrunk == nullptr) shrunk = data;
+              return ExternTwoByteString::New(isolate, shrunk, r.count);
+            }
+            return String::NewFromTwoByte(isolate,
+                                          u16.out(),
+                                          v8::NewStringType::kNormal,
+                                          static_cast<int>(r.count));
+          }
+        } else if (simdutf::validate_utf8(buf, buflen)) {
+          size_t u16size = simdutf::utf16_length_from_utf8(buf, buflen);
+          if (u16size > static_cast<size_t>(v8::String::kMaxLength)) {
+            isolate->ThrowException(ERR_STRING_TOO_LONG(isolate));
+            return MaybeLocal<Value>();
+          }
+          return EncodeTwoByteString(
+              isolate, u16size, [buf, buflen, u16size](uint16_t* dst) {
+                size_t written = simdutf::convert_valid_utf8_to_utf16(
+                    buf, buflen, reinterpret_cast<char16_t*>(dst));
+                CHECK_EQ(written, u16size);
+              });
+        }
       }
 
       val =


### PR DESCRIPTION
In StringBytes::Encode utf8, latin1-fits content was going through the UTF-16 path. I added a latin1 fast path that converts via simdutf and returns a one-byte V8 string. Benefits every `Buffer.toString('utf8')`, including `fs.readFile/promises.readFile` when they delegate to it.

@nodejs/performance @mcollina @anonrig @lemire @addaleax 

Benchmark results:
```
➜  node git:(mert/buffer-tostring-utf8-latin1) ✗ node-benchmark-compare ./buffer-result.csv
                                                                                      confidence improvement accuracy (*)    (**)   (***)
buffers/buffer-tostring-utf8-latin1.js n=10000 content='ascii' size=1024                              0.34 %       ±1.92%  ±2.56%  ±3.35%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='ascii' size=16384                            -0.57 %       ±1.01%  ±1.34%  ±1.74%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='ascii' size=262144                            0.80 %       ±1.13%  ±1.51%  ±1.96%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='ascii' size=4194304                    *      0.52 %       ±0.46%  ±0.61%  ±0.80%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='ascii' size=64                                9.85 %      ±30.50% ±40.59% ±52.85%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1_then_cjk' size=1024           ***      5.25 %       ±1.60%  ±2.13%  ±2.78%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1_then_cjk' size=16384          ***     24.32 %       ±0.71%  ±0.95%  ±1.24%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1_then_cjk' size=262144         ***     24.33 %       ±0.86%  ±1.15%  ±1.51%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1_then_cjk' size=4194304                -0.06 %       ±0.53%  ±0.71%  ±0.92%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1_then_cjk' size=64                     -2.30 %       ±2.95%  ±3.93%  ±5.13%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1' size=1024                    ***      9.02 %       ±3.85%  ±5.17%  ±6.82%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1' size=16384                   ***     34.52 %       ±1.42%  ±1.90%  ±2.50%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1' size=262144                  ***     30.06 %       ±1.48%  ±1.98%  ±2.62%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1' size=4194304                          0.09 %       ±0.42%  ±0.56%  ±0.73%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='latin1' size=64                        *      6.60 %       ±5.00%  ±6.70%  ±8.82%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='utf8_mixed' size=1024                ***      6.47 %       ±1.88%  ±2.50%  ±3.27%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='utf8_mixed' size=16384               ***     33.69 %       ±1.62%  ±2.16%  ±2.82%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='utf8_mixed' size=262144              ***     47.29 %       ±1.09%  ±1.45%  ±1.89%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='utf8_mixed' size=4194304                     -0.31 %       ±0.61%  ±0.82%  ±1.07%
buffers/buffer-tostring-utf8-latin1.js n=10000 content='utf8_mixed' size=64                    *     -2.47 %       ±2.25%  ±2.99%  ±3.89%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 20 comparisons, you can thus expect the following amount of false-positive results:
  1.00 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.20 false positives, when considering a   1% risk acceptance (**, ***),
  0.02 false positives, when considering a 0.1% risk acceptance (***)
➜  node git:(mert/buffer-tostring-utf8-latin1) ✗
```