### PR TITLE
test: deflake test-webcrypto-crypto-job-mode

### DIFF
--- a/test/parallel/test-webcrypto-crypto-job-mode.js
+++ b/test/parallel/test-webcrypto-crypto-job-mode.js
@@ -163,7 +163,7 @@ async function withObjectPrototypeSetters(names, fn) {
       { name: 'AES-CBC', iv },
       key,
       Buffer.alloc(16)));
-    ciphertext[ciphertext.length - 1] ^= 0xff;
+    ciphertext[0] ^= 0xff;
 
     await assert.rejects(
       subtle.decrypt({ name: 'AES-CBC', iv }, key, ciphertext),


### PR DESCRIPTION
Deflake the test by corrupting the first AES-CBC ciphertext byte instead of the final byte. Mutating the final byte made the decrypted padding block random, which could occasionally produce valid PKCS#7 padding and cause subtle.decrypt() to resolve. Mutating the first byte deterministically corrupts the padding block for this two-block ciphertext, so the expected OperationError rejection is stable.


flake e.g. https://ci.nodejs.org/job/node-test-commit-linuxone/55565/nodes=rhel8-s390x/testReport/junit/(root)/parallel/test_webcrypto_crypto_job_mode/