### PR TITLE
test: avoid test_runner watch restart in spec snapshot

### DIFF
--- a/test/fixtures/test-runner/output/test-runner-watch-spec.mjs
+++ b/test/fixtures/test-runner/output/test-runner-watch-spec.mjs
@@ -33,6 +33,10 @@ const { signal } = controller;
 const stream = run({
   watch: true,
   cwd: tmpdir.path,
+  files: [
+    fixturePaths['failing-test.js'],
+    fixturePaths['test.js'],
+  ],
   signal,
 });
 


### PR DESCRIPTION
This updates the `test_runner` watch-mode spec reporter fixture to pass
explicit test files to `run()`.

The fixture no longer watches the whole temporary directory, so setup writes
cannot race with watcher initialization and emit an unexpected restart banner.

Refs:
* https://github.com/nodejs/node/actions/runs/25983032903/job/76375266688
* https://github.com/nodejs/reliability/blob/main/reports/2026-05-12.md#jstest-failure

---

Assisted-by: openai:gpt-5.5