### PR TITLE
[canary-base] test: update for new V8 serialization format

### DIFF
--- a/test/parallel/test-runner-v8-deserializer.mjs
+++ b/test/parallel/test-runner-v8-deserializer.mjs
@@ -21,10 +21,10 @@ const diagnosticEvent = {
 const chunks = await toArray(serializer([diagnosticEvent]));
 const defaultSerializer = new DefaultSerializer();
 defaultSerializer.writeHeader();
-const headerLength = defaultSerializer.releaseBuffer().length;
-const headerOnly = Buffer.from([0xff, 0x0f]);
-const oversizedLengthHeader = Buffer.from([0xff, 0x0f, 0x7f, 0xff, 0xff, 0xff]);
-const truncatedLengthHeader = Buffer.from([0xff, 0x0f, 0x00, 0x01, 0x00, 0x00]);
+const headerOnly = Buffer.from(defaultSerializer.releaseBuffer());
+const headerLength = headerOnly.length;
+const oversizedLengthHeader = Buffer.concat([headerOnly, Buffer.from([0x7f, 0xff, 0xff, 0xff])]);
+const truncatedLengthHeader = Buffer.concat([headerOnly, Buffer.from([0x00, 0x01, 0x00, 0x00])]);
 // Expected stdout for oversizedLengthHeader: first byte is emitted via
 // String.fromCharCode (byte-by-byte fallback in #drainRawBuffer), remaining
 // bytes go through the nonSerialized UTF-8 decode path in #processRawBuffer.
@@ -94,10 +94,10 @@ describe('v8 deserializer', common.mustCall(() => {
 
   it('should not hang when buffer starts with v8Header followed by oversized length', async () => {
     // Regression test for https://github.com/nodejs/node/issues/62693
-    // FF 0F is the v8 serializer header; the next 4 bytes are read as a
-    // big-endian message size.  0x7FFFFFFF far exceeds any actual buffer
-    // size, causing #processRawBuffer to make no progress and
-    // #drainRawBuffer to loop forever without the no-progress guard.
+    // The v8 serializer header is followed by 4 bytes read as a big-endian
+    // message size. 0x7FFFFFFF far exceeds any actual buffer size, causing
+    // #processRawBuffer to make no progress and #drainRawBuffer to loop
+    // forever without the no-progress guard.
     const reported = await collectReported([oversizedLengthHeader]);
     assert.partialDeepStrictEqual(
       reported,
@@ -117,14 +117,14 @@ describe('v8 deserializer', common.mustCall(() => {
   });
 
   it('should flush v8Header-only bytes as stdout when stream ends', async () => {
-    // Just the two-byte v8 header with no size field at all.
+    // Just the v8 header bytes with no size field at all.
     const reported = await collectReported([headerOnly]);
     assert(reported.every((event) => event.type === 'test:stdout'));
     assert.strictEqual(collectStdout(reported), headerOnly.toString('latin1'));
   });
 
   it('should resync and parse valid messages after false v8 header', async () => {
-    // A false v8 header (FF 0F + oversized length) followed by a
+    // A false v8 header (header bytes + oversized length) followed by a
     // legitimate serialized message. The parser must skip the corrupt
     // bytes and still deserialize the real message.
     const reported = await collectReported([

--- a/test/parallel/test-v8-serdes.js
+++ b/test/parallel/test-v8-serdes.js
@@ -184,7 +184,7 @@ const hostObject = new (internalBinding('js_stream').JSStream)();
     Consider opening an issue as a heads up at https://github.com/nodejs/node/issues/new
   `;
 
-  const desStr = 'ff0f6f2203666f6f5e007b01';
+  const desStr = 'ff106f2203666f6f5e007b01';
 
   const desBuf = Buffer.from(desStr, 'hex');
   const des = new v8.DefaultDeserializer(desBuf);


### PR DESCRIPTION
V8 bumped its wire-format version from 0x0f to 0x10. Update the expected hex in test-v8-serdes, and derive the v8 header bytes dynamically in test-runner-v8-deserializer so it tracks future bumps automatically.

Fixes: https://github.com/nodejs/node-v8/issues/311

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
