### PR TITLE
fs: accept uppercase UTF8 encoding in fast paths

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -429,7 +429,8 @@ function tryReadSync(fd, isUserFd, buffer, pos, len) {
 function readFileSync(path, options) {
   options = getOptions(options, { flag: 'r' });
 
-  if (options.encoding === 'utf8' || options.encoding === 'utf-8') {
+  if (options.encoding === 'utf8' || options.encoding === 'utf-8' ||
+      options.encoding === 'UTF8' || options.encoding === 'UTF-8') {
     if (!isInt32(path)) {
       path = getValidatedPath(path);
     }
@@ -2398,7 +2399,9 @@ function writeFileSync(path, data, options) {
   const flag = options.flag || 'w';
 
   // C++ fast path for string data and UTF8 encoding
-  if (typeof data === 'string' && (options.encoding === 'utf8' || options.encoding === 'utf-8')) {
+  if (typeof data === 'string' &&
+      (options.encoding === 'utf8' || options.encoding === 'utf-8' ||
+       options.encoding === 'UTF8' || options.encoding === 'UTF-8')) {
     if (!isInt32(path)) {
       path = getValidatedPath(path);
     }

--- a/test/parallel/test-fs-utf8-fast-path-encoding.js
+++ b/test/parallel/test-fs-utf8-fast-path-encoding.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+// This test ensures that the utf8 fast paths for readFileSync and writeFileSync
+// accept all valid utf8 encoding names, including uppercase variants.
+// Refs: https://github.com/nodejs/node/issues/49888
+
+tmpdir.refresh();
+
+const encodings = ['utf8', 'utf-8', 'UTF8', 'UTF-8'];
+const testData = 'Hello, World! \u4e2d\u6587\u6d4b\u8bd5 \ud83d\ude00';
+const fixture = path.join(tmpdir.path, 'test-utf8-fast-encoding.txt');
+
+// Test writeFileSync with all encoding variants
+for (const encoding of encodings) {
+  fs.writeFileSync(fixture, testData, encoding);
+  const result = fs.readFileSync(fixture, 'utf8');
+  assert.strictEqual(result, testData,
+    `writeFileSync with encoding "${encoding}" should produce correct output`);
+}
+
+// Test readFileSync with all encoding variants
+fs.writeFileSync(fixture, testData, 'utf8');
+for (const encoding of encodings) {
+  const result = fs.readFileSync(fixture, encoding);
+  assert.strictEqual(result, testData,
+    `readFileSync with encoding "${encoding}" should produce correct output`);
+}
+
+// Test readFileSync with encoding option object
+for (const encoding of encodings) {
+  const result = fs.readFileSync(fixture, { encoding });
+  assert.strictEqual(result, testData,
+    `readFileSync with options.encoding "${encoding}" should produce correct output`);
+}
+
+// Test writeFileSync with encoding option object
+for (const encoding of encodings) {
+  fs.writeFileSync(fixture, testData, { encoding });
+  const result = fs.readFileSync(fixture, 'utf8');
+  assert.strictEqual(result, testData,
+    `writeFileSync with options.encoding "${encoding}" should produce correct output`);
+}


### PR DESCRIPTION
## Summary

Fixes #49888

The  and  UTF8 fast paths (introduced in #48658 and #49884) only accepted lowercase encoding strings `'utf8'` and `'utf-8'`. The uppercase variants `'UTF8'` and `'UTF-8'` are valid encodings (accepted by `Buffer.isEncoding()`) but were not routed to the fast path, causing them to fall through to the slower generic code path.

## Changes

- `lib/fs.js`: Extended the fast path checks in `readFileSync` and `writeFileSync` to also accept `'UTF8'` and `'UTF-8'`
- Added test file `test/parallel/test-fs-utf8-fast-path-encoding.js` verifying all four encoding variants work correctly with both string and object form options

## Testing

New test covers:
- `writeFileSync(path, data, encoding)` — string form
- `readFileSync(path, encoding)` — string form  
- `readFileSync(path, { encoding })` — object form
- `writeFileSync(path, data, { encoding })` — object form

All four encoding variants (`'utf8'`, `'utf-8'`, `'UTF8'`, `'UTF-8'`) are tested with Unicode characters (CJK, emoji) to verify correctness.

```
node test/parallel/test-fs-utf8-fast-path-encoding.js
```