### PR TITLE
doc: add Rust toolchain general install instructions

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -237,9 +237,22 @@ tarball and/or browse the git repository checked out at the relevant tag.
 ### Prerequisites
 
 * [A supported version of Python][Python versions] for building and testing.
-* Memory: at least 8GB of RAM is typically required when compiling with 4 parallel jobs (e.g: `make -j4`)
+* A Rust toolchain if [building Node.js with Temporal support](#building-nodejs-with-temporal-support)
+  is required (enabled by default starting in Node.js 26).
+* Memory: at least 8GB of RAM is typically required when compiling with 4 parallel jobs (e.g: `make -j4`).
 
 ### Unix and macOS
+
+Consult the official [Install Rust](https://rust-lang.org/tools/install/)
+instructions to install a Rust toolchain, required for Temporal support introduced in Node.js 25.4.0.
+Individual packages such as `rust` and `cargo` in some operating system distributions may be considered
+as an alternative, for example in CI environments.
+Consult with relevant operating system documentation to ensure that packages
+meet the minimum version specified in the
+[Building Node.js with Temporal support](#building-nodejs-with-temporal-support) section,
+as packaged versions may lag behind the `stable` version installed by the official instructions.
+Avoid mixing `rustup` together with `rust` and `cargo` package installations, due to
+potential version conflicts.
 
 #### Unix prerequisites
 
@@ -1055,6 +1068,8 @@ requires a Rust toolchain:
 
 * rustc >= 1.82 (with LLVM >= 19)
 * cargo >= 1.82
+
+Refer to [Install Rust](https://rust-lang.org/tools/install/) for instructions.
 
 If `--v8-enable-temporal-support` and `--v8-disable-temporal-support` are both
 omitted, `configure.py` probes for `cargo` and `rustc`. If either is missing,


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/issues/63225

## Situation

- [Building Node.js with Temporal support](https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-with-temporal-support) now states:

> Temporal support is enabled by default starting in Node.js 26. Building it requires a Rust toolchain.

It does not provide any guidance on how to install in this section.


- [Building Node.js on supported platforms](https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-on-supported-platforms) does not yet mention Rust

- [BUILDING > Unix and macOS](https://github.com/nodejs/node/blob/main/BUILDING.md#unix-and-macos) also does not yet cover Rust

- [BUILDING > Windows Prerequisites](https://github.com/nodejs/node/blob/main/BUILDING.md#windows-prerequisites) already provides Rust toolchain installation instructions for Windows, with an additional PR https://github.com/nodejs/node/pull/63381 for automated configuration currently pending

## Change

Add link:

[Install Rust](https://rust-lang.org/tools/install/)

to the documentation sections:

- [Building Node.js with Temporal support](https://github.com/nodejs/node/blob/main/BUILDING.md#building-nodejs-with-temporal-support)
- [BUILDING > Unix and macOS](https://github.com/nodejs/node/blob/main/BUILDING.md#unix-and-macos)

Describe alternate use of distro packages `rust` and `cargo`

## Notes

By default, [Install Rust](https://rust-lang.org/tools/install/) installs in a per-user configuration.

Platform advice may differ depending on the use-case. A local developer's system is probably best served by using a downloaded `rustup`. A build-and-test CI system may alternatively prefer to install distro specific `rustup` / `rust` / `cargo` packages.

Node.js 26 requires a minimum Rust toolchain version 1.82. Some older distros package incompatible versions. For example,
Debian 12 (bookworm / oldstable) offers version 1.63, whereas Debian 13 (trixie / stable) offers the compatible Rust toolchain version  1.85.

## Backporting

This PR is applicable to Node.js >=26 only and should not be backported to earlier release lines. (It does have a reference to Node.js 25, however this is EOL in a few days, so backporting would not be relevant.)
