### PR TITLE
tools: mock some Python utils in `v8.nix` to reuse builds

### DIFF
--- a/tools/nix/v8.nix
+++ b/tools/nix/v8.nix
@@ -33,13 +33,8 @@ let
         ../../deps/v8
         ../../node.gyp
         ../../node.gypi
-        ../../src/node_version.h
-        ../../tools/configure.d/nodedownload.py
-        ../../tools/getmoduleversion.py
-        ../../tools/getnapibuildversion.py
         ../../tools/gyp/pylib
         ../../tools/gyp_node.py
-        ../../tools/utils.py
         ../../tools/v8_gypfiles/abseil.gyp
         ../../tools/v8_gypfiles/features.gypi
         ../../tools/v8_gypfiles/ForEachFormat.py
@@ -103,6 +98,30 @@ stdenv.mkDerivation (finalAttrs: {
         patches+=("$filtered")
       fi
     done
+  ''
+  # We also need to mock some Python util files that are not used to configure Python.
+  # Mocking lets us avoid rebuilding the whole derivation if there's a unrelated
+  # change in one of those files.
+  + ''
+    mkdir -p tools/configure.d
+    cat -> tools/configure.d/nodedownload.py <<'EOF'
+    def parse(opt):
+      return {}
+    def help():
+      return ""
+    EOF
+    cat -> tools/getmoduleversion.py <<'EOF'
+    def get_version():
+      return "99"
+    EOF
+    cat -> tools/getnapibuildversion.py <<'EOF'
+    def get_napi_version():
+      return "9"
+    EOF
+    cat -> tools/utils.py <<'EOF'
+    def SearchFiles(dir, ext):
+      return []
+    EOF
   '';
   # We need to remove the node_inspector.gypi ref so GYP does not search for it.
   postPatch = ''


### PR DESCRIPTION
TL;DR: this change allows us to avoid unnecessary rebuilds on CI.

Because our tooling is not at all tailored for building V8 separately, `v8.nix` lists as inputs things that are not related to building V8, causing the cached builds to be invalidated on some unrelated changes. Ideally we would have only things that affect the V8 build as inputs of the `v8.nix`, that way we would spend GHA time on rebuilding V8 on `test-shared` only when we actually need it – but there's a tradeoff to be made between avoid unnecessary rebuilds and keeping the maintenance burden of `v8.nix` low enough.

I noticed when working on preparing 26.2.0 that the CI had to rebuild V8 between the tip of the staging branch and the release proposal, just because the `node` version got bumped, even though the `node` version has nothing to do with V8 or how it gets built. That PR removes `node_version.h` from the inputs, as well as all the Python helper files that are helping setting stuff unrelated to V8.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
