### PR TITLE
crypto: fix warnings in test_node_crypto.cc

### DIFF
--- a/test/cctest/test_node_crypto.cc
+++ b/test/cctest/test_node_crypto.cc
@@ -28,23 +28,23 @@ TEST(NodeCrypto, NewRootCertStore) {
  */
 TEST(NodeCrypto, MemoryTrackingConstants) {
   // Verify that our memory tracking constants are defined and reasonable
-  EXPECT_GT(node::crypto::kSizeOf_SSL_CTX, 0)
+  EXPECT_GT(node::crypto::kSizeOf_SSL_CTX, static_cast<size_t>(0))
       << "SSL_CTX size constant should be positive";
-  EXPECT_GT(node::crypto::kSizeOf_X509, 0)
+  EXPECT_GT(node::crypto::kSizeOf_X509, static_cast<size_t>(0))
       << "X509 size constant should be positive";
-  EXPECT_GT(node::crypto::kSizeOf_EVP_MD_CTX, 0)
+  EXPECT_GT(node::crypto::kSizeOf_EVP_MD_CTX, static_cast<size_t>(0))
       << "EVP_MD_CTX size constant should be positive";
 
   // Verify reasonable size ranges (basic sanity check)
-  EXPECT_LT(node::crypto::kSizeOf_SSL_CTX, 10000)
+  EXPECT_LT(node::crypto::kSizeOf_SSL_CTX, static_cast<size_t>(10000))
       << "SSL_CTX size should be reasonable";
-  EXPECT_LT(node::crypto::kSizeOf_X509, 10000)
+  EXPECT_LT(node::crypto::kSizeOf_X509, static_cast<size_t>(10000))
       << "X509 size should be reasonable";
-  EXPECT_LT(node::crypto::kSizeOf_EVP_MD_CTX, 1000)
+  EXPECT_LT(node::crypto::kSizeOf_EVP_MD_CTX, static_cast<size_t>(1000))
       << "EVP_MD_CTX size should be reasonable";
 
   // Specific values we expect based on our implementation
-  EXPECT_EQ(node::crypto::kSizeOf_SSL_CTX, 240);
-  EXPECT_EQ(node::crypto::kSizeOf_X509, 128);
-  EXPECT_EQ(node::crypto::kSizeOf_EVP_MD_CTX, 48);
+  EXPECT_EQ(node::crypto::kSizeOf_SSL_CTX, static_cast<size_t>(240));
+  EXPECT_EQ(node::crypto::kSizeOf_X509, static_cast<size_t>(128));
+  EXPECT_EQ(node::crypto::kSizeOf_EVP_MD_CTX, static_cast<size_t>(48));
 }


### PR DESCRIPTION
Fix build warnings by casting the number literals to the size_t constants they are compared against.
