### PR TITLE
test: keep finalization ref alive until exit

### DIFF
--- a/test/fixtures/process/different-registry-per-thread.mjs
+++ b/test/fixtures/process/different-registry-per-thread.mjs
@@ -5,6 +5,12 @@ const registeredRefs = [];
 const ref = { foo: 'foo' };
 registeredRefs.push(ref);
 
+process.on('exit', () => {
+  // Keep `ref` strongly reachable until exit so the per-thread finalization
+  // callbacks are tested without depending on GC timing.
+  registeredRefs.length;
+});
+
 if (isMainThread) {
   process.finalization.register(ref, () => {
     process.stdout.write('shutdown on main thread\n');
@@ -13,7 +19,6 @@ if (isMainThread) {
   const worker = new Worker(import.meta.filename);
 
   worker.on('error', (err) => {
-    // Referencing `registeredRefs` here to avoid `ref` being GCed before the worker exits.
     console.log(registeredRefs);
     throw err;
   });


### PR DESCRIPTION
Fixes an intermittent failure in `parallel/test-process-finalization`.

The `different-registry-per-thread.mjs` fixture registered an object with
`process.finalization.register()` but did not keep that object strongly
reachable until process exit. Since finalization stores weak references, GC
could collect the main-thread object before shutdown, causing the expected
`shutdown on main thread` output to be missing.

This keeps the registered reference reachable through the `exit` phase so the
test verifies per-thread finalization behavior without depending on GC timing.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-05-15.md#jstest-failure

---

Assisted-by: openai:gpt-5.5