### PR TITLE
meta: skip scheduled workflows on forks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   analyze:
+    if: github.repository == 'nodejs/node'
     name: Analyze
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   build-lto:
+    if: github.repository == 'nodejs/node' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,6 +20,7 @@ permissions: read-all
 
 jobs:
   analysis:
+    if: github.repository == 'nodejs/node' || github.event_name == 'workflow_dispatch'
     name: Scorecard analysis
     # cannot use ubuntu-slim here because ossf/scorecard-action is dockerized
     # cannot use ubuntu-24.04-arm here because the docker image is x86 only


### PR DESCRIPTION
Scheduled workflows run on forks by default, which wastes minutes and spams fork owners with failure emails. Most workflows here already guard against that (`tools.yml`, `stale.yml`, etc.). This adds the same `if: github.repository == 'nodejs/node'` to the three that don't: `daily.yml`, `codeql.yml`, `scorecard.yml`. Manual `workflow_dispatch` runs still go through.