### PR TITLE
doc,lib: align WebCrypto names with spec

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -850,7 +850,7 @@ The algorithms currently supported include:
 * `'ML-KEM-768'`[^modern-algos]
 * `'ML-KEM-1024'`[^modern-algos]
 
-### `subtle.decapsulateKey(decapsulationAlgorithm, decapsulationKey, ciphertext, sharedKeyAlgorithm, extractable, usages)`
+### `subtle.decapsulateKey(decapsulationAlgorithm, decapsulationKey, ciphertext, sharedKeyAlgorithm, extractable, keyUsages)`
 
 <!-- YAML
 added: v24.7.0
@@ -863,7 +863,7 @@ added: v24.7.0
 * `ciphertext` {ArrayBuffer|TypedArray|DataView|Buffer}
 * `sharedKeyAlgorithm` {string|Algorithm|HmacImportParams|AesDerivedKeyParams|KmacImportParams}
 * `extractable` {boolean}
-* `usages` {string\[]} See [Key usages][].
+* `keyUsages` {string\[]} See [Key usages][].
 * Returns: {Promise} Fulfills with {CryptoKey} upon success.
 
 A message recipient uses their asymmetric private key to decrypt an
@@ -961,7 +961,7 @@ The algorithms currently supported include:
 * `'X25519'`
 * `'X448'`[^secure-curves]
 
-### `subtle.deriveKey(algorithm, baseKey, derivedKeyAlgorithm, extractable, keyUsages)`
+### `subtle.deriveKey(algorithm, baseKey, derivedKeyType, extractable, keyUsages)`
 
 <!-- YAML
 added: v15.0.0
@@ -980,7 +980,7 @@ changes:
 
 * `algorithm` {EcdhKeyDeriveParams|HkdfParams|Pbkdf2Params|Argon2Params}
 * `baseKey` {CryptoKey}
-* `derivedKeyAlgorithm` {string|Algorithm|HmacImportParams|AesDerivedKeyParams|KmacImportParams}
+* `derivedKeyType` {string|Algorithm|HmacImportParams|AesDerivedKeyParams|KmacImportParams}
 * `extractable` {boolean}
 * `keyUsages` {string\[]} See [Key usages][].
 * Returns: {Promise} Fulfills with a {CryptoKey} upon success.
@@ -989,11 +989,11 @@ changes:
 
 Using the method and parameters specified in `algorithm`, and the keying
 material provided by `baseKey`, this method attempts to generate
-a new {CryptoKey} based on the method and parameters in `derivedKeyAlgorithm`.
+a new {CryptoKey} based on the method and parameters in `derivedKeyType`.
 
 Calling this method is equivalent to calling [`subtle.deriveBits()`][] to
 generate raw keying material, then passing the result into the
-[`subtle.importKey()`][] method using the `derivedKeyAlgorithm`, `extractable`, and
+[`subtle.importKey()`][] method using the `derivedKeyType`, `extractable`, and
 `keyUsages` parameters as input.
 
 The algorithms currently supported include:
@@ -1073,7 +1073,7 @@ The algorithms currently supported include:
 * `'ML-KEM-768'`[^modern-algos]
 * `'ML-KEM-1024'`[^modern-algos]
 
-### `subtle.encapsulateKey(encapsulationAlgorithm, encapsulationKey, sharedKeyAlgorithm, extractable, usages)`
+### `subtle.encapsulateKey(encapsulationAlgorithm, encapsulationKey, sharedKeyAlgorithm, extractable, keyUsages)`
 
 <!-- YAML
 added: v24.7.0
@@ -1085,7 +1085,7 @@ added: v24.7.0
 * `encapsulationKey` {CryptoKey}
 * `sharedKeyAlgorithm` {string|Algorithm|HmacImportParams|AesDerivedKeyParams|KmacImportParams}
 * `extractable` {boolean}
-* `usages` {string\[]} See [Key usages][].
+* `keyUsages` {string\[]} See [Key usages][].
 * Returns: {Promise} Fulfills with {EncapsulatedKey} upon success.
 
 Uses a message recipient's asymmetric public key to encrypt a temporary symmetric key.
@@ -1419,7 +1419,7 @@ The algorithms currently supported include:
 * `'RSA-PSS'`
 * `'RSASSA-PKCS1-v1_5'`
 
-### `subtle.unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgo, unwrappedKeyAlgo, extractable, keyUsages)`
+### `subtle.unwrapKey(format, wrappedKey, unwrappingKey, unwrapAlgorithm, unwrappedKeyAlgorithm, extractable, keyUsages)`
 
 <!-- YAML
 added: v15.0.0
@@ -1439,8 +1439,8 @@ changes:
 
 <!--lint disable maximum-line-length remark-lint-->
 
-* `unwrapAlgo` {string|Algorithm|RsaOaepParams|AesCtrParams|AesCbcParams|AeadParams}
-* `unwrappedKeyAlgo` {string|Algorithm|RsaHashedImportParams|EcKeyImportParams|HmacImportParams|KmacImportParams}
+* `unwrapAlgorithm` {string|Algorithm|RsaOaepParams|AesCtrParams|AesCbcParams|AeadParams}
+* `unwrappedKeyAlgorithm` {string|Algorithm|RsaHashedImportParams|EcKeyImportParams|HmacImportParams|KmacImportParams}
 
 <!--lint enable maximum-line-length remark-lint-->
 
@@ -1452,8 +1452,8 @@ In cryptography, "wrapping a key" refers to exporting and then encrypting the
 keying material. This method attempts to decrypt a wrapped
 key and create a {CryptoKey} instance. It is equivalent to calling
 [`subtle.decrypt()`][] first on the encrypted key data (using the `wrappedKey`,
-`unwrapAlgo`, and `unwrappingKey` arguments as input) then passing the results
-to the [`subtle.importKey()`][] method using the `unwrappedKeyAlgo`,
+`unwrapAlgorithm`, and `unwrappingKey` arguments as input) then passing the results
+to the [`subtle.importKey()`][] method using the `unwrappedKeyAlgorithm`,
 `extractable`, and `keyUsages` arguments as inputs. If successful, the returned
 promise is resolved with a {CryptoKey} object.
 
@@ -1541,7 +1541,7 @@ The algorithms currently supported include:
 * `'RSA-PSS'`
 * `'RSASSA-PKCS1-v1_5'`
 
-### `subtle.wrapKey(format, key, wrappingKey, wrapAlgo)`
+### `subtle.wrapKey(format, key, wrappingKey, wrapAlgorithm)`
 
 <!-- YAML
 added: v15.0.0
@@ -1560,7 +1560,7 @@ changes:
   `'raw-public'`[^modern-algos], or `'raw-seed'`[^modern-algos].
 * `key` {CryptoKey}
 * `wrappingKey` {CryptoKey}
-* `wrapAlgo` {string|Algorithm|RsaOaepParams|AesCtrParams|AesCbcParams|AeadParams}
+* `wrapAlgorithm` {string|Algorithm|RsaOaepParams|AesCtrParams|AesCbcParams|AeadParams}
 * Returns: {Promise} Fulfills with an {ArrayBuffer} upon success.
 
 <!--lint enable maximum-line-length remark-lint-->
@@ -1568,10 +1568,10 @@ changes:
 In cryptography, "wrapping a key" refers to exporting and then encrypting the
 keying material. This method exports the keying material into
 the format identified by `format`, then encrypts it using the method and
