### PR TITLE
buffer: fix Blob.stream() leaking source buffer

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -453,19 +453,27 @@ function createBlobReaderStream(reader) {
       // There really should only be one read at a time so using an
       // array here is purely defensive.
       this.pendingPulls = [];
-      // Register a wakeup callback that the C++ side can invoke
+      // Lazily register a wakeup callback that the C++ side can invoke
       // when new data is available after a STATUS_BLOCK.
-      reader.setWakeup(() => {
+      this.wakeup = () => {
         if (this.pendingPulls.length > 0) {
           this.readNext(c);
         }
-      });
+      };
     },
     pull(c) {
       const { promise, resolve, reject } = PromiseWithResolvers();
+      if (this.pendingPulls.length === 0) {
+        reader.setWakeup(this.wakeup);
+      }
       this.pendingPulls.push({ resolve, reject });
       this.readNext(c);
       return promise;
+    },
+    clearWakeupIfIdle() {
+      if (this.pendingPulls.length === 0) {
+        reader.setWakeup(undefined);
+      }
     },
     readNext(c) {
       reader.pull((status, buffer) => {
@@ -473,10 +481,12 @@ function createBlobReaderStream(reader) {
         // been canceled, and we don't really care about the result.
         // We can simply exit.
         if (this.pendingPulls.length === 0) {
+          reader.setWakeup(undefined);
           return;
         }
         if (status === 0) {
           // EOS
+          reader.setWakeup(undefined);
           c.close();
           // This is to signal the end for byob readers
           // see https://streams.spec.whatwg.org/#example-rbs-pull
@@ -488,6 +498,7 @@ function createBlobReaderStream(reader) {
           // The read could fail for many different reasons when reading
           // from a non-memory resident blob part (e.g. file-backed blob).
           // The error details the system error code.
+          reader.setWakeup(undefined);
           const error =
             lazyDOMException('The blob could not be read',
                              'NotReadableError');
@@ -497,7 +508,7 @@ function createBlobReaderStream(reader) {
           return;
         } else if (status === 2) {
           // STATUS_BLOCK: No data available yet. The wakeup callback
-          // registered in start() will re-invoke readNext when data
+          // registered in pull() will re-invoke readNext when data
           // arrives.
           return;
         }
@@ -517,6 +528,7 @@ function createBlobReaderStream(reader) {
             if (this.pendingPulls.length !== 0) {
               const pending = this.pendingPulls.shift();
               pending.resolve();
+              this.clearWakeupIfIdle();
             }
             return;
           }
@@ -525,6 +537,7 @@ function createBlobReaderStream(reader) {
       });
     },
     cancel(reason) {
+      reader.setWakeup(undefined);
       // Reject any currently pending pulls here.
       for (const pending of this.pendingPulls) {
         pending.reject(reason);

--- a/test/parallel/test-blob-stream-gc.js
+++ b/test/parallel/test-blob-stream-gc.js
@@ -1,0 +1,56 @@
+// Flags: --expose-gc --no-concurrent-array-buffer-sweeping
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { setImmediate: setImmediatePromise } = require('timers/promises');
+
+const MiB = 1024 * 1024;
+const iterations = 64;
+const maxRetained = 16 * MiB;
+
+async function collectArrayBuffers() {
+  for (let i = 0; i < 3; i++) {
+    global.gc();
+    await setImmediatePromise();
+  }
+}
+
+async function assertNoBlobStreamRetention(name, fn) {
+  const buffer = Buffer.alloc(MiB);
+
+  await collectArrayBuffers();
+  const before = process.memoryUsage().arrayBuffers;
+
+  for (let i = 0; i < iterations; i++) {
+    await fn(buffer);
+  }
+
+  await collectArrayBuffers();
+  const retained = process.memoryUsage().arrayBuffers - before;
+
+  assert(
+    retained < maxRetained,
+    `${name} retained ${retained} bytes in arrayBuffers`,
+  );
+}
+
+(async () => {
+  await assertNoBlobStreamRetention('unused Blob streams',
+                                    common.mustCall(async (buffer) => {
+                                      new Blob([buffer]).stream();
+                                    }, iterations));
+
+  await assertNoBlobStreamRetention('cancelled Blob streams',
+                                    common.mustCall(async (buffer) => {
+                                      await new Blob([buffer]).stream()
+                                        .cancel();
+                                    }, iterations));
+
+  await assertNoBlobStreamRetention('drained Blob streams',
+                                    common.mustCall(async (buffer) => {
+                                      await new Response(
+                                        new Blob([buffer]).stream(),
+                                      ).arrayBuffer();
+                                    }, iterations));
+})().then(common.mustCall());


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

### Summary

`Blob.prototype.stream()` permanently retained the blob's source buffer
on Node 26+. RSS / `arrayBuffers` climbed without bound while the V8
heap stayed small, making it hard to diagnose. This is a regression from
the QUIC `DataQueue`/`Blob::Reader` work that introduced the `wakeup_`
mechanism.

### Root cause

`createBlobReaderStream()` registered the C++ wakeup callback in the
stream source's `start()` and never cleared it. `Reader::wakeup_` is a
strong `v8::Global<v8::Function>`, so it anchored a cycle as a GC root:

```
wakeup_ (strong Global, root)
  -> wakeup closure -> reader JS wrapper
  -> Blob::Reader (kept alive) -> strong_ptr_ -> Blob
  -> DataQueue -> InMemoryEntry -> BackingStore (source buffer)
```

This matches the maintainer diagnosis in #63574 ("`Reader::wakeup_` is
keeping the stream reference alive").

### Fix

Register the wakeup lazily in `pull()` (only while a read is in flight)
and clear it via `reader.setWakeup(undefined)` on every terminal/idle
path — EOS, error, cancel, and backpressure — mirroring the
`finally { reader.setWakeup(undefined) }` already used by
`createBlobReaderIterable`. The async-iterator and `arrayBuffer()` paths
do not use the wakeup and are unchanged.

### Test

Adds `test/parallel/test-blob-stream-gc.js`, which streams a 1 MiB blob
many times (unused, cancelled, and fully drained) and asserts
`process.memoryUsage().arrayBuffers` does not grow unbounded.

Fixes: https://github.com/nodejs/node/issues/63574
