### PR TITLE
test_runner: pass processExecArgv and globPatterns to run() instead of reading process directly

### DIFF
--- a/lib/internal/main/test_runner.js
+++ b/lib/internal/main/test_runner.js
@@ -31,6 +31,7 @@ if (isUsingInspector() && options.isolation === 'process') {
 }
 
 options.globPatterns = ArrayPrototypeSlice(process.argv, 1);
+options.processExecArgv = process.execArgv;
 
 debug('test runner configuration:', options);
 run(options).on('test:summary', (data) => {

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -187,6 +187,8 @@ function getRunArgs(path, { forceExit,
                             only,
                             argv: suppliedArgs,
                             execArgv,
+                            processExecArgv,
+                            globPatterns,
                             rerunFailuresFilePath,
                             randomize,
                             randomSeed,
@@ -205,7 +207,7 @@ function getRunArgs(path, { forceExit,
    */
   const nodeOptionsSet = new SafeSet(processNodeOptions);
   const unknownProcessExecArgv = ArrayPrototypeFilter(
-    process.execArgv,
+    processExecArgv,
     (arg) => !nodeOptionsSet.has(arg),
   );
   ArrayPrototypePushApply(runArgs, unknownProcessExecArgv);
@@ -245,7 +247,7 @@ function getRunArgs(path, { forceExit,
 
   if (path === kIsolatedProcessName) {
     ArrayPrototypePush(runArgs, '--test');
-    ArrayPrototypePushApply(runArgs, ArrayPrototypeSlice(process.argv, 1));
+    ArrayPrototypePushApply(runArgs, globPatterns);
   } else {
     ArrayPrototypePush(runArgs, path);
   }
@@ -723,6 +725,7 @@ function run(options = kEmptyObject) {
     randomSeed: suppliedRandomSeed,
     execArgv = [],
     argv = [],
+    processExecArgv = process.execArgv,
     cwd = process.cwd(),
     rerunFailuresFilePath,
     env,
@@ -981,6 +984,7 @@ function run(options = kEmptyObject) {
     isolation,
     argv,
     execArgv,
+    processExecArgv,
     rerunFailuresFilePath,
     env,
     workerIdPool: isolation === 'process' ? workerIdPool : null,

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -727,6 +727,28 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
         }));
     });
 
+    it('should accept processExecArgv option and default to process.execArgv', async () => {
+      const stream = run({
+        files: [join(testFixtures, 'default-behavior/test/random.cjs')],
+        processExecArgv: process.execArgv,
+      });
+      stream.on('test:fail', common.mustNotCall());
+      stream.on('test:pass', common.mustCall());
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of stream);
+    });
+
+    it('should accept empty processExecArgv', async () => {
+      const stream = run({
+        files: [join(testFixtures, 'default-behavior/test/random.cjs')],
+        processExecArgv: [],
+      });
+      stream.on('test:fail', common.mustNotCall());
+      stream.on('test:pass', common.mustCall());
+      // eslint-disable-next-line no-unused-vars
+      for await (const _ of stream);
+    });
+
     it('should pass instance of stream to setup', async () => {
       const stream = run({
         files: [join(testFixtures, 'default-behavior/test/random.cjs')],


### PR DESCRIPTION
## Summary

Captures `process.execArgv` and `process.argv` at the CLI entry point (`lib/internal/main/test_runner.js`) and passes them through as explicit options to `run()`. This reduces the coupling between the public `run()` API and global process state.

Refs: #53867

## Changes

### `lib/internal/main/test_runner.js`
- Captures `process.execArgv` at CLI startup and passes it as `options.processExecArgv` to `run()`
- `globPatterns` (from `process.argv[1:]`) is already passed to `run()` (unchanged)

### `lib/internal/test_runner/runner.js`
- Adds `processExecArgv` option to `run()` with `process.execArgv` as backward-compatible default
- Passes `processExecArgv` through the `opts` object to `runTestFile()` and `getRunArgs()`
- Replaces direct `process.execArgv` read in `getRunArgs()` with the passed parameter
- Replaces direct `process.argv[1:]` read in `getRunArgs()` with `globPatterns`

### `test/parallel/test-runner-run.mjs`
- Adds test that `processExecArgv` defaults to `process.execArgv` for backward compatibility
- Adds test that an empty `processExecArgv` array works correctly

## Backward Compatibility

The `processExecArgv` option defaults to `process.execArgv`, so existing programmatic callers of `run()` that don't pass this option will continue to work identically.

## Related

- #54705 (merged): Added `cwd` option to `run()`
- #53867 (open): Parent issue tracking remaining `process` reads in `run()`