### PR TITLE
test: disable Maglev in near-heap-limit worker test

### DIFF
--- a/test/parallel/test-worker-nearheaplimit-deadlock.js
+++ b/test/parallel/test-worker-nearheaplimit-deadlock.js
@@ -1,7 +1,9 @@
-// Flags: --no-node-snapshot
+// Flags: --no-node-snapshot --no-maglev
 // With node snapshot the OOM can occur during the deserialization of the
 // context, so disable it since we want the OOM to occur during the creation of
 // the message port.
+// With Maglev, the OOM can occur during compilation instead, so disable it for
+// the same reason.
 'use strict';
 const common = require('../common');
 const assert = require('assert');


### PR DESCRIPTION
This fixes a flaky failure in `test-worker-nearheaplimit-deadlock` where the
worker's intentionally tiny heap can be exhausted by Maglev compilation before
the test reaches the worker startup path it is meant to cover.

The test already disables snapshots because snapshot deserialization can hit
OOM too early. This applies the same idea to Maglev: disable it so the induced
OOM occurs during message port creation and is reported as
`ERR_WORKER_OUT_OF_MEMORY`.

Refs:
* https://github.com/nodejs/reliability/blob/main/reports/2026-05-18.md#jstest-failure
* https://github.com/nodejs/node/actions/runs/25991234933/job/76397622787

---

Assisted-by: openai:gpt-5.5