### PR TITLE
stream: reject pull() reads on abort

### DIFF
--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -14,6 +14,9 @@ const {
   ArrayPrototypeSlice,
   PromisePrototypeThen,
   PromiseResolve,
+  PromiseWithResolvers,
+  SafePromisePrototypeFinally,
+  SafePromiseRace,
   SymbolAsyncIterator,
   SymbolIterator,
   TypedArrayPrototypeGetByteLength,
@@ -686,6 +689,77 @@ async function* applyValidatedStatefulAsyncTransform(source, transform, options)
 }
 
 /**
+ * Read one item from an async iterator, rejecting early if the signal aborts.
+ * @param {AsyncIterator} iterator - The iterator to read from.
+ * @param {AbortSignal|undefined} signal - Optional abort signal.
+ * @returns {Promise<IteratorResult<Uint8Array[]>>|IteratorResult<Uint8Array[]>}
+ */
+function abortableNext(iterator, signal) {
+  if (signal === undefined) {
+    return iterator.next();
+  }
+
+  signal.throwIfAborted();
+
+  const next = iterator.next();
+  const { promise, reject } = PromiseWithResolvers();
+  const onAbort = () => reject(signal.reason);
+  signal.addEventListener('abort', onAbort, { __proto__: null, once: true });
+  if (signal.aborted) {
+    onAbort();
+  }
+
+  return SafePromisePrototypeFinally(SafePromiseRace([next, promise]), () => {
+    signal.removeEventListener('abort', onAbort);
+  });
+}
+
+/**
+ * Wrap an async source so each pending read is abort-aware.
+ * @param {AsyncIterable<Uint8Array[]>} source - The source to read from.
+ * @param {AbortSignal|undefined} signal - Optional abort signal.
+ * @returns {AsyncIterable<Uint8Array[]>}
+ */
+function yieldAbortable(source, signal) {
+  if (signal === undefined) {
+    return source;
+  }
+
+  return {
+    __proto__: null,
+    async *[SymbolAsyncIterator]() {
+      const iterator = source[SymbolAsyncIterator]();
+      let completed = false;
+      let aborted = false;
+
+      try {
+        while (true) {
+          const { done, value } = await abortableNext(iterator, signal);
+          if (done) {
+            completed = true;
+            return;
+          }
+          signal.throwIfAborted();
+          yield value;
+        }
+      } catch (error) {
+        aborted = signal.aborted;
+        throw error;
+      } finally {
+        if (!completed && typeof iterator.return === 'function') {
+          const result = iterator.return();
+          if (aborted) {
+            PromisePrototypeThen(result, undefined, () => {});
+          } else {
+            await result;
+          }
+        }
+      }
+    },
+  };
+}
+
+/**
  * Create an async pipeline from source through transforms.
  * @yields {Uint8Array[]}
  */
@@ -693,16 +767,13 @@ async function* createAsyncPipeline(source, transforms, signal) {
   // Check for abort
   signal?.throwIfAborted();
 
-  const normalized = source;
-
   // Fast path: no transforms, just yield normalized source directly
   if (transforms.length === 0) {
-    for await (const batch of normalized) {
-      signal?.throwIfAborted();
-      yield batch;
-    }
+    yield* yieldAbortable(source, signal);
     return;
   }
+
+  const normalized = yieldAbortable(source, signal);
 
   // Create internal controller for transform cancellation.
   // Note: if signal was already aborted, we threw above - no need to check here.

--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -24,6 +24,10 @@ const {
 } = primordials;
 
 const {
+  markPromiseAsHandled,
+} = internalBinding('util');
+
+const {
   codes: {
     ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
@@ -753,7 +757,7 @@ function yieldAbortable(source, signal) {
         if (!completed && typeof iterator.return === 'function') {
           const result = iterator.return();
           if (aborted) {
-            PromisePrototypeThen(result, undefined, () => {});
+            markPromiseAsHandled(result);
           } else {
             await result;
           }

--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -688,6 +688,10 @@ async function* applyValidatedStatefulAsyncTransform(source, transform, options)
   options.signal?.throwIfAborted();
 }
 
+function getOnAbort(reject, signal) {
+  return () => reject(signal.reason);
+}
+
 /**
  * Read one item from an async iterator, rejecting early if the signal aborts.
  * @param {AsyncIterator} iterator - The iterator to read from.
@@ -703,7 +707,7 @@ function abortableNext(iterator, signal) {
 
   const next = iterator.next();
   const { promise, reject } = PromiseWithResolvers();
-  const onAbort = () => reject(signal.reason);
+  const onAbort = getOnAbort(reject, signal);
   signal.addEventListener('abort', onAbort, { __proto__: null, once: true });
   if (signal.aborted) {
     onAbort();

--- a/test/parallel/test-stream-iter-pull-async.js
+++ b/test/parallel/test-stream-iter-pull-async.js
@@ -153,6 +153,44 @@ async function testPullSignalAbortMidIteration() {
   await assert.rejects(() => iter.next(), { name: 'AbortError' });
 }
 
+async function testPullSignalAbortWhileSourceNextPending() {
+  const source = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          await new Promise(() => {});
+        },
+      };
+    },
+  };
+  const ac = new AbortController();
+  const iter = pull(source, { signal: ac.signal })[Symbol.asyncIterator]();
+  const next = iter.next();
+  ac.abort();
+  await assert.rejects(next, { name: 'AbortError' });
+}
+
+async function testPullSignalAbortWithTransformWhileSourceNextPending() {
+  const source = {
+    [Symbol.asyncIterator]() {
+      return {
+        async next() {
+          await new Promise(() => {});
+        },
+      };
+    },
+  };
+  const ac = new AbortController();
+  const iter = pull(
+    source,
+    (chunks) => chunks,
+    { signal: ac.signal },
+  )[Symbol.asyncIterator]();
+  const next = iter.next();
+  ac.abort();
+  await assert.rejects(next, { name: 'AbortError' });
+}
+
 // Pull consumer break (return()) cleans up transform signal
 async function testPullConsumerBreakCleanup() {
   let signalAborted = false;
@@ -361,6 +399,8 @@ async function testTransformOptionsNotShared() {
     testPullSourceError(),
     testTapCallbackError(),
     testPullSignalAbortMidIteration(),
+    testPullSignalAbortWhileSourceNextPending(),
+    testPullSignalAbortWithTransformWhileSourceNextPending(),
     testPullConsumerBreakCleanup(),
     testPullTransformReturnsPromise(),
     testPullTransformYieldsStrings(),


### PR DESCRIPTION
This updates `stream/iter` `pull()` so pending source reads are abort-aware.
When `{ signal }` is provided, a pending source `next()` now rejects when the
signal aborts instead of waiting for the source to eventually yield.

The abort-aware wrapper returns the original source unchanged when no signal is
provided, so the normal no-signal path does not add an extra async iterator
layer.

The regression tests cover aborting while the source `next()` is pending in
both the no-transform path and a transform pipeline.

Fixes: https://github.com/nodejs/node/issues/63497

---

Assisted-by: openai:gpt-5.5