### PR TITLE
src: fix edge case when deflateInit2() fails with Z_VERSION_ERROR

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -1285,6 +1285,11 @@ bool ZlibContext::InitZlib() {
     return false;
   }
 
+  // If deflateInit2() fails with Z_VERSION_ERROR, msg remains uninitialized.
+  // Initialize it here to avoid reading the uninitialized pointer during error
+  // emission.
+  strm_.msg = nullptr;
+
   switch (mode_) {
     case DEFLATE:
     case GZIP:


### PR DESCRIPTION
`deflateInit2()` can fail with `Z_VERSION_ERROR` if the compiled library vs loaded library mismatched in version number or in stream structure size.
In those cases, zlib doesn't initialize the `strm_.msg` field to null. Therefore, when a `CompressionError` object is created via `ErrorForMessage()`, it can read a stale or uninitialized `strm_.msg` pointer that will cause a crash.

Example ASAN report:
```
==291205==ERROR: AddressSanitizer: SEGV on unknown address (pc 0x7222adf1a7dd bp 0x7fff2de70650 sp 0x7fff2de6fe08 T0)
==291205==The signal is caused by a READ memory access.
==291205==Hint: this fault was caused by a dereference of a high value address (see register values below).  Disassemble the provided pc to learn which register was used.
    #0 0x7222adf1a7dd in __strlen_avx2 string/../sysdeps/x86_64/multiarch/strlen-avx2.S:76
    #1 0x5bf61d442ab7 in strlen (/work/node/out/Debug/node+0x1a42ab7) (BuildId: 54c4d388769aa50da2f368749b0abbbb804e86a9)
    #2 0x5bf61e2d18c4 in v8::(anonymous namespace)::StringLength(char const*) /work/node/out/../deps/v8/src/api/api.cc:7581:16
    #3 0x5bf61e2d18c4 in v8::(anonymous namespace)::StringLength(unsigned char const*) /work/node/out/../deps/v8/src/api/api.cc:7587:10
    #4 0x5bf61e2d18c4 in v8::String::NewFromOneByte(v8::Isolate*, unsigned char const*, v8::NewStringType, int) /work/node/out/../deps/v8/src/api/api.cc:7677:3
    #5 0x5bf61d5499b8 in node::OneByteString(v8::Isolate*, char const*, int, v8::NewStringType) /work/node/out/../src/util-inl.h:166:10
    #6 0x5bf61de71213 in node::(anonymous namespace)::CompressionStream<node::(anonymous namespace)::ZlibContext>::EmitError(node::(anonymous namespace)::CompressionError const&) /work/node/out/../src/node_zlib.cc:565:7
    #7 0x5bf61de70be6 in node::(anonymous namespace)::CompressionStream<node::(anonymous namespace)::ZlibContext>::CheckError() /work/node/out/../src/node_zlib.cc:519:5
    #8 0x5bf61de6d9c0 in node::(anonymous namespace)::CompressionStream<node::(anonymous namespace)::ZlibContext>::AfterThreadPoolWork(int) /work/node/out/../src/node_zlib.cc:543:10
    #9 0x5bf61d8729be in node::ThreadPoolWork::ScheduleWork()::'lambda'(uv_work_s*, int)::operator()(uv_work_s*, int) const /work/node/out/../src/threadpoolwork-inl.h:57:15
    #10 0x5bf61d87242c in node::ThreadPoolWork::ScheduleWork()::'lambda'(uv_work_s*, int)::__invoke(uv_work_s*, int) /work/node/out/../src/threadpoolwork-inl.h:48:7
    #11 0x7222aea8bfef in uv__work_done /work/libuv-1.51.0/src/threadpool.c:330:5
    #12 0x7222aea900e2 in uv__async_io.part.0 /work/libuv-1.51.0/src/unix/async.c:208:5
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
