### PR TITLE
http: close pre-request sockets in closeIdleConnections

### DIFF
--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -317,6 +317,7 @@ class Parser : public AsyncWrap, public StreamListener {
     num_fields_ = num_values_ = 0;
     headers_completed_ = false;
     chunk_extensions_nread_ = 0;
+    received_data_ = true;
     last_message_start_ = uv_hrtime();
     allocator_.Reset();
     url_.Reset();
@@ -723,6 +724,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
     if (connectionsList != nullptr) {
       parser->connectionsList_ = connectionsList;
+      parser->received_data_ = false;
 
       // This protects from a DoS attack where an attacker establishes
       // the connection without sending any data on applications where
@@ -1064,6 +1066,7 @@ class Parser : public AsyncWrap, public StreamListener {
   const char* current_buffer_data_;
   bool headers_completed_ = false;
   bool pending_pause_ = false;
+  bool received_data_ = false;
   uint64_t header_nread_ = 0;
   uint64_t chunk_extensions_nread_ = 0;
   uint64_t max_http_header_size_;
@@ -1144,7 +1147,7 @@ void ConnectionsList::Idle(const FunctionCallbackInfo<Value>& args) {
   LocalVector<Value> result(isolate);
   result.reserve(list->all_connections_.size());
   for (auto parser : list->all_connections_) {
-    if (parser->last_message_start_ == 0) {
+    if (parser->last_message_start_ == 0 || !parser->received_data_) {
       result.emplace_back(parser->object());
     }
   }

--- a/test/parallel/test-http-server-close-idle-connections-pre-request.js
+++ b/test/parallel/test-http-server-close-idle-connections-pre-request.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const common = require('../common');
+
+const { createServer } = require('http');
+const { createConnection } = require('net');
+
+const server = createServer(common.mustNotCall());
+
+server.listen(0, '127.0.0.1', common.mustCall(() => {
+  const port = server.address().port;
+  server.once('connection', common.mustCall(() => {
+    server.close(common.mustCall());
+    server.closeIdleConnections();
+    setTimeout(common.mustNotCall(), common.platformTimeout(1000)).unref();
+  }));
+
+  const socket = createConnection(port, '127.0.0.1');
+
+  socket.on('connect', common.mustCall());
+  socket.on('close', common.mustCall());
+  socket.on('error', () => {});
+}));


### PR DESCRIPTION


<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
 ### Problem

  `server.closeIdleConnections()` does not close TCP connections that have been accepted but have not yet sent any HTTP data, contradicting its
  [documented behavior](https://nodejs.org/api/http.html#serverclose-idle-connections) ("Closes all connections connected to this server which are not
   sending a request or waiting for a response") and blocking graceful shutdown when peers (e.g. browsers opening speculative connections) hold
  sockets open without writing.

  Repro:

  ```js
  import { createServer } from 'node:http';
  import { createConnection } from 'node:net';

  const server = createServer((req, res) => res.end('ok'));
  server.listen(3099, '127.0.0.1');
  await new Promise((r) => server.once('listening', r));

  const sock = createConnection(3099, '127.0.0.1');
  await new Promise((r) => sock.once('connect', r));
  await new Promise((r) => server.once('connection', r));

  const closed = new Promise((r) => server.close(() => r(performance.now())));
  const closeStart = performance.now();
  server.closeIdleConnections();

  const t = await Promise.race([
    closed,
    new Promise((r) => setTimeout(() => r(null), 2000)),
  ]);
  console.log(t === null ? 'still hung after 2s' : `closed in ${t - closeStart}ms`);
  sock.destroy();
  ```

  Before: `still hung after 2s`. After: closes immediately.

  Reported in #63452.

  ### Cause

  New sockets are pushed into `kConnections` from `connectionListenerInternal` via `parser.initialize(...)`, but `Parser::Initialize`
  (`src/node_http_parser.cc`) sets `last_message_start_ = uv_hrtime()` so that `headersTimeout` / `requestTimeout` can begin counting (DoS
  protection). `ConnectionsList::Idle()` only returns parsers with `last_message_start_ === 0`, which becomes true only after `on_message_complete`
  resets it. Sockets that were accepted but have not sent any HTTP data are therefore classified as active and skipped by `closeIdleConnections()`.

  ### Fix

  `src/node_http_parser.cc`: add a `received_data_` flag on `Parser`. It is reset to `false` in `Parser::Initialize` (for server-side parsers that own
   a `ConnectionsList`) and set to `true` in `on_message_begin`, when llhttp signals the first byte of a new HTTP message. `ConnectionsList::Idle()`
  now also returns parsers where `received_data_` is still `false`, so accepted-but-pre-request sockets are reported as idle and closed by
  `server.closeIdleConnections()`.

  Per @pimterry's [review suggestion](https://github.com/nodejs/node/pull/63470#discussion_r3280141896), the fix lives at the parser layer rather than
   as a JS-side filter, so the semantics of `idle()` are correct for any current or future caller. `received_data_` is not part of
  `ParserComparator`'s ordering key, so it can be updated in place without pop/push around the std::set.

  ### Test

  Added `test/parallel/test-http-server-close-idle-connections-pre-request.js`. It opens a TCP connection without sending any data, calls
  `server.close()` + `server.closeIdleConnections()`, and uses an unref'd `setTimeout(common.mustNotCall(), 1000)` as the safety net: if the fix works
   the event loop drains and the timer never fires; without the fix the timer fires and the assertion trips.

  ### Verification

  The behavior change was first validated by reproducing the fix's semantics in JS (returning pre-request sockets from `idle()` equivalent) and
  running the issue's repro, which closed in `~0.4ms` instead of hanging.

  A full local build of the patched binary was not completed because this machine has Apple clang 16.0.0, while the current tree requires a newer
  toolchain (V8 fails to compile due to missing `std::atomic_ref`). The C++ change is small and the semantics are 1:1 with the validated JS-equivalent
   behavior; CI will confirm.

  Fixes: https://github.com/nodejs/node/issues/63452
