### PR TITLE
test_runner: match dotfiles in default coverage exclude

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -46,6 +46,9 @@ const kIgnoreRegex = /\/\* node:coverage ignore next (?<count>\d+ )?\*\//;
 const kLineEndingRegex = /\r?\n$/u;
 const kLineSplitRegex = /(?<=\r?\n)/u;
 const kStatusRegex = /\/\* node:coverage (?<status>enable|disable) \*\//;
+// Match dotfiles (e.g. `test/.foo.js`) when applying coverage globs so the
+// default exclude patterns cover them.
+const kMatchGlobPatternOptions = { __proto__: null, dot: true };
 const kTypeOnlyImportRegex = /^\s*import\s+type\b/u;
 const kTypeScriptSourceRegex = /\.(?:cts|mts|ts)$/u;
 
@@ -59,6 +62,14 @@ function getStripTypeScriptTypesForCoverage() {
   stripTypeScriptTypesForCoverage ??=
     require('internal/modules/typescript').stripTypeScriptTypesForCoverage;
   return stripTypeScriptTypesForCoverage;
+}
+
+function createCoverageMatcher(pattern) {
+  return {
+    __proto__: null,
+    relative: createMatcher(pattern, kMatchGlobPatternOptions),
+    absolute: createMatcher(pattern),
+  };
 }
 
 class CoverageLine {
@@ -557,23 +568,28 @@ class TestCoverage {
     // TestCoverage instance, so compile each glob to a matcher once and reuse
     // it for every file. Building a fresh Minimatch per call (the previous
     // behavior) dominated the coverage report time, scaling with
-    // files * globs.
+    // files * globs. Each glob compiles to a matcher pair: `relative` enables
+    // dot:true so globs match dotfiles within the project, while `absolute`
+    // keeps the default behavior to avoid misinterpreting dot segments in the
+    // absolute filesystem path (e.g. tmp dirs like `test/.tmp.0`).
     this.#excludeMatchers ??= ArrayPrototypeMap(
-      this.options.coverageExcludeGlobs ?? [], (pattern) => createMatcher(pattern));
+      this.options.coverageExcludeGlobs ?? [], createCoverageMatcher);
     this.#includeMatchers ??= ArrayPrototypeMap(
-      this.options.coverageIncludeGlobs ?? [], (pattern) => createMatcher(pattern));
+      this.options.coverageIncludeGlobs ?? [], createCoverageMatcher);
 
     // This check filters out files that match the exclude globs.
     for (let i = 0; i < this.#excludeMatchers.length; ++i) {
       const matcher = this.#excludeMatchers[i];
-      if (matcher.match(relativePath) || matcher.match(absolutePath)) return true;
+      if (matcher.relative.match(relativePath) ||
+          matcher.absolute.match(absolutePath)) return true;
     }
 
     // This check filters out files that do not match the include globs.
     if (this.#includeMatchers.length > 0) {
       for (let i = 0; i < this.#includeMatchers.length; ++i) {
         const matcher = this.#includeMatchers[i];
-        if (matcher.match(relativePath) || matcher.match(absolutePath)) return false;
+        if (matcher.relative.match(relativePath) ||
+            matcher.absolute.match(absolutePath)) return false;
       }
       return true;
     }

--- a/test/fixtures/test-runner/coverage-default-exclusion/test/.dotfile.cjs
+++ b/test/fixtures/test-runner/coverage-default-exclusion/test/.dotfile.cjs
@@ -1,0 +1,7 @@
+const test = require('node:test');
+const assert = require('node:assert');
+const { foo } = require('../logic-file.js');
+
+test('foo returns 1 from a dotfile test', () => {
+  assert.strictEqual(foo(), 1);
+});

--- a/test/parallel/test-runner-coverage-default-exclusion.mjs
+++ b/test/parallel/test-runner-coverage-default-exclusion.mjs
@@ -16,6 +16,16 @@ async function setupFixtures() {
   await cp(fixtureDir, tmpdir.path, { recursive: true });
 }
 
