### PR TITLE
test: make http2 close-while-writing single-shot

### DIFF
--- a/test/parallel/test-http2-close-while-writing.js
+++ b/test/parallel/test-http2-close-while-writing.js
@@ -24,7 +24,7 @@ let client_stream;
 server.on('session', common.mustCall(function(session) {
   session.on('stream', common.mustCall(function(stream) {
     stream.resume();
-    stream.on('data', function() {
+    stream.once('data', function() {
       this.write(Buffer.alloc(1));
       process.nextTick(() => client_stream.destroy());
     });


### PR DESCRIPTION
This makes `test-http2-close-while-writing` handle only the first server-side
request data chunk.

The test only needs one chunk to exercise the regression path: the server queues
a write, then the client stream is destroyed on the next tick. Keeping the data
listener active can queue multiple writes and schedule multiple destroys for the
same request body, which makes the test occasionally hang until the harness
timeout.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-05-17.md#jstest-failure

---

Assisted-by: openai:gpt-5.5