-parameters specified by `wrapAlgo` and the keying material provided by
+parameters specified by `wrapAlgorithm` and the keying material provided by
 `wrappingKey`. It is the equivalent to calling [`subtle.exportKey()`][] using
 `format` and `key` as the arguments, then passing the result to the
-[`subtle.encrypt()`][] method using `wrappingKey` and `wrapAlgo` as inputs. If
+[`subtle.encrypt()`][] method using `wrappingKey` and `wrapAlgorithm` as inputs. If
 successful, the returned promise will be resolved with an {ArrayBuffer}
 containing the encrypted key data.
 
@@ -2815,19 +2815,19 @@ added:
 [Web Crypto API]: https://www.w3.org/TR/WebCryptoAPI/
 [`SubtleCrypto.supports()`]: #static-method-subtlecryptosupportsoperation-algorithm-lengthoradditionalalgorithm
 [`subtle.decapsulateBits()`]: #subtledecapsulatebitsdecapsulationalgorithm-decapsulationkey-ciphertext
-[`subtle.decapsulateKey()`]: #subtledecapsulatekeydecapsulationalgorithm-decapsulationkey-ciphertext-sharedkeyalgorithm-extractable-usages
+[`subtle.decapsulateKey()`]: #subtledecapsulatekeydecapsulationalgorithm-decapsulationkey-ciphertext-sharedkeyalgorithm-extractable-keyusages
 [`subtle.decrypt()`]: #subtledecryptalgorithm-key-data
 [`subtle.deriveBits()`]: #subtlederivebitsalgorithm-basekey-length
-[`subtle.deriveKey()`]: #subtlederivekeyalgorithm-basekey-derivedkeyalgorithm-extractable-keyusages
+[`subtle.deriveKey()`]: #subtlederivekeyalgorithm-basekey-derivedkeytype-extractable-keyusages
 [`subtle.digest()`]: #subtledigestalgorithm-data
 [`subtle.encapsulateBits()`]: #subtleencapsulatebitsencapsulationalgorithm-encapsulationkey
-[`subtle.encapsulateKey()`]: #subtleencapsulatekeyencapsulationalgorithm-encapsulationkey-sharedkeyalgorithm-extractable-usages
+[`subtle.encapsulateKey()`]: #subtleencapsulatekeyencapsulationalgorithm-encapsulationkey-sharedkeyalgorithm-extractable-keyusages
 [`subtle.encrypt()`]: #subtleencryptalgorithm-key-data
 [`subtle.exportKey()`]: #subtleexportkeyformat-key
 [`subtle.generateKey()`]: #subtlegeneratekeyalgorithm-extractable-keyusages
 [`subtle.getPublicKey()`]: #subtlegetpublickeykey-keyusages
 [`subtle.importKey()`]: #subtleimportkeyformat-keydata-algorithm-extractable-keyusages
 [`subtle.sign()`]: #subtlesignalgorithm-key-data
-[`subtle.unwrapKey()`]: #subtleunwrapkeyformat-wrappedkey-unwrappingkey-unwrapalgo-unwrappedkeyalgo-extractable-keyusages
+[`subtle.unwrapKey()`]: #subtleunwrapkeyformat-wrappedkey-unwrappingkey-unwrapalgorithm-unwrappedkeyalgorithm-extractable-keyusages
 [`subtle.verify()`]: #subtleverifyalgorithm-key-signature-data
-[`subtle.wrapKey()`]: #subtlewrapkeyformat-key-wrappingkey-wrapalgo
+[`subtle.wrapKey()`]: #subtlewrapkeyformat-key-wrappingkey-wrapalgorithm

--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -175,14 +175,14 @@ function aesCipher(mode, key, data, algorithm) {
   }
 }
 
