### PR TITLE
stream: settle pending stream iter reads on return

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -165,6 +165,7 @@ class BroadcastImpl {
 
     function detach() {
       state.detached = true;
+      state.resolve?.({ __proto__: null, done: true, value: undefined });
       state.resolve = null;
       state.reject = null;
       if (self.#deleteConsumer(state)) {

--- a/lib/internal/streams/iter/push.js
+++ b/lib/internal/streams/iter/push.js
@@ -538,6 +538,13 @@ class PushQueue {
     }
   }
 
+  #resolvePendingReadsDone() {
+    while (this.#pendingReads.length > 0) {
+      this.#pendingReads.shift().resolve(
+        { __proto__: null, value: undefined, done: true });
+    }
+  }
+
   #rejectPendingWrites(error) {
     while (this.#pendingWrites.length > 0) {
       this.#pendingWrites.shift().reject(error);

--- a/lib/internal/streams/iter/push.js
+++ b/lib/internal/streams/iter/push.js
@@ -541,7 +541,7 @@ class PushQueue {
   #resolvePendingReadsDone() {
     while (this.#pendingReads.length > 0) {
       this.#pendingReads.shift().resolve(
-        { __proto__: null, value: undefined, done: true });
+        { __proto__: null, done: true, value: undefined });
     }
   }
 

--- a/test/parallel/test-stream-iter-broadcast-basic.js
+++ b/test/parallel/test-stream-iter-broadcast-basic.js
@@ -161,6 +161,18 @@ async function testCancelWithReason() {
   assert.strictEqual(result.message, 'cancelled');
 }
 
+async function testPendingNextSettlesAfterReturn() {
+  const { broadcast: bc } = broadcast();
+  const iter = bc.push()[Symbol.asyncIterator]();
+
+  const pendingNext = iter.next();
+  await iter.return();
+
+  const result = await pendingNext;
+  assert.strictEqual(result.done, true);
+  assert.strictEqual(result.value, undefined);
+}
+
 // =============================================================================
 // Writer fail detaches consumers
 // =============================================================================
@@ -254,6 +266,7 @@ Promise.all([
   testCancelWithoutReason(),
   testCancelWithReason(),
   testCancelWithFalsyReason(),
+  testPendingNextSettlesAfterReturn(),
   testFailDetachesConsumers(),
   testWriterFailIdempotent(),
   testLateJoinerSeesBufferedData(),

--- a/test/parallel/test-stream-iter-push-basic.js
+++ b/test/parallel/test-stream-iter-push-basic.js
@@ -133,6 +133,18 @@ async function testConsumerBreakWriteSyncReturnsFalse() {
   assert.strictEqual(writer.desiredSize, null);
 }
 
+async function testPendingNextSettlesAfterReturn() {
+  const { readable } = push();
+  const iter = readable[Symbol.asyncIterator]();
+
+  const pendingNext = iter.next();
+  await iter.return();
+
+  const result = await pendingNext;
+  assert.strictEqual(result.done, true);
+  assert.strictEqual(result.value, undefined);
+}
+
 async function testPushWithTransforms() {
   const upper = (chunks) => {
     if (chunks === null) return null;
@@ -175,6 +187,7 @@ Promise.all([
   testAbortSignal(),
   testPreAbortedSignal(),
   testConsumerBreakWriteSyncReturnsFalse(),
+  testPendingNextSettlesAfterReturn(),
   testPushWithTransforms(),
   testInvalidBackpressure(),
 ]).then(common.mustCall());


### PR DESCRIPTION
This updates `stream/iter` cleanup so pending `next()` calls are settled when
a consumer calls `return()`.

Previously, `push()` and `broadcast()` could leave a pending `next()` promise
unresolved if `return()` was called before any chunk was written. The cleanup
paths now resolve those pending reads with `{ done: true, value: undefined }`.

Regression coverage was added for both `push()` and `broadcast()`.

Fixes: https://github.com/nodejs/node/issues/63519

---

Assisted-by: openai:gpt-5.5