### PR TITLE
src: remove TOCTOU race condition when encoding SAB-backed `Buffer`s

### DIFF
--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -442,7 +442,7 @@ void BindingData::DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
 
   std::unique_ptr<char[]> data_copy;
   if (isShared && length != 0) {
-    data_copy.reset(new char[length]);
+    data_copy = std::make_unique_for_overwrite<char[]>(length);
     memcpy(data_copy.get(), data, length);
     data = data_copy.get();
   }

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -420,8 +420,7 @@ void BindingData::DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(args.Length(), 1);
   auto isShared = args[0]->IsSharedArrayBuffer();
 
-  if (!(args[0]->IsArrayBuffer() || isShared ||
-        args[0]->IsArrayBufferView())) {
+  if (!(args[0]->IsArrayBuffer() || isShared || args[0]->IsArrayBufferView())) {
     return node::THROW_ERR_INVALID_ARG_TYPE(
         env->isolate(),
         "The \"list\" argument must be an instance of SharedArrayBuffer, "

--- a/src/encoding_binding.cc
+++ b/src/encoding_binding.cc
@@ -418,13 +418,19 @@ void BindingData::DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);  // list, flags
 
   CHECK_GE(args.Length(), 1);
+  auto isShared = args[0]->IsSharedArrayBuffer();
 
-  if (!(args[0]->IsArrayBuffer() || args[0]->IsSharedArrayBuffer() ||
+  if (!(args[0]->IsArrayBuffer() || isShared ||
         args[0]->IsArrayBufferView())) {
     return node::THROW_ERR_INVALID_ARG_TYPE(
         env->isolate(),
         "The \"list\" argument must be an instance of SharedArrayBuffer, "
         "ArrayBuffer or ArrayBufferView.");
+  }
+
+  if (args[0]->IsArrayBufferView()) {
+    Local<v8::ArrayBufferView> view = args[0].As<v8::ArrayBufferView>();
+    isShared = view->Buffer()->IsSharedArrayBuffer();
   }
 
   ArrayBufferViewContents<char> buffer(args[0]);
@@ -434,6 +440,13 @@ void BindingData::DecodeUTF8(const FunctionCallbackInfo<Value>& args) {
 
   const char* data = buffer.data();
   size_t length = buffer.length();
+
+  std::unique_ptr<char[]> data_copy;
+  if (isShared && length != 0) {
+    data_copy.reset(new char[length]);
+    memcpy(data_copy.get(), data, length);
+    data = data_copy.get();
+  }
 
   if (!ignore_bom && length >= 3) {
     if (memcmp(data, "\xEF\xBB\xBF", 3) == 0) {

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -584,7 +584,7 @@ void StringSlice(const FunctionCallbackInfo<Value>& args) {
 
   std::unique_ptr<char[]> data_copy;
   if (view->Buffer()->IsSharedArrayBuffer()) {
-    data_copy.reset(new char[length]);
+    data_copy = std::make_unique_for_overwrite<char[]>(length);
     memcpy(data_copy.get(), data_ptr + start, length);
     data_ptr = data_copy.get();
     start = 0;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -572,8 +572,7 @@ void StringSlice(const FunctionCallbackInfo<Value>& args) {
 
   Local<ArrayBufferView> view = args[0].As<ArrayBufferView>();
 
-  if (buffer_length == 0)
-    return args.GetReturnValue().SetEmptyString();
+  if (buffer_length == 0) return args.GetReturnValue().SetEmptyString();
 
   size_t start = 0;
   size_t end = 0;

--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -567,19 +567,32 @@ void StringSlice(const FunctionCallbackInfo<Value>& args) {
   THROW_AND_RETURN_UNLESS_BUFFER(env, args[0]);
   ArrayBufferViewContents<char> buffer(args[0]);
 
-  if (buffer.length() == 0)
+  auto buffer_length = buffer.length();
+  const char* data_ptr = buffer.data();
+
+  Local<ArrayBufferView> view = args[0].As<ArrayBufferView>();
+
+  if (buffer_length == 0)
     return args.GetReturnValue().SetEmptyString();
 
   size_t start = 0;
   size_t end = 0;
   THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[1], 0, &start));
-  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[2], buffer.length(), &end));
-  if (end < start) end = start;
-  THROW_AND_RETURN_IF_OOB(Just(end <= buffer.length()));
+  THROW_AND_RETURN_IF_OOB(ParseArrayIndex(env, args[2], buffer_length, &end));
+  if (end <= start) return args.GetReturnValue().SetEmptyString();
+  THROW_AND_RETURN_IF_OOB(Just(end <= buffer_length));
   size_t length = end - start;
 
+  std::unique_ptr<char[]> data_copy;
+  if (view->Buffer()->IsSharedArrayBuffer()) {
+    data_copy.reset(new char[length]);
+    memcpy(data_copy.get(), data_ptr + start, length);
+    data_ptr = data_copy.get();
+    start = 0;
+  }
+
   Local<Value> ret;
-  if (StringBytes::Encode(isolate, buffer.data() + start, length, encoding)
+  if (StringBytes::Encode(isolate, data_ptr + start, length, encoding)
           .ToLocal(&ret)) {
     args.GetReturnValue().Set(ret);
   }


### PR DESCRIPTION
If the `BufferView` is backed by a `SharedArrayBuffer`, we want to copy the content before passing it to `String::Encode` in case the data is mutated in a different thread.

Otherwise the `validate_utf8` and `convert_valid_utf8_to_utf16` might get bytes, leading to undefined behavior
https://github.com/nodejs/node/blob/e209dbe103886d75ab6a88af026fc0b1b3805c76/src/string_bytes.cc#L585-L600

Refs: https://hackerone.com/reports/3752489

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
