### PR TITLE
module: load ESM helpers eagerly in the snapshot

### DIFF
--- a/lib/internal/modules/esm/loader.js
+++ b/lib/internal/modules/esm/loader.js
@@ -14,7 +14,8 @@ const {
   hardenRegExp,
 } = primordials;
 
-
+const { LoadCache, ResolveCache } = require('internal/modules/esm/module_map');
+const { ModuleJob, ModuleJobSync } = require('internal/modules/esm/module_job');
 // This is needed to avoid cycles in esm/resolve <-> cjs/loader
 const {
   kIsExecuting,
@@ -85,24 +86,6 @@ const { isPromise } = require('internal/util/types');
  * @typedef {import('url').URL} URL
  */
 
-/**
- * Lazy loads the module_map module and returns a new instance of ResolveCache.
- * @returns {import('./module_map.js').ResolveCache}
- */
-function newResolveCache() {
-  const { ResolveCache } = require('internal/modules/esm/module_map');
-  return new ResolveCache();
-}
-
-/**
- * Generate a load cache (to store the final result of a load-chain for a particular module).
- * @returns {import('./module_map.js').LoadCache}
- */
-function newLoadCache() {
-  const { LoadCache } = require('internal/modules/esm/module_map');
-  return new LoadCache();
-}
-
 const { translators } = require('internal/modules/esm/translators');
 const { defaultResolve } = require('internal/modules/esm/resolve');
 const { defaultLoadSync, throwUnknownModuleFormat } = require('internal/modules/esm/load');
@@ -161,12 +144,12 @@ class ModuleLoader {
   /**
    * Registry of resolved specifiers
    */
-  #resolveCache = newResolveCache();
+  #resolveCache = new ResolveCache();
 
   /**
    * Registry of loaded modules, akin to `require.cache`
    */
-  loadCache = newLoadCache();
+  loadCache = new LoadCache();
 
   /**
    * @see {AsyncLoaderHooks.isForAsyncLoaderHookWorker}
@@ -238,7 +221,6 @@ class ModuleLoader {
    * @returns {Promise<object>} The module object.
    */
   async executeModuleJob(url, wrap, isEntryPoint = false) {
-    const { ModuleJob } = require('internal/modules/esm/module_job');
     const module = await onImport.tracePromise(async () => {
       const job = new ModuleJob(this, url, undefined, wrap, kEvaluationPhase, false, false, kImportInImportedESM);
       this.loadCache.set(url, undefined, job);
@@ -357,7 +339,6 @@ class ModuleLoader {
     const wrap = compileSourceTextModule(url, source, kUser);
     const inspectBrk = (isMain && getOptionValue('--inspect-brk'));
 
-    const { ModuleJobSync } = require('internal/modules/esm/module_job');
     job = new ModuleJobSync(this, url, kEmptyObject, wrap, kEvaluationPhase, isMain, inspectBrk,
                             kImportInRequiredESM);
     this.loadCache.set(url, kImplicitTypeAttribute, job);
@@ -587,7 +568,6 @@ class ModuleLoader {
       assert(moduleOrModulePromise instanceof ModuleWrap, `Expected ModuleWrap for loading ${url}`);
     }
 
-    const { ModuleJob, ModuleJobSync } = require('internal/modules/esm/module_job');
     // TODO(joyeecheung): use ModuleJobSync for kRequireInImportedCJS too.
     const ModuleJobCtor = (requestType === kImportInRequiredESM ? ModuleJobSync : ModuleJob);
     const isMain = (parentURL === undefined);

--- a/test/parallel/test-bootstrap-modules.js
+++ b/test/parallel/test-bootstrap-modules.js
@@ -133,6 +133,8 @@ if (isMainThread) {
     'NativeModule internal/modules/esm/load',
     'NativeModule internal/modules/esm/resolve',
     'NativeModule internal/modules/esm/translators',
+    'NativeModule internal/modules/esm/module_job',
+    'NativeModule internal/modules/esm/module_map',
     'NativeModule url',
   ].forEach(expected.beforePreExec.add.bind(expected.beforePreExec));
 } else {  // Worker.


### PR DESCRIPTION
Since the ESM loader is captured in the snapshot now, there's no need to lazy load the helpers. Load them eagerly to capture them into the snapshot. This also reduces the noise coming out of --print-bytecode since we no longer compile the helper functions at run time.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
