### PR TITLE
lib: fix typos in esm loader comments

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -289,8 +289,8 @@ class ModuleLoader {
     let job = this.loadCache.get(url, kImplicitTypeAttribute);
     // This module job is already created:
     // 1. If it was loaded by `require()` before, at this point the instantiation
-    //    is already completed and we can check the whether it is in a cycle
-    //    (in that case the module status is kEvaluaing), and whether the
+    //    is already completed and we can check whether it is in a cycle
+    //    (in that case the module status is kEvaluating), and whether the
     //    required graph is synchronous.
     // 2. If it was loaded by `import` before, only allow it if it's already evaluated
     //    to forbid cycles.
@@ -298,7 +298,7 @@ class ModuleLoader {
     //    synchronously so that any previously imported synchronous graph is already
     //    evaluated at this point.
     // TODO(joyeecheung): add something similar to CJS loader's requireStack to help
-    // debugging the the problematic links in the graph for import.
+    // debugging the problematic links in the graph for import.
     debug('importSyncForRequire', parent?.filename, '->', filename, job);
     if (job !== undefined) {
       mod[kRequiredModuleSymbol] = job.module;


### PR DESCRIPTION
Fixes three typos in comments in the `importSyncForRequire` path of
`lib/internal/modules/esm/loader.js`:

- "check the whether" → "check whether"
- "kEvaluaing" → "kEvaluating" (matches the symbol used elsewhere in
  the file, e.g. the import on line 53 and the comparisons on lines
  340 and 382)
- "the the problematic" → "the problematic"

Comment-only change; no functional impact.
