### PR TITLE
test: deflake connection refused proxy tests

### DIFF
--- a/test/client-proxy/test-http-proxy-request-connection-refused.mjs
+++ b/test/client-proxy/test-http-proxy-request-connection-refused.mjs
@@ -15,34 +15,19 @@ await once(server, 'listening');
 const serverHost = `localhost:${server.address().port}`;
 const requestUrl = `http://${serverHost}/test`;
 
-let maxRetries = 10;
 let foundRefused = false;
-while (maxRetries-- > 0) {
-  // Make it fail on connection refused by connecting to a port of a closed server.
-  // If it succeeds, get a different port and retry.
-  const proxy = http.createServer((req, res) => {
-    res.destroy();
-  });
-  proxy.listen(0);
-  await once(proxy, 'listening');
-  const port = proxy.address().port;
-  proxy.close();
-  await once(proxy, 'close');
+const port = 10;
+console.log(`Trying proxy at port ${port}`);
+const { stderr } = await runProxiedRequest({
+  NODE_USE_ENV_PROXY: 1,
+  REQUEST_URL: requestUrl,
+  HTTP_PROXY: `http://127.0.0.1:${port}`,
+  NO_PROXY: '',
+  no_proxy: '',
+  REQUEST_TIMEOUT: 5000,
+});
 
-  console.log(`Trying proxy at port ${port}`);
-  const { stderr } = await runProxiedRequest({
-    NODE_USE_ENV_PROXY: 1,
-    REQUEST_URL: requestUrl,
-    HTTP_PROXY: `http://localhost:${port}`,
-    REQUEST_TIMEOUT: 5000,
-  });
-
-  foundRefused = /Error.*connect ECONNREFUSED/.test(stderr);
-  if (foundRefused) {
-    // The proxy client should get a connection refused error.
-    break;
-  }
-}
+foundRefused = /Error.*connect ECONNREFUSED/.test(stderr);
 
 server.close();
 assert(foundRefused, 'Expected ECONNREFUSED error from proxy request');

--- a/test/client-proxy/test-https-proxy-request-connection-refused.mjs
+++ b/test/client-proxy/test-https-proxy-request-connection-refused.mjs
@@ -5,7 +5,6 @@ import fixtures from '../common/fixtures.js';
 import assert from 'node:assert';
 import { once } from 'events';
 import { runProxiedRequest } from '../common/proxy-server.js';
-import http from 'node:http';
 
 if (!common.hasCrypto)
   common.skip('missing crypto');
@@ -25,35 +24,20 @@ await once(server, 'listening');
 const serverHost = `localhost:${server.address().port}`;
 const requestUrl = `https://${serverHost}/test`;
 
-let maxRetries = 10;
 let foundRefused = false;
-while (maxRetries-- > 0) {
-  // Make it fail on connection refused by connecting to a port of a closed server.
-  // If it succeeds, get a different port and retry.
-  const proxy = http.createServer((req, res) => {
-    res.destroy();
-  });
-  proxy.listen(0);
-  await once(proxy, 'listening');
-  const port = proxy.address().port;
-  proxy.close();
-  await once(proxy, 'close');
+const port = 10;
+console.log(`Trying proxy at port ${port}`);
+const { stderr } = await runProxiedRequest({
+  NODE_USE_ENV_PROXY: 1,
+  REQUEST_URL: requestUrl,
+  HTTPS_PROXY: `http://127.0.0.1:${port}`,
+  NO_PROXY: '',
+  no_proxy: '',
+  NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'fake-startcom-root-cert.pem'),
+  REQUEST_TIMEOUT: 5000,
+});
 
-  console.log(`Trying proxy at port ${port}`);
-  const { stderr } = await runProxiedRequest({
-    NODE_USE_ENV_PROXY: 1,
-    REQUEST_URL: requestUrl,
-    HTTPS_PROXY: `http://localhost:${port}`,
-    NODE_EXTRA_CA_CERTS: fixtures.path('keys', 'fake-startcom-root-cert.pem'),
-    REQUEST_TIMEOUT: 5000,
-  });
-
-  foundRefused = /Error.*connect ECONNREFUSED/.test(stderr);
-  if (foundRefused) {
-    // The proxy client should get a connection refused error.
-    break;
-  }
-}
+foundRefused = /Error.*connect ECONNREFUSED/.test(stderr);
 
 server.close();
 assert(foundRefused, 'Expected ECONNREFUSED error from proxy request');


### PR DESCRIPTION
This deflakes the HTTP and HTTPS connection-refused proxy tests.

The tests previously bound an ephemeral port, closed it, and then expected a
child process to get `ECONNREFUSED` when connecting to that released port. That
left a race where the port could be reused before the child process connected.

This updates the tests to use `127.0.0.1:10`, matching existing
refused-connection tests, and clears `NO_PROXY`/`no_proxy` so local proxy
bypass settings do not skip the proxy connection attempt.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-05-15.md#jstest-failure

---

Assisted-by: openai:gpt-5.5