### PR TITLE
stream: handle sync writev completion in pipeTo

### DIFF
--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -13,6 +13,7 @@ const {
   ArrayPrototypePush,
   ArrayPrototypeSlice,
   PromisePrototypeThen,
+  PromiseResolve,
   SymbolAsyncIterator,
   SymbolIterator,
   TypedArrayPrototypeGetByteLength,
@@ -922,7 +923,14 @@ async function pipeTo(source, ...args) {
           return waitForSyncBackpressure();
         }
         const opts = signal ? { __proto__: null, signal } : undefined;
-        return PromisePrototypeThen(writer.writev(batch, opts), () => {
+        const result = writer.writev(batch, opts);
+        if (result === undefined) {
+          for (let i = 0; i < batch.length; i++) {
+            totalBytes += TypedArrayPrototypeGetByteLength(batch[i]);
+          }
+          return;
+        }
+        return PromisePrototypeThen(PromiseResolve(result), () => {
           for (let i = 0; i < batch.length; i++) {
             totalBytes += TypedArrayPrototypeGetByteLength(batch[i]);
           }

--- a/test/parallel/test-stream-iter-pipeto-writev.js
+++ b/test/parallel/test-stream-iter-pipeto-writev.js
@@ -46,6 +46,26 @@ async function testWritevAsyncFallback() {
   assert.ok(batches.some((b) => b.length > 1));
 }
 
+// Multi-chunk batch with synchronous writev success (returns undefined)
+async function testWritevSyncUndefinedSuccess() {
+  const chunks = [];
+  const writer = {
+    write(chunk) {
+      chunks.push(chunk);
+    },
+    writev(batch) {
+      chunks.push(...batch);
+    },
+    end() {},
+  };
+  async function* source() {
+    yield [new Uint8Array([65]), new Uint8Array([66])];
+  }
+  const total = await pipeTo(source(), writer);
+  assert.strictEqual(total, 2);
+  assert.strictEqual(Buffer.concat(chunks).toString(), 'AB');
+}
+
 // writevSync returns false — falls through to async writev
 async function testWritevSyncFails() {
   const asyncCalls = [];
@@ -190,6 +210,7 @@ async function testPipeToSyncWriteFallback() {
 Promise.all([
   testWritevSyncSuccess(),
   testWritevAsyncFallback(),
+  testWritevSyncUndefinedSuccess(),
   testWritevSyncFails(),
   testWriteSyncFailsMidBatch(),
   testWriteSyncAlwaysFails(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63560

Fixes `stream/iter` `pipeTo()` when a duck-typed writer accepts a batched
`writev()` synchronously and returns `undefined`.

`pipeTo()` already tolerated `undefined` from single `write()` calls, but the
`writev()` path passed the return value directly to `PromisePrototypeThen()`,
which caused a `TypeError` for synchronous completion.

---

Assisted-by: openai:gpt-5.5