### PR TITLE
meta: update status of past strategic initiatives

### DIFF
--- a/doc/contributing/strategic-initiatives.md
+++ b/doc/contributing/strategic-initiatives.md
@@ -6,21 +6,19 @@ agenda to ensure they are active and have the support they need.
 
 ## Current initiatives
 
-| Initiative             | Champion                         | Links                                             |
-| ---------------------- | -------------------------------- | ------------------------------------------------- |
-| QUIC / HTTP3           | [James M Snell][jasnell]         | <https://github.com/nodejs/quic>                  |
-| Shadow Realm           | [Chengzhong Wu][legendecas]      | <https://github.com/nodejs/node/issues/42528>     |
-| Startup Snapshot       | [Joyee Cheung][joyeecheung]      | <https://github.com/nodejs/node/issues/35711>     |
-| V8 Currency            | [Michaël Zasso][targos]          |                                                   |
-| Next-10                | [Michael Dawson][mhdawson]       | <https://github.com/nodejs/next-10>               |
-| Single executable apps | [Darshan Sen][RaisinTen]         | <https://github.com/nodejs/single-executable>     |
-| Performance            | [Rafael Gonzaga][RafaelGSS]      | <https://github.com/nodejs/performance>           |
-| Primordials            | [Benjamin Gruenbaum][benjamingr] | <https://github.com/nodejs/primordials-use-cases> |
+| Initiative             | Champion                         | Links                                         |
+| ---------------------- | -------------------------------- | --------------------------------------------- |
+| QUIC / HTTP3           | [James M Snell][jasnell]         | <https://github.com/nodejs/quic>              |
+| Shadow Realm           | [Chengzhong Wu][legendecas]      | <https://github.com/nodejs/node/issues/42528> |
+| V8 Currency            | [Michaël Zasso][targos]          |                                               |
+| Next-10                | [Jacob Smith][JakobJingleheimer] | <https://github.com/nodejs/next-10>           |
+| Single executable apps | [Darshan Sen][RaisinTen]         | <https://github.com/nodejs/single-executable> |
+| Performance            | [Rafael Gonzaga][RafaelGSS]      | <https://github.com/nodejs/performance>       |
 
 <details>
-<summary>List of completed initiatives</summary>
+<summary>List of past initiatives</summary>
 
-## Completed initiatives
+## Past initiatives
 
 | Initiative         | Champion                         | Links                                                                |
 | ------------------ | -------------------------------- | -------------------------------------------------------------------- |
@@ -34,16 +32,18 @@ agenda to ensure they are active and have the support they need.
 | npm Integration    | Myles Borins                     | <https://github.com/nodejs/node/pull/21594>                          |
 | OpenSSL Evolution  | Rod Vagg                         | <https://github.com/nodejs/TSC/issues/677>                           |
 | Open Web Standards | Myles Borins, Joyee Cheung       | <https://github.com/nodejs/open-standards>                           |
+| Primordials        | [Benjamin Gruenbaum][benjamingr] | <https://github.com/nodejs/primordials-use-cases>                    |
+| Startup Snapshot   | [Joyee Cheung][joyeecheung]      | <https://github.com/nodejs/node/issues/35711>                        |
 | VM module fix      | Franziska Hinkelmann             | <https://github.com/nodejs/node/issues/6283>                         |
 | Workers            | Anna Henningsen                  | <https://github.com/nodejs/worker>                                   |
 
 </details>
 
+[JakobJingleheimer]: https://github.com/JakobJingleheimer
 [RafaelGSS]: https://github.com/RafaelGSS
 [RaisinTen]: https://github.com/RaisinTen
 [benjamingr]: https://github.com/benjamingr
 [jasnell]: https://github.com/jasnell
 [joyeecheung]: https://github.com/joyeecheung
 [legendecas]: https://github.com/legendecas
-[mhdawson]: https://github.com/mhdawson
 [targos]: https://github.com/targos


### PR DESCRIPTION
Moving two strategic initiatives that have stablized and don't have much to report at the TSC weekly meetings.

Drive-by: rename "completed initiatives" as "past initiatives" - there rarely is anything that can be considered "completed" in Node.js, but mostly "momentum stablized".

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
