### PR TITLE
test: get rid of unnecessary `AbortController` instanciations

### DIFF
--- a/test/parallel/test-fs-promises-file-handle-writer.js
+++ b/test/parallel/test-fs-promises-file-handle-writer.js
@@ -458,11 +458,8 @@ async function testWriteWithAbortedSignalRejects() {
   const fh = await open(filePath, 'w');
   const w = fh.writer();
 
-  const ac = new AbortController();
-  ac.abort();
-
   await assert.rejects(
-    w.write(Buffer.from('data'), { signal: ac.signal }),
+    w.write(Buffer.from('data'), { signal: AbortSignal.abort() }),
     { name: 'AbortError' },
   );
 
@@ -479,11 +476,8 @@ async function testWritevWithAbortedSignalRejects() {
   const fh = await open(filePath, 'w');
   const w = fh.writer();
 
-  const ac = new AbortController();
-  ac.abort();
-
   await assert.rejects(
-    w.writev([Buffer.from('a'), Buffer.from('b')], { signal: ac.signal }),
+    w.writev([Buffer.from('a'), Buffer.from('b')], { signal: AbortSignal.abort() }),
     { name: 'AbortError' },
   );
 
@@ -501,11 +495,8 @@ async function testEndWithAbortedSignalRejects() {
 
   await w.write(Buffer.from('data'));
 
-  const ac = new AbortController();
-  ac.abort();
-
   await assert.rejects(
-    w.end({ signal: ac.signal }),
+    w.end({ signal: AbortSignal.abort() }),
     { name: 'AbortError' },
   );
 

--- a/test/parallel/test-runner-mock-timers-scheduler.js
+++ b/test/parallel/test-runner-mock-timers-scheduler.js
@@ -97,11 +97,9 @@ describe('Mock Timers Scheduler Test Suite', () => {
 
   it('should abort operation when .abort is called before calling setInterval', async (t) => {
     t.mock.timers.enable({ apis: ['scheduler.wait'] });
-    const controller = new AbortController();
-    controller.abort();
     const p = nodeTimersPromises.scheduler.wait(2000, {
       ref: true,
-      signal: controller.signal,
+      signal: AbortSignal.abort(),
     });
 
     await assert.rejects(() => p, {

--- a/test/parallel/test-runner-mock-timers.js
+++ b/test/parallel/test-runner-mock-timers.js
@@ -551,11 +551,9 @@ describe('Mock Timers Test Suite', () => {
         it('should abort operation when .abort is called before calling setInterval', async (t) => {
           t.mock.timers.enable({ apis: ['setTimeout'] });
           const expectedResult = 'result';
-          const controller = new AbortController();
-          controller.abort();
           const p = nodeTimersPromises.setTimeout(2000, expectedResult, {
             ref: true,
-            signal: controller.signal,
+            signal: AbortSignal.abort(),
           });
 
           await assert.rejects(() => p, {
@@ -778,10 +776,8 @@ describe('Mock Timers Test Suite', () => {
           t.mock.timers.enable({ apis: ['setInterval'] });
 
           const interval = 100;
-          const abortController = new AbortController();
-          abortController.abort();
           const intervalIterator = nodeTimersPromises.setInterval(interval, Date.now(), {
-            signal: abortController.signal,
+            signal: AbortSignal.abort(),
           });
 
           const first = intervalIterator.next();

--- a/test/parallel/test-stream-iter-broadcast-from.js
+++ b/test/parallel/test-stream-iter-broadcast-from.js
@@ -78,10 +78,7 @@ async function testAbortSignal() {
 }
 
 async function testAlreadyAbortedSignal() {
-  const ac = new AbortController();
-  ac.abort();
-
-  const { broadcast: bc } = broadcast({ signal: ac.signal });
+  const { broadcast: bc } = broadcast({ signal: AbortSignal.abort() });
   const consumer = bc.push();
 
   const batches = [];

--- a/test/parallel/test-stream-iter-consumers-bytes.js
+++ b/test/parallel/test-stream-iter-consumers-bytes.js
@@ -45,10 +45,8 @@ async function testBytesAsyncLimit() {
 }
 
 async function testBytesAsyncAbort() {
-  const ac = new AbortController();
-  ac.abort();
   await assert.rejects(
-    () => bytes(from('data'), { signal: ac.signal }),
+    () => bytes(from('data'), { signal: AbortSignal.abort() }),
     { name: 'AbortError' },
   );
 }

--- a/test/parallel/test-stream-iter-consumers-merge.js
+++ b/test/parallel/test-stream-iter-consumers-merge.js
@@ -55,10 +55,7 @@ async function testMergeEmpty() {
 }
 
 async function testMergeWithAbortSignal() {
-  const ac = new AbortController();
-  ac.abort();
-
-  const merged = merge(from('data'), { signal: ac.signal });
+  const merged = merge(from('data'), { signal: AbortSignal.abort() });
 
   await assert.rejects(
     async () => {

--- a/test/parallel/test-stream-iter-consumers-text.js
+++ b/test/parallel/test-stream-iter-consumers-text.js
@@ -96,10 +96,8 @@ async function testTextEmpty() {
 
 // text() with abort signal
 async function testTextWithSignal() {
-  const ac = new AbortController();
-  ac.abort();
   await assert.rejects(
-    () => text(from('data'), { signal: ac.signal }),
+    () => text(from('data'), { signal: AbortSignal.abort() }),
     { name: 'AbortError' },
   );
 }

--- a/test/parallel/test-stream-iter-pull-async.js
+++ b/test/parallel/test-stream-iter-pull-async.js
@@ -41,14 +41,11 @@ async function testPullStatefulTransform() {
 }
 
 async function testPullWithAbortSignal() {
-  const ac = new AbortController();
-  ac.abort();
-
   async function* gen() {
     yield [new Uint8Array([1])];
   }
 
-  const result = pull(gen(), { signal: ac.signal });
+  const result = pull(gen(), { signal: AbortSignal.abort() });
   await assert.rejects(
     async () => {
       // eslint-disable-next-line no-unused-vars

--- a/test/parallel/test-stream-iter-push-basic.js
+++ b/test/parallel/test-stream-iter-push-basic.js
@@ -109,9 +109,7 @@ async function testAbortSignal() {
 }
 
 async function testPreAbortedSignal() {
-  const ac = new AbortController();
-  ac.abort();
-  const { readable } = push({ signal: ac.signal });
+  const { readable } = push({ signal: AbortSignal.abort() });
   await assert.rejects(async () => {
     // eslint-disable-next-line no-unused-vars
     for await (const _ of readable) {

--- a/test/parallel/test-stream-iter-push-writer.js
+++ b/test/parallel/test-stream-iter-push-writer.js
@@ -61,12 +61,9 @@ async function testWriteWithSignalRejects() {
 async function testWriteWithPreAbortedSignal() {
   const { writer, readable } = push({ highWaterMark: 1 });
 
-  const ac = new AbortController();
-  ac.abort();
-
   // Pre-aborted signal should reject immediately
   await assert.rejects(
-    writer.write('data', { signal: ac.signal }),
+    writer.write('data', { signal: AbortSignal.abort() }),
     { name: 'AbortError' },
   );
 

--- a/test/parallel/test-stream-iter-share-async.js
+++ b/test/parallel/test-stream-iter-share-async.js
@@ -147,10 +147,7 @@ async function testShareAbortSignal() {
 }
 
 async function testShareAlreadyAborted() {
-  const ac = new AbortController();
-  ac.abort();
-
-  const shared = share(from('data'), { signal: ac.signal });
+  const shared = share(from('data'), { signal: AbortSignal.abort() });
   const consumer = shared.pull();
 
   const batches = [];

--- a/test/parallel/test-stream-iter-to-readable.js
+++ b/test/parallel/test-stream-iter-to-readable.js
@@ -311,9 +311,7 @@ async function testSignalAlreadyAborted() {
     yield [Buffer.from('should not reach')];
   }
 
-  const ac = new AbortController();
-  ac.abort();
-  const readable = toReadable(gen(), { signal: ac.signal });
+  const readable = toReadable(gen(), { signal: AbortSignal.abort() });
 
   await assert.rejects(async () => {
     // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
I've considered doing a lint rule, but the effort to verify if the controller is used elsewhere makes it probably not worth it.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
