### PR TITLE
test: allow zero min in eventloopdelay histogram

### DIFF
--- a/test/sequential/test-performance-eventloopdelay.js
+++ b/test/sequential/test-performance-eventloopdelay.js
@@ -71,7 +71,8 @@ const { sleep } = require('internal/util');
         // The values are non-deterministic, so we just check that a value is
         // present, as opposed to a specific value.
         assert(histogram.count > 0, `Expected samples to be recorded, got count=${histogram.count}`);
-        assert(histogram.min > 0);
+        // The clock can report the same value for two samples on some systems.
+        assert(histogram.min >= 0);
         assert(histogram.max > 0);
         assert(histogram.stddev > 0);
         assert(histogram.mean > 0);


### PR DESCRIPTION
The `test-performance-eventloopdelay` test can fail intermittently after
recording samples if one event loop delay sample is `0`.

HDR histograms allow `0` values, and `hdr_min()` returns `0` when bucket 0 has
a count. This can happen when two successive `uv_hrtime()` reads observe the
same effective clock value.

This updates the test to keep requiring recorded samples while allowing
`histogram.min` to be `0`.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-05-17.md#jstest-failure

---

Assisted-by: openai:gpt-5.5