### PR TITLE
stream: drop noop .then in pipe orchestration

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -111,6 +111,7 @@ const {
   kState,
   kType,
   lazyTransfer,
+  markPromiseAsHandled,
   nonOpCancel,
   nonOpPull,
   nonOpStart,
@@ -387,7 +388,11 @@ class ReadableStream {
       !!preventAbort,
       !!preventCancel,
       signal);
-    setPromiseHandled(promise);
+    // The pipeTo promise's rejection is also propagated through the
+    // destination stream's state, which the returned readable side
+    // observes via its own error path. markAsHandled silences the
+    // unhandled-rejection event without allocating a no-op .then chain.
+    markPromiseAsHandled(promise);
 
     return readable;
   }
@@ -1617,7 +1622,14 @@ function readableStreamPipeTo(
     disposable = addAbortListener(signal, abortAlgorithm);
   }
 
-  setPromiseHandled(run());
+  // run() rejects when step() throws — i.e. when a write or a
+  // writer.ready/closed await fails. Those same errors reach pipeTo via
+  // watchErrored on writer.closed / reader.closed (registered just below),
+  // which calls shutdownWithAnAction and ultimately resolves pipeTo's outer
+  // promise. The run() promise itself is otherwise unobserved, so a
+  // markAsHandled is sufficient to silence the unhandled-rejection event
+  // without allocating a no-op .then chain.
+  markPromiseAsHandled(run());
 
   watchErrored(source, reader[kState].close.promise, (error) => {
     if (!preventAbort) {

--- a/lib/internal/webstreams/transfer.js
+++ b/lib/internal/webstreams/transfer.js
@@ -9,7 +9,7 @@ const {
 
 const {
   kState,
-  setPromiseHandled,
+  markPromiseAsHandled,
 } = require('internal/webstreams/util');
 
 const {
@@ -279,7 +279,10 @@ function newCrossRealmReadableStream(writable, port) {
 
   const promise = readableStreamPipeTo(readable, writable, false, false, false);
 
-  setPromiseHandled(promise);
+  // pipeTo's rejection here flows back via the MessagePort and the wrapped
+  // source/sink; nothing else observes this internal promise. markAsHandled
+  // silences the unhandled-rejection event without allocating .then chain.
+  markPromiseAsHandled(promise);
 
   return {
     readable,
@@ -295,7 +298,10 @@ function newCrossRealmWritableSink(readable, port) {
 
   const promise = readableStreamPipeTo(readable, writable, false, false, false);
 
-  setPromiseHandled(promise);
+  // pipeTo's rejection here flows back via the MessagePort and the wrapped
+  // source/sink; nothing else observes this internal promise. markAsHandled
+  // silences the unhandled-rejection event without allocating .then chain.
+  markPromiseAsHandled(promise);
 
   return {
     writable,

--- a/lib/internal/webstreams/util.js
+++ b/lib/internal/webstreams/util.js
@@ -35,6 +35,7 @@ const {
     kPending,
   },
   getPromiseDetails,
+  markPromiseAsHandled,
 } = internalBinding('util');
 
 const assert = require('internal/assert');
@@ -225,6 +226,7 @@ module.exports = {
   kState,
   kType,
   lazyTransfer,
+  markPromiseAsHandled,
   nonOpCancel,
   nonOpFlush,
   nonOpPull,


### PR DESCRIPTION
Follow-up to the per-chunk `markPromiseAsHandled` substitution. Apply the same pattern to the four remaining pipe-orchestration `setPromiseHandled` call sites that fire once per pipe setup (rather than per chunk):

- `readablestream.js`: `pipeThrough`'s inner `readableStreamPipeTo` promise
- `readablestream.js`: pipeTo's `run()` loop promise
- `transfer.js`: cross-realm readable + writable pipe promises

In each case the chain Promise + noop closure that `setPromiseHandled` allocates has no observer beyond V8's unhandled-rejection tracker — errors flow back via the relevant stream's closed/errored state path, which surrounding code already monitors. `markPromiseAsHandled` flips the same V8 flag with no allocation.

These sites are not on a per-chunk hot path, so no benchmark impact is expected. The change is purely consistency cleanup matching the per-chunk fix.

WPT streams parity preserved: 1403 subtests passing, 0 unexpected failures.

Other `setPromiseHandled` call sites in `writablestream.js` (`Ensure{Ready,Closed}PromiseRejected`, `setupWritableStreamDefaultWriter`, `RejectCloseAndClosedPromiseIfNeeded`) and `readablestream.js` (`readableStreamError`, `readableStreamReaderGenericRelease`) were considered but **not** converted: probing one of them (`Ensure{Ready,Closed}PromiseRejected` on the writer-release path) reproduces an unhandled-rejection regression on `writable-streams/close.any.js` and the piping error-propagation tests — `MarkAsHandled` and `.then(undefined, () => {})` are not equivalent in that specific V8 path. Those sites stay on `setPromiseHandled`.