### PR TITLE
ffi: validate 'void' as parameter type in getFunction and getFunctions

### DIFF
--- a/src/ffi/types.cc
+++ b/src/ffi/types.cc
@@ -164,6 +164,15 @@ Maybe<FunctionSignature> ParseFunctionSignature(Environment* env,
       if (!ToFFIType(env, arg_str.ToStringView()).To(&arg_type)) {
         return {};
       }
+      if (arg_type == &ffi_type_void) {
+        THROW_ERR_INVALID_ARG_VALUE(
+            env,
+            "Argument %u of function %s must not be 'void'; "
+            "use an empty array for no-argument functions",
+            i,
+            name);
+        return {};
+      }
 
       args.push_back(arg_type);
       arg_type_names.emplace_back(arg_str.ToString());

--- a/test/ffi/test-ffi-void-parameter.js
+++ b/test/ffi/test-ffi-void-parameter.js
@@ -1,0 +1,29 @@
+// Flags: --experimental-ffi
+'use strict';
+
+const common = require('../common');
+common.skipIfFFIMissing();
+
+const assert = require('node:assert');
+const ffi = require('node:ffi');
+const { libraryPath } = require('./ffi-test-common');
+
+// Regression test for https://github.com/nodejs/node/issues/63461
+// 'void' as a parameter type should throw ERR_INVALID_ARG_VALUE
+// instead of triggering ERR_INTERNAL_ASSERTION.
+
+const lib = new ffi.DynamicLibrary(libraryPath);
+
+try {
+  assert.throws(() => {
+    lib.getFunction('add_i32', { return: 'i32', arguments: ['void'] });
+  }, { code: 'ERR_INVALID_ARG_VALUE' });
+
+  assert.throws(() => {
+    lib.getFunctions({
+      add_i32: { return: 'i32', arguments: ['void'] },
+    });
+  }, { code: 'ERR_INVALID_ARG_VALUE' });
+} finally {
+  lib.close();
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63461

Passing `'void'` as a parameter type in `getFunction` or `getFunctions` triggers an internal assertion instead of a user-friendly error.

In C, `void` in a parameter list means a function takes no arguments, expressed in Node.js FFI as an empty array `[]`. There is no valid use case for `'void'` as a parameter type.

Fix: 
add early validation in `getFunction` and `getFunctions` that throws `ERR_INVALID_ARG_VALUE` when `'void'` appears in the parameters array, before `wrapWithSharedBuffer` is called.