-function aesGenerateKey(algorithm, extractable, keyUsages) {
+function aesGenerateKey(algorithm, extractable, usages) {
   const { name, length } = algorithm;
 
   const checkUsages = ['wrapKey', 'unwrapKey'];
   if (name !== 'AES-KW')
     ArrayPrototypePush(checkUsages, 'encrypt', 'decrypt');
 
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   if (hasAnyNotIn(usagesSet, checkUsages)) {
     throw lazyDOMException(
       'Unsupported key usage for an AES key',
@@ -207,13 +207,13 @@ function aesImportKey(
   format,
   keyData,
   extractable,
-  keyUsages) {
+  usages) {
   const { name } = algorithm;
   const checkUsages = ['wrapKey', 'unwrapKey'];
   if (name !== 'AES-KW')
     ArrayPrototypePush(checkUsages, 'encrypt', 'decrypt');
 
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   if (hasAnyNotIn(usagesSet, checkUsages)) {
     throw lazyDOMException(
       'Unsupported key usage for an AES key',

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -73,10 +73,10 @@ function verifyAcceptableCfrgKeyUse(name, isPublic, usages) {
   }
 }
 
-function cfrgGenerateKey(algorithm, extractable, keyUsages) {
+function cfrgGenerateKey(algorithm, extractable, usages) {
   const { name } = algorithm;
 
-  const usageSet = new SafeSet(keyUsages);
+  const usageSet = new SafeSet(usages);
   switch (name) {
     case 'Ed25519':
       // Fall through
@@ -170,11 +170,11 @@ function cfrgImportKey(
   keyData,
   algorithm,
   extractable,
-  keyUsages) {
+  usages) {
 
   const { name } = algorithm;
   let handle;
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   switch (format) {
     case 'KeyObject': {
       verifyAcceptableCfrgKeyUse(

--- a/lib/internal/crypto/chacha20_poly1305.js
+++ b/lib/internal/crypto/chacha20_poly1305.js
@@ -47,12 +47,12 @@ function c20pCipher(mode, key, data, algorithm) {
     algorithm.additionalData));
 }
 
-function c20pGenerateKey(algorithm, extractable, keyUsages) {
+function c20pGenerateKey(algorithm, extractable, usages) {
   const { name } = algorithm;
 
   const checkUsages = ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'];
 
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   if (hasAnyNotIn(usagesSet, checkUsages)) {
     throw lazyDOMException(
       `Unsupported key usage for a ${algorithm.name} key`,
@@ -77,11 +77,11 @@ function c20pImportKey(
   format,
   keyData,
   extractable,
-  keyUsages) {
+  usages) {
   const { name } = algorithm;
   const checkUsages = ['encrypt', 'decrypt', 'wrapKey', 'unwrapKey'];
 
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   if (hasAnyNotIn(usagesSet, checkUsages)) {
     throw lazyDOMException(
       `Unsupported key usage for a ${algorithm.name} key`,

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -77,10 +77,10 @@ function verifyAcceptableEcKeyUse(name, isPublic, usages) {
   }
 }
 
-function ecGenerateKey(algorithm, extractable, keyUsages) {
+function ecGenerateKey(algorithm, extractable, usages) {
   const { name, namedCurve } = algorithm;
 
-  const usageSet = new SafeSet(keyUsages);
+  const usageSet = new SafeSet(usages);
   switch (name) {
     case 'ECDSA':
       if (hasAnyNotIn(usageSet, ['sign', 'verify'])) {
@@ -178,12 +178,12 @@ function ecImportKey(
   keyData,
   algorithm,
   extractable,
-  keyUsages,
+  usages,
 ) {
   const { name, namedCurve } = algorithm;
 
   let handle;
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   switch (format) {
     case 'KeyObject': {
       verifyAcceptableEcKeyUse(

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -40,14 +40,14 @@ const {
   validateJwk,
 } = require('internal/crypto/webcrypto_util');
 
-function hmacGenerateKey(algorithm, extractable, keyUsages) {
+function hmacGenerateKey(algorithm, extractable, usages) {
   const {
     hash,
     name,
     length = getBlockSize(hash.name),
   } = algorithm;
 
-  const usageSet = new SafeSet(keyUsages);
+  const usageSet = new SafeSet(usages);
   if (hasAnyNotIn(usageSet, ['sign', 'verify'])) {
     throw lazyDOMException(
       'Unsupported key usage for an HMAC key',
@@ -67,7 +67,7 @@ function hmacGenerateKey(algorithm, extractable, keyUsages) {
     extractable));
 }
 
-function kmacGenerateKey(algorithm, extractable, keyUsages) {
+function kmacGenerateKey(algorithm, extractable, usages) {
   const {
     name,
     length = {
@@ -77,7 +77,7 @@ function kmacGenerateKey(algorithm, extractable, keyUsages) {
     }[name],
   } = algorithm;
 
-  const usageSet = new SafeSet(keyUsages);
+  const usageSet = new SafeSet(usages);
   if (hasAnyNotIn(usageSet, ['sign', 'verify'])) {
     throw lazyDOMException(
       `Unsupported key usage for ${name} key`,
@@ -102,10 +102,10 @@ function macImportKey(
   keyData,
   algorithm,
   extractable,
-  keyUsages,
+  usages,
 ) {
   const isHmac = algorithm.name === 'HMAC';
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   if (hasAnyNotIn(usagesSet, ['sign', 'verify'])) {
     throw lazyDOMException(
       `Unsupported key usage for ${algorithm.name} key`,

--- a/lib/internal/crypto/ml_dsa.js
+++ b/lib/internal/crypto/ml_dsa.js
@@ -59,10 +59,10 @@ function verifyAcceptableMlDsaKeyUse(name, isPublic, usages) {
   }
 }
 
-function mlDsaGenerateKey(algorithm, extractable, keyUsages) {
+function mlDsaGenerateKey(algorithm, extractable, usages) {
   const { name } = algorithm;
 
-  const usageSet = new SafeSet(keyUsages);
+  const usageSet = new SafeSet(usages);
   if (hasAnyNotIn(usageSet, ['sign', 'verify'])) {
     throw lazyDOMException(
       `Unsupported key usage for an ${name} key`,
@@ -136,11 +136,11 @@ function mlDsaImportKey(
   keyData,
   algorithm,
   extractable,
-  keyUsages) {
+  usages) {
 
   const { name } = algorithm;
   let handle;
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   switch (format) {
     case 'KeyObject': {
       verifyAcceptableMlDsaKeyUse(

--- a/lib/internal/crypto/ml_kem.js
+++ b/lib/internal/crypto/ml_kem.js
@@ -49,10 +49,10 @@ const {
   validateJwk,
 } = require('internal/crypto/webcrypto_util');
 
-function mlKemGenerateKey(algorithm, extractable, keyUsages) {
+function mlKemGenerateKey(algorithm, extractable, usages) {
   const { name } = algorithm;
 
-  const usageSet = new SafeSet(keyUsages);
+  const usageSet = new SafeSet(usages);
   if (hasAnyNotIn(usageSet, ['encapsulateKey', 'encapsulateBits', 'decapsulateKey', 'decapsulateBits'])) {
     throw lazyDOMException(
       `Unsupported key usage for an ${name} key`,
@@ -137,11 +137,11 @@ function mlKemImportKey(
   keyData,
   algorithm,
   extractable,
-  keyUsages) {
+  usages) {
 
   const { name } = algorithm;
   let handle;
-  const usagesSet = new SafeSet(keyUsages);
+  const usagesSet = new SafeSet(usages);
   switch (format) {
     case 'KeyObject': {
       verifyAcceptableMlKemKeyUse(

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -108,7 +108,7 @@ function rsaOaepCipher(mode, key, data, algorithm) {
 function rsaKeyGenerate(
   algorithm,
   extractable,
-  keyUsages,
+  usages,
 ) {
   const publicExponentConverted = bigIntArrayToUnsignedInt(algorithm.publicExponent);
   if (publicExponentConverted === undefined) {
@@ -123,7 +123,7 @@ function rsaKeyGenerate(
     hash,
   } = algorithm;
 
-  const usageSet = new SafeSet(keyUsages);
+  const usageSet = new SafeSet(usages);
 
   switch (name) {
     case 'RSA-OAEP':
@@ -213,8 +213,8 @@ function rsaImportKey(
   keyData,
   algorithm,
   extractable,
-  keyUsages) {
-  const usagesSet = new SafeSet(keyUsages);
+  usages) {
+  const usagesSet = new SafeSet(usages);
   let handle;
   switch (format) {
     case 'KeyObject': {

--- a/lib/internal/crypto/webcrypto.js
+++ b/lib/internal/crypto/webcrypto.js
@@ -128,9 +128,9 @@ function digestImpl(algorithm, data) {
     context: '2nd argument',
   });
 
-  algorithm = normalizeAlgorithm(algorithm, 'digest');
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'digest');
 
-  return FunctionPrototypeCall(asyncDigest, this, algorithm, data);
+  return FunctionPrototypeCall(asyncDigest, this, normalizedAlgorithm, data);
 }
 
 function randomUUID() {
@@ -162,20 +162,20 @@ function generateKeyImpl(
     prefix,
     context: '2nd argument',
   });
-  keyUsages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
+  const usages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
     prefix,
     context: '3rd argument',
   });
 
-  algorithm = normalizeAlgorithm(algorithm, 'generateKey');
-  switch (algorithm.name) {
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'generateKey');
+  switch (normalizedAlgorithm.name) {
     case 'RSASSA-PKCS1-v1_5':
       // Fall through
     case 'RSA-PSS':
       // Fall through
     case 'RSA-OAEP':
       return require('internal/crypto/rsa')
-        .rsaKeyGenerate(algorithm, extractable, keyUsages);
+        .rsaKeyGenerate(normalizedAlgorithm, extractable, usages);
     case 'Ed25519':
       // Fall through
     case 'Ed448':
@@ -184,15 +184,15 @@ function generateKeyImpl(
       // Fall through
     case 'X448':
       return require('internal/crypto/cfrg')
-        .cfrgGenerateKey(algorithm, extractable, keyUsages);
+        .cfrgGenerateKey(normalizedAlgorithm, extractable, usages);
     case 'ECDSA':
       // Fall through
     case 'ECDH':
       return require('internal/crypto/ec')
-        .ecGenerateKey(algorithm, extractable, keyUsages);
+        .ecGenerateKey(normalizedAlgorithm, extractable, usages);
     case 'HMAC':
       return require('internal/crypto/mac')
-        .hmacGenerateKey(algorithm, extractable, keyUsages);
+        .hmacGenerateKey(normalizedAlgorithm, extractable, usages);
     case 'AES-CTR':
       // Fall through
     case 'AES-CBC':
@@ -203,29 +203,29 @@ function generateKeyImpl(
       // Fall through
     case 'AES-KW':
       return require('internal/crypto/aes')
-        .aesGenerateKey(algorithm, extractable, keyUsages);
+        .aesGenerateKey(normalizedAlgorithm, extractable, usages);
     case 'ChaCha20-Poly1305':
       return require('internal/crypto/chacha20_poly1305')
-        .c20pGenerateKey(algorithm, extractable, keyUsages);
+        .c20pGenerateKey(normalizedAlgorithm, extractable, usages);
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
       // Fall through
     case 'ML-DSA-87':
       return require('internal/crypto/ml_dsa')
-        .mlDsaGenerateKey(algorithm, extractable, keyUsages);
+        .mlDsaGenerateKey(normalizedAlgorithm, extractable, usages);
     case 'ML-KEM-512':
       // Fall through
     case 'ML-KEM-768':
       // Fall through
     case 'ML-KEM-1024':
       return require('internal/crypto/ml_kem')
-        .mlKemGenerateKey(algorithm, extractable, keyUsages);
+        .mlKemGenerateKey(normalizedAlgorithm, extractable, usages);
     case 'KMAC128':
       // Fall through
     case 'KMAC256':
       return require('internal/crypto/mac')
-        .kmacGenerateKey(algorithm, extractable, keyUsages);
+        .kmacGenerateKey(normalizedAlgorithm, extractable, usages);
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
@@ -256,35 +256,35 @@ function deriveBitsImpl(algorithm, baseKey, length = null) {
     });
   }
 
-  algorithm = normalizeAlgorithm(algorithm, 'deriveBits');
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'deriveBits');
   if (!hasCryptoKeyUsage(baseKey, 'deriveBits')) {
     throw lazyDOMException(
       'baseKey does not have deriveBits usage',
       'InvalidAccessError');
   }
-  if (getCryptoKeyAlgorithm(baseKey).name !== algorithm.name)
+  if (getCryptoKeyAlgorithm(baseKey).name !== normalizedAlgorithm.name)
     throw lazyDOMException('Key algorithm mismatch', 'InvalidAccessError');
-  switch (algorithm.name) {
+  switch (normalizedAlgorithm.name) {
     case 'X25519':
       // Fall through
     case 'X448':
       // Fall through
     case 'ECDH':
       return require('internal/crypto/diffiehellman')
-        .ecdhDeriveBits(algorithm, baseKey, length);
+        .ecdhDeriveBits(normalizedAlgorithm, baseKey, length);
     case 'HKDF':
       return require('internal/crypto/hkdf')
-        .hkdfDeriveBits(algorithm, baseKey, length);
+        .hkdfDeriveBits(normalizedAlgorithm, baseKey, length);
     case 'PBKDF2':
       return require('internal/crypto/pbkdf2')
-        .pbkdf2DeriveBits(algorithm, baseKey, length);
+        .pbkdf2DeriveBits(normalizedAlgorithm, baseKey, length);
     case 'Argon2d':
       // Fall through
     case 'Argon2i':
       // Fall through
     case 'Argon2id':
       return require('internal/crypto/argon2')
-        .argon2DeriveBits(algorithm, baseKey, length);
+        .argon2DeriveBits(normalizedAlgorithm, baseKey, length);
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
@@ -331,7 +331,7 @@ function getKeyLength({ name, length, hash }) {
 function deriveKey(
   algorithm,
   baseKey,
-  derivedKeyAlgorithm,
+  derivedKeyType,
   extractable,
   keyUsages) {
   return callSubtleCryptoMethod(deriveKeyImpl, this, arguments);
@@ -340,7 +340,7 @@ function deriveKey(
 function deriveKeyImpl(
   algorithm,
   baseKey,
-  derivedKeyAlgorithm,
+  derivedKeyType,
   extractable,
   keyUsages) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
@@ -356,7 +356,7 @@ function deriveKeyImpl(
     prefix,
     context: '2nd argument',
   });
-  derivedKeyAlgorithm = webidl.converters.AlgorithmIdentifier(derivedKeyAlgorithm, {
+  derivedKeyType = webidl.converters.AlgorithmIdentifier(derivedKeyType, {
     prefix,
     context: '3rd argument',
   });
@@ -364,56 +364,63 @@ function deriveKeyImpl(
     prefix,
     context: '4th argument',
   });
-  keyUsages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
+  const usages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
     prefix,
     context: '5th argument',
   });
 
-  algorithm = normalizeAlgorithm(algorithm, 'deriveBits');
-  derivedKeyAlgorithm = normalizeAlgorithm(derivedKeyAlgorithm, 'importKey');
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'deriveBits');
+  const normalizedDerivedKeyAlgorithmImport =
+    normalizeAlgorithm(derivedKeyType, 'importKey');
+  const normalizedDerivedKeyAlgorithmLength =
+    normalizeAlgorithm(derivedKeyType, 'get key length');
   if (!hasCryptoKeyUsage(baseKey, 'deriveKey')) {
     throw lazyDOMException(
       'baseKey does not have deriveKey usage',
       'InvalidAccessError');
   }
-  if (getCryptoKeyAlgorithm(baseKey).name !== algorithm.name)
+  if (getCryptoKeyAlgorithm(baseKey).name !== normalizedAlgorithm.name)
     throw lazyDOMException('Key algorithm mismatch', 'InvalidAccessError');
 
-  const length = getKeyLength(normalizeAlgorithm(arguments[2], 'get key length'));
-  let bits;
-  switch (algorithm.name) {
+  const length = getKeyLength(normalizedDerivedKeyAlgorithmLength);
+  let secret;
+  switch (normalizedAlgorithm.name) {
     case 'X25519':
       // Fall through
     case 'X448':
       // Fall through
     case 'ECDH':
-      bits = require('internal/crypto/diffiehellman')
-        .ecdhDeriveBits(algorithm, baseKey, length);
+      secret = require('internal/crypto/diffiehellman')
+        .ecdhDeriveBits(normalizedAlgorithm, baseKey, length);
       break;
     case 'HKDF':
-      bits = require('internal/crypto/hkdf')
-        .hkdfDeriveBits(algorithm, baseKey, length);
+      secret = require('internal/crypto/hkdf')
+        .hkdfDeriveBits(normalizedAlgorithm, baseKey, length);
       break;
     case 'PBKDF2':
-      bits = require('internal/crypto/pbkdf2')
-        .pbkdf2DeriveBits(algorithm, baseKey, length);
+      secret = require('internal/crypto/pbkdf2')
+        .pbkdf2DeriveBits(normalizedAlgorithm, baseKey, length);
       break;
     case 'Argon2d':
       // Fall through
     case 'Argon2i':
       // Fall through
     case 'Argon2id':
-      bits = require('internal/crypto/argon2')
-        .argon2DeriveBits(algorithm, baseKey, length);
+      secret = require('internal/crypto/argon2')
+        .argon2DeriveBits(normalizedAlgorithm, baseKey, length);
       break;
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  return jobPromiseThen(bits, (bits) => FunctionPrototypeCall(
+  return jobPromiseThen(secret, (secret) => FunctionPrototypeCall(
     importKeySync,
     this,
-    'raw-secret', bits, derivedKeyAlgorithm, extractable, keyUsages,
+    'raw-secret',
+    secret,
+    normalizedDerivedKeyAlgorithmImport,
+    extractable,
+    usages,
   ));
 }
 
@@ -805,14 +812,14 @@ function detachFromUserPrototypes(value) {
 }
 
 // Parse wrapped JWK bytes according to WebCrypto's "parse a JWK" procedure.
-function parseJwk(keyData) {
+function parseJwk(data) {
   let key;
   try {
     // WebCrypto parses JWKs in a fresh global. Detach parsed JSON values
     // from user-mutated prototypes before WebIDL dictionary conversion.
     // Wrapped JWKs may be produced outside WebCrypto, so parse using the
     // spec-required UTF-8.
-    const json = decodeUTF8(keyData, false, true);
+    const json = decodeUTF8(data, false, true);
     const result = JSONParse(json);
     detachFromUserPrototypes(result);
     key = webidl.converters.JsonWebKey(result);
@@ -841,7 +848,7 @@ function aliasKeyFormat(format) {
   }
 }
 
-function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
+function importKeySync(format, keyData, algorithm, extractable, usages) {
   let result;
   switch (algorithm.name) {
     case 'RSASSA-PKCS1-v1_5':
@@ -851,14 +858,24 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
     case 'RSA-OAEP':
       format = aliasKeyFormat(format);
       result = require('internal/crypto/rsa')
-        .rsaImportKey(format, keyData, algorithm, extractable, keyUsages);
+        .rsaImportKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          usages);
       break;
     case 'ECDSA':
       // Fall through
     case 'ECDH':
       format = aliasKeyFormat(format);
       result = require('internal/crypto/ec')
-        .ecImportKey(format, keyData, algorithm, extractable, keyUsages);
+        .ecImportKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          usages);
       break;
     case 'Ed25519':
       // Fall through
@@ -869,7 +886,12 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
     case 'X448':
       format = aliasKeyFormat(format);
       result = require('internal/crypto/cfrg')
-        .cfrgImportKey(format, keyData, algorithm, extractable, keyUsages);
+        .cfrgImportKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          usages);
       break;
     case 'HMAC':
       // Fall through
@@ -877,7 +899,12 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
       // Fall through
     case 'KMAC256':
       result = require('internal/crypto/mac')
-        .macImportKey(format, keyData, algorithm, extractable, keyUsages);
+        .macImportKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          usages);
       break;
     case 'AES-CTR':
       // Fall through
@@ -889,11 +916,21 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
       // Fall through
     case 'AES-OCB':
       result = require('internal/crypto/aes')
-        .aesImportKey(algorithm, format, keyData, extractable, keyUsages);
+        .aesImportKey(
+          algorithm,
+          format,
+          keyData,
+          extractable,
+          usages);
       break;
     case 'ChaCha20-Poly1305':
       result = require('internal/crypto/chacha20_poly1305')
-        .c20pImportKey(algorithm, format, keyData, extractable, keyUsages);
+        .c20pImportKey(
+          algorithm,
+          format,
+          keyData,
+          extractable,
+          usages);
       break;
     case 'HKDF':
       // Fall through
@@ -904,7 +941,7 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
         format,
         keyData,
         extractable,
-        keyUsages);
+        usages);
       break;
     case 'Argon2d':
       // Fall through
@@ -917,7 +954,7 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
           format,
           keyData,
           extractable,
-          keyUsages);
+          usages);
       }
       break;
     case 'ML-DSA-44':
@@ -926,7 +963,12 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
       // Fall through
     case 'ML-DSA-87':
       result = require('internal/crypto/ml_dsa')
-        .mlDsaImportKey(format, keyData, algorithm, extractable, keyUsages);
+        .mlDsaImportKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          usages);
       break;
     case 'ML-KEM-512':
       // Fall through
@@ -934,7 +976,12 @@ function importKeySync(format, keyData, algorithm, extractable, keyUsages) {
       // Fall through
     case 'ML-KEM-1024':
       result = require('internal/crypto/ml_kem')
-        .mlKemImportKey(format, keyData, algorithm, extractable, keyUsages);
+        .mlKemImportKey(
+          format,
+          keyData,
+          algorithm,
+          extractable,
+          usages);
       break;
   }
 
@@ -991,27 +1038,31 @@ function importKeyImpl(
     prefix,
     context: '4th argument',
   });
-  keyUsages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
+  const usages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
     prefix,
     context: '5th argument',
   });
 
-  algorithm = normalizeAlgorithm(algorithm, 'importKey');
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'importKey');
 
   return FunctionPrototypeCall(
     importKeySync,
     this,
-    format, keyData, algorithm, extractable, keyUsages,
+    format,
+    keyData,
+    normalizedAlgorithm,
+    extractable,
+    usages,
   );
 }
 
 // subtle.wrapKey() is essentially a subtle.exportKey() followed
 // by a subtle.encrypt().
-function wrapKey(format, key, wrappingKey, algorithm) {
+function wrapKey(format, key, wrappingKey, wrapAlgorithm) {
   return callSubtleCryptoMethod(wrapKeyImpl, this, arguments);
 }
 
-function wrapKeyImpl(format, key, wrappingKey, algorithm) {
+function wrapKeyImpl(format, key, wrappingKey, wrapAlgorithm) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
@@ -1029,50 +1080,52 @@ function wrapKeyImpl(format, key, wrappingKey, algorithm) {
     prefix,
     context: '3rd argument',
   });
-  algorithm = webidl.converters.AlgorithmIdentifier(algorithm, {
+  const algorithm = webidl.converters.AlgorithmIdentifier(wrapAlgorithm, {
     prefix,
     context: '4th argument',
   });
+  let normalizedAlgorithm;
 
   try {
-    algorithm = normalizeAlgorithm(algorithm, 'wrapKey');
+    normalizedAlgorithm = normalizeAlgorithm(algorithm, 'wrapKey');
   } catch {
-    algorithm = normalizeAlgorithm(algorithm, 'encrypt');
+    normalizedAlgorithm = normalizeAlgorithm(algorithm, 'encrypt');
   }
 
-  if (algorithm.name !== getCryptoKeyAlgorithm(wrappingKey).name)
+  if (normalizedAlgorithm.name !== getCryptoKeyAlgorithm(wrappingKey).name)
     throw lazyDOMException('Key algorithm mismatch', 'InvalidAccessError');
 
   if (!hasCryptoKeyUsage(wrappingKey, 'wrapKey'))
     throw lazyDOMException(
       'Unable to use this key to wrapKey', 'InvalidAccessError');
 
-  let keyData = exportKeySync(format, key);
+  const exportedKey = exportKeySync(format, key);
+  let bytes = exportedKey;
 
   if (format === 'jwk') {
     // The WebCrypto spec stringifies JWKs in a new global object. Rather
     // than create a new realm here, detach this internally generated JWK from
     // user-mutated prototypes so JSON.stringify cannot read inherited toJSON
     // hooks from the current global.
-    detachFromUserPrototypes(keyData);
-    const json = JSONStringify(keyData);
+    detachFromUserPrototypes(exportedKey);
+    const json = JSONStringify(exportedKey);
     // As per the NOTE in step 13 https://w3c.github.io/webcrypto/#SubtleCrypto-method-wrapKey
     // we're padding AES-KW wrapped JWK to make sure it is always a multiple of 8 bytes
     // in length
     // The spec then UTF-8 encodes json.
-    if (algorithm.name === 'AES-KW' && json.length % 8 !== 0) {
-      keyData = encodeUtf8String(
+    if (normalizedAlgorithm.name === 'AES-KW' && json.length % 8 !== 0) {
+      bytes = encodeUtf8String(
         json + StringPrototypeRepeat(' ', 8 - (json.length % 8)));
     } else {
-      keyData = encodeUtf8String(json);
+      bytes = encodeUtf8String(json);
     }
   }
 
   return cipherOrWrap(
     kWebCryptoCipherEncrypt,
-    algorithm,
+    normalizedAlgorithm,
     wrappingKey,
-    keyData,
+    bytes,
     'wrapKey');
 }
 
@@ -1082,8 +1135,8 @@ function unwrapKey(
   format,
   wrappedKey,
   unwrappingKey,
-  unwrapAlgo,
-  unwrappedKeyAlgo,
+  unwrapAlgorithm,
+  unwrappedKeyAlgorithm,
   extractable,
   keyUsages) {
   return callSubtleCryptoMethod(unwrapKeyImpl, this, arguments);
@@ -1093,8 +1146,8 @@ function unwrapKeyImpl(
   format,
   wrappedKey,
   unwrappingKey,
-  unwrapAlgo,
-  unwrappedKeyAlgo,
+  unwrapAlgorithm,
+  unwrappedKeyAlgorithm,
   extractable,
   keyUsages) {
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
@@ -1114,12 +1167,12 @@ function unwrapKeyImpl(
     prefix,
     context: '3rd argument',
   });
-  unwrapAlgo = webidl.converters.AlgorithmIdentifier(unwrapAlgo, {
+  const algorithm = webidl.converters.AlgorithmIdentifier(unwrapAlgorithm, {
     prefix,
     context: '4th argument',
   });
-  unwrappedKeyAlgo = webidl.converters.AlgorithmIdentifier(
-    unwrappedKeyAlgo,
+  unwrappedKeyAlgorithm = webidl.converters.AlgorithmIdentifier(
+    unwrappedKeyAlgorithm,
     {
       prefix,
       context: '5th argument',
@@ -1129,87 +1182,94 @@ function unwrapKeyImpl(
     prefix,
     context: '6th argument',
   });
-  keyUsages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
+  const usages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
     prefix,
     context: '7th argument',
   });
 
+  let normalizedAlgorithm;
   try {
-    unwrapAlgo = normalizeAlgorithm(unwrapAlgo, 'unwrapKey');
+    normalizedAlgorithm = normalizeAlgorithm(algorithm, 'unwrapKey');
   } catch {
-    unwrapAlgo = normalizeAlgorithm(unwrapAlgo, 'decrypt');
+    normalizedAlgorithm = normalizeAlgorithm(algorithm, 'decrypt');
   }
 
-  unwrappedKeyAlgo = normalizeAlgorithm(unwrappedKeyAlgo, 'importKey');
+  const normalizedKeyAlgorithm =
+    normalizeAlgorithm(unwrappedKeyAlgorithm, 'importKey');
 
-  if (unwrapAlgo.name !== getCryptoKeyAlgorithm(unwrappingKey).name)
+  if (normalizedAlgorithm.name !== getCryptoKeyAlgorithm(unwrappingKey).name)
     throw lazyDOMException('Key algorithm mismatch', 'InvalidAccessError');
 
   if (!hasCryptoKeyUsage(unwrappingKey, 'unwrapKey'))
     throw lazyDOMException(
       'Unable to use this key to unwrapKey', 'InvalidAccessError');
 
-  const keyData = cipherOrWrap(
+  const bytes = cipherOrWrap(
     kWebCryptoCipherDecrypt,
-    unwrapAlgo,
+    normalizedAlgorithm,
     unwrappingKey,
     wrappedKey,
     'unwrapKey');
 
-  return jobPromiseThen(keyData, (keyData) => {
+  return jobPromiseThen(bytes, (bytes) => {
+    let keyData = bytes;
     if (format === 'jwk') {
-      keyData = parseJwk(keyData);
+      keyData = parseJwk(bytes);
     }
 
     return FunctionPrototypeCall(
       importKeySync,
       this,
-      format, keyData, unwrappedKeyAlgo, extractable, keyUsages,
+      format,
+      keyData,
+      normalizedKeyAlgorithm,
+      extractable,
+      usages,
     );
   });
 }
 
 function signVerify(algorithm, key, data, signature) {
-  const op = signature !== undefined ? 'verify' : 'sign'; // This is also usage
-  algorithm = normalizeAlgorithm(algorithm, op);
+  const operation = signature !== undefined ? 'verify' : 'sign'; // This is also usage
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm, operation);
 
-  if (algorithm.name !== getCryptoKeyAlgorithm(key).name)
+  if (normalizedAlgorithm.name !== getCryptoKeyAlgorithm(key).name)
     throw lazyDOMException('Key algorithm mismatch', 'InvalidAccessError');
 
-  if (!hasCryptoKeyUsage(key, op))
+  if (!hasCryptoKeyUsage(key, operation))
     throw lazyDOMException(
-      `Unable to use this key to ${op}`, 'InvalidAccessError');
+      `Unable to use this key to ${operation}`, 'InvalidAccessError');
 
-  switch (algorithm.name) {
+  switch (normalizedAlgorithm.name) {
     case 'RSA-PSS':
       // Fall through
     case 'RSASSA-PKCS1-v1_5':
       return require('internal/crypto/rsa')
-        .rsaSignVerify(key, data, algorithm, signature);
+        .rsaSignVerify(key, data, normalizedAlgorithm, signature);
     case 'ECDSA':
       return require('internal/crypto/ec')
-        .ecdsaSignVerify(key, data, algorithm, signature);
+        .ecdsaSignVerify(key, data, normalizedAlgorithm, signature);
     case 'Ed25519':
       // Fall through
     case 'Ed448':
       // Fall through
       return require('internal/crypto/cfrg')
-        .eddsaSignVerify(key, data, algorithm, signature);
+        .eddsaSignVerify(key, data, normalizedAlgorithm, signature);
     case 'HMAC':
       return require('internal/crypto/mac')
-        .hmacSignVerify(key, data, algorithm, signature);
+        .hmacSignVerify(key, data, normalizedAlgorithm, signature);
     case 'ML-DSA-44':
       // Fall through
     case 'ML-DSA-65':
       // Fall through
     case 'ML-DSA-87':
       return require('internal/crypto/ml_dsa')
-        .mlDsaSignVerify(key, data, algorithm, signature);
+        .mlDsaSignVerify(key, data, normalizedAlgorithm, signature);
     case 'KMAC128':
       // Fall through
     case 'KMAC256':
       return require('internal/crypto/mac')
-        .kmacSignVerify(key, data, algorithm, signature);
+        .kmacSignVerify(key, data, normalizedAlgorithm, signature);
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
 }
@@ -1270,16 +1330,16 @@ function verifyImpl(algorithm, key, signature, data) {
   return signVerify(algorithm, key, data, signature);
 }
 
-function cipherOrWrap(mode, algorithm, key, data, op) {
+function cipherOrWrap(mode, normalizedAlgorithm, key, data, operation) {
   // While WebCrypto allows for larger input buffer sizes, we limit
   // those to sizes that can fit within uint32_t because of limitations
   // in the OpenSSL API.
   validateMaxBufferLength(data, 'data');
 
-  switch (algorithm.name) {
+  switch (normalizedAlgorithm.name) {
     case 'RSA-OAEP':
       return require('internal/crypto/rsa')
-        .rsaCipher(mode, key, data, algorithm);
+        .rsaCipher(mode, key, data, normalizedAlgorithm);
     case 'AES-CTR':
       // Fall through
     case 'AES-CBC':
@@ -1288,14 +1348,14 @@ function cipherOrWrap(mode, algorithm, key, data, op) {
       // Fall through
     case 'AES-OCB':
       return require('internal/crypto/aes')
-        .aesCipher(mode, key, data, algorithm);
+        .aesCipher(mode, key, data, normalizedAlgorithm);
     case 'ChaCha20-Poly1305':
       return require('internal/crypto/chacha20_poly1305')
-        .c20pCipher(mode, key, data, algorithm);
+        .c20pCipher(mode, key, data, normalizedAlgorithm);
     case 'AES-KW':
-      if (op === 'wrapKey' || op === 'unwrapKey') {
+      if (operation === 'wrapKey' || operation === 'unwrapKey') {
         return require('internal/crypto/aes')
-          .aesCipher(mode, key, data, algorithm);
+          .aesCipher(mode, key, data, normalizedAlgorithm);
       }
   }
   throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
@@ -1324,9 +1384,9 @@ function encryptImpl(algorithm, key, data) {
     context: '3rd argument',
   });
 
-  algorithm = normalizeAlgorithm(algorithm, 'encrypt');
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'encrypt');
 
-  if (algorithm.name !== getCryptoKeyAlgorithm(key).name)
+  if (normalizedAlgorithm.name !== getCryptoKeyAlgorithm(key).name)
     throw lazyDOMException('Key algorithm mismatch', 'InvalidAccessError');
 
   if (!hasCryptoKeyUsage(key, 'encrypt'))
@@ -1335,7 +1395,7 @@ function encryptImpl(algorithm, key, data) {
 
   return cipherOrWrap(
     kWebCryptoCipherEncrypt,
-    algorithm,
+    normalizedAlgorithm,
     key,
     data,
     'encrypt',
@@ -1365,9 +1425,9 @@ function decryptImpl(algorithm, key, data) {
     context: '3rd argument',
   });
 
-  algorithm = normalizeAlgorithm(algorithm, 'decrypt');
+  const normalizedAlgorithm = normalizeAlgorithm(algorithm, 'decrypt');
 
-  if (algorithm.name !== getCryptoKeyAlgorithm(key).name)
+  if (normalizedAlgorithm.name !== getCryptoKeyAlgorithm(key).name)
     throw lazyDOMException('Key algorithm mismatch', 'InvalidAccessError');
 
   if (!hasCryptoKeyUsage(key, 'decrypt'))
@@ -1376,7 +1436,7 @@ function decryptImpl(algorithm, key, data) {
 
   return cipherOrWrap(
     kWebCryptoCipherDecrypt,
-    algorithm,
+    normalizedAlgorithm,
     key,
     data,
     'decrypt',
@@ -1399,7 +1459,7 @@ function getPublicKeyImpl(key, keyUsages) {
     prefix,
     context: '1st argument',
   });
-  keyUsages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
+  const usages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
     prefix,
     context: '2nd argument',
   });
@@ -1412,7 +1472,7 @@ function getPublicKeyImpl(key, keyUsages) {
   // TODO(panva): this is by no means a hot path, but let's still follow up to get
   //              rid of this awkwardness
   const keyObject = createPublicKey(new PrivateKeyObject(getCryptoKeyHandle(key)));
-  return keyObject.toCryptoKey(getCryptoKeyAlgorithm(key), true, keyUsages);
+  return keyObject.toCryptoKey(getCryptoKeyAlgorithm(key), true, usages);
 }
 
 function encapsulateBits(encapsulationAlgorithm, encapsulationKey) {
@@ -1426,10 +1486,13 @@ function encapsulateBitsImpl(encapsulationAlgorithm, encapsulationKey) {
   webidl ??= require('internal/crypto/webidl');
   const prefix = "Failed to execute 'encapsulateBits' on 'SubtleCrypto'";
   webidl.requiredArguments(arguments.length, 2, { prefix });
-  encapsulationAlgorithm = webidl.converters.AlgorithmIdentifier(encapsulationAlgorithm, {
-    prefix,
-    context: '1st argument',
-  });
+  encapsulationAlgorithm = webidl.converters.AlgorithmIdentifier(
+    encapsulationAlgorithm,
+    {
+      prefix,
+      context: '1st argument',
+    },
+  );
   encapsulationKey = webidl.converters.CryptoKey(encapsulationKey, {
     prefix,
     context: '2nd argument',
@@ -1467,7 +1530,7 @@ function encapsulateKey(
   encapsulationKey,
   sharedKeyAlgorithm,
   extractable,
-  usages) {
+  keyUsages) {
   return callSubtleCryptoMethod(encapsulateKeyImpl, this, arguments);
 }
 
@@ -1476,30 +1539,36 @@ function encapsulateKeyImpl(
   encapsulationKey,
   sharedKeyAlgorithm,
   extractable,
-  usages) {
+  keyUsages) {
   emitExperimentalWarning('The encapsulateKey Web Crypto API method');
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
   const prefix = "Failed to execute 'encapsulateKey' on 'SubtleCrypto'";
   webidl.requiredArguments(arguments.length, 5, { prefix });
-  encapsulationAlgorithm = webidl.converters.AlgorithmIdentifier(encapsulationAlgorithm, {
-    prefix,
-    context: '1st argument',
-  });
+  encapsulationAlgorithm = webidl.converters.AlgorithmIdentifier(
+    encapsulationAlgorithm,
+    {
+      prefix,
+      context: '1st argument',
+    },
+  );
   encapsulationKey = webidl.converters.CryptoKey(encapsulationKey, {
     prefix,
     context: '2nd argument',
   });
-  sharedKeyAlgorithm = webidl.converters.AlgorithmIdentifier(sharedKeyAlgorithm, {
-    prefix,
-    context: '3rd argument',
-  });
+  sharedKeyAlgorithm = webidl.converters.AlgorithmIdentifier(
+    sharedKeyAlgorithm,
+    {
+      prefix,
+      context: '3rd argument',
+    },
+  );
   extractable = webidl.converters.boolean(extractable, {
     prefix,
     context: '4th argument',
   });
-  usages = webidl.converters['sequence<KeyUsage>'](usages, {
+  const usages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
     prefix,
     context: '5th argument',
   });
@@ -1522,28 +1591,31 @@ function encapsulateKeyImpl(
       'InvalidAccessError');
   }
 
-  let encapsulateBits;
+  let encapsulatedBits;
   switch (keyAlgorithm.name) {
     case 'ML-KEM-512':
     case 'ML-KEM-768':
     case 'ML-KEM-1024':
-      encapsulateBits = require('internal/crypto/ml_kem')
+      encapsulatedBits = require('internal/crypto/ml_kem')
         .mlKemEncapsulate(encapsulationKey);
       break;
     default:
       throw lazyDOMException('Unrecognized algorithm name', 'NotSupportedError');
   }
 
-  return jobPromiseThen(encapsulateBits, (encapsulateBits) => {
+  return jobPromiseThen(encapsulatedBits, (encapsulatedBits) => {
     const sharedKey = FunctionPrototypeCall(
       importKeySync,
       this,
-      'raw-secret', encapsulateBits.sharedKey, normalizedSharedKeyAlgorithm,
-      extractable, usages,
+      'raw-secret',
+      encapsulatedBits.sharedKey,
+      normalizedSharedKeyAlgorithm,
+      extractable,
+      usages,
     );
 
     return {
-      ciphertext: encapsulateBits.ciphertext,
+      ciphertext: encapsulatedBits.ciphertext,
       sharedKey,
     };
   });
@@ -1560,10 +1632,13 @@ function decapsulateBitsImpl(decapsulationAlgorithm, decapsulationKey, ciphertex
   webidl ??= require('internal/crypto/webidl');
   const prefix = "Failed to execute 'decapsulateBits' on 'SubtleCrypto'";
   webidl.requiredArguments(arguments.length, 3, { prefix });
-  decapsulationAlgorithm = webidl.converters.AlgorithmIdentifier(decapsulationAlgorithm, {
-    prefix,
-    context: '1st argument',
-  });
+  decapsulationAlgorithm = webidl.converters.AlgorithmIdentifier(
+    decapsulationAlgorithm,
+    {
+      prefix,
+      context: '1st argument',
+    },
+  );
   decapsulationKey = webidl.converters.CryptoKey(decapsulationKey, {
     prefix,
     context: '2nd argument',
@@ -1601,8 +1676,12 @@ function decapsulateBitsImpl(decapsulationAlgorithm, decapsulationKey, ciphertex
 }
 
 function decapsulateKey(
-  decapsulationAlgorithm, decapsulationKey, ciphertext, sharedKeyAlgorithm, extractable, usages,
-) {
+  decapsulationAlgorithm,
+  decapsulationKey,
+  ciphertext,
+  sharedKeyAlgorithm,
+  extractable,
+  keyUsages) {
   return callSubtleCryptoMethod(decapsulateKeyImpl, this, arguments);
 }
 
@@ -1612,17 +1691,20 @@ function decapsulateKeyImpl(
   ciphertext,
   sharedKeyAlgorithm,
   extractable,
-  usages) {
+  keyUsages) {
   emitExperimentalWarning('The decapsulateKey Web Crypto API method');
   if (this !== subtle) throw new ERR_INVALID_THIS('SubtleCrypto');
 
   webidl ??= require('internal/crypto/webidl');
   const prefix = "Failed to execute 'decapsulateKey' on 'SubtleCrypto'";
   webidl.requiredArguments(arguments.length, 6, { prefix });
-  decapsulationAlgorithm = webidl.converters.AlgorithmIdentifier(decapsulationAlgorithm, {
-    prefix,
-    context: '1st argument',
-  });
+  decapsulationAlgorithm = webidl.converters.AlgorithmIdentifier(
+    decapsulationAlgorithm,
+    {
+      prefix,
+      context: '1st argument',
+    },
+  );
   decapsulationKey = webidl.converters.CryptoKey(decapsulationKey, {
     prefix,
     context: '2nd argument',
@@ -1631,15 +1713,18 @@ function decapsulateKeyImpl(
     prefix,
     context: '3rd argument',
   });
-  sharedKeyAlgorithm = webidl.converters.AlgorithmIdentifier(sharedKeyAlgorithm, {
-    prefix,
-    context: '4th argument',
-  });
+  sharedKeyAlgorithm = webidl.converters.AlgorithmIdentifier(
+    sharedKeyAlgorithm,
+    {
+      prefix,
+      context: '4th argument',
+    },
+  );
   extractable = webidl.converters.boolean(extractable, {
     prefix,
     context: '5th argument',
   });
-  usages = webidl.converters['sequence<KeyUsage>'](usages, {
+  const usages = webidl.converters['sequence<KeyUsage>'](keyUsages, {
     prefix,
     context: '6th argument',
   });
@@ -1677,7 +1762,10 @@ function decapsulateKeyImpl(
   return jobPromiseThen(decapsulatedBits, (decapsulatedBits) => FunctionPrototypeCall(
     importKeySync,
     this,
-    'raw-secret', decapsulatedBits, normalizedSharedKeyAlgorithm, extractable,
+    'raw-secret',
+    decapsulatedBits,
+    normalizedSharedKeyAlgorithm,
+    extractable,
     usages,
   ));
 }
@@ -1733,10 +1821,13 @@ class SubtleCrypto {
     let length;
     let additionalAlgorithm;
     if (operation === 'deriveKey') {
-      additionalAlgorithm = webidl.converters.AlgorithmIdentifier(lengthOrAdditionalAlgorithm, {
-        prefix,
-        context: '3rd argument',
-      });
+      additionalAlgorithm = webidl.converters.AlgorithmIdentifier(
+        lengthOrAdditionalAlgorithm,
+        {
+          prefix,
+          context: '3rd argument',
+        },
+      );
 
       if (!check('importKey', additionalAlgorithm)) {
         return false;
@@ -1750,19 +1841,25 @@ class SubtleCrypto {
 
       operation = 'deriveBits';
     } else if (operation === 'wrapKey') {
-      additionalAlgorithm = webidl.converters.AlgorithmIdentifier(lengthOrAdditionalAlgorithm, {
-        prefix,
-        context: '3rd argument',
-      });
+      additionalAlgorithm = webidl.converters.AlgorithmIdentifier(
+        lengthOrAdditionalAlgorithm,
+        {
+          prefix,
+          context: '3rd argument',
+        },
+      );
 
       if (!check('exportKey', additionalAlgorithm)) {
         return false;
       }
     } else if (operation === 'unwrapKey') {
-      additionalAlgorithm = webidl.converters.AlgorithmIdentifier(lengthOrAdditionalAlgorithm, {
-        prefix,
-        context: '3rd argument',
-      });
+      additionalAlgorithm = webidl.converters.AlgorithmIdentifier(
+        lengthOrAdditionalAlgorithm,
+        {
+          prefix,
+          context: '3rd argument',
+        },
+      );
 
       if (!check('importKey', additionalAlgorithm)) {
         return false;
@@ -1796,10 +1893,13 @@ class SubtleCrypto {
           return false;
       }
     } else if (operation === 'encapsulateKey' || operation === 'decapsulateKey') {
-      additionalAlgorithm = webidl.converters.AlgorithmIdentifier(lengthOrAdditionalAlgorithm, {
-        prefix,
-        context: '3rd argument',
-      });
+      additionalAlgorithm = webidl.converters.AlgorithmIdentifier(
+        lengthOrAdditionalAlgorithm,
+        {
+          prefix,
+          context: '3rd argument',
+        },
+      );
 
       let normalizedAdditionalAlgorithm;
       try {
@@ -1824,7 +1924,8 @@ class SubtleCrypto {
         case 'HMAC':
         case 'KMAC128':
         case 'KMAC256':
-          if (normalizedAdditionalAlgorithm.length === undefined || normalizedAdditionalAlgorithm.length === 256) {
+          if (normalizedAdditionalAlgorithm.length === undefined ||
+              normalizedAdditionalAlgorithm.length === 256) {
             break;
           }
           return false;


### PR DESCRIPTION
Rename WebCrypto operation parameters and local variables to match the spec terminology. Use operation, algorithm, and key names consistently between the docs and implementation.