### PR TITLE
doc: clarify tty raw mode applies to input processing only

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -80,10 +80,11 @@ added: v0.7.7
 Allows configuration of `tty.ReadStream` so that it operates as a raw device.
 
 When in raw mode, input is always available character-by-character, not
-including modifiers. Additionally, all special processing of characters by the
-terminal is disabled, including echoing input
+including modifiers. Additionally, all special processing of input characters
+by the terminal is disabled, including echoing input
 characters. <kbd>Ctrl</kbd>+<kbd>C</kbd> will no longer cause a `SIGINT` when
-in this mode.
+in this mode. This mode does not affect terminal output processing, such as
+newline translation on Unix terminals.
 
 ## Class: `tty.WriteStream`
 


### PR DESCRIPTION
The `tty.ReadStream.setRawMode()` documentation currently states that "all special processing of characters by the terminal is disabled", which is misleading. On Unix, raw mode (`cfmakeraw`/`ICANON`+`ISIG`+`IEXTEN` cleared) only affects input character processing. Output processing flags such as `OPOST` and `ONLCR`, which perform the `\n` to `\r\n` translation on terminal output, are untouched by `setRawMode(true)`.

This change scopes the existing sentence to input characters and adds a brief note clarifying that terminal output processing, including newline translation on Unix terminals, is not affected. No runtime behavior changes.

Fixes: https://github.com/nodejs/node/issues/63059

### Checklist

- [x] `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes (documentation only change)
- [x] tests and/or benchmarks are included (test-exempt: this PR corrects documentation text only with no behavioral changes)
- [x] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines)