### PR TITLE
crypto: handle cipher context allocation failures

### DIFF
--- a/src/crypto/crypto_aes.cc
+++ b/src/crypto/crypto_aes.cc
@@ -48,7 +48,9 @@ WebCryptoCipherStatus AES_Cipher(Environment* env,
   CHECK_EQ(key_data.GetKeyType(), kKeyTypeSecret);
 
   auto ctx = CipherCtxPointer::New();
-  CHECK(ctx);
+  if (!ctx) {
+    return WebCryptoCipherStatus::FAILED;
+  }
 
   if (params.cipher.isWrapMode()) {
     ctx.setAllowWrap();

--- a/src/crypto/crypto_chacha20_poly1305.cc
+++ b/src/crypto/crypto_chacha20_poly1305.cc
@@ -222,7 +222,9 @@ WebCryptoCipherStatus ChaCha20Poly1305CipherTraits::DoCipher(
   return WebCryptoCipherStatus::OK;
 #else
   auto ctx = CipherCtxPointer::New();
-  CHECK(ctx);
+  if (!ctx) {
+    return WebCryptoCipherStatus::FAILED;
+  }
 
   const bool encrypt = cipher_mode == kWebCryptoCipherEncrypt;
 

--- a/src/crypto/crypto_cipher.cc
+++ b/src/crypto/crypto_cipher.cc
@@ -93,6 +93,11 @@ void GetCipherInfo(const FunctionCallbackInfo<Value>& args) {
     // If it is, then the getCipherInfo will succeed with the given
     // values.
     auto ctx = CipherCtxPointer::New();
+    if (!ctx) {
+      return THROW_ERR_CRYPTO_OPERATION_FAILED(
+          env, "Failed to allocate cipher context");
+    }
+
     if (!ctx.init(cipher, true)) {
       return;
     }
@@ -338,7 +343,10 @@ void CipherBase::CommonInit(const char* cipher_type,
   MarkPopErrorOnReturn mark_pop_error_on_return;
   CHECK(!ctx_);
   ctx_ = CipherCtxPointer::New();
-  CHECK(ctx_);
+  if (!ctx_) {
+    return THROW_ERR_CRYPTO_OPERATION_FAILED(
+        env(), "Failed to allocate cipher context");
+  }
 
   if (cipher.isWrapMode()) {
     ctx_.setAllowWrap();


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/62774

Handle failed cipher context allocation without hitting CHECK() in crypto/webcrypto paths. The WebCrypto helpers now return FAILED and CipherBase reports a crypto operation error.

No dedicated regression test because this requires forcing OpenSSL allocation failure.

Checks:
- py -3 tools\cpplint.py --quiet src\crypto\crypto_aes.cc src\crypto\crypto_chacha20_poly1305.cc src\crypto\crypto_cipher.cc
- git diff --check