### PR TITLE
test: make Brotli 16GB test wait for backpressure

### DIFF
--- a/test/parallel/test-zlib-brotli-16GB.js
+++ b/test/parallel/test-zlib-brotli-16GB.js
@@ -15,9 +15,30 @@ const buf = Buffer.from(content, 'hex');
 const decoder = createBrotliDecompress();
 decoder.end(buf);
 
-// We need to wait to verify that the libuv thread pool had time
-// to process the data and the buffer is not empty.
-setTimeout(common.mustCall(() => {
-  // There is only one chunk in the buffer
-  assert.strictEqual(decoder._readableState.buffer.length, getDefaultHighWaterMark() / (16 * 1024));
-}), common.platformTimeout(500));
+const expectedBufferedChunks = getDefaultHighWaterMark() / (16 * 1024);
+
+const timeout = setTimeout(() => {
+  assert.fail(`Timed out waiting for Brotli output. ` +
+              `Buffered ${decoder._readableState.buffer.length} chunks.`);
+}, common.platformTimeout(5000));
+
+function waitForBackpressure() {
+  const bufferedChunks = decoder._readableState.buffer.length;
+
+  assert.ok(bufferedChunks <= expectedBufferedChunks);
+
+  if (bufferedChunks < expectedBufferedChunks) {
+    setImmediate(waitForBackpressure);
+    return;
+  }
+
+  clearTimeout(timeout);
+
+  // Verify that decompression stopped once the readable buffer filled up.
+  setTimeout(common.mustCall(() => {
+    assert.strictEqual(decoder._readableState.buffer.length,
+                       expectedBufferedChunks);
+  }), common.platformTimeout(500));
+}
+
+waitForBackpressure();

--- a/test/parallel/test-zlib-brotli-16GB.js
+++ b/test/parallel/test-zlib-brotli-16GB.js
@@ -17,11 +17,6 @@ decoder.end(buf);
 
 const expectedBufferedChunks = getDefaultHighWaterMark() / (16 * 1024);
 
-const timeout = setTimeout(() => {
-  assert.fail(`Timed out waiting for Brotli output. ` +
-              `Buffered ${decoder._readableState.buffer.length} chunks.`);
-}, common.platformTimeout(5000));
-
 function waitForBackpressure() {
   const bufferedChunks = decoder._readableState.buffer.length;
 
@@ -31,8 +26,6 @@ function waitForBackpressure() {
     setImmediate(waitForBackpressure);
     return;
   }
-
-  clearTimeout(timeout);
 
   // Verify that decompression stopped once the readable buffer filled up.
   setTimeout(common.mustCall(() => {


### PR DESCRIPTION
This updates `parallel/test-zlib-brotli-16GB` to wait until the Brotli
decoder reaches the expected readable-buffer backpressure point
before asserting the buffered chunk count.

The previous test used a fixed timeout and could check `_readableState.buffer.length`
before libuv worker-pool processing had pushed any output, causing intermittent
failures like `0 !== 4` on loaded CI machines.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-05-17.md#jstest-failure

---

Assisted-by: openai:gpt-5.5