### PR TITLE
quic: Implement callback for http/3 settings/application options

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -3270,6 +3270,19 @@ added: v23.8.0
   datagram was never sent on the wire (dropped due to queue overflow,
   send attempt limit exceeded, or frame size rejection).
 
+### Callback: `OnApplicationCallback`
+
+<!-- YAML
+added: v23.8.0
+-->
+
+* `this` {quic.QuicSession}
+* `applicationoption` {quic.QuicSession}
+
+The callback function that is invoked when application options change.
+E.g. for http/3 settings are included in applications options and
+may arrive after the connection is established.
+
 ### Callback: `OnPathValidationCallback`
 
 <!-- YAML

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -755,6 +755,8 @@ added: REPLACEME
 The current application-level options for this session. These include settings
 that are specific to the negotiated application protocol (e.g. HTTP/3) and may
 be negotiated separately from the transport parameters. Read only.
+You can use the callback [`session.onapplication`][] to be informed, when settings
+from the remote arrive.
 
 ### `session.close([options])`
 
@@ -886,6 +888,16 @@ added: v23.8.0
 
 The endpoint that created this session. Returns `null` if the session
 has been destroyed. Read only.
+
+### `session.onapplication`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {quic.OnApplicationCallback}
+
+The callback to invoke when new application options, e.g. HTTP/3 settings arrived.
 
 ### `session.onerror`
 
@@ -3200,11 +3212,11 @@ with that error:
 
 * Stream callbacks (`onblocked`, `onreset`, `onheaders`, `ontrailers`,
   `oninfo`, `onwanttrailers`): the stream is destroyed.
-* Session callbacks (`onstream`, `ondatagram`, `ondatagramstatus`,
-  `onpathvalidation`, `onsessionticket`, `onnewtoken`,
-  `onversionnegotiation`, `onorigin`, `ongoaway`, `onhandshake`,
-  `onkeylog`, `onqlog`): the session is destroyed along with all of its
-  streams.
+* Session callbacks (`onapplication`, `onstream`, `ondatagram`,
+  `ondatagramstatus`, `onpathvalidation`, `onsessionticket`,
+  `onnewtoken`, `onversionnegotiation`, `onorigin`, `ongoaway`,
+  `onhandshake`, `onkeylog`, `onqlog`): the session is destroyed along
+  with all of its streams.
 
 Before destruction, the optional [`session.onerror`][] or
 [`stream.onerror`][] callback is invoked (if set), giving the application a
@@ -3732,6 +3744,17 @@ added: v23.8.0
 
 Published when an endpoint's busy state changes.
 
+### Channel: `quic.session.application`
+
+<!-- YAML
+added: v23.8.0
+-->
+
+* `applicationoptions` {quic.ApplicationOptions} Current application options.
+* `session` {quic.QuicSession}
+
+Published when a locally-initiated stream is opened.
+
 ### Channel: `quic.session.created.client`
 
 <!-- YAML
@@ -4099,6 +4122,7 @@ throughput issues caused by flow control.
 [`session.createUnidirectionalStream()`]: #sessioncreateunidirectionalstreamoptions
 [`session.destroy()`]: #sessiondestroyerror-options
 [`session.maxPendingDatagrams`]: #sessionmaxpendingdatagrams
+[`session.onapplication`]: #sessiononapplication
 [`session.ondatagram`]: #sessionondatagram
 [`session.ondatagramstatus`]: #sessionondatagramstatus
 [`session.onearlyrejected`]: #sessiononearlyrejected

--- a/lib/internal/quic/diagnostics.js
+++ b/lib/internal/quic/diagnostics.js
@@ -14,6 +14,7 @@ const onEndpointErrorChannel = dc.channel('quic.endpoint.error');
 const onEndpointBusyChangeChannel = dc.channel('quic.endpoint.busy.change');
 const onEndpointClientSessionChannel = dc.channel('quic.session.created.client');
 const onEndpointServerSessionChannel = dc.channel('quic.session.created.server');
