### PR TITLE
src: fix crash when reading length on Storage.prototype

### DIFF
--- a/src/node_webstorage.cc
+++ b/src/node_webstorage.cc
@@ -43,6 +43,7 @@ using v8::PropertyAttribute;
 using v8::PropertyCallbackInfo;
 using v8::PropertyDescriptor;
 using v8::PropertyHandlerFlags;
+using v8::Signature;
 using v8::String;
 using v8::Value;
 
@@ -737,8 +738,9 @@ static void Initialize(Local<Object> target,
       Local<Value>(),
       PropertyHandlerFlags::kHasNoSideEffect));
 
-  Local<FunctionTemplate> length_getter =
-      FunctionTemplate::New(isolate, StorageLengthGetter);
+  Local<Signature> length_signature = Signature::New(isolate, ctor_tmpl);
+  Local<FunctionTemplate> length_getter = FunctionTemplate::New(
+      isolate, StorageLengthGetter, Local<Value>(), length_signature);
   ctor_tmpl->PrototypeTemplate()->SetAccessorProperty(env->length_string(),
                                                       length_getter,
                                                       Local<FunctionTemplate>(),

--- a/test/parallel/test-webstorage.js
+++ b/test/parallel/test-webstorage.js
@@ -26,6 +26,14 @@ test('Storage instances cannot be created in userland', async () => {
   assert.match(cp.stderr, /Error: Illegal constructor/);
 });
 
+test('calling "length" getter on invalid this throws', async () => {
+  assert.throws(() => Storage.prototype.length, TypeError);
+  const { get } = Object.getOwnPropertyDescriptor(Storage.prototype, 'length');
+  for (const thisArg of [null, undefined, 1n, -0, NaN, true, false, '', [], {}, Symbol()]) {
+    assert.throws(() => get.call(thisArg), TypeError);
+  }
+});
+
 test('sessionStorage is not persisted', async () => {
   let cp = await spawnPromisified(process.execPath, [
     '-pe', 'sessionStorage.foo = "barbaz"',


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63514

### The following one-liner reliably segfaults:

```console
$ node -e 'globalThis.sessionStorage.setItem.length;globalThis.Storage.prototype.length'
[1]    42883 segmentation fault (core dumped)
```
### Stack trace:
```
#0  sqlite3LockAndPrepare ()
#1  sqlite3_prepare_v2 ()
#2  node::webstorage::Storage::Length ()
#3  node::webstorage::StorageLengthGetter ()
```

### Root cause
Storage's length accessor is defined on the prototype template:
```
Local<FunctionTemplate> length_getter =
    FunctionTemplate::New(isolate, StorageLengthGetter);   // no signature
ctor_tmpl->PrototypeTemplate()->SetAccessorProperty(env->length_string(), ...);
```


### Fix 
Create the getter's `FunctionTemplate` with a `v8::Signature` bound to the Storage constructor template, exactly as the methods do. V8 now rejects an incompatible receiver with a TypeError: Illegal invocation before the C++ callback runs matching browser behavior instead of crashing. Real localStorage/sessionStorage instances are unaffected.

