### PR TITLE
test: deflake test-debugger-probe-timeout

### DIFF
--- a/test/parallel/test-debugger-probe-timeout.js
+++ b/test/parallel/test-debugger-probe-timeout.js
@@ -9,10 +9,11 @@ const { spawnSyncAndExit } = require('../common/child_process');
 const { assertProbeJson } = require('../common/debugger-probe');
 const cwd = fixtures.path('debugger');
 
+const timeout = common.platformTimeout(1000);
 spawnSyncAndExit(process.execPath, [
   'inspect',
   '--json',
-  '--timeout=200',
+  `--timeout=${timeout}`,
   '--probe', 'probe-timeout.js:99',
   '--expr', '1',
   'probe-timeout.js',
@@ -31,7 +32,7 @@ spawnSyncAndExit(process.execPath, [
         pending: [0],
         error: {
           code: 'probe_timeout',
-          message: 'Timed out after 200ms waiting for probes: probe-timeout.js:99',
+          message: `Timed out after ${timeout}ms waiting for probes: probe-timeout.js:99`,
         },
       }],
     });


### PR DESCRIPTION
On slow machines in the CI, the 200ms timeout may fire before the probed process finishes evaluation. Increase the timeout to common.platformTimeout(1000) to accomondate.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-05-24.md

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