+const onSessionApplicationChannel = dc.channel('quic.session.application');
 const onSessionOpenStreamChannel = dc.channel('quic.session.open.stream');
 const onSessionReceivedStreamChannel = dc.channel('quic.session.received.stream');
 const onSessionSendDatagramChannel = dc.channel('quic.session.send.datagram');
@@ -48,6 +49,7 @@ module.exports = {
   onEndpointBusyChangeChannel,
   onEndpointClientSessionChannel,
   onEndpointServerSessionChannel,
+  onSessionApplicationChannel,
   onSessionOpenStreamChannel,
   onSessionReceivedStreamChannel,
   onSessionSendDatagramChannel,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -199,6 +199,7 @@ const {
   kPrivateConstructor,
   kReset,
   kSendHeaders,
+  kSessionApplication,
   kSessionTicket,
   kTrailers,
   kVersionNegotiation,
@@ -247,6 +248,7 @@ const {
   onSessionReceiveDatagramStatusChannel,
   onSessionPathValidationChannel,
   onSessionNewTokenChannel,
+  onSessionApplicationChannel,
   onSessionTicketChannel,
   onSessionVersionNegotiationChannel,
   onSessionOriginChannel,
@@ -436,6 +438,7 @@ const endpointRegistry = new SafeSet();
  * @property {OnGoawayCallback} [ongoaway] GOAWAY frame callback.
  * @property {OnKeylogCallback} [onkeylog] TLS key-log callback.
  * @property {OnQlogCallback} [onqlog] qlog data callback.
+ * @property {OnApplicationCallback} [onapplication] application options callback.
  * @property {OnHeadersCallback} [onheaders] Default per-stream initial-headers callback.
  * @property {OnTrailersCallback} [ontrailers] Default per-stream trailing-headers callback.
  * @property {OnInfoCallback} [oninfo] Default per-stream informational-headers callback.
@@ -567,6 +570,13 @@ const endpointRegistry = new SafeSet();
  */
 
 /**
+ * @callback OnApplicationCallback
+ * @this {QuicSession}
+ * @param {ApplicationOptions} applicationoptions
+ * @returns {void}
+ */
+
+/**
  * @callback OnSessionTicketCallback
  * @this {QuicSession}
  * @param {object} ticket
@@ -640,6 +650,14 @@ const endpointRegistry = new SafeSet();
  * @this {QuicSession}
  * @param {string} data A chunk of JSON-SEQ formatted qlog data
  * @param {boolean} fin `true` if this is the final qlog chunk for the session.
+ * @returns {void}
+ */
+
+/**
+ * Called when initial request or response headers are received.
+ * @callback OnApplicationCallback
+ * @this {QuicSession}
+ * @param {ApplicationOptions} applicationoptions ApplicationOptions object
  * @returns {void}
  */
 
@@ -796,6 +814,16 @@ setCallbacks({
     this[kOwner][kPathValidation](result, newLocalAddress, newRemoteAddress,
                                   oldLocalAddress, oldRemoteAddress,
                                   preferredAddress);
+  },
+
+  /**
+   * Called when the session's application object is updated
+   * E.g. http/3 session arrived.
+   * @param {ApplicationOptions} applicationoptions An application object
+   */
+  onSessionApplication(applicationoptions) {
+    debug('session application callback', this[kOwner]);
+    this[kOwner][kSessionApplication](applicationoptions);
   },
 
   /**
@@ -1208,6 +1236,7 @@ function applyCallbacks(session, cbs) {
   if (cbs.ongoaway) session.ongoaway = cbs.ongoaway;
   if (cbs.onkeylog) session.onkeylog = cbs.onkeylog;
   if (cbs.onqlog) session.onqlog = cbs.onqlog;
+  if (cbs.onapplication) session.onapplication = cbs.application;
   if (cbs.onheaders || cbs.ontrailers || cbs.oninfo || cbs.onwanttrailers) {
     session[kStreamCallbacks] = {
       __proto__: null,
@@ -2897,6 +2926,25 @@ class QuicSession {
   }
 
   /** @type {Function|undefined} */
+  get onapplication() {
+    assertIsQuicSession(this);
+    return this.#inner.onapplication;
+  }
+
+  set onapplication(fn) {
+    assertIsQuicSession(this);
+    const inner = this.#inner;
+    if (fn === undefined) {
+      inner.onapplication = undefined;
+      inner.state.hasApplicationListener = false;
+    } else {
+      validateFunction(fn, 'onsessionticket');
+      inner.onapplication = FunctionPrototypeBind(fn, this);
+      inner.state.hasApplicationListener = true;
+    }
+  }
+
+  /** @type {Function|undefined} */
   get onversionnegotiation() {
     assertIsQuicSession(this);
     return this.#inner.onversionnegotiation;
@@ -3483,6 +3531,7 @@ class QuicSession {
     inner.ondatagramstatus = undefined;
     inner.onpathvalidation = undefined;
     inner.onsessionticket = undefined;
+    inner.onapplication = undefined;
     inner.onkeylog = undefined;
     inner.onversionnegotiation = undefined;
     inner.onhandshake = undefined;
@@ -3702,6 +3751,23 @@ class QuicSession {
       });
     }
     safeCallbackInvoke(inner.onsessionticket, this, ticket);
+  }
+
+  /**
+   * @param {ApplicationOptions} applicationoptions
+   */
+  [kSessionApplication](applicationoptions) {
+    if (this.destroyed) return;
+    if (onSessionApplicationChannel.hasSubscribers) {
+      onSessionApplicationChannel.publish({
+        __proto__: null,
+        applicationoptions,
+        session: this,
+      });
+    }
+    const inner = this.#inner;
+    if (typeof inner.onapplication === 'function')
+      safeCallbackInvoke(inner.onapplication, this, applicationoptions);
   }
 
   /**
@@ -4222,6 +4288,7 @@ class QuicEndpoint {
       ongoaway,
       onkeylog,
       onqlog,
+      onapplication,
       // Stream-level callbacks applied to each incoming stream.
       onheaders,
       ontrailers,
@@ -4247,6 +4314,7 @@ class QuicEndpoint {
       ongoaway,
       onkeylog,
       onqlog,
+      onapplication,
       onheaders,
       ontrailers,
       oninfo,
@@ -4955,6 +5023,8 @@ function processSessionOptions(options, config = kEmptyObject) {
     ongoaway,
     onkeylog,
     onqlog,
+    onapplication,
+    // Application level options changed, e.g. HTTP/3 settings related
     // Stream-level callbacks.
     onheaders,
     ontrailers,
@@ -5060,6 +5130,7 @@ function processSessionOptions(options, config = kEmptyObject) {
     ongoaway,
     onkeylog,
     onqlog,
+    onapplication,
     onheaders,
     ontrailers,
     oninfo,

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -654,7 +654,7 @@ const endpointRegistry = new SafeSet();
  */
 
 /**
- * Called when initial request or response headers are received.
+ * Called when `ApplicationOptions` are changed, e.g. HTTP/3 settings.
  * @callback OnApplicationCallback
  * @this {QuicSession}
  * @param {ApplicationOptions} applicationoptions ApplicationOptions object
@@ -1236,7 +1236,7 @@ function applyCallbacks(session, cbs) {
   if (cbs.ongoaway) session.ongoaway = cbs.ongoaway;
   if (cbs.onkeylog) session.onkeylog = cbs.onkeylog;
   if (cbs.onqlog) session.onqlog = cbs.onqlog;
-  if (cbs.onapplication) session.onapplication = cbs.application;
+  if (cbs.onapplication) session.onapplication = cbs.onapplication;
   if (cbs.onheaders || cbs.ontrailers || cbs.oninfo || cbs.onwanttrailers) {
     session[kStreamCallbacks] = {
       __proto__: null,
@@ -2938,7 +2938,7 @@ class QuicSession {
       inner.onapplication = undefined;
       inner.state.hasApplicationListener = false;
     } else {
-      validateFunction(fn, 'onsessionticket');
+      validateFunction(fn, 'onapplication');
       inner.onapplication = FunctionPrototypeBind(fn, this);
       inner.state.hasApplicationListener = true;
     }

--- a/lib/internal/quic/state.js
+++ b/lib/internal/quic/state.js
@@ -349,6 +349,7 @@ class QuicSessionState {
   static #LISTENER_SESSION_TICKET = 1 << 3;
   static #LISTENER_NEW_TOKEN = 1 << 4;
   static #LISTENER_ORIGIN = 1 << 5;
+  static #LISTENER_APPLICATION = 1 << 6;
 
   #getListenerFlag(flag) {
     const handle = this.#handle;
@@ -365,6 +366,14 @@ class QuicSessionState {
     DataViewPrototypeSetUint32(
       handle, this.#offset + IDX_STATE_SESSION_LISTENER_FLAGS,
       val ? (current | flag) : (current & ~flag), kIsLittleEndian);
+  }
+
+  /** @type {boolean} */
+  get hasApplicationListener() {
+    return this.#getListenerFlag(QuicSessionState.#LISTENER_APPLICATION);
+  }
+  set hasApplicationListener(val) {
+    this.#setListenerFlag(QuicSessionState.#LISTENER_APPLICATION, val);
   }
 
   /** @type {boolean} */

--- a/lib/internal/quic/symbols.js
+++ b/lib/internal/quic/symbols.js
@@ -54,6 +54,7 @@ const kRemoveSession = Symbol('kRemoveSession');
 const kRemoveStream = Symbol('kRemoveStream');
 const kReset = Symbol('kReset');
 const kSendHeaders = Symbol('kSendHeaders');
+const kSessionApplication = Symbol('kSessionApplication');
 const kSessionTicket = Symbol('kSessionTicket');
 const kTrailers = Symbol('kTrailers');
 const kVersionNegotiation = Symbol('kVersionNegotiation');
@@ -88,6 +89,7 @@ module.exports = {
   kRemoveStream,
   kReset,
   kSendHeaders,
+  kSessionApplication,
   kSessionTicket,
   kTrailers,
   kVersionNegotiation,

--- a/src/quic/bindingdata.h
+++ b/src/quic/bindingdata.h
@@ -41,6 +41,7 @@ class SessionManager;
 #define QUIC_JS_CALLBACKS(V)                                                   \
   V(endpoint_close, EndpointClose)                                             \
   V(session_close, SessionClose)                                               \
+  V(session_application, SessionApplication)                                   \
   V(session_early_data_rejected, SessionEarlyDataRejected)                     \
   V(session_goaway, SessionGoaway)                                             \
   V(session_datagram, SessionDatagram)                                         \

--- a/src/quic/http3.cc
+++ b/src/quic/http3.cc
@@ -1012,6 +1012,8 @@ class Http3ApplicationImpl final : public Session::Application {
     Debug(&session(),
           "HTTP/3 application received updated settings: %s",
           options_);
+    // The settings are part of the application
+    session().EmitApplication();
   }
 
   bool started_ = false;

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -3601,6 +3601,27 @@ void Session::EmitSessionTicket(Store&& ticket) {
   }
 }
 
+void Session::EmitApplication() {
+  if (is_destroyed()) return;
+  if (!env()->can_call_into_js()) return;
+
+  CallbackScope<Session> cb_scope(this);
+
+  if (!has_application()) {
+    // The application has not yet been selected (ALPN negotiation is not
+    // yet complete on the server) or the session has been destroyed. In
+    // either case, the application options are not available.
+    // Should not happen, but we bail out
+    return;
+  }
+  Local<Value> argv;
+  auto& options = application().options();
+  if (options.ToObject(env()).ToLocal(&argv)) {
+    MakeCallback(
+        BindingData::Get(env()).session_application_callback(), 1, &argv);
+  }
+}
+
 void Session::DestroyAllStreams(const QuicError& error) {
   DCHECK(!is_destroyed());
   // Copy the streams map since streams remove themselves during

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -72,6 +72,7 @@ enum class SessionListenerFlags : uint32_t {
   SESSION_TICKET = 1 << 3,
   NEW_TOKEN = 1 << 4,
   ORIGIN = 1 << 5,
+  APPLICATION = 1 << 6
 };
 
 inline SessionListenerFlags operator|(SessionListenerFlags a,
@@ -3605,8 +3606,6 @@ void Session::EmitApplication() {
   if (is_destroyed()) return;
   if (!env()->can_call_into_js()) return;
 
-  CallbackScope<Session> cb_scope(this);
-
   if (!has_application()) {
     // The application has not yet been selected (ALPN negotiation is not
     // yet complete on the server) or the session has been destroyed. In
@@ -3614,6 +3613,14 @@ void Session::EmitApplication() {
     // Should not happen, but we bail out
     return;
   }
+
+  if (!HasListenerFlag(impl_->state()->listener_flags,
+                       SessionListenerFlags::APPLICATION)) [[likely]] {
+    return;
+  }
+
+  CallbackScope<Session> cb_scope(this);
+
   Local<Value> argv;
   auto& options = application().options();
   if (options.ToObject(env()).ToLocal(&argv)) {

--- a/src/quic/session.h
+++ b/src/quic/session.h
@@ -602,6 +602,7 @@ class Session final : public AsyncWrap, private SessionTicket::AppData::Source {
   void EmitVersionNegotiation(const ngtcp2_pkt_hd& hd,
                               const uint32_t* sv,
                               size_t nsv);
+  void EmitApplication();
   void DatagramStatus(datagram_id datagramId, DatagramStatus status);
   void DatagramReceived(const uint8_t* data,
                         size_t datalen,

--- a/test/parallel/test-quic-h3-settings.mjs
+++ b/test/parallel/test-quic-h3-settings.mjs
@@ -163,7 +163,7 @@ const decoder = new TextDecoder();
     onapplication: mustCall((appopt) => {
       strictEqual(appopt.enableDatagrams, true);
       strictEqual(appopt.enableConnectProtocol, false);
-      // must be false, as this is only sent from server side
+      // Must be false, as this is only sent from server side
     })
   });
 

--- a/test/parallel/test-quic-h3-settings.mjs
+++ b/test/parallel/test-quic-h3-settings.mjs
@@ -162,7 +162,8 @@ const decoder = new TextDecoder();
     }),
     onapplication: mustCall((appopt) => {
       strictEqual(appopt.enableDatagrams, true);
-      strictEqual(appopt.enableConnectProtocol, true); // I have no idea why it is false
+      strictEqual(appopt.enableConnectProtocol, false);
+      // must be false, as this is only sent from server side
     })
   });
 

--- a/test/parallel/test-quic-h3-settings.mjs
+++ b/test/parallel/test-quic-h3-settings.mjs
@@ -160,6 +160,10 @@ const decoder = new TextDecoder();
       this.writer.writeSync(encoder.encode('settings-ok'));
       this.writer.endSync();
     }),
+    onapplication: mustCall((appopt) => {
+      strictEqual(appopt.enableDatagrams, true);
+      strictEqual(appopt.enableConnectProtocol, true); // I have no idea why it is false
+    })
   });
 
   const clientSession = await connect(serverEndpoint.address, {

--- a/test/parallel/test-quic-h3-settings.mjs
+++ b/test/parallel/test-quic-h3-settings.mjs
@@ -166,6 +166,10 @@ const decoder = new TextDecoder();
     servername: 'localhost',
     application: { enableConnectProtocol: true, enableDatagrams: true },
   });
+  clientSession.onapplication = mustCall((appopt) => {
+    strictEqual(appopt.enableConnectProtocol, true);
+    strictEqual(appopt.enableDatagrams, true);
+  });
   await clientSession.opened;
 
   const stream = await clientSession.createBidirectionalStream({


### PR DESCRIPTION
Implements a callback that is invoked once http/3 settings are received.
Background, http/3 settings usually arrive a bit later than connection establishment, and e.g. for
webtransport these settings are used to indicate support. So e.g. the examples for quiche from google, wait for the settings to arrive. (This is different to http/2).
The implemented callback mechanism allows to wait for the settings to arrive until connection attempts are made.
As settings are stored in the generic applications option object, the callback's name refers to the application rather than the settings.
Whether this is a good choice is debatable.

Fixes: https://github.com/nodejs/node/issues/63553

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
