### PR TITLE
stream: fix pipeToSync byte accounting

### DIFF
--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -863,6 +863,18 @@ async function* createAsyncPipeline(source, transforms, signal) {
   }
 }
 
+/**
+ * Check if a false sync write result means accepted backpressure.
+ * @param {object} writer - The writer whose sync method returned.
+ * @param {*} result - The return value from writeSync() or writevSync().
+ * @returns {boolean}
+ */
+function isAcceptedSyncWriteBackpressure(writer, result) {
+  return result === false &&
+         writer[kSyncWriteAcceptedOnFalse] === true &&
+         writer.desiredSize === 0;
+}
+
 // =============================================================================
 // Public API: pull() and pullSync()
 // =============================================================================
@@ -950,16 +962,29 @@ function pipeToSync(source, ...args) {
   const hasEndSync = typeof writer.endSync === 'function';
 
   try {
+    let canContinue = true;
     for (const batch of pipeline) {
+      if (!canContinue) {
+        break;
+      }
       if (hasWritevSync && batch.length > 1) {
-        writer.writevSync(batch);
+        const result = writer.writevSync(batch);
+        if (result === false &&
+            !isAcceptedSyncWriteBackpressure(writer, result)) {
+          break;
+        }
         for (let i = 0; i < batch.length; i++) {
           totalBytes += TypedArrayPrototypeGetByteLength(batch[i]);
         }
       } else {
         for (let i = 0; i < batch.length; i++) {
           const chunk = batch[i];
-          writer.writeSync(chunk);
+          const result = writer.writeSync(chunk);
+          if (result === false &&
+              !isAcceptedSyncWriteBackpressure(writer, result)) {
+            canContinue = false;
+            break;
+          }
           totalBytes += TypedArrayPrototypeGetByteLength(chunk);
         }
       }
@@ -1011,11 +1036,6 @@ async function pipeTo(source, ...args) {
   const hasWritev = typeof writer.writev === 'function';
   const hasWritevSync = typeof writer.writevSync === 'function';
   const hasEndSync = typeof writer.endSync === 'function';
-  const syncFalseCanBeAccepted = writer[kSyncWriteAcceptedOnFalse] === true;
-
-  function syncFalseWasAccepted() {
-    return syncFalseCanBeAccepted && writer.desiredSize === 0;
-  }
 
   function waitForSyncBackpressure() {
     const ondrain = writer[drainableProtocol];
@@ -1032,9 +1052,10 @@ async function pipeTo(source, ...args) {
   async function writeBatchAsyncFallback(batch, startIndex) {
     for (let i = startIndex; i < batch.length; i++) {
       const chunk = batch[i];
-      if (hasWriteSync && writer.writeSync(chunk)) {
+      const result = hasWriteSync && writer.writeSync(chunk);
+      if (result) {
         // Sync retry succeeded
-      } else if (syncFalseWasAccepted()) {
+      } else if (isAcceptedSyncWriteBackpressure(writer, result)) {
         totalBytes += TypedArrayPrototypeGetByteLength(chunk);
         await waitForSyncBackpressure();
         continue;
@@ -1054,22 +1075,23 @@ async function pipeTo(source, ...args) {
   // is required. Callers must check: const p = writeBatch(b); if (p) await p;
   function writeBatch(batch) {
     if (hasWritev && batch.length > 1) {
-      if (!hasWritevSync || !writer.writevSync(batch)) {
-        if (hasWritevSync && syncFalseWasAccepted()) {
+      const result = hasWritevSync && writer.writevSync(batch);
+      if (!result) {
+        if (isAcceptedSyncWriteBackpressure(writer, result)) {
           for (let i = 0; i < batch.length; i++) {
             totalBytes += TypedArrayPrototypeGetByteLength(batch[i]);
           }
           return waitForSyncBackpressure();
         }
         const opts = signal ? { __proto__: null, signal } : undefined;
-        const result = writer.writev(batch, opts);
-        if (result === undefined) {
+        const writevResult = writer.writev(batch, opts);
+        if (writevResult === undefined) {
           for (let i = 0; i < batch.length; i++) {
             totalBytes += TypedArrayPrototypeGetByteLength(batch[i]);
           }
           return;
         }
-        return PromisePrototypeThen(PromiseResolve(result), () => {
+        return PromisePrototypeThen(PromiseResolve(writevResult), () => {
           for (let i = 0; i < batch.length; i++) {
             totalBytes += TypedArrayPrototypeGetByteLength(batch[i]);
           }
@@ -1082,8 +1104,9 @@ async function pipeTo(source, ...args) {
     }
     for (let i = 0; i < batch.length; i++) {
       const chunk = batch[i];
-      if (!hasWriteSync || !writer.writeSync(chunk)) {
-        if (hasWriteSync && syncFalseWasAccepted()) {
+      const result = hasWriteSync && writer.writeSync(chunk);
+      if (!result) {
+        if (isAcceptedSyncWriteBackpressure(writer, result)) {
           totalBytes += TypedArrayPrototypeGetByteLength(chunk);
           return writeBatchAfterAcceptedBackpressure(batch, i + 1);
         }

--- a/test/parallel/test-stream-iter-pipeto-writev.js
+++ b/test/parallel/test-stream-iter-pipeto-writev.js
@@ -154,6 +154,43 @@ async function testPushWriterBlockSyncFalseAccepted() {
   })(), 'abcd', 4);
 }
 
+async function testPipeToSyncPushWriterStrictFalseRejected() {
+  const decoder = new TextDecoder();
+  const { writer, readable } = push({ highWaterMark: 1 });
+
+  const total = pipeToSync(['a', 'b'], writer, { preventClose: true });
+  assert.strictEqual(total, 1);
+
+  const iter = readable[Symbol.asyncIterator]();
+  const first = await iter.next();
+  assert.strictEqual(first.done, false);
+  assert.strictEqual(decoder.decode(first.value[0]), 'a');
+
+  const second = await Promise.race([
+    iter.next().then((result) => {
+      return result.done ? '<done>' : decoder.decode(result.value[0]);
+    }),
+    setImmediatePromise().then(() => '<no second chunk>'),
+  ]);
+  assert.strictEqual(second, '<no second chunk>');
+
+  await iter.return?.();
+}
+
+async function testPipeToSyncWritevFalseNotCounted() {
+  const writer = {
+    writevSync() { return false; },
+    writeSync: common.mustNotCall(),
+    endSync() { return 0; },
+  };
+  function* source() {
+    yield [new Uint8Array([1]), new Uint8Array([2])];
+  }
+
+  const total = pipeToSync(source(), writer);
+  assert.strictEqual(total, 0);
+}
+
 // pipeToSync with writevSync
 async function testPipeToSyncWritev() {
   const batches = [];
@@ -215,6 +252,8 @@ Promise.all([
   testWriteSyncFailsMidBatch(),
   testWriteSyncAlwaysFails(),
   testPushWriterBlockSyncFalseAccepted(),
+  testPipeToSyncPushWriterStrictFalseRejected(),
+  testPipeToSyncWritevFalseNotCounted(),
   testPipeToSyncWritev(),
   testPipeToSyncPlainChunksWritev(),
   testPipeToSyncWriteFallback(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63562

`pipeToSync()` ignored explicit `false` returns from `writeSync()` and
`writevSync()`, so it could report bytes for chunks that were not accepted by
the writer.

This updates `pipeToSync()` to stop counting rejected sync writes while still
preserving writers that intentionally return `false` after accepting data as a
backpressure signal.

---

Assisted-by: openai:gpt-5.5
