### PR TITLE
test: isolate rerun-failures state file under tmpdir

### DIFF
--- a/test/parallel/test-runner-test-rerun-failures.js
+++ b/test/parallel/test-runner-test-rerun-failures.js
@@ -1,5 +1,6 @@
 'use strict';
 const common = require('../common');
+const tmpdir = require('../common/tmpdir');
 
 const fixtures = require('../common/fixtures');
 const assert = require('node:assert');
@@ -8,7 +9,8 @@ const { setTimeout } = require('node:timers/promises');
 const { test, beforeEach, afterEach, run } = require('node:test');
 
 const fixture = fixtures.path('test-runner', 'rerun.js');
-const stateFile = fixtures.path('test-runner', 'rerun-state.json');
+tmpdir.refresh();
+const stateFile = tmpdir.resolve('rerun-state.json');
 
 beforeEach(() => rm(stateFile, { force: true }));
 afterEach(() => rm(stateFile, { force: true }));


### PR DESCRIPTION
While working on #63431 I noticed that running `python tools/test.py --repeat 100 -j 10 "test/parallel/test-runner-test-rerun-failures"` would keep failing since we saved all tests on to the same single JSON file.

This change fixes the issue by writing the stats file onto tmpdir instead.