### PR TITLE
quic: apply multiple security posture improvements

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -189,6 +189,50 @@ object. Each rate limiter has a corresponding counter
 were dropped. A non-zero value indicates the rate limiter is actively
 protecting the endpoint.
 
+#### Block lists
+
+Endpoints can filter incoming packets by source address using a
+[`net.BlockList`][]. The block list is checked before any QUIC processing
+occurs, so blocked packets consume no resources beyond the check itself.
+
+In **deny** mode (the default), packets from addresses in the list are dropped:
+
+```mjs
+import { BlockList } from 'node:net';
+import { listen } from 'node:quic';
+
+const blocked = new BlockList();
+blocked.addSubnet('192.168.1.0', 24);  // Block an entire subnet
+blocked.addAddress('10.0.0.5');        // Block a specific address
+
+const endpoint = await listen(onSession, {
+  endpoint: {
+    blockList: blocked,
+    blockListPolicy: 'deny',
+  },
+  // ...
+});
+```
+
+In **allow** mode, only packets from addresses in the list are accepted:
+
+```mjs
+const trusted = new BlockList();
+trusted.addSubnet('10.0.0.0', 8);
+
+const endpoint = await listen(onSession, {
+  endpoint: {
+    blockList: trusted,
+    blockListPolicy: 'allow',
+  },
+  // ...
+});
+```
+
+The block list is evaluated live — rules added or removed after the endpoint
+is created take effect immediately. The `endpoint.stats.packetsBlocked`
+counter tracks how many packets have been dropped by the filter.
+
 ### Applications
 
 Every `QuicSession` is associated with a single application protocol, negotiated
@@ -850,6 +894,11 @@ added: v23.8.0
 * Type: {bigint} The total number of session creation attempts dropped by the
   per-host rate limiter. Read only. A non-zero value indicates one or more
   remote addresses are creating sessions faster than the configured rate allows.
+
+### `endpointStats.packetsBlocked`
+
+* Type: {bigint} The total number of incoming packets dropped by the
+  block list filter. Read only.
 
 ## Class: `QuicSession`
 
@@ -2448,6 +2497,34 @@ added: v23.8.0
 * Type: {net.SocketAddress | string} The local UDP address and port the endpoint should bind to.
 
 If not specified the endpoint will bind to IPv4 `localhost` on a random port.
+
+#### `endpointOptions.blockList`
+
+* Type: {net.BlockList}
+
+An optional [`net.BlockList`][] instance for filtering incoming packets by
+source address. When configured, every received UDP packet is checked against
+the block list before any QUIC processing occurs, minimizing resource
+expenditure on blocked sources. The block list is evaluated live — rules
+added to the `BlockList` object after the endpoint is created take effect
+immediately.
+
+See [`endpointOptions.blockListPolicy`][] for how matches are interpreted.
+
+#### `endpointOptions.blockListPolicy`
+
+* Type: {string} One of `'deny'` or `'allow'`.
+* **Default:** `'deny'`
+
+Controls how the [`endpointOptions.blockList`][] is interpreted:
+
+* `'deny'` — Packets from addresses matching the block list are dropped.
+  All other addresses are accepted. This is the typical blocklist mode.
+* `'allow'` — Only packets from addresses matching the block list are
+  accepted. All other addresses are dropped. This is an allowlist mode
+  for restricting access to known clients.
+
+If no block list is configured, this option has no effect.
 
 #### `endpointOptions.addressLRUSize`
 
@@ -4303,6 +4380,8 @@ throughput issues caused by flow control.
 [`endpoint.busy`]: #endpointbusy
 [`endpoint.maxConnectionsPerHost`]: #endpointmaxconnectionsperhost
 [`endpoint.maxConnectionsTotal`]: #endpointmaxconnectionstotal
+[`endpointOptions.blockListPolicy`]: #endpointoptionsblocklistpolicy
+[`endpointOptions.blockList`]: #endpointoptionsblocklist
 [`endpointOptions.immediateCloseBurst`]: #endpointoptionsimmediatecloseburst
 [`endpointOptions.immediateCloseRate`]: #endpointoptionsimmediatecloserate
 [`endpointOptions.retryBurst`]: #endpointoptionsretryburst
@@ -4316,6 +4395,7 @@ throughput issues caused by flow control.
 [`error.errorCode`]: #errorerrorcode
 [`fs.promises.open(path, 'r')`]: fs.md#fspromisesopenpath-flags-mode
 [`maxDatagramFrameSize`]: #transportparamsmaxdatagramframesize
+[`net.BlockList`]: net.md#class-netblocklist
 [`quic.connect()`]: #quicconnectaddress-options
 [`quic.listen()`]: #quiclistenonsession-options
 [`session.close()`]: #sessioncloseoptions

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -140,6 +140,55 @@ Certificate compression ([RFC 8879][]) can also address this issue by
 compressing the certificate chain during the handshake. However, Node.js does
 not currently support TLS certificate compression.
 
+### Rate limiting
+
+QUIC endpoints include built-in rate limiting to protect against
+denial-of-service attacks. There are two layers of defense:
+
+**Global rate limits** cap the total rate of stateless responses that the
+endpoint will send, regardless of the source address. These protect against
+floods from spoofed source IP addresses, where an attacker rotates through
+many fake source addresses to bypass per-host limits. Four types of stateless
+responses are independently rate-limited:
+
+* **Retry packets** — sent to validate a client's address during connection
+  setup. Configurable via [`endpointOptions.retryRate`][] and
+  [`endpointOptions.retryBurst`][].
+* **Stateless reset packets** — sent when the endpoint receives a packet for an
+  unknown session. Configurable via [`endpointOptions.statelessResetRate`][]
+  and [`endpointOptions.statelessResetBurst`][].
+* **Version negotiation packets** — sent when a client uses an unsupported QUIC
+  version. Configurable via [`endpointOptions.versionNegotiationRate`][] and
+  [`endpointOptions.versionNegotiationBurst`][].
+* **Immediate connection close packets** — sent when the server is busy or a
+  token is invalid. Configurable via [`endpointOptions.immediateCloseRate`][]
+  and [`endpointOptions.immediateCloseBurst`][].
+
+Each rate limit uses a token bucket: the endpoint can send up to the burst
+capacity instantly, and tokens refill at the configured rate per second. When
+the bucket is empty, additional responses of that type are silently dropped.
+The defaults (100 per second, burst of 200) are suitable for most deployments.
+
+**Per-host session creation rate limits** cap how fast a single remote address
+can create new sessions. This is tracked per validated remote address and
+prevents a single client from churning through sessions (rapidly connecting and
+disconnecting) to consume server resources. Configurable via
+[`endpointOptions.sessionCreationRate`][] and
+[`endpointOptions.sessionCreationBurst`][]. The defaults (50 per second, burst
+of 100) are generous enough for legitimate traffic patterns. For benchmarking
+scenarios where traffic comes from a single source, increase these values.
+
+In addition to rate limiting, the endpoint supports **concurrent connection
+limits** via `maxConnectionsPerHost` and `maxConnectionsTotal`, and a
+**busy mode** via [`endpoint.busy`][] that rejects all new connections.
+
+Rate limiting activity can be monitored through the endpoint's statistics
+object. Each rate limiter has a corresponding counter
+(e.g., `endpoint.stats.retryRateLimited`,
+`endpoint.stats.sessionCreationRateLimited`) that tracks how many responses
+were dropped. A non-zero value indicates the rate limiter is actively
+protecting the endpoint.
+
 ### Applications
 
 Every `QuicSession` is associated with a single application protocol, negotiated
@@ -4225,8 +4274,19 @@ throughput issues caused by flow control.
 [`application.enableConnectProtocol`]: #sessionoptionsapplication
 [`application.enableDatagrams`]: #sessionoptionsapplication
 [`application.qpackMaxDTableCapacity`]: #sessionoptionsapplication
+[`endpoint.busy`]: #endpointbusy
 [`endpoint.maxConnectionsPerHost`]: #endpointmaxconnectionsperhost
 [`endpoint.maxConnectionsTotal`]: #endpointmaxconnectionstotal
+[`endpointOptions.immediateCloseBurst`]: #endpointoptionsimmediatecloseburst
+[`endpointOptions.immediateCloseRate`]: #endpointoptionsimmediatecloserate
+[`endpointOptions.retryBurst`]: #endpointoptionsretryburst
+[`endpointOptions.retryRate`]: #endpointoptionsretryrate
+[`endpointOptions.sessionCreationBurst`]: #endpointoptionssessioncreationburst
+[`endpointOptions.sessionCreationRate`]: #endpointoptionssessioncreationrate
+[`endpointOptions.statelessResetBurst`]: #endpointoptionsstatelessresetburst
+[`endpointOptions.statelessResetRate`]: #endpointoptionsstatelessresetrate
+[`endpointOptions.versionNegotiationBurst`]: #endpointoptionsversionnegotiationburst
+[`endpointOptions.versionNegotiationRate`]: #endpointoptionsversionnegotiationrate
 [`error.errorCode`]: #errorerrorcode
 [`fs.promises.open(path, 'r')`]: fs.md#fspromisesopenpath-flags-mode
 [`maxDatagramFrameSize`]: #transportparamsmaxdatagramframesize

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -104,6 +104,42 @@ to negotiate the application protocol (via ALPN), authenticate the server (and
 optionally the client), exchange transport parameters, and establish shared keys
 for encryption.
 
+#### Certificate size and handshake performance
+
+QUIC includes an anti-amplification limit ([RFC 9000 Section 8.1][]) that
+restricts the server to sending at most three times the data received from
+the client before the client's address is validated. Because the client's
+Initial packet is typically around 1200 bytes, the server can send at most
+approximately 3600 bytes before it must wait for the client to acknowledge.
+
+The server's initial response is dominated by its TLS certificate chain. If
+the certificate chain exceeds the amplification limit, the handshake requires
+an additional round trip — the server must pause, wait for the client's
+acknowledgement, and then continue sending the remainder of the certificate.
+This eliminates QUIC's 1-RTT handshake advantage over TCP+TLS and can add
+50–100 ms or more of latency on the first connection, depending on the network
+path.
+
+To avoid this, servers should use compact certificate chains:
+
+* **Use ECDSA certificates** (P-256 or P-384) rather than RSA. ECDSA keys and
+  signatures are significantly smaller. A typical ECDSA P-256 certificate chain
+  with one intermediate is approximately 1.5–2 KB, well within the amplification
+  limit. An equivalent RSA-2048 chain is often 3–5 KB, which may exceed it.
+
+* **Minimize the certificate chain.** Include only the leaf certificate and
+  the necessary intermediate(s). Do not include the root certificate (clients
+  already have it in their trust store). Avoid cross-signed intermediates when
+  the self-signed root is already widely trusted.
+
+* **Prefer certificate authorities with short chains.** Some CAs issue
+  certificates with a single small intermediate, while others require multiple
+  large RSA intermediates. The choice of CA directly affects handshake latency.
+
+Certificate compression ([RFC 8879][]) can also address this issue by
+compressing the certificate chain during the handshake. However, Node.js does
+not currently support TLS certificate compression.
+
 ### Applications
 
 Every `QuicSession` is associated with a single application protocol, negotiated
@@ -4063,8 +4099,10 @@ throughput issues caused by flow control.
 [JSON-SEQ]: https://www.rfc-editor.org/rfc/rfc7464
 [NSS Key Log Format]: https://udn.realityripple.com/docs/Mozilla/Projects/NSS/Key_Log_Format
 [Permission Model]: permissions.md#permission-model
+[RFC 8879]: https://www.rfc-editor.org/rfc/rfc8879
 [RFC 8999]: https://www.rfc-editor.org/rfc/rfc8999
 [RFC 9000]: https://www.rfc-editor.org/rfc/rfc9000
+[RFC 9000 Section 8.1]: https://www.rfc-editor.org/rfc/rfc9000#section-8.1
 [RFC 9001]: https://www.rfc-editor.org/rfc/rfc9001
 [RFC 9002]: https://www.rfc-editor.org/rfc/rfc9002
 [RFC 9114]: https://www.rfc-editor.org/rfc/rfc9114

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1679,6 +1679,11 @@ added: v23.8.0
 
 * Type: {bigint}
 
+### `sessionStats.streamsIdleTimedOut`
+
+* Type: {bigint} The total number of peer-initiated streams destroyed by the
+  stream idle timeout. Read only.
+
 ## Class: `QuicError`
 
 <!-- YAML
@@ -3049,6 +3054,23 @@ Controls which datagram to drop when the pending datagram queue
 reported as lost via the `ondatagramstatus` callback.
 
 This option is immutable after session creation.
+
+#### `sessionOptions.streamIdleTimeout`
+
+* Type: {bigint|number}
+* **Default:** `30000` (30 seconds)
+
+The maximum time in milliseconds that a peer-initiated stream can be idle
+(no data received) before it is automatically destroyed. This protects
+against slowloris-style attacks where a remote peer opens streams but never
+sends data, holding server resources indefinitely. Only peer-initiated
+streams are checked — locally-initiated streams are the application's
+responsibility. Set to `0` to disable.
+
+The idle check runs as part of the normal send processing loop, so it adds
+no additional timers or event loop overhead. The
+`session.stats.streamsIdleTimedOut` counter tracks how many streams have been
+destroyed by this mechanism.
 
 #### `sessionOptions.maxDatagramSendAttempts`
 

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -3042,6 +3042,32 @@ value, PING frames will be sent automatically to keep the connection alive
 before the idle timeout fires. The value should be less than the effective
 idle timeout (`maxIdleTimeout` transport parameter) to be useful.
 
+#### `sessionOptions.verifyPeer` (client only)
+
+* Type: {string} One of `'strict'`, `'auto'`, or `'manual'`.
+* **Default:** `'auto'`
+
+Controls how the client handles server certificate validation:
+
+* `'strict'` — OpenSSL aborts the TLS handshake immediately if the server's
+  certificate fails validation. The `session.opened` promise rejects with a
+  TLS error. The application cannot inspect the certificate or the error
+  details. This is the most secure mode.
+
+* `'auto'` — The TLS handshake completes regardless of validation result.
+  If validation fails, the `session.opened` promise is rejected with an error
+  containing the validation reason, and the session is destroyed. The
+  `onhandshake` callback (if set) fires before rejection, allowing diagnostic
+  logging. This is the default and matches the behavior of `tls.connect()`
+  with `rejectUnauthorized: true`.
+
+* `'manual'` — The TLS handshake completes regardless of validation result.
+  The `session.opened` promise resolves with the handshake info, which includes
+  `validationErrorReason` and `validationErrorCode` if validation failed. The
+  application is responsible for checking these values and deciding whether to
+  continue. Use this mode for custom validation logic, certificate pinning, or
+  intentionally accepting self-signed certificates.
+
 #### `sessionOptions.servername` (client only)
 
 <!-- YAML

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -2782,9 +2782,15 @@ added: v23.8.0
 -->
 
 * Type: {string} One of `'use'`, `'ignore'`, or `'default'`.
+* **Default:** `'ignore'`
 
 When the remote peer advertises a preferred address, this option specifies whether
-to use it or ignore it.
+to use it or ignore it. The default is `'ignore'` because honoring a server's
+preferred address causes the client to migrate its connection to a different IP
+address, which can be exploited for data exfiltration attacks that are
+indistinguishable from legitimate QUIC connection migration at the network level.
+Set to `'use'` only when connecting to trusted servers that require preferred
+address migration.
 
 #### `sessionOptions.qlog`
 

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -746,7 +746,13 @@ added: v23.8.0
 added: v23.8.0
 -->
 
-* Type: {bigint} The total number of QUIC retry attempts on this endpoint. Read only.
+* Type: {bigint} The total number of retry packets sent by this endpoint. Read only.
+
+### `endpointStats.retryRateLimited`
+
+* Type: {bigint} The total number of retry packets dropped by the global rate
+  limiter. Read only. A non-zero value indicates the endpoint is under retry
+  flood pressure.
 
 ### `endpointStats.versionNegotiationCount`
 
@@ -754,7 +760,13 @@ added: v23.8.0
 added: v23.8.0
 -->
 
-* Type: {bigint} The total number of sessions rejected due to QUIC version mismatch. Read only.
+* Type: {bigint} The total number of version negotiation packets sent by this
+  endpoint. Read only.
+
+### `endpointStats.versionNegotiationRateLimited`
+
+* Type: {bigint} The total number of version negotiation packets dropped by
+  the global rate limiter. Read only.
 
 ### `endpointStats.statelessResetCount`
 
@@ -762,7 +774,13 @@ added: v23.8.0
 added: v23.8.0
 -->
 
-* Type: {bigint} The total number of stateless resets handled by this endpoint. Read only.
+* Type: {bigint} The total number of stateless reset packets sent by this
+  endpoint. Read only.
+
+### `endpointStats.statelessResetRateLimited`
+
+* Type: {bigint} The total number of stateless reset packets dropped by the
+  global rate limiter. Read only.
 
 ### `endpointStats.immediateCloseCount`
 
@@ -770,7 +788,13 @@ added: v23.8.0
 added: v23.8.0
 -->
 
-* Type: {bigint} The total number of sessions that were closed before handshake completed. Read only.
+* Type: {bigint} The total number of immediate connection close packets sent
+  by this endpoint. Read only.
+
+### `endpointStats.immediateCloseRateLimited`
+
+* Type: {bigint} The total number of immediate connection close packets
+  dropped by the global rate limiter. Read only.
 
 ## Class: `QuicSession`
 
@@ -2475,25 +2499,69 @@ addresses. When the limit is reached, new connections are refused with
 This limit can also be changed dynamically after construction via
 [`endpoint.maxConnectionsTotal`][].
 
-#### `endpointOptions.maxRetries`
+#### `endpointOptions.retryRate`
 
-<!-- YAML
-added: v23.8.0
--->
+* Type: {number}
+* **Default:** `100`
 
-* Type: {bigint|number}
+The maximum number of QUIC retry packets the endpoint will send per second.
+This is a global rate limit (not per-host) that caps the total server-wide
+retry response rate, preventing spoofed-source floods from consuming unbounded
+resources.
 
-Specifies the maximum number of QUIC retry attempts allowed per remote peer address.
+#### `endpointOptions.retryBurst`
 
-#### `endpointOptions.maxStatelessResetsPerHost`
+* Type: {number}
+* **Default:** `200`
 
-<!-- YAML
-added: v23.8.0
--->
+The maximum burst of retry packets allowed before rate limiting takes effect.
 
-* Type: {bigint|number}
+#### `endpointOptions.statelessResetRate`
 
-Specifies the maximum number of stateless resets that are allowed per remote peer address.
+* Type: {number}
+* **Default:** `100`
+
+The maximum number of stateless reset packets the endpoint will send per second.
+
+#### `endpointOptions.statelessResetBurst`
+
+* Type: {number}
+* **Default:** `200`
+
+The maximum burst of stateless reset packets allowed before rate limiting
+takes effect.
+
+#### `endpointOptions.versionNegotiationRate`
+
+* Type: {number}
+* **Default:** `100`
+
+The maximum number of version negotiation packets the endpoint will send per
+second.
+
+#### `endpointOptions.versionNegotiationBurst`
+
+* Type: {number}
+* **Default:** `200`
+
+The maximum burst of version negotiation packets allowed before rate limiting
+takes effect.
+
+#### `endpointOptions.immediateCloseRate`
+
+* Type: {number}
+* **Default:** `100`
+
+The maximum number of immediate connection close packets the endpoint will
+send per second.
+
+#### `endpointOptions.immediateCloseBurst`
+
+* Type: {number}
+* **Default:** `200`
+
+The maximum burst of immediate connection close packets allowed before rate
+limiting takes effect.
 
 #### `endpointOptions.retryTokenExpiration`
 

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -796,6 +796,12 @@ added: v23.8.0
 * Type: {bigint} The total number of immediate connection close packets
   dropped by the global rate limiter. Read only.
 
+### `endpointStats.sessionCreationRateLimited`
+
+* Type: {bigint} The total number of session creation attempts dropped by the
+  per-host rate limiter. Read only. A non-zero value indicates one or more
+  remote addresses are creating sessions faster than the configured rate allows.
+
 ## Class: `QuicSession`
 
 <!-- YAML
@@ -2562,6 +2568,26 @@ send per second.
 
 The maximum burst of immediate connection close packets allowed before rate
 limiting takes effect.
+
+#### `endpointOptions.sessionCreationRate`
+
+* Type: {number}
+* **Default:** `50`
+
+The maximum number of new sessions that a single remote address can create per
+second. This is a per-host rate limit tracked in the address validation LRU
+cache. It prevents a validated remote address from churning through sessions
+(rapidly opening and abandoning connections) faster than the server can handle.
+For benchmarking where traffic comes from a single source, set this to a high
+value.
+
+#### `endpointOptions.sessionCreationBurst`
+
+* Type: {number}
+* **Default:** `100`
+
+The maximum burst of new session creations allowed from a single remote address
+before rate limiting takes effect.
 
 #### `endpointOptions.retryTokenExpiration`
 