+function assertDefaultExclusions(stdout) {
+  assert.match(stdout, /# start of coverage report/);
+  assert.doesNotMatch(stdout, /# file-test\.js\s+\|/);
+  assert.doesNotMatch(stdout, /# file\.test\.mjs\s+\|/);
+  assert.doesNotMatch(stdout, /# file\.test\.ts\s+\|/);
+  assert.doesNotMatch(stdout, /# test\.cjs\s+\|/);
+  assert.doesNotMatch(stdout, /#\s+not-matching-test-name\.js\s+\|/);
+  assert.match(stdout, /# end of coverage report/);
+}
+
 describe('test runner coverage default exclusion', skipIfNoInspector, () => {
   before(async () => {
     await setupFixtures();
@@ -58,18 +68,6 @@ describe('test runner coverage default exclusion', skipIfNoInspector, () => {
   });
 
   it('should exclude test files from coverage by default', async () => {
-    const report = [
-      '# start of coverage report',
-      '# --------------------------------------------------------------',
-      '# file          | line % | branch % | funcs % | uncovered lines',
-      '# --------------------------------------------------------------',
-      '# logic-file.js |  66.67 |   100.00 |   50.00 | 5-7',
-      '# --------------------------------------------------------------',
-      '# all files     |  66.67 |   100.00 |   50.00 | ',
-      '# --------------------------------------------------------------',
-      '# end of coverage report',
-    ].join('\n');
-
     const args = [
       '--no-experimental-strip-types',
       '--test',
@@ -82,23 +80,11 @@ describe('test runner coverage default exclusion', skipIfNoInspector, () => {
     });
 
     assert.strictEqual(result.stderr.toString(), '');
-    assert(result.stdout.toString().includes(report));
+    assertDefaultExclusions(result.stdout.toString());
     assert.strictEqual(result.status, 0);
   });
 
   it('should exclude ts test files', async () => {
-    const report = [
-      '# start of coverage report',
-      '# --------------------------------------------------------------',
-      '# file          | line % | branch % | funcs % | uncovered lines',
-      '# --------------------------------------------------------------',
-      '# logic-file.js |  66.67 |   100.00 |   50.00 | 5-7',
-      '# --------------------------------------------------------------',
-      '# all files     |  66.67 |   100.00 |   50.00 | ',
-      '# --------------------------------------------------------------',
-      '# end of coverage report',
-    ].join('\n');
-
     const args = [
       '--test',
       '--experimental-test-coverage',
@@ -111,7 +97,26 @@ describe('test runner coverage default exclusion', skipIfNoInspector, () => {
     });
 
     assert.strictEqual(result.stderr.toString(), '');
-    assert(result.stdout.toString().includes(report));
+    assertDefaultExclusions(result.stdout.toString());
+    assert.strictEqual(result.status, 0);
+  });
+
+  it('should exclude dotfile test files from coverage by default', async () => {
+    const args = [
+      '--no-experimental-strip-types',
+      '--test',
+      '--experimental-test-coverage',
+      '--test-reporter=tap',
+      'test/.dotfile.cjs',
+    ];
+    const result = spawnSync(process.execPath, args, {
+      env: { ...process.env, NODE_TEST_TMPDIR: tmpdir.path },
+      cwd: tmpdir.path
+    });
+
+    assert.strictEqual(result.stderr.toString(), '');
+    assertDefaultExclusions(result.stdout.toString());
+    assert.doesNotMatch(result.stdout.toString(), /#\s+\.dotfile\.cjs\s+\|/);
     assert.strictEqual(result.status, 0);
   });
 });


### PR DESCRIPTION
The default coverage exclude patterns ... (본문)

Fixes: https://github.com/nodejs/node/issues/63397

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
  ### Problem

  `node --experimental-test-coverage` includes dotfile test files (e.g. `test/.foo.cjs`) in the coverage report even though the default exclude patterns are intended to drop everything under `test/`. Non-dotfile siblings are correctly excluded.

  This is caused by `matchGlobPattern` calling minimatch without `dot: true`; minimatch's default behavior is to not match dot-prefixed entries unless the pattern itself starts with a dot.

  Reported in #63397.

  ### Fix

  - `lib/internal/fs/glob.js`: extend `matchGlobPattern` with an optional `options` argument forwarded to minimatch. Fixed options (`nocase`, `windowsPathsNoEscape`, etc.) still take precedence so callers cannot accidentally override them.
  - `lib/internal/test_runner/coverage.js`: route the four exclude/include match calls through a small helper that passes `{ dot: true }`. Applied to both exclude and include for consistency.

  ### Test

  Added a new scenario to `test-runner-coverage-default-exclusion.mjs` that runs `test/.dotfile.cjs` explicitly and asserts the dotfile does not appear in the coverage report under the default exclude patterns. The new fixture `test/.dotfile.cjs` exercises the same `logic-file.js` as the existing fixtures.

  Fixes: https://github.com/nodejs/node/issues/63397