### PR TITLE
doc: document net Socket server property

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -1347,6 +1347,17 @@ added: v0.5.10
 The numeric representation of the remote port. For example, `80` or `21`. Value may be `undefined` if
 the socket is destroyed (for example, if the client disconnected).
 
+### `socket.server`
+
+<!-- YAML
+added: v0.3.4
+-->
+
+* Type: {net.Server|null}
+
+Reference to the server that accepted the socket. This is `null` for sockets
+that were not accepted by a server.
+
 ### `socket.resetAndDestroy()`
 
 <!-- YAML


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/47148

Documents the `net.Socket#server` property for sockets accepted by a server.

Validation:
- `node tools/lint-md/lint-md.mjs doc/api/net.md`
- `git diff --check`