### PR TITLE
stream: drop per-chunk Promise alloc in pipeTo

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -48,6 +48,10 @@ const {
 } = internalBinding('messaging');
 
 const {
+  markPromiseAsHandled,
+} = internalBinding('util');
+
+const {
   isArrayBufferView,
   isDataView,
   isSharedArrayBuffer,
@@ -1569,9 +1573,9 @@ function readableStreamPipeTo(
         }
 
         // Write the chunk - we're already in a separate microtask from enqueue
-        // because we awaited writer[kState].ready.promise above
+        // because we awaited writer[kState].ready.promise above.
         state.currentWrite = writableStreamDefaultWriterWrite(writer, chunk);
-        setPromiseHandled(state.currentWrite);
+        markPromiseAsHandled(state.currentWrite);
 
         // Check backpressure after each write
         if (dest[kState].backpressure) {
@@ -1675,7 +1679,7 @@ class PipeToReadableStreamReadRequest {
     // "ReadableStreamPipeTo" step 15's "chunk steps".
     queueMicrotask(() => {
       this.state.currentWrite = writableStreamDefaultWriterWrite(this.writer, chunk);
-      setPromiseHandled(this.state.currentWrite);
+      markPromiseAsHandled(this.state.currentWrite);
       this.promise.resolve(false);
     });
   }


### PR DESCRIPTION
Replace `setPromiseHandled` with `markPromiseAsHandled` at the two pipeTo per-chunk call sites in `readablestream.js`. The `.then(undefined, () => {})` chain that `setPromiseHandled` allocates per chunk has no observer in pipeTo: errors already propagate through `writer.closed` (which `watchErrored` monitors) and the last `state.currentWrite` is awaited in `waitForCurrentWrite` during shutdown (markAsHandled does not affect that subsequent `.then`). The per-chunk chain Promise + noop closure exist solely to silence the unhandled-rejection event: `markPromiseAsHandled` sets V8's `MarkAsHandled` + `MarkAsSilent` flags directly with no allocation.

`benchmark/webstreams/pipe-to.js` at HWM=1024: ~5% throughput improvement (728K vs 694K ops/s mean, 6 alternating samples), with substantially tighter run-to-run variance.

WPT streams parity preserved: 1403 subtests passing, 0 unexpected failures.