### PR TITLE
deps: cherry-pick e807d4e379 from SQLite

### DIFF
--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -496,6 +496,27 @@ test('database.applyChangeset() - wrong arguments', (t) => {
   });
 });
 
+test('database.applyChangeset() - malformed changeset returns SQLITE_CORRUPT', {
+  skip: process.config.variables.node_shared_sqlite ?
+    'requires the bundled SQLite session fix' : false,
+}, (t) => {
+  const database = new DatabaseSync(':memory:');
+  database.exec('CREATE TABLE t1(a INTEGER PRIMARY KEY, b, c, d)');
+
+  const changeset = Buffer.from(
+    '540401000000743100177e0072286565286565',
+    'hex');
+
+  t.assert.throws(() => {
+    database.applyChangeset(changeset);
+  }, {
+    name: 'Error',
+    message: 'database disk image is malformed',
+    errcode: 11,
+    code: 'ERR_SQLITE_ERROR',
+  });
+});
+
 test('session.patchset()', (t) => {
   const database = new DatabaseSync(':memory:');
   database.exec('CREATE TABLE data(key INTEGER PRIMARY KEY, value TEXT)');


### PR DESCRIPTION
Backport the SQLite session extension fix for malformed changesets that omit
old values for primary-key columns. The upstream fix avoids passing NULL to
sessionBindValue() while applying UPDATE changesets.

This adds a regression test for `DatabaseSync#applyChangeset()` to verify that
the malformed changeset returns `SQLITE_CORRUPT` instead of crashing.

Refs: https://sqlite.org/src/info/e807d4e3798efd53
Refs: https://hackerone.com/reports/3736889
Refs: https://github.com/sqlite/sqlite/commit/b869ed6b067d623cb1383549f2a18aa35508385d

Tested on Linux x64:

```console
$ python3 configure.py --without-npm --without-lief
$ make -j16
$ python3 tools/test.py --mode=release test/parallel/test-sqlite-session.js
All tests passed.