### PR TITLE
http: call _writeRaw callback when destroyed

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -418,7 +418,7 @@ function _writeRaw(data, encoding, callback, size) {
 
   if (this.destroyed) {
     if (typeof callback === 'function') {
-      process.nextTick(callback, new ERR_STREAM_DESTROYED('write'));
+      process.nextTick(callback, this.errored ?? new ERR_STREAM_DESTROYED('write'));
     }
     return false;
   }
@@ -428,7 +428,7 @@ function _writeRaw(data, encoding, callback, size) {
     // The socket was destroyed. If we're still trying to write to it,
     // then we haven't gotten the 'close' event yet.
     if (typeof callback === 'function') {
-      process.nextTick(callback, new ERR_STREAM_DESTROYED('write'));
+      process.nextTick(callback, this.errored ?? new ERR_STREAM_DESTROYED('write'));
     }
     return false;
   }

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -411,16 +411,26 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
 
 OutgoingMessage.prototype._writeRaw = _writeRaw;
 function _writeRaw(data, encoding, callback, size) {
+  if (typeof encoding === 'function') {
+    callback = encoding;
+    encoding = null;
+  }
+
+  if (this.destroyed) {
+    if (typeof callback === 'function') {
+      process.nextTick(callback, new ERR_STREAM_DESTROYED('write'));
+    }
+    return false;
+  }
+
   const conn = this[kSocket];
   if (conn?.destroyed) {
     // The socket was destroyed. If we're still trying to write to it,
     // then we haven't gotten the 'close' event yet.
+    if (typeof callback === 'function') {
+      process.nextTick(callback, new ERR_STREAM_DESTROYED('write'));
+    }
     return false;
-  }
-
-  if (typeof encoding === 'function') {
-    callback = encoding;
-    encoding = null;
   }
 
   if (conn && conn._httpMessage === this && conn.writable) {

--- a/test/parallel/test-http-outgoing-destroy.js
+++ b/test/parallel/test-http-outgoing-destroy.js
@@ -15,3 +15,23 @@ const OutgoingMessage = http.OutgoingMessage;
   }));
   msg.on('error', common.mustNotCall());
 }
+
+{
+  const msg = new OutgoingMessage();
+  msg.destroy();
+
+  assert.strictEqual(msg._writeRaw('asd', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+  })), false);
+  msg.on('error', common.mustNotCall());
+}
+
+{
+  const msg = new OutgoingMessage();
+  msg.socket = { destroyed: true };
+
+  assert.strictEqual(msg._writeRaw('asd', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_STREAM_DESTROYED');
+  })), false);
+  msg.on('error', common.mustNotCall());
+}

--- a/test/parallel/test-http-outgoing-destroy.js
+++ b/test/parallel/test-http-outgoing-destroy.js
@@ -28,6 +28,17 @@ const OutgoingMessage = http.OutgoingMessage;
 
 {
   const msg = new OutgoingMessage();
+  const destroyError = new Error('destroyed');
+  msg.destroy(destroyError);
+
+  assert.strictEqual(msg._writeRaw('asd', common.mustCall((err) => {
+    assert.strictEqual(err, destroyError);
+  })), false);
+  msg.on('error', common.mustNotCall());
+}
+
+{
+  const msg = new OutgoingMessage();
   msg.socket = { destroyed: true };
 
   assert.strictEqual(msg._writeRaw('asd', common.mustCall((err) => {


### PR DESCRIPTION
`OutgoingMessage._writeRaw()` could return early without invoking the write
callback when the message, or its socket, was already destroyed.

This updates `_writeRaw()` to call the callback with `ERR_STREAM_DESTROYED`
in those cases, matching the existing destroyed `write()` behavior.

Fixes: https://github.com/nodejs/node/issues/36673

---

Assisted-by: openai:gpt-5.5