### PR TITLE
build: def `NODE_USE_NODE_CODE_CACHE` only used in node_mksnapshot

### DIFF
--- a/node.gyp
+++ b/node.gyp
@@ -1033,11 +1033,6 @@
               '@rpath/lib<(node_core_target_name).<(shlib_suffix)'
           },
         }],
-        [ 'node_use_node_code_cache=="true"', {
-          'defines': [
-            'NODE_USE_NODE_CODE_CACHE=1',
-          ],
-        }],
         ['node_shared=="true" and OS in "aix os400"', {
           'product_name': 'node_base',
         }],


### PR DESCRIPTION
`NODE_USE_NODE_CODE_CACHE` is only used in [`node_mksnapshot.cc`](https://github.com/nodejs/node/blob/92f48f43fec1c8cf84c1461db9863311ac0660ec/tools/snapshot/node_mksnapshot.cc#L98). It is unnecessary to define it for target `libnode`.