--- a/lib/internal/blocklist.js
+++ b/lib/internal/blocklist.js
@@ -296,4 +296,5 @@ ObjectSetPrototypeOf(InternalBlockList.prototype, BlockList.prototype);
 module.exports = {
   BlockList,
   InternalBlockList,
+  kHandle,
 };

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -183,6 +183,7 @@ const {
   kGoaway,
   kHandshake,
   kHandshakeCompleted,
+  kVerifyPeer,
   kHeaders,
   kOwner,
   kRemoveSession,
@@ -382,6 +383,7 @@ const endpointRegistry = new SafeSet();
  * @property {number} [version] The QUIC version
  * @property {number} [minVersion] The minimum acceptable QUIC version
  * @property {'use'|'ignore'|'default'} [preferredAddressPolicy] The preferred address policy
+ * @property {'strict'|'auto'|'manual'} [verifyPeer='auto'] Peer certificate verification policy (client only)
  * @property {ApplicationOptions} [application] The application options
  * @property {TransportParams} [transportParams] The transport parameters
  * @property {string} [servername] The server name identifier (client only)
@@ -2628,6 +2630,11 @@ class QuicSession {
     onkeylog: undefined,
     onqlog: undefined,
     pendingQlog: undefined,
+    // Default to 'manual' (no auto-rejection). Client sessions override
+    // this via kVerifyPeer in kConnect. Server sessions keep 'manual'
+    // because server-side cert validation is handled by rejectUnauthorized
+    // at the C++ level.
+    verifyPeer: 'manual',
     handshakeInfo: undefined,
     /** @type {QuicSessionPath|undefined} */
     path: undefined,
@@ -3844,6 +3851,22 @@ class QuicSession {
       safeCallbackInvoke(inner.onhandshake, this, info);
     }
 
+    // In 'auto' mode, reject the connection if peer certificate validation
+    // failed. In 'manual' mode, resolve regardless and let the application
+    // decide. In 'strict' mode, the handshake already failed at the C++
+    // level (SSL_VERIFY_PEER) so we won't reach here.
+    if (inner.verifyPeer === 'auto' && validationErrorReason !== undefined) {
+      const err = new ERR_QUIC_TRANSPORT_ERROR(
+        0, `Peer certificate validation failed: ${validationErrorReason}` +
+           ` [${validationErrorCode}]`);
+      inner.pendingOpen.reject?.(err);
+      inner.pendingOpen.resolve = undefined;
+      inner.pendingOpen.reject = undefined;
+      inner.handshakeCompleted = true;
+      this.destroy();
+      return;
+    }
+
     inner.pendingOpen.resolve?.(info);
     inner.pendingOpen.resolve = undefined;
     inner.pendingOpen.reject = undefined;
@@ -3853,6 +3876,14 @@ class QuicSession {
   /** @type {boolean} */
   get [kHandshakeCompleted]() {
     return this.#inner.handshakeCompleted;
+  }
+
+  get [kVerifyPeer]() {
+    return this.#inner.verifyPeer;
+  }
+
+  set [kVerifyPeer](value) {
+    this.#inner.verifyPeer = value;
   }
 
   /**
@@ -4306,6 +4337,10 @@ class QuicEndpoint {
     // Set callbacks before any async work to avoid missing events
     // that fire during or immediately after the handshake.
     applyCallbacks(session, options);
+    // Store the verifyPeer policy for use in the handshake handler.
+    if (options.verifyPeer !== undefined) {
+      session[kVerifyPeer] = options.verifyPeer;
+    }
     return session;
   }
 
@@ -4959,6 +4994,7 @@ function processSessionOptions(options, config = kEmptyObject) {
     datagramDropPolicy = 'drop-oldest',
     drainingPeriodMultiplier = 3,
     maxDatagramSendAttempts = 5,
+    verifyPeer = 'auto',
     // HTTP/3 application-specific options. Nested under `application`
     // to separate protocol-specific settings from transport-level ones.
     application = kEmptyObject,
@@ -5004,6 +5040,9 @@ function processSessionOptions(options, config = kEmptyObject) {
 
   validateOneOf(datagramDropPolicy, 'options.datagramDropPolicy',
                 ['drop-oldest', 'drop-newest']);
+
+  validateOneOf(verifyPeer, 'options.verifyPeer',
+                ['strict', 'auto', 'manual']);
 
   validateInteger(drainingPeriodMultiplier, 'options.drainingPeriodMultiplier',
                   3, 255);
@@ -5054,7 +5093,14 @@ function processSessionOptions(options, config = kEmptyObject) {
       preferredAddressIpv4: preferredAddressIpv4?.[kSocketAddressHandle],
       preferredAddressIpv6: preferredAddressIpv6?.[kSocketAddressHandle],
     },
-    tls: processTlsOptions(options, forServer),
+    tls: {
+      ...processTlsOptions(options, forServer),
+      // Forward strict mode to C++ so SSL_VERIFY_PEER is set on the
+      // client SSL_CTX. For 'auto' and 'manual' modes, the handshake
+      // completes regardless and the result is handled in JS.
+      verifyPeerStrict: verifyPeer === 'strict',
+    },
+    verifyPeer,
     qlog,
     maxPayloadSize,
     unacknowledgedPacketThreshold,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -436,6 +436,7 @@ const endpointRegistry = new SafeSet();
  * @property {number} [drainingPeriodMultiplier] Multiplier applied to the
  *   draining period (3 * PTO) used by ngtcp2. Range `3..255`.
  *   **Default:** `3`.
+ * @property {bigint|number} [streamIdleTimeout] Time in ms before idle peer-initiated streams are destroyed
  * @property {number} [maxDatagramSendAttempts] Maximum number of times a
  *   datagram is retried before being abandoned. Range `1..255`.
  *   **Default:** `5`.
@@ -922,6 +923,17 @@ setCallbacks({
     // from QuicError::ToV8Value. Convert to a proper Node.js Error.
     if (error !== undefined) {
       error = convertQuicError(error);
+    } else if (this[kOwner] && !this[kOwner].destroyed) {
+      // The stream is closing cleanly, but it may have been reset by the
+      // peer (ReceiveStreamReset) or locally (resetStream). The C++ side
+      // records the reset code in state.resetCode. If set, surface the
+      // reset as the close error so stream.closed rejects -- the reset
+      // was an abnormal termination even if the session closed cleanly.
+      const resetCode = getQuicStreamState(this[kOwner]).resetCode;
+      if (resetCode !== undefined && resetCode > 0n) {
+        error = new ERR_QUIC_APPLICATION_ERROR(
+          resetCode, `stream reset with code ${resetCode}`);
+      }
     }
     debug(`stream ${this[kOwner].id} closed callback with error: ${error}`);
     this[kOwner][kFinishClose](error);
@@ -5015,6 +5027,7 @@ function processSessionOptions(options, config = kEmptyObject) {
     datagramDropPolicy = 'drop-oldest',
     drainingPeriodMultiplier = 3,
     maxDatagramSendAttempts = 5,
+    streamIdleTimeout,
     verifyPeer = 'auto',
     // HTTP/3 application-specific options. Nested under `application`
     // to separate protocol-specific settings from transport-level ones.
@@ -5136,6 +5149,7 @@ function processSessionOptions(options, config = kEmptyObject) {
     datagramDropPolicy,
     drainingPeriodMultiplier,
     maxDatagramSendAttempts,
+    streamIdleTimeout,
     application,
     onerror,
     onstream,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -4919,7 +4919,7 @@ function processSessionOptions(options, config = kEmptyObject) {
     reuseEndpoint = true,
     version,
     minVersion,
-    preferredAddressPolicy = 'default',
+    preferredAddressPolicy = 'ignore',
     transportParams = kEmptyObject,
     qlog = false,
     sessionTicket,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -315,6 +315,8 @@ const endpointRegistry = new SafeSet();
  * @property {number} [versionNegotiationBurst] Burst capacity for version negotiation rate limiter
  * @property {number} [immediateCloseRate] Global rate limit for immediate close packets (per second)
  * @property {number} [immediateCloseBurst] Burst capacity for immediate close rate limiter
+ * @property {number} [sessionCreationRate] Per-host rate limit for session creation (per second)
+ * @property {number} [sessionCreationBurst] Per-host burst capacity for session creation rate limiter
  * @property {ArrayBufferView} [resetTokenSecret] The reset token secret
  * @property {bigint|number} [retryTokenExpiration] The retry token expiration
  * @property {number} [rxDiagnosticLoss] The receive diagnostic loss probability (range 0.0-1.0)
@@ -4013,6 +4015,8 @@ class QuicEndpoint {
       versionNegotiationBurst,
       immediateCloseRate,
       immediateCloseBurst,
+      sessionCreationRate,
+      sessionCreationBurst,
       rxDiagnosticLoss,
       txDiagnosticLoss,
       udpReceiveBufferSize,
@@ -4056,6 +4060,8 @@ class QuicEndpoint {
       versionNegotiationBurst,
       immediateCloseRate,
       immediateCloseBurst,
+      sessionCreationRate,
+      sessionCreationBurst,
       rxDiagnosticLoss,
       txDiagnosticLoss,
       udpReceiveBufferSize,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -5133,6 +5133,11 @@ function processSessionOptions(options, config = kEmptyObject) {
       // client SSL_CTX. For 'auto' and 'manual' modes, the handshake
       // completes regardless and the result is handled in JS.
       verifyPeerStrict: verifyPeer === 'strict',
+      // Enable hostname verification for 'strict' and 'auto' modes.
+      // SSL_set1_host tells OpenSSL to verify the server certificate's
+      // SAN/CN matches the servername. Without this, a valid cert for
+      // any domain would be accepted.
+      verifyHostname: verifyPeer !== 'manual',
     },
     verifyPeer,
     qlog,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -307,8 +307,14 @@ const endpointRegistry = new SafeSet();
  * @property {boolean} [reusePort] Enable SO_REUSEPORT for multi-process load balancing
  * @property {bigint|number} [maxConnectionsPerHost] The maximum number of connections per host
  * @property {bigint|number} [maxConnectionsTotal] The maximum number of total connections
- * @property {bigint|number} [maxRetries] The maximum number of retries
- * @property {bigint|number} [maxStatelessResetsPerHost] The maximum number of stateless resets per host
+ * @property {number} [retryRate] Global rate limit for retry packets (per second)
+ * @property {number} [retryBurst] Burst capacity for retry rate limiter
+ * @property {number} [statelessResetRate] Global rate limit for stateless reset packets (per second)
+ * @property {number} [statelessResetBurst] Burst capacity for stateless reset rate limiter
+ * @property {number} [versionNegotiationRate] Global rate limit for version negotiation packets (per second)
+ * @property {number} [versionNegotiationBurst] Burst capacity for version negotiation rate limiter
+ * @property {number} [immediateCloseRate] Global rate limit for immediate close packets (per second)
+ * @property {number} [immediateCloseBurst] Burst capacity for immediate close rate limiter
  * @property {ArrayBufferView} [resetTokenSecret] The reset token secret
  * @property {bigint|number} [retryTokenExpiration] The retry token expiration
  * @property {number} [rxDiagnosticLoss] The receive diagnostic loss probability (range 0.0-1.0)
@@ -3997,10 +4003,16 @@ class QuicEndpoint {
       tokenExpiration,
       maxConnectionsPerHost = 100,
       maxConnectionsTotal = 10_000,
-      maxStatelessResetsPerHost,
       disableStatelessReset,
       addressLRUSize,
-      maxRetries,
+      retryRate,
+      retryBurst,
+      statelessResetRate,
+      statelessResetBurst,
+      versionNegotiationRate,
+      versionNegotiationBurst,
+      immediateCloseRate,
+      immediateCloseBurst,
       rxDiagnosticLoss,
       txDiagnosticLoss,
       udpReceiveBufferSize,
@@ -4034,10 +4046,16 @@ class QuicEndpoint {
       // Connection limits are set on the state buffer, not passed to C++.
       maxConnectionsPerHost,
       maxConnectionsTotal,
-      maxStatelessResetsPerHost,
       disableStatelessReset,
       addressLRUSize,
-      maxRetries,
+      retryRate,
+      retryBurst,
+      statelessResetRate,
+      statelessResetBurst,
+      versionNegotiationRate,
+      versionNegotiationBurst,
+      immediateCloseRate,
+      immediateCloseBurst,
       rxDiagnosticLoss,
       txDiagnosticLoss,
       udpReceiveBufferSize,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -36,6 +36,10 @@ if (!process.features.quic || !getOptionValue('--experimental-quic')) {
 }
 
 const { inspect } = require('internal/util/inspect');
+const {
+  BlockList,
+  kHandle: kBlockListHandle,
+} = require('internal/blocklist');
 
 let debug = require('internal/util/debuglog').debuglog('quic', (fn) => {
   debug = fn;
@@ -318,6 +322,8 @@ const endpointRegistry = new SafeSet();
  * @property {number} [immediateCloseBurst] Burst capacity for immediate close rate limiter
  * @property {number} [sessionCreationRate] Per-host rate limit for session creation (per second)
  * @property {number} [sessionCreationBurst] Per-host burst capacity for session creation rate limiter
+ * @property {net.BlockList} [blockList] Block list for filtering incoming packets by source address
+ * @property {'deny'|'allow'} [blockListPolicy='deny'] How to interpret the block list
  * @property {ArrayBufferView} [resetTokenSecret] The reset token secret
  * @property {bigint|number} [retryTokenExpiration] The retry token expiration
  * @property {number} [rxDiagnosticLoss] The receive diagnostic loss probability (range 0.0-1.0)
@@ -4048,6 +4054,8 @@ class QuicEndpoint {
       immediateCloseBurst,
       sessionCreationRate,
       sessionCreationBurst,
+      blockList,
+      blockListPolicy = 'deny',
       rxDiagnosticLoss,
       txDiagnosticLoss,
       udpReceiveBufferSize,
@@ -4061,6 +4069,16 @@ class QuicEndpoint {
       resetTokenSecret,
       tokenSecret,
     } = options;
+
+    if (blockList !== undefined) {
+      if (!BlockList.isBlockList(blockList)) {
+        throw new ERR_INVALID_ARG_TYPE('options.blockList',
+                                       'net.BlockList', blockList);
+      }
+    }
+
+    validateOneOf(blockListPolicy, 'options.blockListPolicy',
+                  ['deny', 'allow']);
 
     // All of the other options will be validated internally by the C++ code
     if (address !== undefined && !SocketAddress.isSocketAddress(address)) {
@@ -4093,6 +4111,9 @@ class QuicEndpoint {
       immediateCloseBurst,
       sessionCreationRate,
       sessionCreationBurst,
+      // Pass the C++ handle, not the JS BlockList wrapper.
+      blockList: blockList?.[kBlockListHandle],
+      blockListPolicy,
       rxDiagnosticLoss,
       txDiagnosticLoss,
       udpReceiveBufferSize,

--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -68,6 +68,7 @@ const {
   IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_COUNT,
   IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_RATE_LIMITED,
   IDX_STATS_ENDPOINT_SESSION_CREATION_RATE_LIMITED,
+  IDX_STATS_ENDPOINT_PACKETS_BLOCKED,
 
   IDX_STATS_SESSION_CREATED_AT,
   IDX_STATS_SESSION_DESTROYED_AT,
@@ -136,6 +137,7 @@ assert(IDX_STATS_ENDPOINT_STATELESS_RESET_RATE_LIMITED !== undefined);
 assert(IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_COUNT !== undefined);
 assert(IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_RATE_LIMITED !== undefined);
 assert(IDX_STATS_ENDPOINT_SESSION_CREATION_RATE_LIMITED !== undefined);
+assert(IDX_STATS_ENDPOINT_PACKETS_BLOCKED !== undefined);
 assert(IDX_STATS_SESSION_CREATED_AT !== undefined);
 assert(IDX_STATS_SESSION_DESTROYED_AT !== undefined);
 assert(IDX_STATS_SESSION_CLOSING_AT !== undefined);
@@ -338,6 +340,12 @@ class QuicEndpointStats {
     return this.#handle[IDX_STATS_ENDPOINT_SESSION_CREATION_RATE_LIMITED];
   }
 
+  /** @type {bigint} */
+  get packetsBlocked() {
+    assertIsQuicEndpointStats(this);
+    return this.#handle[IDX_STATS_ENDPOINT_PACKETS_BLOCKED];
+  }
+
   toString() {
     return JSONStringify(this.toJSON());
   }
@@ -363,6 +371,7 @@ class QuicEndpointStats {
       immediateCloseCount,
       immediateCloseRateLimited,
       sessionCreationRateLimited,
+      packetsBlocked,
     } = this;
     return {
       __proto__: null,
@@ -387,6 +396,7 @@ class QuicEndpointStats {
       immediateCloseCount: `${immediateCloseCount}`,
       immediateCloseRateLimited: `${immediateCloseRateLimited}`,
       sessionCreationRateLimited: `${sessionCreationRateLimited}`,
+      packetsBlocked: `${packetsBlocked}`,
     };
   }
 
@@ -421,6 +431,7 @@ class QuicEndpointStats {
       immediateCloseCount,
       immediateCloseRateLimited,
       sessionCreationRateLimited,
+      packetsBlocked,
     } = this;
 
     return `QuicEndpointStats ${inspect({
@@ -443,6 +454,7 @@ class QuicEndpointStats {
       immediateCloseCount,
       immediateCloseRateLimited,
       sessionCreationRateLimited,
+      packetsBlocked,
     }, opts)}`;
   }
 

--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -101,6 +101,7 @@ const {
   IDX_STATS_SESSION_DATAGRAMS_SENT,
   IDX_STATS_SESSION_DATAGRAMS_ACKNOWLEDGED,
   IDX_STATS_SESSION_DATAGRAMS_LOST,
+  IDX_STATS_SESSION_STREAMS_IDLE_TIMED_OUT,
   IDX_STATS_SESSION_COUNT,
 
   IDX_STATS_STREAM_CREATED_AT,
@@ -169,6 +170,7 @@ assert(IDX_STATS_SESSION_DATAGRAMS_RECEIVED !== undefined);
 assert(IDX_STATS_SESSION_DATAGRAMS_SENT !== undefined);
 assert(IDX_STATS_SESSION_DATAGRAMS_ACKNOWLEDGED !== undefined);
 assert(IDX_STATS_SESSION_DATAGRAMS_LOST !== undefined);
+assert(IDX_STATS_SESSION_STREAMS_IDLE_TIMED_OUT !== undefined);
 assert(IDX_STATS_STREAM_CREATED_AT !== undefined);
 assert(IDX_STATS_STREAM_OPENED_AT !== undefined);
 assert(IDX_STATS_STREAM_RECEIVED_AT !== undefined);
@@ -689,6 +691,13 @@ class QuicSessionStats {
     return this.#handle[this.#offset + IDX_STATS_SESSION_DATAGRAMS_LOST];
   }
 
+  /** @type {bigint} */
+  get streamsIdleTimedOut() {
+    assertIsQuicSessionStats(this);
+    return this.#handle[this.#offset +
+                         IDX_STATS_SESSION_STREAMS_IDLE_TIMED_OUT];
+  }
+
   toString() {
     return JSONStringify(this.toJSON());
   }
@@ -726,6 +735,7 @@ class QuicSessionStats {
       datagramsSent,
       datagramsAcknowledged,
       datagramsLost,
+      streamsIdleTimedOut,
     } = this;
     return {
       __proto__: null,
@@ -762,6 +772,7 @@ class QuicSessionStats {
       datagramsSent: `${datagramsSent}`,
       datagramsAcknowledged: `${datagramsAcknowledged}`,
       datagramsLost: `${datagramsLost}`,
+      streamsIdleTimedOut: `${streamsIdleTimedOut}`,
     };
   }
 
@@ -807,6 +818,7 @@ class QuicSessionStats {
       datagramsSent,
       datagramsAcknowledged,
       datagramsLost,
+      streamsIdleTimedOut,
     } = this;
 
     return `QuicSessionStats ${inspect({
@@ -841,6 +853,7 @@ class QuicSessionStats {
       datagramsSent,
       datagramsAcknowledged,
       datagramsLost,
+      streamsIdleTimedOut,
     }, opts)}`;
   }
 

--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -67,6 +67,7 @@ const {
   IDX_STATS_ENDPOINT_STATELESS_RESET_RATE_LIMITED,
   IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_COUNT,
   IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_RATE_LIMITED,
+  IDX_STATS_ENDPOINT_SESSION_CREATION_RATE_LIMITED,
 
   IDX_STATS_SESSION_CREATED_AT,
   IDX_STATS_SESSION_DESTROYED_AT,
@@ -134,6 +135,7 @@ assert(IDX_STATS_ENDPOINT_STATELESS_RESET_COUNT !== undefined);
 assert(IDX_STATS_ENDPOINT_STATELESS_RESET_RATE_LIMITED !== undefined);
 assert(IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_COUNT !== undefined);
 assert(IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_RATE_LIMITED !== undefined);
+assert(IDX_STATS_ENDPOINT_SESSION_CREATION_RATE_LIMITED !== undefined);
 assert(IDX_STATS_SESSION_CREATED_AT !== undefined);
 assert(IDX_STATS_SESSION_DESTROYED_AT !== undefined);
 assert(IDX_STATS_SESSION_CLOSING_AT !== undefined);
@@ -330,6 +332,12 @@ class QuicEndpointStats {
     return this.#handle[IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_RATE_LIMITED];
   }
 
+  /** @type {bigint} */
+  get sessionCreationRateLimited() {
+    assertIsQuicEndpointStats(this);
+    return this.#handle[IDX_STATS_ENDPOINT_SESSION_CREATION_RATE_LIMITED];
+  }
+
   toString() {
     return JSONStringify(this.toJSON());
   }
@@ -354,6 +362,7 @@ class QuicEndpointStats {
       statelessResetRateLimited,
       immediateCloseCount,
       immediateCloseRateLimited,
+      sessionCreationRateLimited,
     } = this;
     return {
       __proto__: null,
@@ -377,6 +386,7 @@ class QuicEndpointStats {
       statelessResetRateLimited: `${statelessResetRateLimited}`,
       immediateCloseCount: `${immediateCloseCount}`,
       immediateCloseRateLimited: `${immediateCloseRateLimited}`,
+      sessionCreationRateLimited: `${sessionCreationRateLimited}`,
     };
   }
 
@@ -410,6 +420,7 @@ class QuicEndpointStats {
       statelessResetRateLimited,
       immediateCloseCount,
       immediateCloseRateLimited,
+      sessionCreationRateLimited,
     } = this;
 
     return `QuicEndpointStats ${inspect({
@@ -431,6 +442,7 @@ class QuicEndpointStats {
       statelessResetRateLimited,
       immediateCloseCount,
       immediateCloseRateLimited,
+      sessionCreationRateLimited,
     }, opts)}`;
   }
 

--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -60,9 +60,13 @@ const {
   IDX_STATS_ENDPOINT_CLIENT_SESSIONS,
   IDX_STATS_ENDPOINT_SERVER_BUSY_COUNT,
   IDX_STATS_ENDPOINT_RETRY_COUNT,
+  IDX_STATS_ENDPOINT_RETRY_RATE_LIMITED,
   IDX_STATS_ENDPOINT_VERSION_NEGOTIATION_COUNT,
+  IDX_STATS_ENDPOINT_VERSION_NEGOTIATION_RATE_LIMITED,
   IDX_STATS_ENDPOINT_STATELESS_RESET_COUNT,
+  IDX_STATS_ENDPOINT_STATELESS_RESET_RATE_LIMITED,
   IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_COUNT,
+  IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_RATE_LIMITED,
 
   IDX_STATS_SESSION_CREATED_AT,
   IDX_STATS_SESSION_DESTROYED_AT,
@@ -123,9 +127,13 @@ assert(IDX_STATS_ENDPOINT_SERVER_SESSIONS !== undefined);
 assert(IDX_STATS_ENDPOINT_CLIENT_SESSIONS !== undefined);
 assert(IDX_STATS_ENDPOINT_SERVER_BUSY_COUNT !== undefined);
 assert(IDX_STATS_ENDPOINT_RETRY_COUNT !== undefined);
+assert(IDX_STATS_ENDPOINT_RETRY_RATE_LIMITED !== undefined);
 assert(IDX_STATS_ENDPOINT_VERSION_NEGOTIATION_COUNT !== undefined);
+assert(IDX_STATS_ENDPOINT_VERSION_NEGOTIATION_RATE_LIMITED !== undefined);
 assert(IDX_STATS_ENDPOINT_STATELESS_RESET_COUNT !== undefined);
+assert(IDX_STATS_ENDPOINT_STATELESS_RESET_RATE_LIMITED !== undefined);
 assert(IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_COUNT !== undefined);
+assert(IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_RATE_LIMITED !== undefined);
 assert(IDX_STATS_SESSION_CREATED_AT !== undefined);
 assert(IDX_STATS_SESSION_DESTROYED_AT !== undefined);
 assert(IDX_STATS_SESSION_CLOSING_AT !== undefined);
@@ -281,9 +289,21 @@ class QuicEndpointStats {
   }
 
   /** @type {bigint} */
+  get retryRateLimited() {
+    assertIsQuicEndpointStats(this);
+    return this.#handle[IDX_STATS_ENDPOINT_RETRY_RATE_LIMITED];
+  }
+
+  /** @type {bigint} */
   get versionNegotiationCount() {
     assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_VERSION_NEGOTIATION_COUNT];
+  }
+
+  /** @type {bigint} */
+  get versionNegotiationRateLimited() {
+    assertIsQuicEndpointStats(this);
+    return this.#handle[IDX_STATS_ENDPOINT_VERSION_NEGOTIATION_RATE_LIMITED];
   }
 
   /** @type {bigint} */
@@ -293,9 +313,21 @@ class QuicEndpointStats {
   }
 
   /** @type {bigint} */
+  get statelessResetRateLimited() {
+    assertIsQuicEndpointStats(this);
+    return this.#handle[IDX_STATS_ENDPOINT_STATELESS_RESET_RATE_LIMITED];
+  }
+
+  /** @type {bigint} */
   get immediateCloseCount() {
     assertIsQuicEndpointStats(this);
     return this.#handle[IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_COUNT];
+  }
+
+  /** @type {bigint} */
+  get immediateCloseRateLimited() {
+    assertIsQuicEndpointStats(this);
+    return this.#handle[IDX_STATS_ENDPOINT_IMMEDIATE_CLOSE_RATE_LIMITED];
   }
 
   toString() {
@@ -315,9 +347,13 @@ class QuicEndpointStats {
       clientSessions,
       serverBusyCount,
       retryCount,
+      retryRateLimited,
       versionNegotiationCount,
+      versionNegotiationRateLimited,
       statelessResetCount,
+      statelessResetRateLimited,
       immediateCloseCount,
+      immediateCloseRateLimited,
     } = this;
     return {
       __proto__: null,
@@ -334,9 +370,13 @@ class QuicEndpointStats {
       clientSessions: `${clientSessions}`,
       serverBusyCount: `${serverBusyCount}`,
       retryCount: `${retryCount}`,
+      retryRateLimited: `${retryRateLimited}`,
       versionNegotiationCount: `${versionNegotiationCount}`,
+      versionNegotiationRateLimited: `${versionNegotiationRateLimited}`,
       statelessResetCount: `${statelessResetCount}`,
+      statelessResetRateLimited: `${statelessResetRateLimited}`,
       immediateCloseCount: `${immediateCloseCount}`,
+      immediateCloseRateLimited: `${immediateCloseRateLimited}`,
     };
   }
 
@@ -363,9 +403,13 @@ class QuicEndpointStats {
       clientSessions,
       serverBusyCount,
       retryCount,
+      retryRateLimited,
       versionNegotiationCount,
+      versionNegotiationRateLimited,
       statelessResetCount,
+      statelessResetRateLimited,
       immediateCloseCount,
+      immediateCloseRateLimited,
     } = this;
 
     return `QuicEndpointStats ${inspect({
@@ -380,9 +424,13 @@ class QuicEndpointStats {
       clientSessions,
       serverBusyCount,
       retryCount,
+      retryRateLimited,
       versionNegotiationCount,
+      versionNegotiationRateLimited,
       statelessResetCount,
+      statelessResetRateLimited,
       immediateCloseCount,
+      immediateCloseRateLimited,
     }, opts)}`;
   }
 

--- a/lib/internal/quic/symbols.js
+++ b/lib/internal/quic/symbols.js
@@ -38,6 +38,7 @@ const kFinishClose = Symbol('kFinishClose');
 const kGoaway = Symbol('kGoaway');
 const kHandshake = Symbol('kHandshake');
 const kHandshakeCompleted = Symbol('kHandshakeCompleted');
+const kVerifyPeer = Symbol('kVerifyPeer');
 const kHeaders = Symbol('kHeaders');
 const kKeylog = Symbol('kKeylog');
 const kListen = Symbol('kListen');
@@ -70,6 +71,7 @@ module.exports = {
   kGoaway,
   kHandshake,
   kHandshakeCompleted,
+  kVerifyPeer,
   kHeaders,
   kInspect,
   kKeylog,

--- a/node.gyp
+++ b/node.gyp
@@ -463,6 +463,7 @@
       'test/cctest/test_quic_cid.cc',
       'test/cctest/test_quic_error.cc',
       'test/cctest/test_quic_preferredaddress.cc',
+      'test/cctest/test_quic_tokenbucket.cc',
       'test/cctest/test_quic_tokens.cc',
     ],
     'node_cctest_inspector_sources': [

--- a/src/node_sockaddr-inl.h
+++ b/src/node_sockaddr-inl.h
@@ -186,10 +186,10 @@ typename T::Type* SocketAddressLRU<T>::Peek(
 }
 
 template <typename T>
-void SocketAddressLRU<T>::CheckExpired() {
+void SocketAddressLRU<T>::CheckExpired(uint64_t now) {
   auto it = list_.rbegin();
   while (it != list_.rend()) {
-    if (T::CheckExpired(it->first, it->second)) {
+    if (T::CheckExpired(it->first, it->second, now)) {
       map_.erase(it->first);
       list_.pop_back();
       it = list_.rbegin();
@@ -211,21 +211,20 @@ void SocketAddressLRU<T>::MemoryInfo(MemoryTracker* tracker) const {
 // cache and adjust if necessary. Whether the item exists or not,
 // purge expired items.
 template <typename T>
-typename T::Type* SocketAddressLRU<T>::Upsert(
-    const SocketAddress& address) {
-
-  auto on_exit = OnScopeLeave([&]() { CheckExpired(); });
+typename T::Type* SocketAddressLRU<T>::Upsert(const SocketAddress& address,
+                                              uint64_t now) {
+  auto on_exit = OnScopeLeave([&]() { CheckExpired(now); });
 
   auto it = map_.find(address);
   if (it != std::end(map_)) {
     list_.splice(list_.begin(), list_, it->second);
-    T::Touch(it->first, &it->second->second);
+    T::Touch(it->first, &it->second->second, now);
     return &it->second->second;
   }
 
   list_.push_front(Pair(address, { }));
   map_[address] = list_.begin();
-  T::Touch(list_.begin()->first, &list_.begin()->second);
+  T::Touch(list_.begin()->first, &list_.begin()->second, now);
 
   // Drop the last item in the list if we are
   // over the size limit...

--- a/src/node_sockaddr.cc
+++ b/src/node_sockaddr.cc
@@ -434,8 +434,7 @@ void SocketAddressBlockList::AddSocketAddressMask(
   rules_.emplace_front(std::move(rule));
 }
 
-bool SocketAddressBlockList::Apply(
-    const std::shared_ptr<SocketAddress>& address) {
+bool SocketAddressBlockList::Apply(const SocketAddress& address) {
   Mutex::ScopedLock lock(mutex_);
   for (const auto& rule : rules_) {
     if (rule->Apply(address)) return true;
@@ -457,8 +456,8 @@ SocketAddressBlockList::SocketAddressMaskRule::SocketAddressMaskRule(
     : network(network_), prefix(prefix_) {}
 
 bool SocketAddressBlockList::SocketAddressRule::Apply(
-    const std::shared_ptr<SocketAddress>& address) {
-  return this->address->is_match(*address.get());
+    const SocketAddress& address) {
+  return this->address->is_match(address);
 }
 
 std::string SocketAddressBlockList::SocketAddressRule::ToString() {
@@ -470,8 +469,8 @@ std::string SocketAddressBlockList::SocketAddressRule::ToString() {
 }
 
 bool SocketAddressBlockList::SocketAddressRangeRule::Apply(
-    const std::shared_ptr<SocketAddress>& address) {
-  return *address.get() >= *start.get() && *address.get() <= *end.get();
+    const SocketAddress& address) {
+  return address >= *start.get() && address <= *end.get();
 }
 
 std::string SocketAddressBlockList::SocketAddressRangeRule::ToString() {
@@ -485,8 +484,8 @@ std::string SocketAddressBlockList::SocketAddressRangeRule::ToString() {
 }
 
 bool SocketAddressBlockList::SocketAddressMaskRule::Apply(
-    const std::shared_ptr<SocketAddress>& address) {
-  return address->is_in_network(*network.get(), prefix);
+    const SocketAddress& address) {
+  return address.is_in_network(*network.get(), prefix);
 }
 
 std::string SocketAddressBlockList::SocketAddressMaskRule::ToString() {
@@ -656,7 +655,7 @@ void SocketAddressBlockListWrap::Check(
   SocketAddressBase* addr;
   ASSIGN_OR_RETURN_UNWRAP(&addr, args[0]);
 
-  args.GetReturnValue().Set(wrap->blocklist_->Apply(addr->address()));
+  args.GetReturnValue().Set(wrap->blocklist_->Apply(*addr->address()));
 }
 
 void SocketAddressBlockListWrap::GetRules(

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -258,14 +258,14 @@ class SocketAddressBlockList : public MemoryRetainer {
   void AddSocketAddressMask(const std::shared_ptr<SocketAddress>& address,
                             int prefix);
 
-  bool Apply(const std::shared_ptr<SocketAddress>& address);
+  bool Apply(const SocketAddress& address);
 
   size_t size() const { return rules_.size(); }
 
   v8::MaybeLocal<v8::Array> ListRules(Environment* env);
 
   struct Rule : public MemoryRetainer {
-    virtual bool Apply(const std::shared_ptr<SocketAddress>& address) = 0;
+    virtual bool Apply(const SocketAddress& address) = 0;
     inline v8::MaybeLocal<v8::Value> ToV8String(Environment* env);
     virtual std::string ToString() = 0;
   };
@@ -275,7 +275,7 @@ class SocketAddressBlockList : public MemoryRetainer {
 
     explicit SocketAddressRule(const std::shared_ptr<SocketAddress>& address);
 
-    bool Apply(const std::shared_ptr<SocketAddress>& address) override;
+    bool Apply(const SocketAddress& address) override;
     std::string ToString() override;
 
     void MemoryInfo(node::MemoryTracker* tracker) const override;
@@ -290,7 +290,7 @@ class SocketAddressBlockList : public MemoryRetainer {
     SocketAddressRangeRule(const std::shared_ptr<SocketAddress>& start,
                            const std::shared_ptr<SocketAddress>& end);
 
-    bool Apply(const std::shared_ptr<SocketAddress>& address) override;
+    bool Apply(const SocketAddress& address) override;
     std::string ToString() override;
 
     void MemoryInfo(node::MemoryTracker* tracker) const override;
@@ -305,7 +305,7 @@ class SocketAddressBlockList : public MemoryRetainer {
     SocketAddressMaskRule(const std::shared_ptr<SocketAddress>& address,
                           int prefix);
 
-    bool Apply(const std::shared_ptr<SocketAddress>& address) override;
+    bool Apply(const SocketAddress& address) override;
     std::string ToString() override;
 
     void MemoryInfo(node::MemoryTracker* tracker) const override;
@@ -352,6 +352,10 @@ class SocketAddressBlockListWrap : public BaseObject {
                              v8::Local<v8::Object> wrap,
                              std::shared_ptr<SocketAddressBlockList> blocklist =
                                  std::make_shared<SocketAddressBlockList>());
+
+  inline const std::shared_ptr<SocketAddressBlockList>& blocklist() const {
+    return blocklist_;
+  }
 
   void MemoryInfo(node::MemoryTracker* tracker) const override;
   SET_MEMORY_INFO_NAME(SocketAddressBlockListWrap)

--- a/src/node_sockaddr.h
+++ b/src/node_sockaddr.h
@@ -213,8 +213,9 @@ class SocketAddressLRU : public MemoryRetainer {
   // If the item already exists, returns a reference to
   // the existing item, adjusting items position in the
   // LRU. If the item does not exist, emplaces the item
-  // and returns the new item.
-  Type* Upsert(const SocketAddress& address);
+  // and returns the new item. The caller provides a
+  // timestamp to avoid redundant uv_hrtime() calls.
+  Type* Upsert(const SocketAddress& address, uint64_t now);
 
   // Returns a reference to the item if it exists, or
   // nullptr. The position in the LRU is not modified.
@@ -231,7 +232,7 @@ class SocketAddressLRU : public MemoryRetainer {
   using Pair = std::pair<SocketAddress, Type>;
   using Iterator = typename std::list<Pair>::iterator;
 
-  void CheckExpired();
+  void CheckExpired(uint64_t now);
 
   std::list<Pair> list_;
   SocketAddress::Map<Iterator> map_;

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -115,6 +115,13 @@ Maybe<Session::Application_Options> Session::Application_Options::From(
 
 #undef SET
 
+  // Ensure the advertised max_field_section_size in SETTINGS is at least
+  // as large as max_header_length. Otherwise the peer would be told to
+  // restrict headers to a smaller size than what CanAddHeader accepts.
+  if (options.max_field_section_size < options.max_header_length) {
+    options.max_field_section_size = options.max_header_length;
+  }
+
   return Just<Application_Options>(options);
 }
 

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -724,8 +724,11 @@ class DefaultApplication final : public Session::Application {
 
   void EarlyDataRejected() override {
     // Destroy all open streams — ngtcp2 has already discarded their
-    // internal state when it rejected the early data.
-    session().DestroyAllStreams(QuicError::ForApplication(0));
+    // internal state when it rejected the early data. Use the
+    // application's internal error code since this is an error
+    // condition (code 0 would be treated as a clean close).
+    session().DestroyAllStreams(
+        QuicError::ForApplication(GetInternalErrorCode()));
     if (!session().is_destroyed()) {
       session().EmitEarlyDataRejected();
     }

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -125,6 +125,8 @@ class SessionManager;
   V(version_negotiation_burst, "versionNegotiationBurst")                      \
   V(immediate_close_rate, "immediateCloseRate")                                \
   V(immediate_close_burst, "immediateCloseBurst")                              \
+  V(session_creation_rate, "sessionCreationRate")                              \
+  V(session_creation_burst, "sessionCreationBurst")                            \
   V(max_stream_window, "maxStreamWindow")                                      \
   V(max_window, "maxWindow")                                                   \
   V(min_version, "minVersion")                                                 \

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -113,6 +113,7 @@ class SessionManager;
   V(max_connections_total, "maxConnectionsTotal")                              \
   V(max_datagram_frame_size, "maxDatagramFrameSize")                           \
   V(max_datagram_send_attempts, "maxDatagramSendAttempts")                     \
+  V(stream_idle_timeout, "streamIdleTimeout")                                  \
   V(max_field_section_size, "maxFieldSectionSize")                             \
   V(max_header_length, "maxHeaderLength")                                      \
   V(max_header_pairs, "maxHeaderPairs")                                        \

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -117,8 +117,14 @@ class SessionManager;
   V(idle_timeout, "idleTimeout")                                               \
   V(max_idle_timeout, "maxIdleTimeout")                                        \
   V(max_payload_size, "maxPayloadSize")                                        \
-  V(max_retries, "maxRetries")                                                 \
-  V(max_stateless_resets, "maxStatelessResetsPerHost")                         \
+  V(retry_rate, "retryRate")                                                   \
+  V(retry_burst, "retryBurst")                                                 \
+  V(stateless_reset_rate, "statelessResetRate")                                \
+  V(stateless_reset_burst, "statelessResetBurst")                              \
+  V(version_negotiation_rate, "versionNegotiationRate")                        \
+  V(version_negotiation_burst, "versionNegotiationBurst")                      \
+  V(immediate_close_rate, "immediateCloseRate")                                \
+  V(immediate_close_burst, "immediateCloseBurst")                              \
   V(max_stream_window, "maxStreamWindow")                                      \
   V(max_window, "maxWindow")                                                   \
   V(min_version, "minVersion")                                                 \

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -164,6 +164,7 @@ class SessionManager;
   V(unacknowledged_packet_threshold, "unacknowledgedPacketThreshold")          \
   V(validate_address, "validateAddress")                                       \
   V(verify_client, "verifyClient")                                             \
+  V(verify_peer_strict, "verifyPeerStrict")                                    \
   V(verify_private_key, "verifyPrivateKey")                                    \
   V(version, "version")
 

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -169,6 +169,7 @@ class SessionManager;
   V(unacknowledged_packet_threshold, "unacknowledgedPacketThreshold")          \
   V(validate_address, "validateAddress")                                       \
   V(verify_client, "verifyClient")                                             \
+  V(verify_hostname, "verifyHostname")                                         \
   V(verify_peer_strict, "verifyPeerStrict")                                    \
   V(verify_private_key, "verifyPrivateKey")                                    \
   V(version, "version")

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -70,6 +70,7 @@ class SessionManager;
   V(ack_delay_exponent, "ackDelayExponent")                                    \
   V(active_connection_id_limit, "activeConnectionIDLimit")                     \
   V(address_lru_size, "addressLRUSize")                                        \
+  V(allow, "allow")                                                            \
   V(application, "application")                                                \
   V(authoritative, "authoritative")                                            \
   V(bbr, "bbr")                                                                \
@@ -81,6 +82,7 @@ class SessionManager;
   V(crl, "crl")                                                                \
   V(cubic, "cubic")                                                            \
   V(datagram_drop_policy, "datagramDropPolicy")                                \
+  V(deny, "deny")                                                              \
   V(disable_stateless_reset, "disableStatelessReset")                          \
   V(draining_period_multiplier, "drainingPeriodMultiplier")                    \
   V(enable_connect_protocol, "enableConnectProtocol")                          \
@@ -127,6 +129,8 @@ class SessionManager;
   V(immediate_close_burst, "immediateCloseBurst")                              \
   V(session_creation_rate, "sessionCreationRate")                              \
   V(session_creation_burst, "sessionCreationBurst")                            \
+  V(block_list, "blockList")                                                   \
+  V(block_list_policy, "blockListPolicy")                                      \
   V(max_stream_window, "maxStreamWindow")                                      \
   V(max_window, "maxWindow")                                                   \
   V(min_version, "minVersion")                                                 \

--- a/src/quic/data.cc
+++ b/src/quic/data.cc
@@ -365,12 +365,12 @@ std::optional<int> QuicError::get_crypto_error() const {
 
 MaybeLocal<Value> QuicError::ToV8Value(Environment* env) const {
   if ((type() == Type::TRANSPORT && code() == NGTCP2_NO_ERROR) ||
-      (type() == Type::APPLICATION && code() == NGHTTP3_H3_NO_ERROR) ||
+      (type() == Type::APPLICATION &&
+       (code() == 0 || code() == NGHTTP3_H3_NO_ERROR)) ||
       type() == Type::IDLE_CLOSE) {
-    // Note that we only return undefined for *known* no-error application
-    // codes. It is possible that other application types use other specific
-    // no-error codes, but since we don't know which application is being used,
-    // we'll just return the error code value for those below.
+    // Application code 0 is the default no-error code for raw QUIC
+    // applications (DefaultApplication::GetNoErrorCode() returns 0).
+    // NGHTTP3_H3_NO_ERROR (0x100) is the HTTP/3 no-error code.
     // Idle close is always clean — the session timed out normally.
     return Undefined(env->isolate());
   }

--- a/src/quic/defs.h
+++ b/src/quic/defs.h
@@ -360,6 +360,24 @@ constexpr auto kSocketAddressInfoTimeout = 60 * NGTCP2_SECONDS;
 constexpr size_t kMaxVectorCount = 16;
 constexpr stream_id kMaxStreamId = std::numeric_limits<stream_id>::max();
 
+// A token bucket rate limiter using lazy refill. No timer needed — tokens
+// are computed on demand from the elapsed time since the last check.
+// Used to cap the total rate of stateless responses (retry, reset,
+// version negotiation, immediate close) regardless of source address,
+// preventing spoofed-source floods from bypassing per-host limits.
+struct TokenBucket final {
+  double rate;       // tokens per second (refill rate)
+  double burst;      // maximum tokens (bucket capacity)
+  double tokens;     // current token count
+  uint64_t last_ts;  // last refill timestamp (nanoseconds, uv_hrtime)
+
+  TokenBucket(double rate, double burst);
+
+  // Try to consume one token. Refills based on elapsed time, then
+  // attempts to consume. Returns true if the request is allowed.
+  bool consume();
+};
+
 class DebugIndentScope final {
  public:
   inline DebugIndentScope() { ++indent_; }

--- a/src/quic/defs.h
+++ b/src/quic/defs.h
@@ -378,11 +378,13 @@ struct TokenBucket final {
   // hasn't been initialized yet (last_ts == 0). Used for per-host
   // buckets in the address LRU where the rate/burst aren't known
   // at construction time.
-  void InitOnce(double r, double b);
+  void InitOnce(double r, double b, uint64_t now);
 
   // Try to consume one token. Refills based on elapsed time, then
   // attempts to consume. Returns true if the request is allowed.
-  bool consume();
+  // The caller provides the current timestamp to avoid redundant
+  // uv_hrtime() calls in hot paths.
+  bool consume(uint64_t now);
 };
 
 class DebugIndentScope final {

--- a/src/quic/defs.h
+++ b/src/quic/defs.h
@@ -371,7 +371,14 @@ struct TokenBucket final {
   double tokens;     // current token count
   uint64_t last_ts;  // last refill timestamp (nanoseconds, uv_hrtime)
 
+  TokenBucket() : rate(0), burst(0), tokens(0), last_ts(0) {}
   TokenBucket(double rate, double burst);
+
+  // Reinitialize the bucket with new rate/burst parameters if it
+  // hasn't been initialized yet (last_ts == 0). Used for per-host
+  // buckets in the address LRU where the rate/burst aren't known
+  // at construction time.
+  void InitOnce(double r, double b);
 
   // Try to consume one token. Refills based on elapsed time, then
   // attempts to consume. Returns true if the request is allowed.

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -93,19 +93,18 @@ STAT_STRUCT(Endpoint, ENDPOINT)
 TokenBucket::TokenBucket(double rate, double burst)
     : rate(rate), burst(burst), tokens(burst), last_ts(uv_hrtime()) {}
 
-void TokenBucket::InitOnce(double r, double b) {
+void TokenBucket::InitOnce(double r, double b, uint64_t now) {
   if (last_ts == 0) {
     rate = r;
     burst = b;
     tokens = b;
-    last_ts = uv_hrtime();
+    last_ts = now;
   }
 }
 
 // Try to consume one token. Refills based on elapsed time, then
 // attempts to consume. Returns true if the request is allowed.
-bool TokenBucket::consume() {
-  uint64_t now = uv_hrtime();
+bool TokenBucket::consume(uint64_t now) {
   double elapsed = static_cast<double>(now - last_ts) / 1e9;  // seconds
   last_ts = now;
   tokens = std::min(burst, tokens + elapsed * rate);
@@ -1026,9 +1025,9 @@ void Endpoint::SendBatch(Packet::Ptr* packets, size_t count) {
   }
 }
 
-void Endpoint::SendRetry(const PathDescriptor& options) {
+void Endpoint::SendRetry(const PathDescriptor& options, uint64_t now) {
   Debug(this, "Sending retry on path %s", options);
-  if (!retry_bucket_.consume()) {
+  if (!retry_bucket_.consume(now)) {
     Debug(this, "Retry rate limit exceeded (global)");
     STAT_INCREMENT(Stats, retry_rate_limited);
     return;
@@ -1042,9 +1041,10 @@ void Endpoint::SendRetry(const PathDescriptor& options) {
   }
 }
 
-void Endpoint::SendVersionNegotiation(const PathDescriptor& options) {
+void Endpoint::SendVersionNegotiation(const PathDescriptor& options,
+                                      uint64_t now) {
   Debug(this, "Sending version negotiation on path %s", options);
-  if (!version_negotiation_bucket_.consume()) {
+  if (!version_negotiation_bucket_.consume(now)) {
     Debug(this, "Version negotiation rate limit exceeded (global)");
     STAT_INCREMENT(Stats, version_negotiation_rate_limited);
     return;
@@ -1058,7 +1058,8 @@ void Endpoint::SendVersionNegotiation(const PathDescriptor& options) {
 }
 
 bool Endpoint::SendStatelessReset(const PathDescriptor& options,
-                                  size_t source_len) {
+                                  size_t source_len,
+                                  uint64_t now) {
   if (options_.disable_stateless_reset) [[unlikely]] {
     return false;
   }
@@ -1067,7 +1068,7 @@ bool Endpoint::SendStatelessReset(const PathDescriptor& options,
         options,
         source_len);
 
-  if (!stateless_reset_bucket_.consume()) {
+  if (!stateless_reset_bucket_.consume(now)) {
     Debug(this, "Stateless reset rate limit exceeded (global)");
     STAT_INCREMENT(Stats, stateless_reset_rate_limited);
     return false;
@@ -1087,12 +1088,13 @@ bool Endpoint::SendStatelessReset(const PathDescriptor& options,
 }
 
 void Endpoint::SendImmediateConnectionClose(const PathDescriptor& options,
-                                            QuicError reason) {
+                                            QuicError reason,
+                                            uint64_t now) {
   Debug(this,
         "Sending immediate connection close on path %s with reason %s",
         options,
         reason);
-  if (!immediate_close_bucket_.consume()) {
+  if (!immediate_close_bucket_.consume(now)) {
     Debug(this, "Immediate connection close rate limit exceeded (global)");
     STAT_INCREMENT(Stats, immediate_close_rate_limited);
     return;
@@ -1314,6 +1316,8 @@ void Endpoint::CloseGracefully() {
 void Endpoint::Receive(const uint8_t* data,
                        size_t len,
                        const SocketAddress& remote_address) {
+  const uint64_t now = uv_hrtime();
+
   const auto receive = [&](Session* session,
                            const uint8_t* pkt_data,
                            size_t pkt_len,
@@ -1328,7 +1332,12 @@ void Endpoint::Receive(const uint8_t* data,
     // are generated. The deferred flush via BindingData's uv_check
     // callback calls SendPendingData once per dirty session after all
     // packets in the burst have been read.
-    if (session->ReadPacket(pkt_data, pkt_len, local_address, remote_address)) {
+    if (session->ReadPacket(pkt_data,
+                            pkt_len,
+                            local_address,
+                            remote_address,
+                            PacketInfo(),
+                            now)) {
       STAT_INCREMENT_N(Stats, bytes_received, pkt_len);
       STAT_INCREMENT(Stats, packets_received);
     }
@@ -1350,10 +1359,10 @@ void Endpoint::Receive(const uint8_t* data,
 
     // Per-host session creation rate limit. The bucket is initialized
     // on first access with the configured rate/burst from options.
-    auto info = addr_validation_lru_.Upsert(config.remote_address);
-    info->session_creation_bucket.InitOnce(options_.session_creation_rate,
-                                           options_.session_creation_burst);
-    if (!info->session_creation_bucket.consume()) {
+    auto info = addr_validation_lru_.Upsert(config.remote_address, now);
+    info->session_creation_bucket.InitOnce(
+        options_.session_creation_rate, options_.session_creation_burst, now);
+    if (!info->session_creation_bucket.consume(now)) {
       Debug(this,
             "Session creation rate limit exceeded for %s",
             config.remote_address);
@@ -1452,7 +1461,8 @@ void Endpoint::Receive(const uint8_t* data,
       if (state_->busy) STAT_INCREMENT(Stats, server_busy_count);
       SendImmediateConnectionClose(
           PathDescriptor{version, dcid, scid, local_address, remote_address},
-          QuicError::ForTransport(NGTCP2_CONNECTION_REFUSED));
+          QuicError::ForTransport(NGTCP2_CONNECTION_REFUSED),
+          now);
       // The packet was successfully processed, even if we did refuse the
       // connection.
       STAT_INCREMENT(Stats, packets_received);
@@ -1526,7 +1536,8 @@ void Endpoint::Receive(const uint8_t* data,
         Debug(this, "Retry token from %s is invalid.", remote_address);
         SendImmediateConnectionClose(
             PathDescriptor{version, scid, dcid, local_address, remote_address},
-            QuicError::ForTransport(NGTCP2_CONNECTION_REFUSED));
+            QuicError::ForTransport(NGTCP2_CONNECTION_REFUSED),
+            now);
         STAT_INCREMENT(Stats, packets_received);
         return;
       }
@@ -1542,7 +1553,7 @@ void Endpoint::Receive(const uint8_t* data,
       // Mark the address as validated since the retry round-trip proves
       // reachability.
       Debug(this, "Remote address %s is validated", remote_address);
-      addr_validation_lru_.Upsert(remote_address)->validated = true;
+      addr_validation_lru_.Upsert(remote_address, now)->validated = true;
     }
 
     // Step 2: Address validation — decide whether to send a Retry or
@@ -1558,13 +1569,15 @@ void Endpoint::Receive(const uint8_t* data,
                     "Initial packet has no token. Sending retry to %s to start "
                     "validation",
                     remote_address);
-              SendRetry(PathDescriptor{
-                  version,
-                  dcid,
-                  scid,
-                  local_address,
-                  remote_address,
-              });
+              SendRetry(
+                  PathDescriptor{
+                      version,
+                      dcid,
+                      scid,
+                      local_address,
+                      remote_address,
+                  },
+                  now);
               STAT_INCREMENT(Stats, packets_received);
               return;
             }
@@ -1585,13 +1598,15 @@ void Endpoint::Receive(const uint8_t* data,
                   Debug(this,
                         "Regular token from %s is invalid.",
                         remote_address);
-                  SendRetry(PathDescriptor{
-                      version,
-                      dcid,
-                      scid,
-                      local_address,
-                      remote_address,
-                  });
+                  SendRetry(
+                      PathDescriptor{
+                          version,
+                          dcid,
+                          scid,
+                          local_address,
+                          remote_address,
+                      },
+                      now);
                   STAT_INCREMENT(Stats, packets_received);
                   return;
                 }
@@ -1603,20 +1618,22 @@ void Endpoint::Receive(const uint8_t* data,
                 Debug(this,
                       "Initial packet from %s has unknown token type",
                       remote_address);
-                SendRetry(PathDescriptor{
-                    version,
-                    dcid,
-                    scid,
-                    local_address,
-                    remote_address,
-                });
+                SendRetry(
+                    PathDescriptor{
+                        version,
+                        dcid,
+                        scid,
+                        local_address,
+                        remote_address,
+                    },
+                    now);
                 STAT_INCREMENT(Stats, packets_received);
                 return;
               }
             }
 
             Debug(this, "Remote address %s is validated", remote_address);
-            addr_validation_lru_.Upsert(remote_address)->validated = true;
+            addr_validation_lru_.Upsert(remote_address, now)->validated = true;
           } else if (hd.tokenlen > 0) {
             Debug(this,
                   "Ignoring initial packet from %s with unexpected token",
@@ -1628,13 +1645,15 @@ void Endpoint::Receive(const uint8_t* data,
           if (options_.validate_address) {
             Debug(
                 this, "Sending retry to %s due to 0RTT packet", remote_address);
-            SendRetry(PathDescriptor{
-                version,
-                dcid,
-                scid,
-                local_address,
-                remote_address,
-            });
+            SendRetry(
+                PathDescriptor{
+                    version,
+                    dcid,
+                    scid,
+                    local_address,
+                    remote_address,
+                },
+                now);
             STAT_INCREMENT(Stats, packets_received);
             return;
           }
@@ -1743,8 +1762,12 @@ void Endpoint::Receive(const uint8_t* data,
             pversion_cid.version);
       CID dcid(pversion_cid.dcid, pversion_cid.dcidlen);
       CID scid(pversion_cid.scid, pversion_cid.scidlen);
-      SendVersionNegotiation(PathDescriptor{
-          pversion_cid.version, dcid, scid, local_address(), remote_address});
+      SendVersionNegotiation(PathDescriptor{pversion_cid.version,
+                                            dcid,
+                                            scid,
+                                            local_address(),
+                                            remote_address},
+                             now);
       STAT_INCREMENT(Stats, packets_received);
       return;
     }
@@ -1823,7 +1846,8 @@ void Endpoint::Receive(const uint8_t* data,
       SendStatelessReset(
           PathDescriptor{
               pversion_cid.version, dcid, scid, addr, remote_address},
-          len);
+          len,
+          now);
       return;
     }
 
@@ -1885,13 +1909,14 @@ void Endpoint::MemoryInfo(MemoryTracker* tracker) const {
 // Endpoint::SocketAddressInfoTraits
 
 bool Endpoint::SocketAddressInfoTraits::CheckExpired(
-    const SocketAddress& address, const Type& type) {
-  return (uv_hrtime() - type.timestamp) > kSocketAddressInfoTimeout;
+    const SocketAddress& address, const Type& type, uint64_t now) {
+  return (now - type.timestamp) > kSocketAddressInfoTimeout;
 }
 
 void Endpoint::SocketAddressInfoTraits::Touch(const SocketAddress& address,
-                                              Type* type) {
-  type->timestamp = uv_hrtime();
+                                              Type* type,
+                                              uint64_t now) {
+  type->timestamp = now;
 }
 
 // ======================================================================================

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -73,9 +73,13 @@ namespace quic {
   V(CLIENT_SESSIONS, client_sessions)                                          \
   V(SERVER_BUSY_COUNT, server_busy_count)                                      \
   V(RETRY_COUNT, retry_count)                                                  \
+  V(RETRY_RATE_LIMITED, retry_rate_limited)                                    \
   V(VERSION_NEGOTIATION_COUNT, version_negotiation_count)                      \
+  V(VERSION_NEGOTIATION_RATE_LIMITED, version_negotiation_rate_limited)        \
   V(STATELESS_RESET_COUNT, stateless_reset_count)                              \
-  V(IMMEDIATE_CLOSE_COUNT, immediate_close_count)
+  V(STATELESS_RESET_RATE_LIMITED, stateless_reset_rate_limited)                \
+  V(IMMEDIATE_CLOSE_COUNT, immediate_close_count)                              \
+  V(IMMEDIATE_CLOSE_RATE_LIMITED, immediate_close_rate_limited)
 
 struct Endpoint::State {
 #define V(_, name, type) type name;
@@ -84,6 +88,23 @@ struct Endpoint::State {
 };
 
 STAT_STRUCT(Endpoint, ENDPOINT)
+
+TokenBucket::TokenBucket(double rate, double burst)
+    : rate(rate), burst(burst), tokens(burst), last_ts(uv_hrtime()) {}
+
+// Try to consume one token. Refills based on elapsed time, then
+// attempts to consume. Returns true if the request is allowed.
+bool TokenBucket::consume() {
+  uint64_t now = uv_hrtime();
+  double elapsed = static_cast<double>(now - last_ts) / 1e9;  // seconds
+  last_ts = now;
+  tokens = std::min(burst, tokens + elapsed * rate);
+  if (tokens >= 1.0) {
+    tokens -= 1.0;
+    return true;
+  }
+  return false;
+}
 
 // ============================================================================
 // Endpoint::Options
@@ -97,6 +118,7 @@ bool is_diagnostic_packet_loss(double probability) {
   CHECK(ncrypto::CSPRNG(&c, 1));
   return (static_cast<double>(c) / 255) < probability;
 }
+#endif  // DEBUG
 
 template <typename Opt, double Opt::*member>
 bool SetOption(Environment* env,
@@ -106,18 +128,24 @@ bool SetOption(Environment* env,
   Local<Value> value;
   if (!object->Get(env->context(), name).ToLocal(&value)) return false;
   if (!value->IsUndefined()) {
-    Local<Number> num;
-    if (!value->ToNumber(env->context()).ToLocal(&num)) {
+    if (!value->IsNumber()) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
           env, "The %s option must be a number", nameStr);
       return false;
     }
-    options->*member = num->Value();
+    Local<Number> num = value.As<Number>();
+    double dbl = num->Value();
+    if (dbl < 0) {
+      Utf8Value nameStr(env->isolate(), name);
+      THROW_ERR_INVALID_ARG_VALUE(
+          env, "The %s option must be a non-negative number", nameStr);
+      return false;
+    }
+    options->*member = dbl;
   }
   return true;
 }
-#endif  // DEBUG
 
 template <typename Opt, uint8_t Opt::*member>
 bool SetOption(Environment* env,
@@ -133,15 +161,15 @@ bool SetOption(Environment* env,
           env, "The %s option must be an uint8", nameStr);
       return false;
     }
-    Local<Uint32> num;
-    if (!value->ToUint32(env->context()).ToLocal(&num) ||
-        num->Value() > std::numeric_limits<uint8_t>::max()) {
+    Local<Uint32> num = value.As<Uint32>();
+    uint32_t val = num->Value();
+    if (val > std::numeric_limits<uint8_t>::max()) {
       Utf8Value nameStr(env->isolate(), name);
       THROW_ERR_INVALID_ARG_VALUE(
           env, "The %s option must be an uint8", nameStr);
       return false;
     }
-    options->*member = num->Value();
+    options->*member = val;
   }
   return true;
 }
@@ -195,9 +223,12 @@ Maybe<Endpoint::Options> Endpoint::Options::From(Environment* env,
       env, &options, params, state.name##_string())
 
   if (!SET(retry_token_expiration) || !SET(token_expiration) ||
-      !SET(max_stateless_resets) || !SET(address_lru_size) ||
-      !SET(max_retries) || !SET(validate_address) ||
+      !SET(address_lru_size) || !SET(validate_address) ||
       !SET(disable_stateless_reset) || !SET(ipv6_only) || !SET(reuse_port) ||
+      !SET(retry_rate) || !SET(retry_burst) || !SET(stateless_reset_rate) ||
+      !SET(stateless_reset_burst) || !SET(version_negotiation_rate) ||
+      !SET(version_negotiation_burst) || !SET(immediate_close_rate) ||
+      !SET(immediate_close_burst) ||
 #ifdef DEBUG
       !SET(rx_loss) || !SET(tx_loss) ||
 #endif
@@ -251,10 +282,21 @@ std::string Endpoint::Options::ToString() const {
          " seconds";
   res += prefix + "token expiration: " + std::to_string(token_expiration) +
          " seconds";
-  res +=
-      prefix + "max stateless resets: " + std::to_string(max_stateless_resets);
   res += prefix + "address lru size: " + std::to_string(address_lru_size);
-  res += prefix + "max retries: " + std::to_string(max_retries);
+  res += prefix + "retry rate: " + std::to_string(retry_rate) + "/s";
+  res += prefix + "retry burst: " + std::to_string(retry_burst);
+  res += prefix +
+         "stateless reset rate: " + std::to_string(stateless_reset_rate) + "/s";
+  res += prefix +
+         "stateless reset burst: " + std::to_string(stateless_reset_burst);
+  res += prefix + "version negotiation rate: " +
+         std::to_string(version_negotiation_rate) + "/s";
+  res += prefix + "version negotiation burst: " +
+         std::to_string(version_negotiation_burst);
+  res += prefix +
+         "immediate close rate: " + std::to_string(immediate_close_rate) + "/s";
+  res += prefix +
+         "immediate close burst: " + std::to_string(immediate_close_burst);
   res += prefix + "validate address: " + boolToString(validate_address);
   res += prefix +
          "disable stateless reset: " + boolToString(disable_stateless_reset);
@@ -580,8 +622,6 @@ void Endpoint::InitPerContext(Realm* realm, Local<Object> target) {
 #undef V
 
   NODE_DEFINE_CONSTANT(target, DEFAULT_MAX_SOCKETADDRESS_LRU_SIZE);
-  NODE_DEFINE_CONSTANT(target, DEFAULT_MAX_STATELESS_RESETS);
-  NODE_DEFINE_CONSTANT(target, DEFAULT_MAX_RETRY_LIMIT);
 
   static constexpr auto DEFAULT_RETRYTOKEN_EXPIRATION =
       RetryToken::QUIC_DEFAULT_RETRYTOKEN_EXPIRATION / NGTCP2_SECONDS;
@@ -643,7 +683,14 @@ Endpoint::Endpoint(Environment* env,
                     HandleScope scope(this->env()->isolate());
                     Destroy();
                   }),
-      addr_validation_lru_(options_.address_lru_size) {
+      addr_validation_lru_(options_.address_lru_size),
+      retry_bucket_(options_.retry_rate, options_.retry_burst),
+      stateless_reset_bucket_(options_.stateless_reset_rate,
+                              options_.stateless_reset_burst),
+      version_negotiation_bucket_(options_.version_negotiation_rate,
+                                  options_.version_negotiation_burst),
+      immediate_close_bucket_(options_.immediate_close_rate,
+                              options_.immediate_close_burst) {
   MakeWeak();
   udp_.Unref();
   idle_timer_.Unref();
@@ -964,55 +1011,31 @@ void Endpoint::SendBatch(Packet::Ptr* packets, size_t count) {
 }
 
 void Endpoint::SendRetry(const PathDescriptor& options) {
-  // Generating and sending retry packets does consume some system resources,
-  // and it is possible for a malicious peer to trigger sending a large number
-  // of retry packets, resulting in a potential DOS vector. To help ward that
-  // off, we track how many retry packets we send to a particular host and
-  // enforce limits. Note that since we are using an LRU cache these limits
-  // aren't strict. If a retry is sent, we increment the retry_count statistic
-  // to give application code a means of detecting and responding to abuse on
-  // its own. What this count does not give is the rate of retry, so it is still
-  // somewhat limited.
   Debug(this, "Sending retry on path %s", options);
-  auto info = addr_validation_lru_.Upsert(options.remote_address);
-  if (++(info->retry_count) <= options_.max_retries) {
-    auto packet =
-        Packet::CreateRetryPacket(*this, options, options_.token_secret);
-    if (packet) {
-      STAT_INCREMENT(Stats, retry_count);
-      Send(std::move(packet));
-    }
+  if (!retry_bucket_.consume()) {
+    Debug(this, "Retry rate limit exceeded (global)");
+    STAT_INCREMENT(Stats, retry_rate_limited);
+    return;
+  }
 
-    // If creating the retry is unsuccessful, we just drop things on the floor.
-    // It's not worth committing any further resources to this one packet. We
-    // might want to log the failure at some point tho.
+  auto packet =
+      Packet::CreateRetryPacket(*this, options, options_.token_secret);
+  if (packet) {
+    STAT_INCREMENT(Stats, retry_count);
+    Send(std::move(packet));
   }
 }
 
 void Endpoint::SendVersionNegotiation(const PathDescriptor& options) {
   Debug(this, "Sending version negotiation on path %s", options);
-  // A malicious peer can trivially force version negotiation packets by
-  // sending packets with unsupported QUIC versions, potentially from
-  // spoofed source addresses. Rate-limit per remote host to prevent
-  // amplification attacks.
-  const auto exceeds_limits = [&] {
-    SocketAddressInfoTraits::Type* counts =
-        addr_validation_lru_.Peek(options.remote_address);
-    auto count = counts != nullptr ? counts->version_negotiation_count : 0;
-    return count >= kMaxVersionNegotiations;
-  };
-
-  if (exceeds_limits()) {
-    Debug(this,
-          "Version negotiation rate limit exceeded for %s",
-          options.remote_address);
+  if (!version_negotiation_bucket_.consume()) {
+    Debug(this, "Version negotiation rate limit exceeded (global)");
+    STAT_INCREMENT(Stats, version_negotiation_rate_limited);
     return;
   }
 
   auto packet = Packet::CreateVersionNegotiationPacket(*this, options);
   if (packet) {
-    addr_validation_lru_.Upsert(options.remote_address)
-        ->version_negotiation_count++;
     STAT_INCREMENT(Stats, version_negotiation_count);
     Send(std::move(packet));
   }
@@ -1028,17 +1051,9 @@ bool Endpoint::SendStatelessReset(const PathDescriptor& options,
         options,
         source_len);
 
-  const auto exceeds_limits = [&] {
-    SocketAddressInfoTraits::Type* counts =
-        addr_validation_lru_.Peek(options.remote_address);
-    auto count = counts != nullptr ? counts->reset_count : 0;
-    return count >= options_.max_stateless_resets;
-  };
-
-  // Per the QUIC spec, we need to protect against sending too many stateless
-  // reset tokens to an endpoint to prevent endless looping.
-  if (exceeds_limits()) {
-    Debug(this, "Stateless reset rate limit exceeded");
+  if (!stateless_reset_bucket_.consume()) {
+    Debug(this, "Stateless reset rate limit exceeded (global)");
+    STAT_INCREMENT(Stats, stateless_reset_rate_limited);
     return false;
   }
 
@@ -1047,7 +1062,6 @@ bool Endpoint::SendStatelessReset(const PathDescriptor& options,
 
   if (packet) {
     Debug(this, "Sending stateless reset packet (%zu bytes)", packet->length());
-    addr_validation_lru_.Upsert(options.remote_address)->reset_count++;
     STAT_INCREMENT(Stats, stateless_reset_count);
     Send(std::move(packet));
     return true;
@@ -1062,28 +1076,15 @@ void Endpoint::SendImmediateConnectionClose(const PathDescriptor& options,
         "Sending immediate connection close on path %s with reason %s",
         options,
         reason);
-  // A malicious peer can trigger immediate connection close packets by
-  // sending Initial packets with invalid tokens or when the server is
-  // busy. Rate-limit per remote host to prevent amplification attacks.
-  const auto exceeds_limits = [&] {
-    SocketAddressInfoTraits::Type* counts =
-        addr_validation_lru_.Peek(options.remote_address);
-    auto count = counts != nullptr ? counts->immediate_close_count : 0;
-    return count >= kMaxImmediateCloses;
-  };
-
-  if (exceeds_limits()) {
-    Debug(this,
-          "Immediate connection close rate limit exceeded for %s",
-          options.remote_address);
+  if (!immediate_close_bucket_.consume()) {
+    Debug(this, "Immediate connection close rate limit exceeded (global)");
+    STAT_INCREMENT(Stats, immediate_close_rate_limited);
     return;
   }
 
   auto packet =
       Packet::CreateImmediateConnectionClosePacket(*this, options, reason);
   if (packet) {
-    addr_validation_lru_.Upsert(options.remote_address)
-        ->immediate_close_count++;
     STAT_INCREMENT(Stats, immediate_close_count);
     Send(std::move(packet));
   }

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -79,7 +79,8 @@ namespace quic {
   V(STATELESS_RESET_COUNT, stateless_reset_count)                              \
   V(STATELESS_RESET_RATE_LIMITED, stateless_reset_rate_limited)                \
   V(IMMEDIATE_CLOSE_COUNT, immediate_close_count)                              \
-  V(IMMEDIATE_CLOSE_RATE_LIMITED, immediate_close_rate_limited)
+  V(IMMEDIATE_CLOSE_RATE_LIMITED, immediate_close_rate_limited)                \
+  V(SESSION_CREATION_RATE_LIMITED, session_creation_rate_limited)
 
 struct Endpoint::State {
 #define V(_, name, type) type name;
@@ -91,6 +92,15 @@ STAT_STRUCT(Endpoint, ENDPOINT)
 
 TokenBucket::TokenBucket(double rate, double burst)
     : rate(rate), burst(burst), tokens(burst), last_ts(uv_hrtime()) {}
+
+void TokenBucket::InitOnce(double r, double b) {
+  if (last_ts == 0) {
+    rate = r;
+    burst = b;
+    tokens = b;
+    last_ts = uv_hrtime();
+  }
+}
 
 // Try to consume one token. Refills based on elapsed time, then
 // attempts to consume. Returns true if the request is allowed.
@@ -228,7 +238,8 @@ Maybe<Endpoint::Options> Endpoint::Options::From(Environment* env,
       !SET(retry_rate) || !SET(retry_burst) || !SET(stateless_reset_rate) ||
       !SET(stateless_reset_burst) || !SET(version_negotiation_rate) ||
       !SET(version_negotiation_burst) || !SET(immediate_close_rate) ||
-      !SET(immediate_close_burst) ||
+      !SET(immediate_close_burst) || !SET(session_creation_rate) ||
+      !SET(session_creation_burst) ||
 #ifdef DEBUG
       !SET(rx_loss) || !SET(tx_loss) ||
 #endif
@@ -297,6 +308,11 @@ std::string Endpoint::Options::ToString() const {
          "immediate close rate: " + std::to_string(immediate_close_rate) + "/s";
   res += prefix +
          "immediate close burst: " + std::to_string(immediate_close_burst);
+  res += prefix +
+         "session creation rate: " + std::to_string(session_creation_rate) +
+         "/s";
+  res += prefix +
+         "session creation burst: " + std::to_string(session_creation_burst);
   res += prefix + "validate address: " + boolToString(validate_address);
   res += prefix +
          "disable stateless reset: " + boolToString(disable_stateless_reset);
@@ -1331,6 +1347,19 @@ void Endpoint::Receive(const uint8_t* data,
     // One final check. If the endpoint is closed, closing, or is not listening
     // as a server, then we cannot accept the initial packet.
     if (is_closed() || is_closing() || !is_listening()) return;
+
+    // Per-host session creation rate limit. The bucket is initialized
+    // on first access with the configured rate/burst from options.
+    auto info = addr_validation_lru_.Upsert(config.remote_address);
+    info->session_creation_bucket.InitOnce(options_.session_creation_rate,
+                                           options_.session_creation_burst);
+    if (!info->session_creation_bucket.consume()) {
+      Debug(this,
+            "Session creation rate limit exceeded for %s",
+            config.remote_address);
+      STAT_INCREMENT(Stats, session_creation_rate_limited);
+      return;
+    }
 
     Debug(this, "Creating new session for %s", config.dcid);
 

--- a/src/quic/endpoint.cc
+++ b/src/quic/endpoint.cc
@@ -80,7 +80,8 @@ namespace quic {
   V(STATELESS_RESET_RATE_LIMITED, stateless_reset_rate_limited)                \
   V(IMMEDIATE_CLOSE_COUNT, immediate_close_count)                              \
   V(IMMEDIATE_CLOSE_RATE_LIMITED, immediate_close_rate_limited)                \
-  V(SESSION_CREATION_RATE_LIMITED, session_creation_rate_limited)
+  V(SESSION_CREATION_RATE_LIMITED, session_creation_rate_limited)              \
+  V(PACKETS_BLOCKED, packets_blocked)
 
 struct Endpoint::State {
 #define V(_, name, type) type name;
@@ -264,6 +265,42 @@ Maybe<Endpoint::Options> Endpoint::Options::From(Environment* env,
     options.local_address = std::make_shared<SocketAddress>();
     if (!SocketAddress::New("127.0.0.1", 0, options.local_address.get())) {
       THROW_ERR_INVALID_ADDRESS(env);
+      return Nothing<Options>();
+    }
+  }
+
+  // Parse block list option. Expects the C++ SocketAddressBlockListWrap handle
+  // (the JS side extracts [kHandle] before passing it through).
+  Local<Value> block_list_val;
+  if (!params->Get(env->context(), state.block_list_string())
+           .ToLocal(&block_list_val)) {
+    return Nothing<Options>();
+  }
+  if (!block_list_val->IsUndefined()) {
+    if (!SocketAddressBlockListWrap::HasInstance(env, block_list_val)) {
+      THROW_ERR_INVALID_ARG_TYPE(
+          env, "The blockList option must be a BlockList handle");
+      return Nothing<Options>();
+    }
+    auto* wrap =
+        FromJSObject<SocketAddressBlockListWrap>(block_list_val.As<Object>());
+    options.block_list = wrap->blocklist();
+  }
+
+  // Parse block list policy.
+  Local<Value> policy_val;
+  if (!params->Get(env->context(), state.block_list_policy_string())
+           .ToLocal(&policy_val)) {
+    return Nothing<Options>();
+  }
+  if (!policy_val->IsUndefined()) {
+    if (policy_val->StrictEquals(state.allow_string())) {
+      options.block_list_policy = Options::BlockListPolicy::ALLOW;
+    } else if (policy_val->StrictEquals(state.deny_string())) {
+      options.block_list_policy = Options::BlockListPolicy::DENY;
+    } else {
+      THROW_ERR_INVALID_ARG_VALUE(
+          env, "The blockListPolicy option must be 'deny' or 'allow'");
       return Nothing<Options>();
     }
   }
@@ -1318,6 +1355,20 @@ void Endpoint::Receive(const uint8_t* data,
                        const SocketAddress& remote_address) {
   const uint64_t now = uv_hrtime();
 
+  // Block list filtering — applied before any packet processing to
+  // minimize resource expenditure on blocked sources.
+  if (options_.block_list) {
+    bool matched = options_.block_list->Apply(remote_address);
+    bool drop = (options_.block_list_policy == Options::BlockListPolicy::DENY)
+                    ? matched    // deny list: drop if address matches
+                    : !matched;  // allow list: drop if address doesn't match
+    if (drop) {
+      Debug(this, "Packet from %s blocked by block list", remote_address);
+      STAT_INCREMENT(Stats, packets_blocked);
+      return;
+    }
+  }
+
   const auto receive = [&](Session* session,
                            const uint8_t* pkt_data,
                            size_t pkt_len,
@@ -1732,12 +1783,6 @@ void Endpoint::Receive(const uint8_t* data,
     return;
   }
 #endif  // DEBUG
-
-  // TODO(@jasnell): Implement blocklist support
-  // if (block_list_->Apply(remote_address)) [[unlikely]] {
-  //   Debug(this, "Ignoring blocked remote address: %s", remote_address);
-  //   return;
-  // }
 
   Debug(this, "Received %zu-byte packet from %s", len, remote_address);
 

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -159,6 +159,17 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     static constexpr uint64_t DEFAULT_IDLE_TIMEOUT = 0;
     uint64_t idle_timeout = DEFAULT_IDLE_TIMEOUT;
 
+    // Optional block list for filtering incoming packets by source address.
+    // When block_list_policy is DENY, packets from addresses matching the
+    // block list are dropped. When ALLOW, only packets from addresses
+    // matching the block list are accepted (all others dropped).
+    enum class BlockListPolicy : uint8_t {
+      DENY,   // Drop packets from matching addresses (blocklist)
+      ALLOW,  // Drop packets from non-matching addresses (allowlist)
+    };
+    std::shared_ptr<SocketAddressBlockList> block_list;
+    BlockListPolicy block_list_policy = BlockListPolicy::DENY;
+
     void MemoryInfo(MemoryTracker* tracker) const override;
     SET_MEMORY_INFO_NAME(Endpoint::Config)
     SET_SELF_SIZE(Options)

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -44,6 +44,14 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
   static constexpr double DEFAULT_IMMEDIATE_CLOSE_RATE = 100;
   static constexpr double DEFAULT_IMMEDIATE_CLOSE_BURST = 200;
 
+  // Per-host session creation rate limit. This is tracked per validated
+  // remote address in the address LRU, preventing a single source from
+  // churning through sessions faster than the server can handle. Unlike
+  // the global stateless response buckets, this only applies after address
+  // validation (spoofed sources can't reach this path).
+  static constexpr double DEFAULT_SESSION_CREATION_RATE = 50;
+  static constexpr double DEFAULT_SESSION_CREATION_BURST = 100;
+
   // Endpoint configuration options
   struct Options final : public MemoryRetainer {
     // The local socket address to which the UDP port will be bound. The port
@@ -82,6 +90,12 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     double version_negotiation_burst = DEFAULT_VERSION_NEGOTIATION_BURST;
     double immediate_close_rate = DEFAULT_IMMEDIATE_CLOSE_RATE;
     double immediate_close_burst = DEFAULT_IMMEDIATE_CLOSE_BURST;
+
+    // Per-host session creation rate limit. Tracked per validated remote
+    // address in the address LRU. Set to high values for benchmarking
+    // where traffic comes from a single source.
+    double session_creation_rate = DEFAULT_SESSION_CREATION_RATE;
+    double session_creation_burst = DEFAULT_SESSION_CREATION_BURST;
 
     // The validate_address parameter instructs the Endpoint to perform explicit
     // address validation using retry tokens. This is strongly recommended and
@@ -452,6 +466,7 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     struct Type final {
       uint64_t timestamp;
       bool validated;
+      TokenBucket session_creation_bucket;
     };
 
     static bool CheckExpired(const SocketAddress& address, const Type& type);

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -252,24 +252,27 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
   // ellicit retry packets (It can do so by intentionally sending initial
   // packets that ignore the retry token). To help mitigate that risk, we limit
   // the number of retries we send to a given remote endpoint.
-  void SendRetry(const PathDescriptor& options);
+  void SendRetry(const PathDescriptor& options, uint64_t now);
 
   // Sends a version negotiation packet. This is terminal for the connection and
   // is sent only when a QUIC packet is received for an unsupported QUIC
   // version. It is possible that a malicious packet triggered this so we need
   // to be careful not to commit too many resources.
-  void SendVersionNegotiation(const PathDescriptor& options);
+  void SendVersionNegotiation(const PathDescriptor& options, uint64_t now);
 
   // Possibly generates and sends a stateless reset packet. This is terminal for
   // the connection. It is possible that a malicious packet triggered this so we
   // need to be careful not to commit too many resources.
-  bool SendStatelessReset(const PathDescriptor& options, size_t source_len);
+  bool SendStatelessReset(const PathDescriptor& options,
+                          size_t source_len,
+                          uint64_t now);
 
   // Shutdown a connection prematurely, before a Session is created. This should
   // only be called at the start of a session before the crypto keys have been
   // established.
   void SendImmediateConnectionClose(const PathDescriptor& options,
-                                    QuicError error);
+                                    QuicError error,
+                                    uint64_t now);
 
   // Listen for connections (act as a server).
   void Listen(const Session::Options& options);
@@ -469,8 +472,10 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
       TokenBucket session_creation_bucket;
     };
 
-    static bool CheckExpired(const SocketAddress& address, const Type& type);
-    static void Touch(const SocketAddress& address, Type* type);
+    static bool CheckExpired(const SocketAddress& address,
+                             const Type& type,
+                             uint64_t now);
+    static void Touch(const SocketAddress& address, Type* type, uint64_t now);
   };
 
   SocketAddressLRU<SocketAddressInfoTraits> addr_validation_lru_;

--- a/src/quic/endpoint.h
+++ b/src/quic/endpoint.h
@@ -29,37 +29,20 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
   // The socket address LRU is used for tracking validated remote addresses.
   static constexpr uint64_t DEFAULT_MAX_SOCKETADDRESS_LRU_SIZE = 1024;
 
-  // The max stateless resets is the maximum number of stateless reset packets
-  // that the Endpoint will generate for a given remote host within a window of
-  // time (while tracking that host in the socket address LRU). This is not
-  // mandated by QUIC, and the limit is arbitrary. We can set it to whatever
-  // we'd like. The purpose is to prevent a malicious peer from intentionally
-  // triggering generation of a large number of stateless resets. Once the
-  // limit is reached, packets that would have otherwise triggered generation
-  // of a stateless reset will simply be dropped instead.
-  static constexpr uint64_t DEFAULT_MAX_STATELESS_RESETS = 10;
-
-  // Similar to stateless resets, the max retry limit is the maximum number of
-  // retry packets that the Endpoint will generate for a given remote host
-  // within a window of time (while tracking that host in the socket address
-  // LRU). This is not mandated by QUIC, and the limit is arbitrary. We can set
-  // it to whatever we'd like. The purpose is to prevent a malicious peer from
-  // intentionally triggering generation of a large number of retries.
-  static constexpr uint64_t DEFAULT_MAX_RETRY_LIMIT = 10;
-
-  // Maximum number of version negotiation packets that will be sent to a
-  // given remote host within the LRU tracking window. Version negotiation
-  // packets are cheap to generate but can be used as an amplification
-  // vector with spoofed source addresses.
-  // TODO(@jasnell): Consider making this configurable via Endpoint::Options.
-  static constexpr uint64_t kMaxVersionNegotiations = 10;
-
-  // Maximum number of immediate connection close packets that will be sent
-  // to a given remote host within the LRU tracking window. These are sent
-  // when the server is busy or a token is invalid — a malicious peer could
-  // trigger a large number of them.
-  // TODO(@jasnell): Consider making this configurable via Endpoint::Options.
-  static constexpr uint64_t kMaxImmediateCloses = 10;
+  // Default rate limits for stateless responses. These are global token
+  // bucket limits that cap the total rate of each response type regardless
+  // of source address. This prevents spoofed-source floods from bypassing
+  // per-host limits (which are keyed by source IP and trivially defeated
+  // by rotating spoofed addresses). The rate is in responses per second
+  // and the burst is the maximum tokens the bucket can hold.
+  static constexpr double DEFAULT_RETRY_RATE = 100;
+  static constexpr double DEFAULT_RETRY_BURST = 200;
+  static constexpr double DEFAULT_STATELESS_RESET_RATE = 100;
+  static constexpr double DEFAULT_STATELESS_RESET_BURST = 200;
+  static constexpr double DEFAULT_VERSION_NEGOTIATION_RATE = 100;
+  static constexpr double DEFAULT_VERSION_NEGOTIATION_BURST = 200;
+  static constexpr double DEFAULT_IMMEDIATE_CLOSE_RATE = 100;
+  static constexpr double DEFAULT_IMMEDIATE_CLOSE_BURST = 200;
 
   // Endpoint configuration options
   struct Options final : public MemoryRetainer {
@@ -83,30 +66,22 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
     uint64_t token_expiration =
         RegularToken::QUIC_DEFAULT_REGULARTOKEN_EXPIRATION / NGTCP2_SECONDS;
 
-    // A stateless reset in QUIC is a discrete mechanism that one endpoint can
-    // use to communicate to a peer that it has lost whatever state it
-    // previously held about a session. Because generating a stateless reset
-    // consumes resources (even very modestly), they can be a DOS vector in
-    // which a malicious peer intentionally sends a large number of stateless
-    // reset eliciting packets. To protect against that risk, we limit the
-    // number of stateless resets that may be generated for a given remote host
-    // within a window of time. This is not mandated by QUIC, and the limit is
-    // arbitrary. We can set it to whatever we'd like.
-    uint64_t max_stateless_resets = DEFAULT_MAX_STATELESS_RESETS;
-
-    // For tracking the number of connections per host, the number of stateless
-    // resets that have been sent, and tracking the path verification status of
-    // a remote host, we maintain an LRU cache of the most recently seen hosts.
-    // The address_lru_size parameter determines the size of that cache. The
-    // default is set modestly at 10 times the default max connections per host.
+    // For tracking the path verification status of remote hosts, we maintain
+    // an LRU cache of the most recently seen hosts.
     uint64_t address_lru_size = DEFAULT_MAX_SOCKETADDRESS_LRU_SIZE;
 
-    // Similar to stateless resets, we enforce a limit on the number of retry
-    // packets that can be generated and sent for a remote host. Generating
-    // retry packets consumes a modest amount of resources and it's fairly
-    // trivial for a malicious peer to trigger generation of a large number of
-    // retries, so limiting them helps prevent a DOS vector.
-    uint64_t max_retries = DEFAULT_MAX_RETRY_LIMIT;
+    // Global token bucket rate limits for stateless responses. These cap
+    // the total rate of each response type regardless of source address,
+    // preventing spoofed-source floods. Rate is in responses per second,
+    // burst is the maximum number of responses that can be sent in a burst.
+    double retry_rate = DEFAULT_RETRY_RATE;
+    double retry_burst = DEFAULT_RETRY_BURST;
+    double stateless_reset_rate = DEFAULT_STATELESS_RESET_RATE;
+    double stateless_reset_burst = DEFAULT_STATELESS_RESET_BURST;
+    double version_negotiation_rate = DEFAULT_VERSION_NEGOTIATION_RATE;
+    double version_negotiation_burst = DEFAULT_VERSION_NEGOTIATION_BURST;
+    double immediate_close_rate = DEFAULT_IMMEDIATE_CLOSE_RATE;
+    double immediate_close_burst = DEFAULT_IMMEDIATE_CLOSE_BURST;
 
     // The validate_address parameter instructs the Endpoint to perform explicit
     // address validation using retry tokens. This is strongly recommended and
@@ -475,10 +450,6 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
 
   struct SocketAddressInfoTraits final {
     struct Type final {
-      size_t reset_count;
-      size_t retry_count;
-      size_t version_negotiation_count;
-      size_t immediate_close_count;
       uint64_t timestamp;
       bool validated;
     };
@@ -488,6 +459,14 @@ class Endpoint final : public AsyncWrap, public Packet::Listener {
   };
 
   SocketAddressLRU<SocketAddressInfoTraits> addr_validation_lru_;
+
+  // Global token buckets for stateless response rate limiting.
+  // These cap the total server-wide rate of each response type,
+  // regardless of source address.
+  TokenBucket retry_bucket_;
+  TokenBucket stateless_reset_bucket_;
+  TokenBucket version_negotiation_bucket_;
+  TokenBucket immediate_close_bucket_;
 
   // Per-IP connection counts for maxConnectionsPerHost enforcement.
   // Only populated when max_connections_per_host > 0. Entries are

--- a/src/quic/http3.cc
+++ b/src/quic/http3.cc
@@ -177,10 +177,13 @@ class Http3ApplicationImpl final : public Session::Application {
     // When 0-RTT is rejected, destroy the nghttp3 connection and all
     // open streams — ngtcp2 has discarded their internal state.
     // Reset started_ so Start() is called again via on_receive_rx_key
-    // at 1RTT to recreate the nghttp3 connection.
+    // at 1RTT to recreate the nghttp3 connection. Use the
+    // application's internal error code since this is an error
+    // condition (code 0 would be treated as a clean close).
     conn_.reset();
     started_ = false;
-    session().DestroyAllStreams(QuicError::ForApplication(0));
+    session().DestroyAllStreams(
+        QuicError::ForApplication(GetInternalErrorCode()));
     if (!session().is_destroyed()) {
       session().EmitEarlyDataRejected();
     }

--- a/src/quic/preferredaddress.cc
+++ b/src/quic/preferredaddress.cc
@@ -140,7 +140,7 @@ void PreferredAddress::Initialize(Environment* env, Local<Object> target) {
   static constexpr auto PREFERRED_ADDRESS_IGNORE =
       static_cast<uint8_t>(Policy::IGNORE_PREFERRED);
   static constexpr auto DEFAULT_PREFERRED_ADDRESS_POLICY =
-      static_cast<uint8_t>(Policy::USE_PREFERRED);
+      static_cast<uint8_t>(Policy::IGNORE_PREFERRED);
 
   NODE_DEFINE_CONSTANT(target, PREFERRED_ADDRESS_IGNORE);
   NODE_DEFINE_CONSTANT(target, PREFERRED_ADDRESS_USE);

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -618,8 +618,7 @@ Maybe<Session::Options> Session::Options::From(Environment* env,
       !SET(keep_alive_timeout) || !SET(max_stream_window) || !SET(max_window) ||
       !SET(max_payload_size) || !SET(unacknowledged_packet_threshold) ||
       !SET(cc_algorithm) || !SET(draining_period_multiplier) ||
-      !SET(max_datagram_send_attempts) ||
-      !SET(stream_idle_timeout)) {
+      !SET(max_datagram_send_attempts) || !SET(stream_idle_timeout)) {
     return Nothing<Options>();
   }
 
@@ -2831,8 +2830,8 @@ void Session::ShutdownStream(stream_id id, QuicError error) {
 
 void Session::ShutdownStreamWrite(stream_id id, QuicError error) {
   DCHECK(!is_destroyed());
-  Debug(this, "Shutting down stream %" PRIi64 " write with error %s",
-        id, error);
+  Debug(
+      this, "Shutting down stream %" PRIi64 " write with error %s", id, error);
   SendPendingDataScope send_scope(this);
   error_code code;
   if (error.type() == QuicError::Type::APPLICATION) {
@@ -3058,17 +3057,15 @@ void Session::CheckStreamIdleTimeout(uint64_t now) {
 
     uint64_t last_activity = stream->last_activity_timestamp();
     if (last_activity > 0 && (now - last_activity) > timeout_ns) {
-      Debug(this,
-            "Stream %" PRId64 " idle timeout exceeded, destroying",
-            id);
+      Debug(this, "Stream %" PRId64 " idle timeout exceeded, destroying", id);
       // Notify the peer before destroying. ShutdownStream sends both
       // STOP_SENDING and RESET_STREAM as appropriate, using the
       // application's no-error code for non-APPLICATION errors (since
       // these frames carry application-level error codes per RFC 9000).
       // Without this, the peer's stream sits orphaned until the
       // session closes.
-      auto error = QuicError::ForTransport(NGTCP2_ERR_PROTO,
-                                           "stream idle timeout");
+      auto error =
+          QuicError::ForTransport(NGTCP2_ERR_PROTO, "stream idle timeout");
       ShutdownStream(id, error);
       stream->Destroy(error);
       STAT_INCREMENT(Stats, streams_idle_timed_out);

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2371,13 +2371,15 @@ bool Session::ReadPacket(const uint8_t* data,
       DCHECK(is_server());
       Debug(this, "Receiving packet failed: Server must send a retry packet");
       if (!is_destroyed()) {
-        endpoint().SendRetry(PathDescriptor{
-            version(),
-            config().dcid,
-            config().scid,
-            impl_->local_address_,
-            impl_->remote_address_,
-        });
+        endpoint().SendRetry(
+            PathDescriptor{
+                version(),
+                config().dcid,
+                config().scid,
+                impl_->local_address_,
+                impl_->remote_address_,
+            },
+            uv_hrtime());
         Close(CloseMethod::SILENT);
       }
       return false;

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -174,7 +174,8 @@ uint64_t MaxDatagramPayload(uint64_t max_frame_size) {
   V(DATAGRAMS_RECEIVED, datagrams_received)                                    \
   V(DATAGRAMS_SENT, datagrams_sent)                                            \
   V(DATAGRAMS_ACKNOWLEDGED, datagrams_acknowledged)                            \
-  V(DATAGRAMS_LOST, datagrams_lost)
+  V(DATAGRAMS_LOST, datagrams_lost)                                            \
+  V(STREAMS_IDLE_TIMED_OUT, streams_idle_timed_out)
 
 #define NO_SIDE_EFFECT true
 #define SIDE_EFFECT false
@@ -617,7 +618,8 @@ Maybe<Session::Options> Session::Options::From(Environment* env,
       !SET(keep_alive_timeout) || !SET(max_stream_window) || !SET(max_window) ||
       !SET(max_payload_size) || !SET(unacknowledged_packet_threshold) ||
       !SET(cc_algorithm) || !SET(draining_period_multiplier) ||
-      !SET(max_datagram_send_attempts)) {
+      !SET(max_datagram_send_attempts) ||
+      !SET(stream_idle_timeout)) {
     return Nothing<Options>();
   }
 
@@ -2811,24 +2813,36 @@ void Session::ShutdownStream(stream_id id, QuicError error) {
   DCHECK(!is_destroyed());
   Debug(this, "Shutting down stream %" PRIi64 " with error %s", id, error);
   SendPendingDataScope send_scope(this);
-  ngtcp2_conn_shutdown_stream(*this,
-                              0,
-                              id,
-                              error.type() == QuicError::Type::APPLICATION
-                                  ? error.code()
-                                  : application().GetNoErrorCode());
+  // STOP_SENDING and RESET_STREAM frames carry application-level error
+  // codes (RFC 9000 §19.4, §19.5). Map the QuicError to an appropriate
+  // application code: APPLICATION errors pass through directly; transport
+  // no-error maps to the application's no-error code; any other error
+  // maps to the application's internal error code.
+  error_code code;
+  if (error.type() == QuicError::Type::APPLICATION) {
+    code = error.code();
+  } else if (error.code() == NGTCP2_NO_ERROR) {
+    code = application().GetNoErrorCode();
+  } else {
+    code = application().GetInternalErrorCode();
+  }
+  ngtcp2_conn_shutdown_stream(*this, 0, id, code);
 }
 
-void Session::ShutdownStreamWrite(stream_id id, QuicError code) {
+void Session::ShutdownStreamWrite(stream_id id, QuicError error) {
   DCHECK(!is_destroyed());
-  Debug(this, "Shutting down stream %" PRIi64 " write with error %s", id, code);
+  Debug(this, "Shutting down stream %" PRIi64 " write with error %s",
+        id, error);
   SendPendingDataScope send_scope(this);
-  ngtcp2_conn_shutdown_stream_write(*this,
-                                    0,
-                                    id,
-                                    code.type() == QuicError::Type::APPLICATION
-                                        ? code.code()
-                                        : application().GetNoErrorCode());
+  error_code code;
+  if (error.type() == QuicError::Type::APPLICATION) {
+    code = error.code();
+  } else if (error.code() == NGTCP2_NO_ERROR) {
+    code = application().GetNoErrorCode();
+  } else {
+    code = application().GetInternalErrorCode();
+  }
+  ngtcp2_conn_shutdown_stream_write(*this, 0, id, code);
 }
 
 void Session::StreamDataBlocked(stream_id id) {
@@ -3027,6 +3041,41 @@ void Session::UpdateDataStats() {
       std::max(STAT_GET(Stats, max_bytes_in_flight), info.bytes_in_flight));
 }
 
+void Session::CheckStreamIdleTimeout(uint64_t now) {
+  if (is_destroyed()) return;
+  uint64_t timeout = options().stream_idle_timeout;
+  if (timeout == 0) return;
+
+  uint64_t timeout_ns = timeout * NGTCP2_MILLISECONDS;
+  auto all_streams = streams();
+
+  for (const auto& [id, stream] : all_streams) {
+    if (!stream) continue;
+
+    // Only check peer-initiated streams. Locally-initiated streams
+    // that haven't been written to are the application's concern.
+    if (ngtcp2_conn_is_local_stream(*this, id)) continue;
+
+    uint64_t last_activity = stream->last_activity_timestamp();
+    if (last_activity > 0 && (now - last_activity) > timeout_ns) {
+      Debug(this,
+            "Stream %" PRId64 " idle timeout exceeded, destroying",
+            id);
+      // Notify the peer before destroying. ShutdownStream sends both
+      // STOP_SENDING and RESET_STREAM as appropriate, using the
+      // application's no-error code for non-APPLICATION errors (since
+      // these frames carry application-level error codes per RFC 9000).
+      // Without this, the peer's stream sits orphaned until the
+      // session closes.
+      auto error = QuicError::ForTransport(NGTCP2_ERR_PROTO,
+                                           "stream idle timeout");
+      ShutdownStream(id, error);
+      stream->Destroy(error);
+      STAT_INCREMENT(Stats, streams_idle_timed_out);
+    }
+  }
+}
+
 void Session::SendConnectionClose() {
   // Method is a non-op if the session is already destroyed or the
   // endpoint cannot send. Note: we intentionally do NOT check
@@ -3111,6 +3160,8 @@ void Session::OnTimeout() {
   if (is_destroyed()) return;
   if (NGTCP2_OK(ret) && !is_in_closing_period() && !is_in_draining_period()) {
     application().SendPendingData();
+    if (is_destroyed()) return;
+    CheckStreamIdleTimeout(uv_hrtime());
     return;
   }
   if (is_destroyed()) return;
@@ -3156,6 +3207,15 @@ void Session::UpdateTimer() {
 
   auto timeout = (expiry - now) / NGTCP2_MILLISECONDS;
   Debug(this, "Updating timeout to %zu milliseconds", timeout);
+
+  // If a stream idle timeout is configured, ensure the timer fires at
+  // least that often so CheckStreamIdleTimeout runs. Without this, an
+  // idle session with idle streams might not fire the timer until the
+  // connection idle timeout, which could be much longer.
+  uint64_t stream_idle = options().stream_idle_timeout;
+  if (stream_idle > 0 && timeout > stream_idle) {
+    timeout = stream_idle;
+  }
 
   // If timeout is zero here, it means our timer is less than a millisecond
   // off from expiry. Let's bump the timer to 1.

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -227,6 +227,14 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
     // 10.2 requires at least 3x PTO. Range: 3-255. Default: 3.
     uint8_t draining_period_multiplier = 3;
 
+    // The amount of time (in milliseconds) that a stream can be idle
+    // (no data received) before it is automatically destroyed. This
+    // protects against slowloris-style attacks where a peer opens streams
+    // but never sends data, holding server resources indefinitely.
+    // Only applies to peer-initiated streams. Set to 0 to disable.
+    static constexpr uint64_t DEFAULT_STREAM_IDLE_TIMEOUT = 30'000;
+    uint64_t stream_idle_timeout = DEFAULT_STREAM_IDLE_TIMEOUT;
+
     // An optional NEW_TOKEN from a previous connection to the same
     // server. When set, the token is included in the Initial packet
     // to skip address validation. Client-side only.
@@ -569,6 +577,7 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   // Has to be called after certain operations that generate packets.
   void UpdatePacketTxTime();
   void UpdateDataStats();
+  void CheckStreamIdleTimeout(uint64_t now);
   void UpdatePath(const PathStorage& path);
 
   void ProcessPendingBidiStreams();

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -72,7 +72,11 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
     uint64_t max_header_length = DEFAULT_MAX_HEADER_LENGTH;
 
     // HTTP/3 specific options.
-    uint64_t max_field_section_size = 0;
+    // The maximum header section size advertised to the peer in SETTINGS.
+    // Defaults to match max_header_length so the SETTINGS frame accurately
+    // reflects the enforcement limit. A value of 0 would incorrectly tell
+    // the peer not to send any headers at all.
+    uint64_t max_field_section_size = DEFAULT_MAX_HEADER_LENGTH;
     uint64_t qpack_max_dtable_capacity = 4096;
     uint64_t qpack_encoder_max_dtable_capacity = 4096;
     uint64_t qpack_blocked_streams = 100;

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1891,6 +1891,7 @@ void Stream::EmitClose(const QuicError& error) {
 }
 
 void Stream::EmitHeaders() {
+  STAT_RECORD_TIMESTAMP(Stats, received_at);
   // state()->wants_headers will be set from the javascript side if the
   // stream object has a handler for the headers event.
   if (!env()->can_call_into_js() || !state()->wants_headers) {

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1270,7 +1270,8 @@ void Stream::NotifyStreamOpened(stream_id id) {
       // Headers were enqueued while the application was not yet known
       // (headers_supported == 0), and the negotiated application does
       // not support headers. This is a fatal mismatch.
-      Destroy(QuicError::ForApplication(0));
+      Destroy(QuicError::ForApplication(
+          session().application().GetInternalErrorCode()));
       return;
     }
     decltype(pending_headers_queue_) queue;
@@ -1345,6 +1346,11 @@ Direction Stream::direction() const {
 
 Session& Stream::session() const {
   return *session_;
+}
+
+uint64_t Stream::last_activity_timestamp() const {
+  uint64_t ts = stats()->received_at;
+  return ts != 0 ? ts : stats()->created_at;
 }
 
 bool Stream::is_local_unidirectional() const {
@@ -1625,6 +1631,7 @@ void Stream::EndReadable(std::optional<uint64_t> maybe_final_size) {
 
 void Stream::Destroy(QuicError error) {
   if (stats()->destroyed_at != 0) return;
+
   // Record the destroyed at timestamp before notifying the JavaScript side
   // that the stream is being destroyed.
   STAT_RECORD_TIMESTAMP(Stats, destroyed_at);

--- a/src/quic/streams.h
+++ b/src/quic/streams.h
@@ -258,6 +258,11 @@ class Stream final : public AsyncWrap,
 
   Session& session() const;
 
+  // Returns the most recent activity timestamp for this stream in
+  // nanoseconds (uv_hrtime). Uses received_at if data has been received,
+  // otherwise falls back to created_at. Returns 0 if neither is set.
+  uint64_t last_activity_timestamp() const;
+
   // True if this stream was created in a pending state and is still waiting
   // to be created.
   bool is_pending() const;

--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -715,12 +715,11 @@ Maybe<TLSContext::Options> TLSContext::Options::From(Environment* env,
 
   if (!SET(verify_client) || !SET(reject_unauthorized) ||
       !SET(verify_peer_strict) || !SET(enable_early_data) ||
-      !SET(enable_tls_trace) || !SET(alpn) ||
-      !SET(servername) || !SET(ciphers) || !SET(groups) ||
-      !SET(verify_private_key) || !SET(keylog) || !SET(port) ||
-      !SET(authoritative) || !SET_VECTOR(crypto::KeyObjectData, keys) ||
-      !SET_VECTOR(Store, certs) || !SET_VECTOR(Store, ca) ||
-      !SET_VECTOR(Store, crl)) {
+      !SET(enable_tls_trace) || !SET(alpn) || !SET(servername) ||
+      !SET(ciphers) || !SET(groups) || !SET(verify_private_key) ||
+      !SET(keylog) || !SET(port) || !SET(authoritative) ||
+      !SET_VECTOR(crypto::KeyObjectData, keys) || !SET_VECTOR(Store, certs) ||
+      !SET_VECTOR(Store, ca) || !SET_VECTOR(Store, crl)) {
     return Nothing<Options>();
   }
 

--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -261,6 +261,18 @@ bool OSSLContext::set_hostname(std::string_view hostname) const {
                   const_cast<char*>(name.c_str())) == 1;
 }
 
+bool OSSLContext::set_verify_hostname(std::string_view hostname) const {
+  // SSL_set1_host tells OpenSSL to verify the peer certificate's
+  // subject name (SAN/CN) matches this hostname. This is separate
+  // from SSL_set_tlsext_host_name which only sets the SNI extension.
+  static const char* kDefaultHostname = "localhost";
+  if (hostname.empty()) {
+    return SSL_set1_host(*this, kDefaultHostname) == 1;
+  } else {
+    return SSL_set1_host(*this, hostname.data()) == 1;
+  }
+}
+
 bool OSSLContext::set_early_data_enabled() const {
   return SSL_set_quic_tls_early_data_enabled(*this, 1) == 1;
 }
@@ -714,12 +726,13 @@ Maybe<TLSContext::Options> TLSContext::Options::From(Environment* env,
       env, &options, params, state.name##_string())
 
   if (!SET(verify_client) || !SET(reject_unauthorized) ||
-      !SET(verify_peer_strict) || !SET(enable_early_data) ||
-      !SET(enable_tls_trace) || !SET(alpn) || !SET(servername) ||
-      !SET(ciphers) || !SET(groups) || !SET(verify_private_key) ||
-      !SET(keylog) || !SET(port) || !SET(authoritative) ||
-      !SET_VECTOR(crypto::KeyObjectData, keys) || !SET_VECTOR(Store, certs) ||
-      !SET_VECTOR(Store, ca) || !SET_VECTOR(Store, crl)) {
+      !SET(verify_hostname) || !SET(verify_peer_strict) ||
+      !SET(enable_early_data) || !SET(enable_tls_trace) || !SET(alpn) ||
+      !SET(servername) || !SET(ciphers) || !SET(groups) ||
+      !SET(verify_private_key) || !SET(keylog) || !SET(port) ||
+      !SET(authoritative) || !SET_VECTOR(crypto::KeyObjectData, keys) ||
+      !SET_VECTOR(Store, certs) || !SET_VECTOR(Store, ca) ||
+      !SET_VECTOR(Store, crl)) {
     return Nothing<Options>();
   }
 
@@ -852,6 +865,14 @@ void TLSSession::Initialize(
         validation_error_ = "Failed to set server name";
         ossl_context_.reset();
         return;
+      }
+
+      if (options.verify_hostname) {
+        if (!ossl_context_.set_verify_hostname(options.servername)) {
+          validation_error_ = "Failed to set verify hostname";
+          ossl_context_.reset();
+          return;
+        }
       }
 
       if (maybeSessionTicket.has_value()) {

--- a/src/quic/tlscontext.cc
+++ b/src/quic/tlscontext.cc
@@ -500,6 +500,14 @@ SSLCtxPointer TLSContext::Initialize(Environment* env) {
       SSL_CTX_set_session_cache_mode(
           ctx.get(), SSL_SESS_CACHE_CLIENT | SSL_SESS_CACHE_NO_INTERNAL);
       SSL_CTX_sess_set_new_cb(ctx.get(), OnNewSession);
+
+      // In strict mode, set SSL_VERIFY_PEER so OpenSSL aborts the
+      // handshake if the server's certificate fails validation. In
+      // non-strict modes, verification still occurs but the handshake
+      // completes regardless — the result is surfaced to JS.
+      if (options_.verify_peer_strict) {
+        SSL_CTX_set_verify(ctx.get(), SSL_VERIFY_PEER, nullptr);
+      }
       break;
     }
   }
@@ -706,7 +714,8 @@ Maybe<TLSContext::Options> TLSContext::Options::From(Environment* env,
       env, &options, params, state.name##_string())
 
   if (!SET(verify_client) || !SET(reject_unauthorized) ||
-      !SET(enable_early_data) || !SET(enable_tls_trace) || !SET(alpn) ||
+      !SET(verify_peer_strict) || !SET(enable_early_data) ||
+      !SET(enable_tls_trace) || !SET(alpn) ||
       !SET(servername) || !SET(ciphers) || !SET(groups) ||
       !SET(verify_private_key) || !SET(keylog) || !SET(port) ||
       !SET(authoritative) || !SET_VECTOR(crypto::KeyObjectData, keys) ||
@@ -730,6 +739,8 @@ std::string TLSContext::Options::ToString() const {
          (verify_client ? std::string("yes") : std::string("no"));
   res += prefix + "reject unauthorized: " +
          (reject_unauthorized ? std::string("yes") : std::string("no"));
+  res += prefix + "verify peer strict: " +
+         (verify_peer_strict ? std::string("yes") : std::string("no"));
   res += prefix + "enable early data: " +
          (enable_early_data ? std::string("yes") : std::string("no"));
   res += prefix + "enable_tls_trace: " +

--- a/src/quic/tlscontext.h
+++ b/src/quic/tlscontext.h
@@ -207,6 +207,14 @@ class TLSContext final : public MemoryRetainer,
     // This option is only used by the server side.
     bool reject_unauthorized = true;
 
+    // When true, the client will set SSL_VERIFY_PEER so that OpenSSL
+    // aborts the handshake if the server's certificate fails validation.
+    // This is the "strict" verify_peer mode. When false (the default),
+    // the handshake completes regardless and VerifyPeerIdentity is
+    // called after to surface errors to JS. This option is only used
+    // by the client side.
+    bool verify_peer_strict = false;
+
     // When true (the default), the server accepts 0-RTT early data
     // from clients with valid session tickets. When false, early data
     // is disabled and clients must complete a full handshake before

--- a/src/quic/tlscontext.h
+++ b/src/quic/tlscontext.h
@@ -51,6 +51,7 @@ class OSSLContext final {
 
   bool set_alpn_protocols(std::string_view protocols) const;
   bool set_hostname(std::string_view hostname) const;
+  bool set_verify_hostname(std::string_view hostname) const;
   bool set_early_data_enabled() const;
   bool set_transport_params(const ngtcp2_vec& tp) const;
 
@@ -214,6 +215,13 @@ class TLSContext final : public MemoryRetainer,
     // called after to surface errors to JS. This option is only used
     // by the client side.
     bool verify_peer_strict = false;
+
+    // When true, OpenSSL verifies that the server's certificate matches
+    // the servername (hostname verification via SSL_set1_host). Should
+    // be true for 'strict' and 'auto' verifyPeer modes, false for
+    // 'manual'. Without this, a valid certificate for any domain would
+    // be accepted. This option is only used by the client side.
+    bool verify_hostname = false;
 
     // When true (the default), the server accepts 0-RTT early data
     // from clients with valid session tickets. When false, early data

--- a/src/quic/tokens.cc
+++ b/src/quic/tokens.cc
@@ -170,10 +170,9 @@ ngtcp2_vec GenerateRetryToken(uint8_t* buffer,
                                          odcid,
                                          uv_hrtime());
   DCHECK_GE(ret, 0);
-  DCHECK_LE(ret, RetryToken::kRetryTokenLen);
   DCHECK_EQ(buffer[0], RetryToken::kTokenMagic);
   // This shouldn't be possible but we handle it anyway just to be safe.
-  if (ret == 0) return {nullptr, 0};
+  if (ret <= 0) return {nullptr, 0};
   return {buffer, static_cast<size_t>(ret)};
 }
 
@@ -189,10 +188,9 @@ ngtcp2_vec GenerateRegularToken(uint8_t* buffer,
                                            address.length(),
                                            uv_hrtime());
   DCHECK_GE(ret, 0);
-  DCHECK_LE(ret, RegularToken::kRegularTokenLen);
   DCHECK_EQ(buffer[0], RegularToken::kTokenMagic);
   // This shouldn't be possible but we handle it anyway just to be safe.
-  if (ret == 0) return {nullptr, 0};
+  if (ret <= 0) return {nullptr, 0};
   return {buffer, static_cast<size_t>(ret)};
 }
 }  // namespace

--- a/test/cctest/test_quic_tokenbucket.cc
+++ b/test/cctest/test_quic_tokenbucket.cc
@@ -9,65 +9,113 @@
 namespace node::quic {
 namespace {
 
+// Helper: nanoseconds from seconds
+static constexpr uint64_t secs(double s) {
+  return static_cast<uint64_t>(s * 1e9);
+}
+
 TEST(QuicTokenBucket, AllowsBurst) {
   TokenBucket bucket(10, 5);  // 10/sec rate, burst of 5
+  uint64_t now = secs(1000);
 
   // Should allow up to burst count immediately
   for (int i = 0; i < 5; i++) {
-    EXPECT_TRUE(bucket.consume()) << "consume " << i << " should succeed";
+    EXPECT_TRUE(bucket.consume(now)) << "consume " << i << " should succeed";
   }
 
   // Bucket should be empty now
-  EXPECT_FALSE(bucket.consume());
+  EXPECT_FALSE(bucket.consume(now));
 }
 
 TEST(QuicTokenBucket, RefillsOverTime) {
   TokenBucket bucket(1000, 1);  // 1000/sec rate, burst of 1
+  uint64_t now = secs(1000);
 
   // Drain the bucket
-  EXPECT_TRUE(bucket.consume());
-  EXPECT_FALSE(bucket.consume());
+  EXPECT_TRUE(bucket.consume(now));
+  EXPECT_FALSE(bucket.consume(now));
 
-  // Sleep 2ms — at 1000/sec that's ~2 tokens, but burst is 1
-  uv_sleep(2);
+  // Advance 2ms — at 1000/sec that's ~2 tokens, but burst is 1
+  now += secs(0.002);
 
-  // Should have refilled to at least 1 (capped by burst)
-  EXPECT_TRUE(bucket.consume());
+  // Should have refilled to 1 (capped by burst)
+  EXPECT_TRUE(bucket.consume(now));
+  EXPECT_FALSE(bucket.consume(now));
 }
 
 TEST(QuicTokenBucket, BurstCapacity) {
   TokenBucket bucket(10000, 3);  // high rate, burst of 3
+  uint64_t now = secs(1000);
 
   // Drain
-  EXPECT_TRUE(bucket.consume());
-  EXPECT_TRUE(bucket.consume());
-  EXPECT_TRUE(bucket.consume());
-  EXPECT_FALSE(bucket.consume());
+  EXPECT_TRUE(bucket.consume(now));
+  EXPECT_TRUE(bucket.consume(now));
+  EXPECT_TRUE(bucket.consume(now));
+  EXPECT_FALSE(bucket.consume(now));
 
-  // Sleep enough to fully refill
-  uv_sleep(10);
+  // Advance enough to fully refill
+  now += secs(1);
 
   // Should be capped at burst (3), not more
   int count = 0;
-  while (bucket.consume()) count++;
+  while (bucket.consume(now)) count++;
   EXPECT_EQ(count, 3);
 }
 
 TEST(QuicTokenBucket, ZeroRateAlwaysDenies) {
   TokenBucket bucket(0, 0);
-  EXPECT_FALSE(bucket.consume());
-  EXPECT_FALSE(bucket.consume());
+  uint64_t now = secs(1000);
+  EXPECT_FALSE(bucket.consume(now));
+  now += secs(10);
+  EXPECT_FALSE(bucket.consume(now));
 }
 
 TEST(QuicTokenBucket, HighRateAllowsRapidConsume) {
   TokenBucket bucket(1000000, 1000);  // 1M/sec, burst 1000
+  uint64_t now = secs(1000);
 
-  // Should be able to consume many quickly
+  // Should be able to consume the full burst
   int count = 0;
   for (int i = 0; i < 1000; i++) {
-    if (bucket.consume()) count++;
+    if (bucket.consume(now)) count++;
   }
   EXPECT_EQ(count, 1000);
+}
+
+TEST(QuicTokenBucket, InitOnce) {
+  TokenBucket bucket;  // default: rate=0, burst=0, last_ts=0
+  uint64_t now = secs(1000);
+
+  // Init with rate=100, burst=5
+  bucket.InitOnce(100, 5, now);
+  EXPECT_TRUE(bucket.consume(now));
+
+  // InitOnce is idempotent — second call is a no-op
+  bucket.InitOnce(0, 0, now);        // would make it deny-all if applied
+  EXPECT_TRUE(bucket.consume(now));  // still has tokens from first init
+}
+
+TEST(QuicTokenBucket, DefaultConstructorDenies) {
+  TokenBucket bucket;  // default: rate=0, burst=0, last_ts=0
+  uint64_t now = secs(1000);
+  EXPECT_FALSE(bucket.consume(now));
+}
+
+TEST(QuicTokenBucket, GradualRefill) {
+  TokenBucket bucket(10, 10);  // 10/sec rate, burst of 10
+  uint64_t now = secs(1000);
+
+  // Drain fully
+  for (int i = 0; i < 10; i++) {
+    EXPECT_TRUE(bucket.consume(now));
+  }
+  EXPECT_FALSE(bucket.consume(now));
+
+  // Advance 500ms — should get 5 tokens
+  now += secs(0.5);
+  int count = 0;
+  while (bucket.consume(now)) count++;
+  EXPECT_EQ(count, 5);
 }
 
 }  // namespace

--- a/test/cctest/test_quic_tokenbucket.cc
+++ b/test/cctest/test_quic_tokenbucket.cc
@@ -1,0 +1,77 @@
+#if HAVE_OPENSSL && HAVE_QUIC
+#include "quic/guard.h"
+#ifndef OPENSSL_NO_QUIC
+#include <env-inl.h>
+#include <gtest/gtest.h>
+#include <quic/defs.h>
+#include <uv.h>
+
+namespace node::quic {
+namespace {
+
+TEST(QuicTokenBucket, AllowsBurst) {
+  TokenBucket bucket(10, 5);  // 10/sec rate, burst of 5
+
+  // Should allow up to burst count immediately
+  for (int i = 0; i < 5; i++) {
+    EXPECT_TRUE(bucket.consume()) << "consume " << i << " should succeed";
+  }
+
+  // Bucket should be empty now
+  EXPECT_FALSE(bucket.consume());
+}
+
+TEST(QuicTokenBucket, RefillsOverTime) {
+  TokenBucket bucket(1000, 1);  // 1000/sec rate, burst of 1
+
+  // Drain the bucket
+  EXPECT_TRUE(bucket.consume());
+  EXPECT_FALSE(bucket.consume());
+
+  // Sleep 2ms — at 1000/sec that's ~2 tokens, but burst is 1
+  uv_sleep(2);
+
+  // Should have refilled to at least 1 (capped by burst)
+  EXPECT_TRUE(bucket.consume());
+}
+
+TEST(QuicTokenBucket, BurstCapacity) {
+  TokenBucket bucket(10000, 3);  // high rate, burst of 3
+
+  // Drain
+  EXPECT_TRUE(bucket.consume());
+  EXPECT_TRUE(bucket.consume());
+  EXPECT_TRUE(bucket.consume());
+  EXPECT_FALSE(bucket.consume());
+
+  // Sleep enough to fully refill
+  uv_sleep(10);
+
+  // Should be capped at burst (3), not more
+  int count = 0;
+  while (bucket.consume()) count++;
+  EXPECT_EQ(count, 3);
+}
+
+TEST(QuicTokenBucket, ZeroRateAlwaysDenies) {
+  TokenBucket bucket(0, 0);
+  EXPECT_FALSE(bucket.consume());
+  EXPECT_FALSE(bucket.consume());
+}
+
+TEST(QuicTokenBucket, HighRateAllowsRapidConsume) {
+  TokenBucket bucket(1000000, 1000);  // 1M/sec, burst 1000
+
+  // Should be able to consume many quickly
+  int count = 0;
+  for (int i = 0; i < 1000; i++) {
+    if (bucket.consume()) count++;
+  }
+  EXPECT_EQ(count, 1000);
+}
+
+}  // namespace
+}  // namespace node::quic
+
+#endif  // OPENSSL_NO_QUIC
+#endif  // HAVE_OPENSSL && HAVE_QUIC

--- a/test/cctest/test_sockaddr.cc
+++ b/test/cctest/test_sockaddr.cc
@@ -146,11 +146,13 @@ TEST(SocketAddressLRU, SocketAddressLRU) {
   struct FooLRUTraits {
     using Type = Foo;
 
-    static bool CheckExpired(const SocketAddress& address, const Type& type) {
+    static bool CheckExpired(const SocketAddress& address,
+                             const Type& type,
+                             uint64_t now) {
       return type.expired;
     }
 
-    static void Touch(const SocketAddress& address, Type* type) {
+    static void Touch(const SocketAddress& address, Type* type, uint64_t now) {
       type->expired = false;
     }
   };
@@ -169,7 +171,8 @@ TEST(SocketAddressLRU, SocketAddressLRU) {
   SocketAddress addr3(reinterpret_cast<const sockaddr*>(&storage[2]));
   SocketAddress addr4(reinterpret_cast<const sockaddr*>(&storage[3]));
 
-  Foo* foo = lru.Upsert(addr1);
+  uint64_t now = uv_hrtime();
+  Foo* foo = lru.Upsert(addr1, now);
   CHECK_NOT_NULL(foo);
   CHECK_EQ(foo->c, 0);
   CHECK_EQ(foo->expired, false);
@@ -177,14 +180,14 @@ TEST(SocketAddressLRU, SocketAddressLRU) {
   foo->c = 1;
   foo->expired = true;
 
-  foo = lru.Upsert(addr1);
+  foo = lru.Upsert(addr1, now);
   CHECK_NOT_NULL(lru.Peek(addr1));
   CHECK_EQ(lru.Peek(addr1), lru.Peek(addr4));
   CHECK_EQ(lru.Peek(addr1)->c, 1);
   CHECK_EQ(lru.Peek(addr1)->expired, false);
   CHECK_EQ(lru.size(), 1);
 
-  foo = lru.Upsert(addr2);
+  foo = lru.Upsert(addr2, now);
   foo->c = 2;
   foo->expired = true;
   CHECK_NOT_NULL(lru.Peek(addr2));
@@ -193,7 +196,7 @@ TEST(SocketAddressLRU, SocketAddressLRU) {
 
   foo->expired = true;
 
-  foo = lru.Upsert(addr3);
+  foo = lru.Upsert(addr3, now);
   foo->c = 3;
   foo->expired = false;
   CHECK_NOT_NULL(lru.Peek(addr3));

--- a/test/cctest/test_sockaddr.cc
+++ b/test/cctest/test_sockaddr.cc
@@ -286,11 +286,11 @@ TEST(SocketAddressBlockList, Simple) {
   bl.AddSocketAddress(addr1);
   bl.AddSocketAddress(addr2);
 
-  CHECK(bl.Apply(addr1));
-  CHECK(bl.Apply(addr2));
+  CHECK(bl.Apply(*addr1));
+  CHECK(bl.Apply(*addr2));
 
   bl.RemoveSocketAddress(addr1);
 
-  CHECK(!bl.Apply(addr1));
-  CHECK(bl.Apply(addr2));
+  CHECK(!bl.Apply(*addr1));
+  CHECK(bl.Apply(*addr2));
 }

--- a/test/common/quic.mjs
+++ b/test/common/quic.mjs
@@ -44,9 +44,13 @@ async function listen(callback, options = {}) {
 async function connect(address, options = {}) {
   const {
     alpn = 'quic-test',
+    // Test helper defaults to 'manual' because tests use self-signed
+    // certs without a CA. Tests that want to verify cert validation
+    // behavior should set verifyPeer explicitly.
+    verifyPeer = 'manual',
     ...rest
   } = options;
-  return quic.connect(address, { alpn, ...rest });
+  return quic.connect(address, { alpn, verifyPeer, ...rest });
 }
 
 export {

--- a/test/parallel/test-permission-net-quic.mjs
+++ b/test/parallel/test-permission-net-quic.mjs
@@ -19,7 +19,7 @@ const cert = fixtures.readKey('agent1-cert.pem');
 // Test: connect() should reject with ERR_ACCESS_DENIED
 {
   await assert.rejects(
-    connect('127.0.0.1:12345', { alpn: 'h3' }),
+    connect('127.0.0.1:12345', { alpn: 'h3', verifyPeer: 'manual' }),
     {
       code: 'ERR_ACCESS_DENIED',
       permission: 'Net',

--- a/test/parallel/test-quic-address-validation.mjs
+++ b/test/parallel/test-quic-address-validation.mjs
@@ -37,6 +37,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   servername: 'localhost',
 });
 

--- a/test/parallel/test-quic-alpn-h3.mjs
+++ b/test/parallel/test-quic-alpn-h3.mjs
@@ -35,6 +35,7 @@ notStrictEqual(serverEndpoint.address, undefined);
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
 });
 
 async function checkClient() {

--- a/test/parallel/test-quic-alpn.mjs
+++ b/test/parallel/test-quic-alpn.mjs
@@ -41,6 +41,7 @@ notStrictEqual(serverEndpoint.address, undefined);
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'proto-b',
   servername: 'localhost',
+  verifyPeer: 'manual',
 });
 
 await Promise.all([serverOpened.promise, checkSession(clientSession)]);

--- a/test/parallel/test-quic-blocklist.mjs
+++ b/test/parallel/test-quic-blocklist.mjs
@@ -1,0 +1,79 @@
+// Flags: --experimental-quic --no-warnings
+
+// Test: endpoint block list filtering.
+// Deny mode: packets from blocked addresses are dropped.
+// Allow mode: only packets from listed addresses are accepted.
+
+import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
+import assert from 'node:assert';
+import net from 'node:net';
+
+const { ok, rejects, strictEqual } = assert;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+
+// --- Deny mode: block 127.0.0.1 ---
+{
+  const blockList = new net.BlockList();
+  blockList.addAddress('127.0.0.1');
+
+  const serverEndpoint = await listen(mustNotCall(), {
+    endpoint: {
+      blockList,
+      blockListPolicy: 'deny',
+    },
+  });
+
+  // Connecting from 127.0.0.1 should be silently dropped.
+  // The client will time out waiting for a response.
+  const clientSession = await connect(serverEndpoint.address, {
+    handshakeTimeout: 500,
+    verifyPeer: 'manual',
+    onerror: mustCall((err) => {
+      strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+    }),
+  });
+
+  // The session should fail — the server never sees the packet.
+  await rejects(clientSession.opened, {
+    code: 'ERR_QUIC_TRANSPORT_ERROR',
+  });
+
+  // Verify the stat counter.
+  ok(serverEndpoint.stats.packetsBlocked > 0n,
+     'packetsBlocked should be non-zero');
+
+  await serverEndpoint.close();
+}
+
+// --- Allow mode: only allow 127.0.0.1 ---
+{
+  const allowList = new net.BlockList();
+  allowList.addAddress('127.0.0.1');
+
+  const serverEndpoint = await listen(mustCall(async (serverSession) => {
+    await serverSession.opened;
+    serverSession.close();
+  }), {
+    endpoint: {
+      blockList: allowList,
+      blockListPolicy: 'allow',
+    },
+  });
+
+  // Connecting from 127.0.0.1 should succeed — it's in the allow list.
+  const clientSession = await connect(serverEndpoint.address, {
+    verifyPeer: 'manual',
+  });
+  await clientSession.opened;
+  await clientSession.close();
+
+  strictEqual(serverEndpoint.stats.packetsBlocked, 0n,
+              'No packets should be blocked for allowed address');
+
+  await serverEndpoint.close();
+}

--- a/test/parallel/test-quic-callback-error-onpathvalidation.mjs
+++ b/test/parallel/test-quic-callback-error-onpathvalidation.mjs
@@ -36,6 +36,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   reuseEndpoint: false,
+  preferredAddressPolicy: 'use',
   onpathvalidation() {
     throw testError;
   },

--- a/test/parallel/test-quic-connection-limits.mjs
+++ b/test/parallel/test-quic-connection-limits.mjs
@@ -49,6 +49,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 // First connection should succeed.
 const cs1 = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxIdleTimeout: 2 },
 });
 await cs1.opened;
@@ -56,6 +57,7 @@ await cs1.opened;
 // Second connection — server rejects with CONNECTION_REFUSED.
 const cs2 = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxIdleTimeout: 1 },
   onerror: mustCall((err) => {
     strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');

--- a/test/parallel/test-quic-datagram-drop-newest.mjs
+++ b/test/parallel/test-quic-datagram-drop-newest.mjs
@@ -48,6 +48,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxDatagramFrameSize: 1200 },
   datagramDropPolicy: 'drop-newest',
   ondatagramstatus: mustCall((_, status) => {

--- a/test/parallel/test-quic-datagram-drop-oldest.mjs
+++ b/test/parallel/test-quic-datagram-drop-oldest.mjs
@@ -48,6 +48,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxDatagramFrameSize: 1200 },
   datagramDropPolicy: 'drop-oldest',
   ondatagramstatus: mustCall((_, status) => {

--- a/test/parallel/test-quic-datagram-echo.mjs
+++ b/test/parallel/test-quic-datagram-echo.mjs
@@ -48,6 +48,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxDatagramFrameSize: 10 },
   // Client receives datagram from server.
   ondatagram: mustCall(function(data) {

--- a/test/parallel/test-quic-datagram-multiple.mjs
+++ b/test/parallel/test-quic-datagram-multiple.mjs
@@ -56,6 +56,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxDatagramFrameSize: 1200 },
 });
 

--- a/test/parallel/test-quic-datagram-status.mjs
+++ b/test/parallel/test-quic-datagram-status.mjs
@@ -45,6 +45,7 @@ let statusValue;
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagramstatus: mustCall((id, status) => {
     strictEqual(typeof id, 'bigint');

--- a/test/parallel/test-quic-datagram.mjs
+++ b/test/parallel/test-quic-datagram.mjs
@@ -45,6 +45,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxDatagramFrameSize: 1200 },
 });
 

--- a/test/parallel/test-quic-diagnostics-channel-path.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-path.mjs
@@ -47,6 +47,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   reuseEndpoint: false,
+  preferredAddressPolicy: 'use',
   // The onpathvalidation must be set for the JS handler to fire,
   // which in turn publishes to the diagnostics channel.
   onpathvalidation: mustCall(),

--- a/test/parallel/test-quic-enable-early-data.mjs
+++ b/test/parallel/test-quic-enable-early-data.mjs
@@ -45,6 +45,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   servername: 'localhost',
   enableEarlyData: false,
 });

--- a/test/parallel/test-quic-endpoint-bind.mjs
+++ b/test/parallel/test-quic-endpoint-bind.mjs
@@ -46,6 +46,7 @@ const cert = readKey('agent1-cert.pem');
   // Verify a client can connect to the bound address.
   const clientSession = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 1 },
   });
   await clientSession.opened;

--- a/test/parallel/test-quic-endpoint-busy.mjs
+++ b/test/parallel/test-quic-endpoint-busy.mjs
@@ -36,6 +36,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 // First connection before busy — should succeed.
 const cs1 = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxIdleTimeout: 2 },
 });
 await cs1.opened;
@@ -48,6 +49,7 @@ strictEqual(endpoint.busy, true);
 // Second connection while busy — server rejects.
 const cs2 = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   transportParams: { maxIdleTimeout: 1 },
   onerror: mustCall((err) => {
     strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');

--- a/test/parallel/test-quic-endpoint-idle-timeout.mjs
+++ b/test/parallel/test-quic-endpoint-idle-timeout.mjs
@@ -31,6 +31,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   const clientEndpoint = new QuicEndpoint();
   const client = await connect(serverEndpoint.address, {
     endpoint: clientEndpoint,
+    verifyPeer: 'manual',
   });
   await client.opened;
 
@@ -57,6 +58,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   const clientEndpoint = new QuicEndpoint({ idleTimeout: 1 });
   const client = await connect(serverEndpoint.address, {
     endpoint: clientEndpoint,
+    verifyPeer: 'manual',
   });
   await client.opened;
   await client.close();

--- a/test/parallel/test-quic-endpoint-state-transitions.mjs
+++ b/test/parallel/test-quic-endpoint-state-transitions.mjs
@@ -40,7 +40,10 @@ const cert = readKey('agent1-cert.pem');
   strictEqual(serverEndpoint.closing, false);
   strictEqual(serverEndpoint.destroyed, false);
 
-  const cs = await connect(serverEndpoint.address, { alpn: 'quic-test' });
+  const cs = await connect(serverEndpoint.address, {
+    alpn: 'quic-test',
+    verifyPeer: 'manual',
+  });
   await cs.opened;
   await cs.close();
 
@@ -75,6 +78,7 @@ const cert = readKey('agent1-cert.pem');
   // Connect via 127.0.0.1 since 0.0.0.0 listens on all interfaces.
   const cs = await connect(`127.0.0.1:${addr.port}`, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 1 },
   });
   await cs.opened;

--- a/test/parallel/test-quic-h3-callback-errors.mjs
+++ b/test/parallel/test-quic-h3-callback-errors.mjs
@@ -56,6 +56,7 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
 
   const c = await connect(ep.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 1 },
   });
   await c.opened;
@@ -95,6 +96,7 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
 
   const c = await connect(ep.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 1 },
   });
   await c.opened;
@@ -139,6 +141,7 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
 
   const c = await connect(ep.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 1 },
   });
   await c.opened;
@@ -187,6 +190,7 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'example.com',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 1 },
     onorigin: mustCall(function() {
       throw new Error('onorigin error');
@@ -251,6 +255,7 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 1 },
   });
   await clientSession.opened;

--- a/test/parallel/test-quic-h3-close-behavior.mjs
+++ b/test/parallel/test-quic-h3-close-behavior.mjs
@@ -53,6 +53,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 

--- a/test/parallel/test-quic-h3-concurrent-requests.mjs
+++ b/test/parallel/test-quic-h3-concurrent-requests.mjs
@@ -57,6 +57,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
 });
 await clientSession.opened;
 

--- a/test/parallel/test-quic-h3-datagram.mjs
+++ b/test/parallel/test-quic-h3-datagram.mjs
@@ -66,6 +66,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     application: { enableDatagrams: true },
     transportParams: { maxDatagramFrameSize: 100 },
     // Client receives datagram from server.
@@ -139,6 +140,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     application: { enableDatagrams: true },
     transportParams: { maxDatagramFrameSize: 100 },
   });

--- a/test/parallel/test-quic-h3-error-codes.mjs
+++ b/test/parallel/test-quic-h3-error-codes.mjs
@@ -46,6 +46,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 
@@ -96,6 +97,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 

--- a/test/parallel/test-quic-h3-goaway-non-h3.mjs
+++ b/test/parallel/test-quic-h3-goaway-non-h3.mjs
@@ -45,6 +45,7 @@ const serverEndpoint = await listen(mustCall(async (ss) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
   alpn: 'quic-test',
   // Ongoaway must NOT fire for non-H3 sessions.
   ongoaway: mustNotCall(),

--- a/test/parallel/test-quic-h3-goaway.mjs
+++ b/test/parallel/test-quic-h3-goaway.mjs
@@ -71,6 +71,7 @@ dc.subscribe('quic.session.goaway', mustCall((msg) => {
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     // Ongoaway fires when the peer sends GOAWAY.
     ongoaway: mustCall(function(lastStreamId) {
       strictEqual(lastStreamId, -1n);

--- a/test/parallel/test-quic-h3-handshake-failure.mjs
+++ b/test/parallel/test-quic-h3-handshake-failure.mjs
@@ -40,6 +40,7 @@ const serverEndpoint = await listen(async (serverSession) => {
 // exists but hasn't started (control streams not yet bound).
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
   // h3 ALPN — must match the server so the H3 application is selected
   // on the server side before we tear it down.
 });

--- a/test/parallel/test-quic-h3-header-validation.mjs
+++ b/test/parallel/test-quic-h3-header-validation.mjs
@@ -77,6 +77,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 
@@ -138,6 +139,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 

--- a/test/parallel/test-quic-h3-headers-support.mjs
+++ b/test/parallel/test-quic-h3-headers-support.mjs
@@ -61,6 +61,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
   alpn: 'quic-test',
 });
 await clientSession.opened;

--- a/test/parallel/test-quic-h3-informational-headers.mjs
+++ b/test/parallel/test-quic-h3-informational-headers.mjs
@@ -77,6 +77,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
 });
 await clientSession.opened;
 

--- a/test/parallel/test-quic-h3-origin.mjs
+++ b/test/parallel/test-quic-h3-origin.mjs
@@ -55,6 +55,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'example.com',
+    verifyPeer: 'manual',
     // Client receives ORIGIN frame via onorigin callback.
     onorigin: mustCall(function(origins) {
       ok(Array.isArray(origins));
@@ -132,6 +133,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'custom-port.example.com',
+    verifyPeer: 'manual',
     onorigin: mustCall(function(origins) {
       ok(Array.isArray(origins));
 

--- a/test/parallel/test-quic-h3-pending-stream.mjs
+++ b/test/parallel/test-quic-h3-pending-stream.mjs
@@ -51,6 +51,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
 
   // Create the stream BEFORE awaiting opened. The stream is pending

--- a/test/parallel/test-quic-h3-post-filehandle.mjs
+++ b/test/parallel/test-quic-h3-post-filehandle.mjs
@@ -61,6 +61,7 @@ writeFileSync(testFile, testContent);
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
 
   const info = await clientSession.opened;

--- a/test/parallel/test-quic-h3-post-request.mjs
+++ b/test/parallel/test-quic-h3-post-request.mjs
@@ -68,6 +68,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
 });
 
 const info = await clientSession.opened;

--- a/test/parallel/test-quic-h3-priority.mjs
+++ b/test/parallel/test-quic-h3-priority.mjs
@@ -55,6 +55,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 
@@ -194,6 +195,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 

--- a/test/parallel/test-quic-h3-qpack-settings.mjs
+++ b/test/parallel/test-quic-h3-qpack-settings.mjs
@@ -71,6 +71,7 @@ async function makeRequest(clientSession, path) {
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     // Client also disables QPACK dynamic table.
     application: { qpackMaxDTableCapacity: 0, qpackBlockedStreams: 0 },
   });
@@ -108,6 +109,7 @@ async function makeRequest(clientSession, path) {
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     application: { qpackMaxDTableCapacity: 8192, qpackBlockedStreams: 200 },
   });
   await clientSession.opened;

--- a/test/parallel/test-quic-h3-request-response.mjs
+++ b/test/parallel/test-quic-h3-request-response.mjs
@@ -77,6 +77,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
   // Default ALPN is h3.
 });
 

--- a/test/parallel/test-quic-h3-settings.mjs
+++ b/test/parallel/test-quic-h3-settings.mjs
@@ -60,6 +60,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 
@@ -118,6 +119,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
   });
   await clientSession.opened;
 
@@ -164,6 +166,7 @@ const decoder = new TextDecoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     application: { enableConnectProtocol: true, enableDatagrams: true },
   });
   await clientSession.opened;

--- a/test/parallel/test-quic-h3-stream-destroy-with-headers.mjs
+++ b/test/parallel/test-quic-h3-stream-destroy-with-headers.mjs
@@ -34,6 +34,7 @@ const serverEndpoint = await listen(mustCall(async (ss) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
 });
 await clientSession.opened;
 

--- a/test/parallel/test-quic-h3-stream-idle-timeout.mjs
+++ b/test/parallel/test-quic-h3-stream-idle-timeout.mjs
@@ -1,0 +1,185 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// Test: HTTP/3 stream idle timeout.
+// Peer-initiated streams that receive no data within the configured
+// timeout are automatically destroyed. This test verifies the behavior
+// with HTTP/3 bidirectional streams, where ShutdownStream maps
+// transport errors to the application's internal error code
+// (NGHTTP3_H3_INTERNAL_ERROR = 0x102) on the wire.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import assert from 'node:assert';
+import { setTimeout } from 'node:timers/promises';
+import * as fixtures from '../common/fixtures.mjs';
+import { text } from 'node:stream/iter';
+
+const { rejects, strictEqual } = assert;
+const { readKey } = fixtures;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('node:quic');
+const { createPrivateKey } = await import('node:crypto');
+
+const key = createPrivateKey(readKey('agent1-key.pem'));
+const cert = readKey('agent1-cert.pem');
+
+const encoder = new TextEncoder();
+
+// --- H3 stream destroyed after idle timeout ---
+{
+  const streamDestroyed = Promise.withResolvers();
+
+  const serverEndpoint = await listen(mustCall(async (serverSession) => {
+    serverSession.onstream = mustCall(async (stream) => {
+      // Don't read — let the stream sit idle after the initial headers.
+      // The stream idle timeout should destroy it, rejecting stream.closed.
+      await rejects(stream.closed, {
+        code: 'ERR_QUIC_TRANSPORT_ERROR',
+      });
+      streamDestroyed.resolve();
+    });
+  }), {
+    sni: { '*': { keys: [key], certs: [cert] } },
+    streamIdleTimeout: 100,
+    onheaders() {
+      // Receive headers but do nothing — let the stream go idle.
+    },
+  });
+
+  const clientSession = await connect(serverEndpoint.address, {
+    servername: 'localhost',
+    verifyPeer: 'manual',
+    transportParams: { maxIdleTimeout: 1 },
+  });
+
+  await clientSession.opened;
+
+  // Send a POST request with a body byte so the server creates the
+  // stream, then stop sending (don't end the write side).
+  const stream = await clientSession.createBidirectionalStream({
+    headers: {
+      ':method': 'POST',
+      ':path': '/',
+      ':scheme': 'https',
+      ':authority': 'localhost',
+    },
+    onheaders() {},
+  });
+  const writer = stream.writer;
+  writer.writeSync(encoder.encode('x'));
+
+  // Wait for the server to destroy the idle stream.
+  await streamDestroyed.promise;
+
+  // The server sent STOP_SENDING / RESET_STREAM when it destroyed the
+  // idle stream. ShutdownStream maps the transport error to the H3
+  // internal error code (0x102) on the wire.
+  await rejects(stream.closed, {
+    code: 'ERR_QUIC_APPLICATION_ERROR',
+  });
+
+  await clientSession.close();
+  await serverEndpoint.close();
+}
+
+// --- H3 stream with ongoing data is NOT destroyed ---
+{
+  const serverGotData = Promise.withResolvers();
+
+  const serverEndpoint = await listen(mustCall(async (serverSession) => {
+    serverSession.onstream = mustCall(async (stream) => {
+      const data = await text(stream);
+      strictEqual(data, 'xy');
+      serverGotData.resolve();
+      await serverSession.close();
+    });
+  }), {
+    sni: { '*': { keys: [key], certs: [cert] } },
+    streamIdleTimeout: 500,
+    onheaders: mustCall(function(headers) {
+      strictEqual(headers[':method'], 'POST');
+      // Send response headers so the stream is fully established.
+      this.sendHeaders({ ':status': '200' }, { terminal: true });
+    }),
+  });
+
+  const clientSession = await connect(serverEndpoint.address, {
+    servername: 'localhost',
+    verifyPeer: 'manual',
+  });
+  await clientSession.opened;
+
+  const stream = await clientSession.createBidirectionalStream({
+    onheaders() {},
+  });
+  stream.sendHeaders({
+    ':method': 'POST',
+    ':path': '/',
+    ':scheme': 'https',
+    ':authority': 'localhost',
+    'content-length': '2',
+  }, { terminal: false });
+  const writer = stream.writer;
+  writer.writeSync(encoder.encode('x'));
+
+  // Wait less than the 500ms idle timeout, then send more data.
+  await setTimeout(300);
+
+  writer.writeSync(encoder.encode('y'));
+  writer.endSync();
+
+  await Promise.all([serverGotData.promise, clientSession.closed]);
+  await serverEndpoint.close();
+}
+
+// --- Disabled when set to 0 ---
+{
+  const streamSurvived = Promise.withResolvers();
+
+  const serverEndpoint = await listen(mustCall(async (serverSession) => {
+    serverSession.onstream = mustCall(async (stream) => {
+      const data = await text(stream);
+      strictEqual(data, 'xy');
+      streamSurvived.resolve();
+    });
+
+    await setTimeout(700);
+    await serverSession.close();
+  }), {
+    sni: { '*': { keys: [key], certs: [cert] } },
+    streamIdleTimeout: 0,  // Disabled
+    onheaders: mustCall(function(headers) {
+      this.sendHeaders({ ':status': '200' }, { terminal: true });
+    }),
+  });
+
+  const clientSession = await connect(serverEndpoint.address, {
+    servername: 'localhost',
+    verifyPeer: 'manual',
+  });
+  await clientSession.opened;
+
+  const stream = await clientSession.createBidirectionalStream({
+    onheaders() {},
+  });
+  stream.sendHeaders({
+    ':method': 'POST',
+    ':path': '/',
+    ':scheme': 'https',
+    ':authority': 'localhost',
+  }, { terminal: false });
+  const writer = stream.writer;
+  writer.writeSync(encoder.encode('x'));
+
+  // Pause beyond any reasonable idle timeout to verify it's disabled.
+  await setTimeout(600);
+
+  writer.writeSync(encoder.encode('y'));
+  writer.endSync();
+
+  await Promise.all([streamSurvived.promise, clientSession.closed]);
+  await serverEndpoint.close();
+}

--- a/test/parallel/test-quic-h3-trailing-headers.mjs
+++ b/test/parallel/test-quic-h3-trailing-headers.mjs
@@ -82,6 +82,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
 });
 await clientSession.opened;
 

--- a/test/parallel/test-quic-h3-zero-rtt-bogus-ticket.mjs
+++ b/test/parallel/test-quic-h3-zero-rtt-bogus-ticket.mjs
@@ -30,6 +30,7 @@ const serverEndpoint = await listen(mustNotCall(), {
 await rejects(
   connect(serverEndpoint.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     sessionTicket: randomBytes(256),
   }),
   { code: 'ERR_INVALID_ARG_VALUE' },

--- a/test/parallel/test-quic-h3-zero-rtt-rejected-settings.mjs
+++ b/test/parallel/test-quic-h3-zero-rtt-rejected-settings.mjs
@@ -53,6 +53,7 @@ async function getTicket(endpointOptions) {
 
   const cs = await connect(ep.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     ...endpointOptions,
     onsessionticket(ticket) {
       ok(Buffer.isBuffer(ticket));
@@ -102,6 +103,7 @@ async function attemptRejected0RTT(endpointOptions, ticket, token) {
 
   const cs = await connect(ep.address, {
     servername: 'localhost',
+    verifyPeer: 'manual',
     ...endpointOptions,
     sessionTicket: ticket,
     token,

--- a/test/parallel/test-quic-h3-zero-rtt.mjs
+++ b/test/parallel/test-quic-h3-zero-rtt.mjs
@@ -58,6 +58,7 @@ const serverEndpoint = await listen(mustCall((ss) => {
 // --- First connection: establish H3 session, receive ticket ---
 const cs1 = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
   onsessionticket: mustCall(function(ticket) {
     ok(Buffer.isBuffer(ticket));
     ok(ticket.length > 0);
@@ -99,6 +100,7 @@ ok(savedToken);
 // --- Second connection: 0-RTT with H3 ---
 const cs2 = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
   sessionTicket: savedTicket,
   token: savedToken,
 });

--- a/test/parallel/test-quic-handshake-ipv6-only.mjs
+++ b/test/parallel/test-quic-handshake-ipv6-only.mjs
@@ -60,6 +60,7 @@ ok(serverEndpoint.address !== undefined);
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   endpoint: {
     address: {
       address: '::',

--- a/test/parallel/test-quic-handshake.mjs
+++ b/test/parallel/test-quic-handshake.mjs
@@ -54,6 +54,7 @@ ok(serverEndpoint.address !== undefined);
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
 });
 
 const info = await clientSession.opened;

--- a/test/parallel/test-quic-internal-endpoint-options.mjs
+++ b/test/parallel/test-quic-internal-endpoint-options.mjs
@@ -100,6 +100,16 @@ const cases = [
     invalid: [-1, 'a', null, false, true, {}, [], () => {}]
   },
   {
+    key: 'sessionCreationRate',
+    valid: [0, 1, 10, 100.5, 1000, Infinity],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'sessionCreationBurst',
+    valid: [0, 1, 10, 100.5, 1000, Infinity],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
     key: 'validateAddress',
     valid: [true, false, 0, 1, 'a'],
     invalid: [],

--- a/test/parallel/test-quic-internal-endpoint-options.mjs
+++ b/test/parallel/test-quic-internal-endpoint-options.mjs
@@ -11,6 +11,7 @@ if (!hasQuic) {
 
 // Import after the hasQuic check
 const { QuicEndpoint } = await import('node:quic');
+const { BlockList } = await import('node:net');
 
 // Reject invalid options
 ['a', null, false, NaN].forEach((i) => {
@@ -108,6 +109,16 @@ const cases = [
     key: 'sessionCreationBurst',
     valid: [0, 1, 10, 100.5, 1000, Infinity],
     invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'blockList',
+    valid: [new BlockList()],
+    invalid: ['a', 0, null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'blockListPolicy',
+    valid: ['deny', 'allow'],
+    invalid: ['invalid', 0, null, false, true, {}, [], () => {}]
   },
   {
     key: 'validateAddress',

--- a/test/parallel/test-quic-internal-endpoint-options.mjs
+++ b/test/parallel/test-quic-internal-endpoint-options.mjs
@@ -53,13 +53,6 @@ const cases = [
     invalid: [-1, 65536, 1.5, 'a', null, false, true, {}, [], () => {}]
   },
   {
-    key: 'maxStatelessResetsPerHost',
-    valid: [
-      1, 10, 100, 1000, 10000, 10000n,
-    ],
-    invalid: [-1, -1n, 'a', null, false, true, {}, [], () => {}]
-  },
-  {
     key: 'addressLRUSize',
     valid: [
       1, 10, 100, 1000, 10000, 10000n,
@@ -67,11 +60,44 @@ const cases = [
     invalid: [-1, -1n, 'a', null, false, true, {}, [], () => {}]
   },
   {
-    key: 'maxRetries',
-    valid: [
-      1, 10, 100, 1000, 10000, 10000n,
-    ],
-    invalid: [-1, -1n, 'a', null, false, true, {}, [], () => {}]
+    key: 'retryRate',
+    valid: [0, 1, 10, 100.5, 1000],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'retryBurst',
+    valid: [0, 1, 10, 100.5, 1000],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'statelessResetRate',
+    valid: [0, 1, 10, 100.5, 1000],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'statelessResetBurst',
+    valid: [0, 1, 10, 100.5, 1000],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'versionNegotiationRate',
+    valid: [0, 1, 10, 100.5, 1000],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'versionNegotiationBurst',
+    valid: [0, 1, 10, 100.5, 1000],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'immediateCloseRate',
+    valid: [0, 1, 10, 100.5, 1000],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
+  },
+  {
+    key: 'immediateCloseBurst',
+    valid: [0, 1, 10, 100.5, 1000],
+    invalid: [-1, 'a', null, false, true, {}, [], () => {}]
   },
   {
     key: 'validateAddress',

--- a/test/parallel/test-quic-internal-endpoint-stats-state.mjs
+++ b/test/parallel/test-quic-internal-endpoint-stats-state.mjs
@@ -96,6 +96,7 @@ const {
   strictEqual(typeof endpoint.stats.immediateCloseCount, 'bigint');
   strictEqual(typeof endpoint.stats.immediateCloseRateLimited, 'bigint');
   strictEqual(typeof endpoint.stats.sessionCreationRateLimited, 'bigint');
+  strictEqual(typeof endpoint.stats.packetsBlocked, 'bigint');
 
   deepStrictEqual(Object.keys(endpoint.stats.toJSON()), [
     'connected',
@@ -117,6 +118,7 @@ const {
     'immediateCloseCount',
     'immediateCloseRateLimited',
     'sessionCreationRateLimited',
+    'packetsBlocked',
   ]);
   strictEqual(typeof inspect(endpoint.stats), 'string');
 }

--- a/test/parallel/test-quic-internal-endpoint-stats-state.mjs
+++ b/test/parallel/test-quic-internal-endpoint-stats-state.mjs
@@ -95,6 +95,7 @@ const {
   strictEqual(typeof endpoint.stats.statelessResetRateLimited, 'bigint');
   strictEqual(typeof endpoint.stats.immediateCloseCount, 'bigint');
   strictEqual(typeof endpoint.stats.immediateCloseRateLimited, 'bigint');
+  strictEqual(typeof endpoint.stats.sessionCreationRateLimited, 'bigint');
 
   deepStrictEqual(Object.keys(endpoint.stats.toJSON()), [
     'connected',
@@ -115,6 +116,7 @@ const {
     'statelessResetRateLimited',
     'immediateCloseCount',
     'immediateCloseRateLimited',
+    'sessionCreationRateLimited',
   ]);
   strictEqual(typeof inspect(endpoint.stats), 'string');
 }

--- a/test/parallel/test-quic-internal-endpoint-stats-state.mjs
+++ b/test/parallel/test-quic-internal-endpoint-stats-state.mjs
@@ -88,9 +88,13 @@ const {
   strictEqual(typeof endpoint.stats.clientSessions, 'bigint');
   strictEqual(typeof endpoint.stats.serverBusyCount, 'bigint');
   strictEqual(typeof endpoint.stats.retryCount, 'bigint');
+  strictEqual(typeof endpoint.stats.retryRateLimited, 'bigint');
   strictEqual(typeof endpoint.stats.versionNegotiationCount, 'bigint');
+  strictEqual(typeof endpoint.stats.versionNegotiationRateLimited, 'bigint');
   strictEqual(typeof endpoint.stats.statelessResetCount, 'bigint');
+  strictEqual(typeof endpoint.stats.statelessResetRateLimited, 'bigint');
   strictEqual(typeof endpoint.stats.immediateCloseCount, 'bigint');
+  strictEqual(typeof endpoint.stats.immediateCloseRateLimited, 'bigint');
 
   deepStrictEqual(Object.keys(endpoint.stats.toJSON()), [
     'connected',
@@ -104,9 +108,13 @@ const {
     'clientSessions',
     'serverBusyCount',
     'retryCount',
+    'retryRateLimited',
     'versionNegotiationCount',
+    'versionNegotiationRateLimited',
     'statelessResetCount',
+    'statelessResetRateLimited',
     'immediateCloseCount',
+    'immediateCloseRateLimited',
   ]);
   strictEqual(typeof inspect(endpoint.stats), 'string');
 }

--- a/test/parallel/test-quic-internal-endpoint-stats-state.mjs
+++ b/test/parallel/test-quic-internal-endpoint-stats-state.mjs
@@ -231,6 +231,7 @@ strictEqual(typeof sessionStats.datagramsReceived, 'bigint');
 strictEqual(typeof sessionStats.datagramsSent, 'bigint');
 strictEqual(typeof sessionStats.datagramsAcknowledged, 'bigint');
 strictEqual(typeof sessionStats.datagramsLost, 'bigint');
+strictEqual(typeof sessionStats.streamsIdleTimedOut, 'bigint');
 strictEqual(typeof sessionStats.toJSON(), 'object');
 strictEqual(typeof inspect(sessionStats), 'string');
 streamStats[kFinishClose]();

--- a/test/parallel/test-quic-module-exports.mjs
+++ b/test/parallel/test-quic-module-exports.mjs
@@ -37,6 +37,7 @@ ok(quic.QuicEndpoint);
   });
 
   const clientSession = await connect(serverEndpoint.address, {
+    verifyPeer: 'manual',
     onsessionticket(ticket) {
       savedTicket = ticket;
       gotTicket.resolve();

--- a/test/parallel/test-quic-new-token.mjs
+++ b/test/parallel/test-quic-new-token.mjs
@@ -40,6 +40,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   servername: 'localhost',
   // Set onnewtoken at connection time to avoid missing the event.
   onnewtoken: mustCall(function(token, address) {

--- a/test/parallel/test-quic-reject-unauthorized.mjs
+++ b/test/parallel/test-quic-reject-unauthorized.mjs
@@ -25,30 +25,77 @@ await rejects(connect({ port: 1234 }, {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 
-// With rejectUnauthorized: true (the default), connecting with self-signed
-// certs and no CA should produce a validation error in the handshake info.
-
-const serverEndpoint = await listen(mustCall(async (serverSession) => {
-  await serverSession.opened;
-  serverSession.close();
-  await serverSession.closed;
+// verifyPeer must be one of 'strict', 'auto', 'manual'
+await rejects(connect({ port: 1234 }, {
+  alpn: 'quic-test',
+  verifyPeer: 'invalid',
 }), {
+  code: 'ERR_INVALID_ARG_VALUE',
+});
+
+const serverEndpoint = await listen(async (serverSession) => {
+  serverSession.onerror = () => {};
+  await rejects(serverSession.opened, (err) => {
+    ok(err.code === 'ERR_QUIC_TRANSPORT_ERROR' ||
+        err.code === 'ERR_INVALID_STATE');
+    return true;
+  });
+  serverSession.close();
+}, {
   sni: { '*': { keys: [key], certs: [cert] } },
   alpn: ['quic-test'],
 });
 
-const clientSession = await connect(serverEndpoint.address, {
-  alpn: 'quic-test',
-  servername: 'localhost',
-  // Default: rejectUnauthorized: true
-});
+// --- verifyPeer: 'manual' (current behavior) ---
+// The session.opened promise resolves even with an invalid cert.
+// The validation error is available in the info object.
+{
+  const clientSession = await connect(serverEndpoint.address, {
+    alpn: 'quic-test',
+    servername: 'localhost',
+    verifyPeer: 'manual',
+  });
 
-const info = await clientSession.opened;
-// Self-signed cert without CA should produce a validation error.
-strictEqual(typeof info.validationErrorReason, 'string');
-ok(info.validationErrorReason.length > 0);
-strictEqual(typeof info.validationErrorCode, 'string');
-ok(info.validationErrorCode.length > 0);
+  const info = await clientSession.opened;
+  // Self-signed cert without CA should produce a validation error.
+  strictEqual(typeof info.validationErrorReason, 'string');
+  ok(info.validationErrorReason.length > 0);
+  strictEqual(typeof info.validationErrorCode, 'string');
+  ok(info.validationErrorCode.length > 0);
 
-await clientSession.close();
+  await clientSession.close();
+}
+
+// --- verifyPeer: 'auto' (default) ---
+// The session.opened promise rejects when the cert is invalid.
+{
+  const clientSession = await connect(serverEndpoint.address, {
+    alpn: 'quic-test',
+    servername: 'localhost',
+    // verifyPeer defaults to 'auto'
+  });
+
+  await rejects(clientSession.opened, {
+    code: 'ERR_QUIC_TRANSPORT_ERROR',
+  });
+}
+
+// --- verifyPeer: 'strict' ---
+// The TLS handshake itself fails. The session.opened promise rejects.
+{
+  const clientSession = await connect(serverEndpoint.address, {
+    alpn: 'quic-test',
+    servername: 'localhost',
+    verifyPeer: 'strict',
+    // The TLS failure triggers onerror before opened rejects.
+    onerror: mustCall((err) => {
+      ok(err, 'strict mode should fire onerror on invalid cert');
+    }),
+  });
+
+  await rejects(clientSession.opened, {
+    code: 'ERR_QUIC_TRANSPORT_ERROR',
+  });
+}
+
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-opened-early-destroy.mjs
+++ b/test/parallel/test-quic-session-opened-early-destroy.mjs
@@ -44,6 +44,7 @@ const transportParams = { maxIdleTimeout: 1 };
   }, { transportParams });
 
   const clientSession = await connect(serverEndpoint.address, {
+    verifyPeer: 'manual',
     transportParams,
   });
 
@@ -70,6 +71,7 @@ const transportParams = { maxIdleTimeout: 1 };
   const serverEndpoint = await listen(mustNotCall, { transportParams });
 
   const clientSession = await connect(serverEndpoint.address, {
+    verifyPeer: 'manual',
     transportParams,
   });
 
@@ -96,6 +98,7 @@ const transportParams = { maxIdleTimeout: 1 };
   const clientEndpoint = new QuicEndpoint();
 
   const clientSession = await connect(serverEndpoint.address, {
+    verifyPeer: 'manual',
     transportParams,
     endpoint: clientEndpoint,
   });
@@ -127,6 +130,7 @@ const transportParams = { maxIdleTimeout: 1 };
   }), { transportParams });
 
   const clientSession = await connect(serverEndpoint.address, {
+    verifyPeer: 'manual',
     transportParams,
   });
 

--- a/test/parallel/test-quic-session-opened-validation.mjs
+++ b/test/parallel/test-quic-session-opened-validation.mjs
@@ -27,7 +27,9 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   serverSession.close();
 }));
 
-const clientSession = await connect(serverEndpoint.address);
+const clientSession = await connect(serverEndpoint.address, {
+  verifyPeer: 'manual',
+});
 const clientInfo = await clientSession.opened;
 
 // validationErrorReason is a non-empty string describing

--- a/test/parallel/test-quic-session-preferred-address-ipv6.mjs
+++ b/test/parallel/test-quic-session-preferred-address-ipv6.mjs
@@ -81,6 +81,7 @@ console.log(serverEndpoint.address);
 const clientSession = await connect(serverEndpoint.address, {
   // We don't want this endpoint to reuse either of the two listening endpoints.
   reuseEndpoint: false,
+  preferredAddressPolicy: 'use',
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagramstatus: mustCall((id, status) => {
     if (++statusCount >= 4) allStatusDone.resolve();

--- a/test/parallel/test-quic-session-preferred-address.mjs
+++ b/test/parallel/test-quic-session-preferred-address.mjs
@@ -65,6 +65,7 @@ const serverEndpoint = await listen(handleSession, {
 const clientSession = await connect(serverEndpoint.address, {
   // We don't want this endpoint to reuse either of the two listening endpoints.
   reuseEndpoint: false,
+  preferredAddressPolicy: 'use',
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagramstatus: mustCall((id, status) => {
     if (++statusCount >= 4) allStatusDone.resolve();

--- a/test/parallel/test-quic-session-stream-lifecycle.mjs
+++ b/test/parallel/test-quic-session-stream-lifecycle.mjs
@@ -52,7 +52,9 @@ strictEqual(epStats.isConnected, true);
 ok(epStats.createdAt > 0n);
 
 // Connect with a client
-const clientSession = await quic.connect(serverEndpoint.address);
+const clientSession = await quic.connect(serverEndpoint.address, {
+  verifyPeer: 'manual',
+});
 
 strictEqual(clientSession.destroyed, false);
 ok(clientSession.endpoint !== null);

--- a/test/parallel/test-quic-shared-endpoint-stream-close.mjs
+++ b/test/parallel/test-quic-shared-endpoint-stream-close.mjs
@@ -51,6 +51,7 @@ const clientEndpoint = new QuicEndpoint();
 // The client receives the stateless reset and closes session 1.
 const client1 = await connect(serverEndpoint.address, {
   endpoint: clientEndpoint,
+  verifyPeer: 'manual',
   onerror: mustCall((err) => { assert.ok(err); }),
 });
 await client1.opened;
@@ -75,6 +76,7 @@ await assert.rejects(client1.closed, { code: 'ERR_QUIC_TRANSPORT_ERROR' });
 // for session 2 hangs.
 const client2 = await connect(serverEndpoint.address, {
   endpoint: clientEndpoint,
+  verifyPeer: 'manual',
   onerror(err) { /* marks promises as handled */ },
 });
 await client2.opened;

--- a/test/parallel/test-quic-sni-mismatch.mjs
+++ b/test/parallel/test-quic-sni-mismatch.mjs
@@ -44,6 +44,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
   servername: 'wrong.example.com',
+  verifyPeer: 'manual',
   transportParams: { maxIdleTimeout: 1 },
   onerror: mustCall((err) => {
     strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');

--- a/test/parallel/test-quic-sni-multi-entry.mjs
+++ b/test/parallel/test-quic-sni-multi-entry.mjs
@@ -48,6 +48,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 {
   const cs = await connect(serverEndpoint.address, {
     servername: 'host1.example.com',
+    verifyPeer: 'manual',
     alpn: 'quic-test',
   });
   const info = await cs.opened;
@@ -59,6 +60,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 {
   const cs = await connect(serverEndpoint.address, {
     servername: 'host2.example.com',
+    verifyPeer: 'manual',
     alpn: 'quic-test',
   });
   const info = await cs.opened;
@@ -70,6 +72,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 {
   const cs = await connect(serverEndpoint.address, {
     servername: 'unknown.example.com',
+    verifyPeer: 'manual',
     alpn: 'quic-test',
   });
   const info = await cs.opened;

--- a/test/parallel/test-quic-sni-setcontexts.mjs
+++ b/test/parallel/test-quic-sni-setcontexts.mjs
@@ -42,6 +42,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 {
   const cs = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 2 },
   });
   const info = await cs.opened;
@@ -58,6 +59,7 @@ endpoint.setSNIContexts(
 {
   const cs = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     transportParams: { maxIdleTimeout: 2 },
   });
   const info = await cs.opened;

--- a/test/parallel/test-quic-sni.mjs
+++ b/test/parallel/test-quic-sni.mjs
@@ -39,6 +39,7 @@ ok(serverEndpoint.address !== undefined);
 // Client connects with servername 'localhost' — should match the SNI entry.
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
+  verifyPeer: 'manual',
   alpn: 'quic-test',
 });
 const clientInfo = await clientSession.opened;

--- a/test/parallel/test-quic-stateless-reset.mjs
+++ b/test/parallel/test-quic-stateless-reset.mjs
@@ -6,8 +6,7 @@
 //        session closes.
 // When disableStatelessReset is true, the server does NOT
 //        send a stateless reset.
-// maxStatelessResetsPerHost rate limits the number of resets
-//        sent to a single remote address.
+// Global token bucket rate limits the total number of resets.
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
@@ -138,9 +137,8 @@ const encoder = new TextEncoder();
   await serverEndpoint.close();
 }
 
-// maxStatelessResetsPerHost rate limits resets per remote address.
-// The LRU tracks resets per IP+port, so both sessions must share a
-// client endpoint to have the same source address.
+// Global token bucket rate limits stateless resets.
+// With burst=1 and rate=0, only one reset can be sent.
 {
   let sessionCount = 0;
   const serverDestroyed1 = Promise.withResolvers();
@@ -161,12 +159,12 @@ const encoder = new TextEncoder();
       deferred.resolve();
     });
   }, 2), {
-    endpoint: { maxStatelessResetsPerHost: 1 },
+    endpoint: { statelessResetBurst: 1, statelessResetRate: 0 },
     onerror(err) { ok(err); },
   });
 
-  // Both clients share an endpoint so the server sees the same
-  // remote IP+port for both, making the rate limiter apply.
+  // The global token bucket rate limiter applies regardless of
+  // client source address.
   const { QuicEndpoint } = await import('node:quic');
   const clientEndpoint = new QuicEndpoint();
 
@@ -215,7 +213,7 @@ const encoder = new TextEncoder();
   await serverDestroyed2.promise;
 
   // Send a packet — the server would normally send a stateless reset,
-  // but the rate limit (1 per host) is already exhausted.
+  // but the global rate limit (burst of 1) is already exhausted.
   // eslint-disable-next-line no-unused-vars
   const s2b = await client2.createBidirectionalStream({
     body: encoder.encode('after destroy 2'),
@@ -226,6 +224,8 @@ const encoder = new TextEncoder();
 
   strictEqual(serverEndpoint.stats.statelessResetCount, 1n,
               'Second reset should have been rate-limited');
+  ok(serverEndpoint.stats.statelessResetRateLimited > 0n,
+     'Rate-limited counter should be non-zero');
 
   await clientEndpoint.close();
   await serverEndpoint.close();

--- a/test/parallel/test-quic-stateless-reset.mjs
+++ b/test/parallel/test-quic-stateless-reset.mjs
@@ -47,6 +47,7 @@ const encoder = new TextEncoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     reuseEndpoint: false,
+    verifyPeer: 'manual',
     onerror: mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
     }),
@@ -103,6 +104,7 @@ const encoder = new TextEncoder();
 
   const clientSession = await connect(serverEndpoint.address, {
     reuseEndpoint: false,
+    verifyPeer: 'manual',
     // Short idle timeout so the client doesn't hang waiting for
     // a stateless reset that will never arrive.
     transportParams: { maxIdleTimeout: 1 },
@@ -172,6 +174,7 @@ const encoder = new TextEncoder();
 
   const client1 = await connect(serverEndpoint.address, {
     endpoint: clientEndpoint,
+    verifyPeer: 'manual',
     onerror: mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
     }),
@@ -198,6 +201,7 @@ const encoder = new TextEncoder();
 
   const client2 = await connect(serverEndpoint.address, {
     endpoint: clientEndpoint,
+    verifyPeer: 'manual',
     // Short idle timeout so the client closes after the server
     // destroys (no stateless reset will arrive, rate-limited).
     transportParams: { maxIdleTimeout: 1 },

--- a/test/parallel/test-quic-stream-destroy-emits-reset.mjs
+++ b/test/parallel/test-quic-stream-destroy-emits-reset.mjs
@@ -28,11 +28,7 @@ const { listen, connect } = await import('../common/quic.mjs');
 const serverResetSeen = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall((serverSession) => {
-  serverSession.onstream = mustCall((stream) => {
-    // The cascade-driven destroy of the server-side stream after the
-    // peer reset rejects `stream.closed` with the wire error; the
-    // test does not assert on its specific shape, only that `onreset`
-    // fired with the expected code.
+  serverSession.onstream = mustCall(async (stream) => {
     stream.onreset = mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
       // The DefaultApplication's internal error code is 0x1n, which
@@ -40,6 +36,12 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
       ok(err.message.includes('1n'),
          `expected '1n' in message, got: ${err.message}`);
       serverResetSeen.resolve();
+    });
+
+    // The peer's reset causes stream.closed to reject with the reset
+    // error code.
+    await rejects(stream.closed, {
+      code: 'ERR_QUIC_APPLICATION_ERROR',
     });
   });
 }));

--- a/test/parallel/test-quic-stream-destroy-emits-stop-sending.mjs
+++ b/test/parallel/test-quic-stream-destroy-emits-stop-sending.mjs
@@ -35,7 +35,7 @@ const { listen, connect } = await import('../common/quic.mjs');
 const serverObservation = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall((serverSession) => {
-  serverSession.onstream = mustCall((stream) => {
+  serverSession.onstream = mustCall(async (stream) => {
     const writer = stream.writer;
     // Sanity: the writer is active before the peer tears the stream
     // down, so desiredSize is a number reflecting the initial
@@ -57,6 +57,11 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
       setImmediate(() => {
         serverObservation.resolve(writer.desiredSize);
       });
+    });
+
+    // The peer's reset causes stream.closed to reject.
+    await assert.rejects(stream.closed, {
+      code: 'ERR_QUIC_APPLICATION_ERROR',
     });
   });
 }));

--- a/test/parallel/test-quic-stream-destroy-options-code.mjs
+++ b/test/parallel/test-quic-stream-destroy-options-code.mjs
@@ -24,12 +24,18 @@ const { listen, connect } = await import('../common/quic.mjs');
 const serverResetSeen = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall((serverSession) => {
-  serverSession.onstream = mustCall((stream) => {
+  serverSession.onstream = mustCall(async (stream) => {
     stream.onreset = mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
       ok(err.message.includes('66n'),
          `expected '66n' in message, got: ${err.message}`);
       serverResetSeen.resolve();
+    });
+
+    // The peer's reset causes stream.closed to reject with the reset
+    // error code.
+    await rejects(stream.closed, {
+      code: 'ERR_QUIC_APPLICATION_ERROR',
     });
   });
 }));

--- a/test/parallel/test-quic-stream-idle-timeout.mjs
+++ b/test/parallel/test-quic-stream-idle-timeout.mjs
@@ -1,0 +1,141 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// Test: stream idle timeout.
+// Peer-initiated streams that receive no data within the configured
+// timeout are automatically destroyed.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import assert from 'node:assert';
+import { setTimeout } from 'node:timers/promises';
+import { text } from 'node:stream/iter';
+
+const { rejects, strictEqual } = assert;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+
+// --- Stream destroyed after idle timeout ---
+{
+  const streamDestroyed = Promise.withResolvers();
+
+  const serverEndpoint = await listen(mustCall(async (serverSession) => {
+    serverSession.onstream = mustCall(async (stream) => {
+      // Don't read — let the stream sit idle after the initial data.
+      // The stream idle timeout should destroy it, rejecting stream.closed.
+      await rejects(stream.closed, {
+        code: 'ERR_QUIC_TRANSPORT_ERROR',
+      });
+      streamDestroyed.resolve();
+    });
+  }), {
+    // Short idle timeout for the test — 500ms.
+    streamIdleTimeout: 100,
+  });
+
+  const clientSession = await connect(serverEndpoint.address, {
+    verifyPeer: 'manual',
+    transportParams: { maxIdleTimeout: 1 },
+  });
+
+  await clientSession.opened;
+
+  // Open a stream and send one byte so the server creates the
+  // peer-initiated stream, then stop sending.
+  const clientStream = await clientSession.createUnidirectionalStream();
+  const writer = clientStream.writer;
+  writer.writeSync('x');
+
+  // Wait for the server to destroy the idle stream.
+  await streamDestroyed.promise;
+
+  // The server sent STOP_SENDING when it destroyed the idle stream.
+  // ShutdownStream maps the transport error to the application's
+  // internal error code on the wire, so the client sees an application
+  // error indicating the server rejected the stream.
+  await rejects(clientStream.closed, {
+    code: 'ERR_QUIC_APPLICATION_ERROR',
+  });
+
+  await clientSession.close();
+  await serverEndpoint.close();
+}
+
+// --- Stream with data is NOT destroyed ---
+{
+  const encoder = new TextEncoder();
+  const serverGotData = Promise.withResolvers();
+
+  const serverEndpoint = await listen(mustCall(async (serverSession) => {
+    serverSession.onstream = mustCall(async (stream) => {
+      const data = await text(stream);
+      strictEqual(data, 'xy');
+      serverGotData.resolve();
+      await serverSession.close();
+    });
+  }), {
+    streamIdleTimeout: 500,
+  });
+
+  const clientSession = await connect(serverEndpoint.address, {
+    verifyPeer: 'manual',
+  });
+  await clientSession.opened;
+
+  // Open a stream and send data immediately.
+  const clientStrema = await clientSession.createUnidirectionalStream();
+  const writer = clientStrema.writer;
+  writer.writeSync(encoder.encode('x'));
+
+  // Less than the 500ms idle timeout.
+  await setTimeout(300);
+
+  writer.writeSync(encoder.encode('y'));
+  writer.endSync();
+
+  await Promise.all([serverGotData.promise, clientSession.closed]);
+  await serverEndpoint.close();
+}
+
+// --- Disabled when set to 0 ---
+{
+  const streamSurvived = Promise.withResolvers();
+
+  const serverEndpoint = await listen(mustCall(async (serverSession) => {
+    serverSession.onstream = mustCall(async (stream) => {
+
+      // Do not await this yet.
+      const data = await text(stream);
+
+      // We should receive all the data, even though it is sent with a pause
+      // longer than the default idle timeout.
+      strictEqual(data, 'xy');
+      streamSurvived.resolve();
+    });
+
+    await setTimeout(700);
+    await serverSession.close();
+  }), {
+    streamIdleTimeout: 0,  // Disabled
+  });
+
+  const clientSession = await connect(serverEndpoint.address);
+  await clientSession.opened;
+
+  // Send one byte so the server creates the stream, then stop.
+  const clientStream = await clientSession.createUnidirectionalStream();
+  const writer = clientStream.writer;
+  writer.writeSync('x');
+
+  // Now pause beyond the 500ms default timeout to verify the stream is not
+  // killed by idle timeout.
+  await setTimeout(600);
+
+  writer.writeSync('y');
+  writer.endSync();
+
+  await Promise.all([streamSurvived.promise, clientSession.closed]);
+  await serverEndpoint.close();
+}

--- a/test/parallel/test-quic-stream-priority.mjs
+++ b/test/parallel/test-quic-stream-priority.mjs
@@ -27,6 +27,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
 });
 await clientSession.opened;
 

--- a/test/parallel/test-quic-stream-writer-fail-error-code.mjs
+++ b/test/parallel/test-quic-stream-writer-fail-error-code.mjs
@@ -72,7 +72,9 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   }, 2);
 }));
 
-const clientSession = await connect(serverEndpoint.address);
+const clientSession = await connect(serverEndpoint.address, {
+  verifyPeer: 'manual',
+});
 await clientSession.opened;
 
 // 1. Plain Error -> session.internalErrorCode (0x1n for non-h3).

--- a/test/parallel/test-quic-stream-writer-fail-error-code.mjs
+++ b/test/parallel/test-quic-stream-writer-fail-error-code.mjs
@@ -60,7 +60,7 @@ const allDone = Promise.withResolvers();
 const observed = [];
 
 const serverEndpoint = await listen(mustCall((serverSession) => {
-  serverSession.onstream = mustCall((stream) => {
+  serverSession.onstream = mustCall(async (stream) => {
     const i = nextStreamIndex++;
     stream.onreset = mustCall((err) => {
       observed[i] = wireCodeOf(err);
@@ -68,6 +68,11 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
           observed[0] !== undefined && observed[1] !== undefined) {
         allDone.resolve();
       }
+    });
+
+    // The peer's reset causes stream.closed to reject.
+    await assert.rejects(stream.closed, {
+      code: 'ERR_QUIC_APPLICATION_ERROR',
     });
   }, 2);
 }));

--- a/test/parallel/test-quic-tls-ca.mjs
+++ b/test/parallel/test-quic-tls-ca.mjs
@@ -36,6 +36,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
   servername: 'localhost',
+  verifyPeer: 'manual',
   ca,
 });
 

--- a/test/parallel/test-quic-tls-crl.mjs
+++ b/test/parallel/test-quic-tls-crl.mjs
@@ -38,6 +38,7 @@ const agent3Cert = readKey('agent3-cert.pem');
 
   const clientSession = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     ca: [ca2Cert],
     crl: [ca2Crl],
   });
@@ -64,6 +65,7 @@ const agent3Cert = readKey('agent3-cert.pem');
 
   const clientSession = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     ca: [ca2Cert],
     crl: [ca2CrlAgent3],
   });

--- a/test/parallel/test-quic-tls-options.mjs
+++ b/test/parallel/test-quic-tls-options.mjs
@@ -37,6 +37,7 @@ const cert = readKey('agent1-cert.pem');
 
   const clientSession = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     servername: 'localhost',
     ciphers: 'TLS_AES_256_GCM_SHA384',
   });
@@ -62,6 +63,7 @@ const cert = readKey('agent1-cert.pem');
 
   const clientSession = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     servername: 'localhost',
     groups: 'P-256',
   });

--- a/test/parallel/test-quic-tls-verify-client.mjs
+++ b/test/parallel/test-quic-tls-verify-client.mjs
@@ -42,6 +42,7 @@ const clientCert = readKey('agent2-cert.pem');
 
   const clientSession = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     keys: [clientKey],
     certs: [clientCert],
   });
@@ -72,6 +73,7 @@ const clientCert = readKey('agent2-cert.pem');
   // Client connects WITHOUT providing a certificate.
   const clientSession = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
+    verifyPeer: 'manual',
     onerror: mustCall((err) => {
       strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
     }),

--- a/test/parallel/test-quic-token-expired.mjs
+++ b/test/parallel/test-quic-token-expired.mjs
@@ -41,6 +41,7 @@ const serverEndpoint = await listen((serverSession) => {
 // First connection: receive the token.
 const cs1 = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   onnewtoken: mustCall((token) => {
     savedToken = token;
     gotToken.resolve();
@@ -58,6 +59,7 @@ await setTimeout(1500);
 // connection should still succeed (Retry is transparent).
 const cs2 = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   token: savedToken,
 });
 await cs2.opened;

--- a/test/parallel/test-quic-token-secret.mjs
+++ b/test/parallel/test-quic-token-secret.mjs
@@ -41,6 +41,7 @@ const ep1 = await listen(async (serverSession) => {
 // Get a token from the first server.
 const cs1 = await connect(ep1.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   onnewtoken: mustCall((token) => {
     savedToken = token;
     gotToken.resolve();
@@ -63,6 +64,7 @@ const ep2 = await listen(async (serverSession) => {
 
 const cs2 = await connect(ep2.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   token: savedToken,
 });
 await cs2.opened;
@@ -82,6 +84,7 @@ const ep3 = await listen(async (serverSession) => {
 
 const cs3 = await connect(ep3.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   token: savedToken,
 });
 await cs3.opened;

--- a/test/parallel/test-quic-zero-rtt-disabled-server.mjs
+++ b/test/parallel/test-quic-zero-rtt-disabled-server.mjs
@@ -49,6 +49,7 @@ const serverEndpoint1 = await listen((serverSession) => {
 
 const cs1 = await connect(serverEndpoint1.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   onsessionticket(ticket) {
     savedTicket = ticket;
     gotTicket.resolve();
@@ -77,6 +78,7 @@ const serverEndpoint2 = await listen(async (serverSession) => {
 
 const cs2 = await connect(serverEndpoint2.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   sessionTicket: savedTicket,
   token: savedToken,
 });

--- a/test/parallel/test-quic-zero-rtt-rejected-settings.mjs
+++ b/test/parallel/test-quic-zero-rtt-rejected-settings.mjs
@@ -53,6 +53,7 @@ const ep1 = await listen(async (serverSession) => {
 
 const cs1 = await connect(ep1.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   onsessionticket: mustCall((ticket) => {
     savedTicket = ticket;
     gotTicket.resolve();
@@ -88,6 +89,7 @@ const ep2 = await listen((serverSession) => {
 
 const cs2 = await connect(ep2.address, {
   alpn: 'quic-test',
+  verifyPeer: 'manual',
   sessionTicket: savedTicket,
   token: savedToken,
   onerror(err) { ok(err); },


### PR DESCRIPTION
Improve the security footing of the quic implementation with multiple improvements

* Document that TLS certs used with QUIC connections are best when small (established practice)
* Flip the default preferred address policy to 'ignore' (client's should opt in to switching paths)
* Improve the rate limiting for connectionless responses (e.g. stateless resets, retry, immediately close, etc; limits potential DOS vector)
* Add session creation rate limiting (limit the number of new sessions an endpoint can create per second; configurable)
* Document the rate limiting mechanisms
* Improve h3 header size limits
* Add configurable peer cert verification
* Enable net.BlockList support
* Add stream idle timeout (slow loris DOS protection)

There are still a number of ergonomic issues with the API, particularly around streams, but the security details are shaping up nicely.

@nodejs/quic 