### PR TITLE
test: avoid repeated writes in watch helper

### DIFF
--- a/test/common/watch.js
+++ b/test/common/watch.js
@@ -106,7 +106,7 @@ async function testRunnerWatch({
   child.stdout.on('data', (data) => {
     stdout += data.toString();
     currentRun += data.toString();
-    const testRuns = stdout.match(/duration_ms\s\d+/g);
+    const testRuns = stdout.match(/^\S+ duration_ms\s\d+/gm);
     if (testRuns?.length >= 1) ran1.resolve();
     if (testRuns?.length >= 2) ran2.resolve();
   });
@@ -118,18 +118,11 @@ async function testRunnerWatch({
     const content = fixtureContent[fileToUpdate];
     const path = fixturePaths[fileToUpdate];
 
-    if (useRunApi) {
-      const interval = setInterval(
-        () => writeFileSync(path, content),
-        common.platformTimeout(1000),
-      );
-      await ran2.promise;
-      clearInterval(interval);
-    } else {
-      writeFileSync(path, content);
-      await setTimeout(common.platformTimeout(1000));
-      await ran2.promise;
-    }
+    await performFileOperation(
+      () => writeFileSync(path, content),
+      useRunApi,
+    );
+    await ran2.promise;
 
     runs.push(currentRun);
     child.kill();


### PR DESCRIPTION
The shared watch helper was repeatedly writing the watched file in the
`run({ watch: true })` update path until the second run completed. On slow CI,
that can trigger another watch restart while the previous rerun is still
active. The test runner then terminates the in-flight child process with
`SIGTERM`, and the captured output can include both a failed file-level subtest
and the next successful run.

This changes the update path to use `performFileOperation()`, matching the
helper’s rename/create paths. For the `run()` API path, that schedules a single
delayed write instead of rewriting until the second run completes. The helper
still waits for the next completed run before asserting output.

This also tightens run completion detection to count only root summary
`duration_ms` lines, instead of any `duration_ms` field in the TAP output.

Historical context:

- The original watch test used a single write after the first run.
- https://github.com/nodejs/node/commit/dd31255d4f changed the test to repeated writes as a flake workaround.
- https://github.com/nodejs/node/commit/1a4ae462f8 slowed that interval to `common.platformTimeout(1000)`.
- https://github.com/nodejs/node/commit/1c7795e52e later removed repeated writes from the normal CLI watch path.
- https://github.com/nodejs/node/commit/ea1a240633b reintroduced repeated writes for the new `run()` API watch
  path when the monolithic watch test was split.

The repeated-write retry helped ensure the watcher observed a change, but
keeping it active until the whole second run completes creates a new race.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-05-17.md#jstest-failure

---

Assisted-by: openai:gpt-5.5