### PR TITLE
stream: handle falsy push writer fail reasons

### DIFF
--- a/lib/internal/streams/iter/push.js
+++ b/lib/internal/streams/iter/push.js
@@ -12,6 +12,7 @@ const {
   PromiseReject,
   PromiseResolve,
   PromiseWithResolvers,
+  Symbol,
   SymbolAsyncDispose,
   SymbolAsyncIterator,
   SymbolDispose,
@@ -54,6 +55,8 @@ const {
 const {
   RingBuffer,
 } = require('internal/streams/iter/ringbuffer');
+
+const kNoFailReason = Symbol('kNoFailReason');
 
 // =============================================================================
 // PushQueue - Internal Queue with Chunk-Based Backpressure
@@ -317,14 +320,16 @@ class PushQueue {
    * No-op if errored or closed (fully drained).
    * If closing (draining), short-circuits the drain.
    */
-  fail(reason) {
+  fail(reason = kNoFailReason) {
     if (this.#writerState === 'errored' || this.#writerState === 'closed') {
       return;
     }
 
     const wasClosing = this.#writerState === 'closing';
     this.#writerState = 'errored';
-    this.#error = reason ?? new ERR_INVALID_STATE('Failed');
+    this.#error = reason === kNoFailReason ?
+      new ERR_INVALID_STATE('Failed') :
+      reason;
     this.#cleanup();
     this.#rejectPendingReads(this.#error);
     this.#rejectPendingDrains(this.#error);
@@ -413,7 +418,7 @@ class PushQueue {
       return { __proto__: null, done: true, value: undefined };
     }
 
-    if (this.#writerState === 'errored' && this.#error) {
+    if (this.#writerState === 'errored') {
       throw this.#error;
     }
 
@@ -488,7 +493,7 @@ class PushQueue {
       } else if (this.#writerState === 'closed') {
         const pending = this.#pendingReads.shift();
         pending.resolve({ __proto__: null, done: true, value: undefined });
-      } else if (this.#writerState === 'errored' && this.#error) {
+      } else if (this.#writerState === 'errored') {
         const pending = this.#pendingReads.shift();
         pending.reject(this.#error);
       } else if (this.#consumerState === 'returned') {
@@ -668,7 +673,7 @@ class PushWriter {
   }
 
   fail(reason) {
-    this.#queue.fail(reason);
+    this.#queue.fail(arguments.length === 0 ? kNoFailReason : reason);
   }
 
   [SymbolAsyncDispose]() {

--- a/test/parallel/test-stream-iter-push-writer.js
+++ b/test/parallel/test-stream-iter-push-writer.js
@@ -451,6 +451,39 @@ async function testEndRejectsWhenErrored() {
   }
 }
 
+async function testFailRejectsFutureReadWithFalsyReason() {
+  for (const reason of [0, null]) {
+    const { writer, readable } = push();
+
+    writer.fail(reason);
+
+    const iter = readable[Symbol.asyncIterator]();
+    await iter.next().then(
+      common.mustNotCall(),
+      common.mustCall((rejection) => {
+        assert.strictEqual(rejection, reason);
+      }),
+    );
+  }
+}
+
+async function testFailRejectsPendingReadWithFalsyReason() {
+  const { writer, readable } = push();
+
+  const iter = readable[Symbol.asyncIterator]();
+  const readPromise = iter.next();
+
+  await new Promise(setImmediate);
+
+  writer.fail(false);
+  await readPromise.then(
+    common.mustNotCall(),
+    common.mustCall((reason) => {
+      assert.strictEqual(reason, false);
+    }),
+  );
+}
+
 Promise.all([
   testOndrain(),
   testOndrainNonDrainable(),
@@ -473,6 +506,8 @@ Promise.all([
   testConsumerThrowRejectsWrites(),
   testEndResolvesPendingRead(),
   testFailRejectsPendingRead(),
+  testFailRejectsFutureReadWithFalsyReason(),
+  testFailRejectsPendingReadWithFalsyReason(),
   testConsumerReturnResolvesPendingRead(),
   testConsumerThrowRejectsPendingRead(),
   testEndRejectsPendingWrites(),


### PR DESCRIPTION
This fixes `stream/iter` push writer reads after `writer.fail()` is called
with an explicit falsy reason.

Reads now use the writer state instead of the truthiness of the stored error,
so reasons like `0` and `false` reject correctly instead of leaving reads
pending.

Fixes: https://github.com/nodejs/node/issues/63568

---

Assisted-by: openai:gpt-5.5