### PR TITLE
tools: add lint rule for aborted AbortController

### DIFF
--- a/test/eslint.config_partial.mjs
+++ b/test/eslint.config_partial.mjs
@@ -162,6 +162,7 @@ export default [
       'node-core/require-common-first': 'error',
       'node-core/no-duplicate-requires': 'off',
       'node-core/must-call-assert': 'error',
+      'node-core/prefer-abort-signal-abort': 'error',
     },
   },
   {

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -161,9 +161,9 @@ test('AbortController inspection depth 1 or null works', () => {
 
 test('AbortSignal reason is set correctly', () => {
   // Test AbortSignal.reason
+  // eslint-disable-next-line node-core/prefer-abort-signal-abort
   const ac = new AbortController();
   ac.abort('reason');
-  // eslint-disable-next-line node-core/prefer-abort-signal-abort
   assert.strictEqual(ac.signal.reason, 'reason');
 });
 
@@ -236,6 +236,7 @@ test('AbortSignal.reason should default', () => {
   assert.ok(signal.reason instanceof DOMException);
   assert.strictEqual(signal.reason.code, 20);
 
+  // eslint-disable-next-line node-core/prefer-abort-signal-abort
   const ac = new AbortController();
   ac.abort();
   assert.ok(ac.signal.reason instanceof DOMException);

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -161,9 +161,8 @@ test('AbortController inspection depth 1 or null works', () => {
 
 test('AbortSignal reason is set correctly', () => {
   // Test AbortSignal.reason
-  const ac = new AbortController();
-  ac.abort('reason');
-  assert.strictEqual(ac.signal.reason, 'reason');
+  const signal = AbortSignal.abort('reason');
+  assert.strictEqual(signal.reason, 'reason');
 });
 
 test('AbortSignal reasonable is set correctly with AbortSignal.abort()', () => {

--- a/test/parallel/test-abortcontroller.js
+++ b/test/parallel/test-abortcontroller.js
@@ -161,8 +161,10 @@ test('AbortController inspection depth 1 or null works', () => {
 
 test('AbortSignal reason is set correctly', () => {
   // Test AbortSignal.reason
-  const signal = AbortSignal.abort('reason');
-  assert.strictEqual(signal.reason, 'reason');
+  const ac = new AbortController();
+  ac.abort('reason');
+  // eslint-disable-next-line node-core/prefer-abort-signal-abort
+  assert.strictEqual(ac.signal.reason, 'reason');
 });
 
 test('AbortSignal reasonable is set correctly with AbortSignal.abort()', () => {

--- a/test/parallel/test-eslint-prefer-abort-signal-abort.js
+++ b/test/parallel/test-eslint-prefer-abort-signal-abort.js
@@ -16,76 +16,76 @@ new RuleTester().run('prefer-abort-signal-abort', rule, {
   valid: [
     'const signal = AbortSignal.abort();',
     `
-const controller = new AbortController();
-controller.abort();
-controller.abort();
-fn(controller.signal);
-`,
+      const controller = new AbortController();
+      controller.abort();
+      controller.abort();
+      fn(controller.signal);
+    `,
     `
-const controller = new AbortController();
-controller.abort();
-fn(controller.signal, controller.signal);
-`,
+      const controller = new AbortController();
+      controller.abort();
+      fn(controller.signal, controller.signal);
+    `,
     `
-const controller = new AbortController();
-controller.abort();
-console.log(controller);
-fn(controller.signal);
-`,
+      const controller = new AbortController();
+      controller.abort();
+      console.log(controller);
+      fn(controller.signal);
+    `,
     `
-const controller = new AbortController();
-// This comment should not be removed.
-controller.abort();
-fn(controller.signal);
-`,
+      const controller = new AbortController();
+      // This comment should not be removed.
+      controller.abort();
+      fn(controller.signal);
+    `,
     `
-const controller = new AbortController();
-setImmediate(() => controller.abort());
-fn(controller.signal);
-`,
+      const controller = new AbortController();
+      setImmediate(() => controller.abort());
+      fn(controller.signal);
+    `,
     `
-const controller = new AbortController();
-controller.abort('reason', 'extra');
-fn(controller.signal);
-`,
+      const controller = new AbortController();
+      controller.abort('reason', 'extra');
+      fn(controller.signal);
+    `,
   ],
   invalid: [
     {
       code: `
-const controller = new AbortController();
-controller.abort();
-fn(controller.signal);
-`,
+        const controller = new AbortController();
+        controller.abort();
+        fn(controller.signal);
+      `,
       errors: [{ message }],
       output: `
-fn(AbortSignal.abort());
-`,
+        fn(AbortSignal.abort());
+      `,
     },
     {
       code: `
-const abortController = new AbortController();
-abortController.abort(new Error('aborted'));
-fn({ signal: abortController.signal });
-`,
+        const abortController = new AbortController();
+        abortController.abort(new Error('aborted'));
+        fn({ signal: abortController.signal });
+      `,
       errors: [{ message }],
       output: `
-fn({ signal: AbortSignal.abort(new Error('aborted')) });
-`,
+        fn({ signal: AbortSignal.abort(new Error('aborted')) });
+      `,
     },
     {
       code: `
-{
-  const ac = new AbortController();
-  ac.abort();
-  await wait({ signal: ac.signal });
-}
-`,
+        {
+          const ac = new AbortController();
+          ac.abort();
+          await wait({ signal: ac.signal });
+        }
+      `,
       errors: [{ message }],
       output: `
-{
-  await wait({ signal: AbortSignal.abort() });
-}
-`,
+        {
+          await wait({ signal: AbortSignal.abort() });
+        }
+      `,
     },
   ]
 });

--- a/test/parallel/test-eslint-prefer-abort-signal-abort.js
+++ b/test/parallel/test-eslint-prefer-abort-signal-abort.js
@@ -24,11 +24,6 @@ new RuleTester().run('prefer-abort-signal-abort', rule, {
     `
       const controller = new AbortController();
       controller.abort();
-      fn(controller.signal, controller.signal);
-    `,
-    `
-      const controller = new AbortController();
-      controller.abort();
       console.log(controller);
       fn(controller.signal);
     `,
@@ -84,6 +79,38 @@ new RuleTester().run('prefer-abort-signal-abort', rule, {
       output: `
         {
           await wait({ signal: AbortSignal.abort() });
+        }
+      `,
+    },
+    {
+      code: `
+        {
+          const controller = new AbortController();
+          controller.abort();
+          fn(controller.signal, controller.signal);
+        }
+      `,
+      errors: [{ message }],
+      output: `
+        {
+          const controller = AbortSignal.abort();
+          fn(controller, controller);
+        }
+      `,
+    },
+    {
+      code: `
+        {
+          const controller = new AbortController();
+          controller.abort("reason");
+          fn(controller.signal, controller.signal);
+        }
+      `,
+      errors: [{ message }],
+      output: `
+        {
+          const controller = AbortSignal.abort("reason");
+          fn(controller, controller);
         }
       `,
     },

--- a/test/parallel/test-eslint-prefer-abort-signal-abort.js
+++ b/test/parallel/test-eslint-prefer-abort-signal-abort.js
@@ -1,0 +1,91 @@
+'use strict';
+
+const common = require('../common');
+if ((!common.hasCrypto) || (!common.hasIntl)) {
+  common.skip('ESLint tests require crypto and Intl');
+}
+
+common.skipIfEslintMissing();
+
+const RuleTester = require('../../tools/eslint/node_modules/eslint').RuleTester;
+const rule = require('../../tools/eslint-rules/prefer-abort-signal-abort');
+
+const message = 'Use AbortSignal.abort() instead of creating and aborting an AbortController.';
+
+new RuleTester().run('prefer-abort-signal-abort', rule, {
+  valid: [
+    'const signal = AbortSignal.abort();',
+    `
+const controller = new AbortController();
+controller.abort();
+controller.abort();
+fn(controller.signal);
+`,
+    `
+const controller = new AbortController();
+controller.abort();
+fn(controller.signal, controller.signal);
+`,
+    `
+const controller = new AbortController();
+controller.abort();
+console.log(controller);
+fn(controller.signal);
+`,
+    `
+const controller = new AbortController();
+// This comment should not be removed.
+controller.abort();
+fn(controller.signal);
+`,
+    `
+const controller = new AbortController();
+setImmediate(() => controller.abort());
+fn(controller.signal);
+`,
+    `
+const controller = new AbortController();
+controller.abort('reason', 'extra');
+fn(controller.signal);
+`,
+  ],
+  invalid: [
+    {
+      code: `
+const controller = new AbortController();
+controller.abort();
+fn(controller.signal);
+`,
+      errors: [{ message }],
+      output: `
+fn(AbortSignal.abort());
+`,
+    },
+    {
+      code: `
+const abortController = new AbortController();
+abortController.abort(new Error('aborted'));
+fn({ signal: abortController.signal });
+`,
+      errors: [{ message }],
+      output: `
+fn({ signal: AbortSignal.abort(new Error('aborted')) });
+`,
+    },
+    {
+      code: `
+{
+  const ac = new AbortController();
+  ac.abort();
+  await wait({ signal: ac.signal });
+}
+`,
+      errors: [{ message }],
+      output: `
+{
+  await wait({ signal: AbortSignal.abort() });
+}
+`,
+    },
+  ]
+});

--- a/test/parallel/test-quic-writer-abort-signal.mjs
+++ b/test/parallel/test-quic-writer-abort-signal.mjs
@@ -33,12 +33,11 @@ const stream = await clientSession.createBidirectionalStream();
 const w = stream.writer;
 
 // Create an already-aborted signal.
-const ac = new AbortController();
-ac.abort(new Error('already aborted'));
+const signal = AbortSignal.abort(new Error('already aborted'));
 
 // write() with an already-aborted signal should reject immediately.
 await rejects(
-  w.write(encoder.encode('data'), { signal: ac.signal }),
+  w.write(encoder.encode('data'), { signal }),
   { message: 'already aborted' },
 );
 

--- a/tools/eslint-rules/prefer-abort-signal-abort.js
+++ b/tools/eslint-rules/prefer-abort-signal-abort.js
@@ -118,8 +118,7 @@ module.exports = {
             return isAbortReference(reference, abortStatement, name);
           });
 
-          if (references.length !== 2 ||
-              signalReferences.length !== 1 ||
+          if (references.length !== (1 + signalReferences.length) ||
               abortReferences.length !== 1) {
             continue;
           }

--- a/tools/eslint-rules/prefer-abort-signal-abort.js
+++ b/tools/eslint-rules/prefer-abort-signal-abort.js
@@ -129,13 +129,21 @@ module.exports = {
             '' : sourceCode.getText(abortArguments[0]);
 
           context.report({
-            node: signalNode,
+            node: declarator,
             message,
             fix(fixer) {
+              const abortSignalCreationCall = `AbortSignal.abort(${abortReason})`;
+              if (signalReferences.length > 1) {
+                return [
+                  fixer.replaceText(declarator.init, abortSignalCreationCall),
+                  fixer.removeRange(rangeIncludingTrailingLine(abortStatement)),
+                  ...signalReferences.map(({ identifier: { parent } }) => fixer.replaceText(parent, name)),
+                ];
+              }
               return [
                 fixer.removeRange(rangeIncludingTrailingLine(variableDeclaration)),
                 fixer.removeRange(rangeIncludingTrailingLine(abortStatement)),
-                fixer.replaceText(signalNode, `AbortSignal.abort(${abortReason})`),
+                fixer.replaceText(signalNode, abortSignalCreationCall),
               ];
             },
           });

--- a/tools/eslint-rules/prefer-abort-signal-abort.js
+++ b/tools/eslint-rules/prefer-abort-signal-abort.js
@@ -1,0 +1,147 @@
+/**
+ * @file Prefer AbortSignal.abort() for already-aborted signals.
+ */
+'use strict';
+
+const message = 'Use AbortSignal.abort() instead of creating and aborting an AbortController.';
+
+function isAbortControllerConstruction(node) {
+  return node?.type === 'NewExpression' &&
+         node.callee.type === 'Identifier' &&
+         node.callee.name === 'AbortController' &&
+         node.arguments.length === 0;
+}
+
+function isIdentifier(node, name) {
+  return node?.type === 'Identifier' && node.name === name;
+}
+
+function isProperty(node, name) {
+  return !node.computed && isIdentifier(node.property, name);
+}
+
+function isAbortCallStatement(node, name) {
+  const expression = node?.expression;
+  const callee = expression?.callee;
+  return node?.type === 'ExpressionStatement' &&
+         expression.type === 'CallExpression' &&
+         callee.type === 'MemberExpression' &&
+         isIdentifier(callee.object, name) &&
+         isProperty(callee, 'abort') &&
+         expression.arguments.length <= 1;
+}
+
+function isSignalReference(reference, name) {
+  const { identifier } = reference;
+  const parent = identifier.parent;
+  return isIdentifier(identifier, name) &&
+         parent?.type === 'MemberExpression' &&
+         parent.object === identifier &&
+         isProperty(parent, 'signal');
+}
+
+function isAbortReference(reference, abortStatement, name) {
+  const { identifier } = reference;
+  const parent = identifier.parent;
+  return isIdentifier(identifier, name) &&
+         parent?.type === 'MemberExpression' &&
+         parent.object === identifier &&
+         isProperty(parent, 'abort') &&
+         parent.parent === abortStatement.expression;
+}
+
+module.exports = {
+  meta: {
+    fixable: 'code',
+  },
+
+  create(context) {
+    const sourceCode = context.sourceCode;
+    const candidates = [];
+
+    function hasCommentsBetween(left, right) {
+      return sourceCode.getCommentsBefore(right)
+        .some((comment) => comment.range[0] > left.range[1]);
+    }
+
+    function rangeIncludingTrailingLine(statement) {
+      const tokenAfter = sourceCode.getTokenAfter(statement, { includeComments: true });
+      if (tokenAfter && tokenAfter.loc.start.line > statement.loc.end.line) {
+        return [statement.range[0], tokenAfter.range[0]];
+      }
+      return statement.range;
+    }
+
+    return {
+      VariableDeclarator(node) {
+        if (node.id.type !== 'Identifier' ||
+            !isAbortControllerConstruction(node.init) ||
+            node.parent.declarations.length !== 1) {
+          return;
+        }
+
+        const variableDeclaration = node.parent;
+        const parent = variableDeclaration.parent;
+        if (parent.type !== 'BlockStatement' && parent.type !== 'Program') {
+          return;
+        }
+
+        const index = parent.body.indexOf(variableDeclaration);
+        const abortStatement = parent.body[index + 1];
+        if (!isAbortCallStatement(abortStatement, node.id.name) ||
+            hasCommentsBetween(variableDeclaration, abortStatement)) {
+          return;
+        }
+
+        candidates.push({
+          abortStatement,
+          declarator: node,
+          variableDeclaration,
+        });
+      },
+
+      'Program:exit'() {
+        for (const { abortStatement, declarator, variableDeclaration } of candidates) {
+          const [variable] = sourceCode.scopeManager.getDeclaredVariables(declarator);
+          if (!variable) {
+            continue;
+          }
+
+          const name = declarator.id.name;
+          const references = variable.references.filter((reference) => {
+            return reference.identifier !== declarator.id;
+          });
+          const signalReferences = references.filter((reference) => {
+            return isSignalReference(reference, name);
+          });
+          const abortReferences = references.filter((reference) => {
+            return isAbortReference(reference, abortStatement, name);
+          });
+
+          if (references.length !== 2 ||
+              signalReferences.length !== 1 ||
+              abortReferences.length !== 1) {
+            continue;
+          }
+
+          const signalNode = signalReferences[0].identifier.parent;
+          const abortArguments = abortStatement.expression.arguments;
+          const abortReason = abortArguments.length === 0 ?
+            '' : sourceCode.getText(abortArguments[0]);
+
+          context.report({
+            node: signalNode,
+            message,
+            fix(fixer) {
+              return [
+                fixer.removeRange(rangeIncludingTrailingLine(variableDeclaration)),
+                fixer.removeRange(rangeIncludingTrailingLine(abortStatement)),
+                fixer.replaceText(signalNode, `AbortSignal.abort(${abortReason})`),
+              ];
+            },
+          });
+        }
+      },
+    };
+  },
+};


### PR DESCRIPTION
This adds an ESLint rule to prefer `AbortSignal.abort()` when a test creates an
`AbortController`, immediately aborts it, and only uses the resulting
`controller.signal`.

The rule is intentionally conservative and only fixes the simple already-aborted
signal pattern from https://github.com/nodejs/node/pull/63489.

---

The rule uses ESLint scope analysis rather than text matching. After finding a
candidate declaration, it gets the declared variable with
`sourceCode.scopeManager.getDeclaredVariables()` and checks all references to
that variable.

It only reports when the variable has exactly two non-declaration references:

1. the immediate `controller.abort()` call
2. one `controller.signal` read

If the controller is logged, passed somewhere else, aborted later, read more than
once, or otherwise referenced, the rule does not report or autofix it.

---

Assisted-by: openai:gpt-5.5