### PR TITLE
stream: fast path single-destination pipe

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -132,6 +132,7 @@ const kFlowing = 1 << 24;
 const kHasPaused = 1 << 25;
 const kPaused = 1 << 26;
 const kDataListening = 1 << 27;
+const kHasPipeData = 1 << 28;
 
 // TODO(benjamingr) it is likely slower to do it this way than with free functions
 function makeBitMapDescriptor(bit) {
@@ -290,7 +291,6 @@ function ReadableState(options, stream, isDuplex) {
   this.bufferIndex = 0;
   this.length = 0;
   this.pipes = [];
-  this[kPipeData] = null;
 
   // Should close be emitted on destroy. Defaults to true.
   if (options && options.emitClose === false) this[kState] &= ~kEmitClose;
@@ -803,7 +803,8 @@ Readable.prototype.read = function(n) {
 
 function emitData(stream, state, chunk) {
   state[kState] |= kDataEmitted;
-  if (stream._events.data === state[kPipeData]) {
+  if ((state[kState] & kHasPipeData) !== 0 &&
+      stream._events.data === state[kPipeData]) {
     state[kPipeData](chunk);
   } else {
     stream.emit('data', chunk);
@@ -990,7 +991,7 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     src.removeListener('end', unpipe);
     src.removeListener('data', ondata);
     if (state[kPipeData] === ondata)
-      state[kPipeData] = null;
+      state[kState] &= ~kHasPipeData;
 
     cleanedUp = true;
 
@@ -1035,8 +1036,10 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   }
 
   src.on('data', ondata);
-  if (src._events.data === ondata)
+  if (src._events.data === ondata) {
     state[kPipeData] = ondata;
+    state[kState] |= kHasPipeData;
+  }
   function ondata(chunk) {
     debug('ondata');
     try {

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -111,6 +111,7 @@ const kErroredValue = Symbol('kErroredValue');
 const kDefaultEncodingValue = Symbol('kDefaultEncodingValue');
 const kDecoderValue = Symbol('kDecoderValue');
 const kEncodingValue = Symbol('kEncodingValue');
+const kPipeData = Symbol('kPipeData');
 
 const kEnded = 1 << 9;
 const kEndEmitted = 1 << 10;
@@ -289,6 +290,7 @@ function ReadableState(options, stream, isDuplex) {
   this.bufferIndex = 0;
   this.length = 0;
   this.pipes = [];
+  this[kPipeData] = null;
 
   // Should close be emitted on destroy. Defaults to true.
   if (options && options.emitClose === false) this[kState] &= ~kEmitClose;
@@ -564,8 +566,7 @@ function addChunk(stream, state, chunk, addToFront) {
       state.awaitDrainWriters = null;
     }
 
-    state[kState] |= kDataEmitted;
-    stream.emit('data', chunk);
+    emitData(stream, state, chunk);
   } else {
     // Update the buffer info.
     state.length += (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
@@ -794,12 +795,20 @@ Readable.prototype.read = function(n) {
   }
 
   if (ret !== null && (state[kState] & (kErrorEmitted | kCloseEmitted)) === 0) {
-    state[kState] |= kDataEmitted;
-    this.emit('data', ret);
+    emitData(this, state, ret);
   }
 
   return ret;
 };
+
+function emitData(stream, state, chunk) {
+  state[kState] |= kDataEmitted;
+  if (stream._events.data === state[kPipeData]) {
+    state[kPipeData](chunk);
+  } else {
+    stream.emit('data', chunk);
+  }
+}
 
 function onEofChunk(stream, state) {
   debug('onEofChunk');
@@ -980,6 +989,8 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     src.removeListener('end', onend);
     src.removeListener('end', unpipe);
     src.removeListener('data', ondata);
+    if (state[kPipeData] === ondata)
+      state[kPipeData] = null;
 
     cleanedUp = true;
 
@@ -1024,6 +1035,8 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
   }
 
   src.on('data', ondata);
+  if (src._events.data === ondata)
+    state[kPipeData] = ondata;
   function ondata(chunk) {
     debug('ondata');
     try {

--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -566,7 +566,13 @@ function addChunk(stream, state, chunk, addToFront) {
       state.awaitDrainWriters = null;
     }
 
-    emitData(stream, state, chunk);
+    state[kState] |= kDataEmitted;
+    if ((state[kState] & kHasPipeData) !== 0 &&
+        stream._events.data === state[kPipeData]) {
+      state[kPipeData](chunk);
+    } else {
+      stream.emit('data', chunk);
+    }
   } else {
     // Update the buffer info.
     state.length += (state[kState] & kObjectMode) !== 0 ? 1 : chunk.length;
@@ -795,21 +801,17 @@ Readable.prototype.read = function(n) {
   }
 
   if (ret !== null && (state[kState] & (kErrorEmitted | kCloseEmitted)) === 0) {
-    emitData(this, state, ret);
+    state[kState] |= kDataEmitted;
+    if ((state[kState] & kHasPipeData) !== 0 &&
+        this._events.data === state[kPipeData]) {
+      state[kPipeData](ret);
+    } else {
+      this.emit('data', ret);
+    }
   }
 
   return ret;
 };
-
-function emitData(stream, state, chunk) {
-  state[kState] |= kDataEmitted;
-  if ((state[kState] & kHasPipeData) !== 0 &&
-      stream._events.data === state[kPipeData]) {
-    state[kPipeData](chunk);
-  } else {
-    stream.emit('data', chunk);
-  }
-}
 
 function onEofChunk(stream, state) {
   debug('onEofChunk');

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -146,6 +146,54 @@ class TestWriter extends EE {
   r.pipe(w);
 }
 
+{
+  // Verify data listener ordering around pipe.
+  function makeWritable(events) {
+    return new W({
+      write(chunk, enc, cb) {
+        events.push('write');
+        cb();
+      },
+    });
+  }
+
+  {
+    const events = [];
+    const r = R.from(['x']);
+    const w = makeWritable(events);
+
+    r.on('data', () => events.push('data'));
+    r.pipe(w);
+    w.on('finish', common.mustCall(() => {
+      assert.deepStrictEqual(events, ['data', 'write']);
+    }));
+  }
+
+  {
+    const events = [];
+    const r = R.from(['x']);
+    const w = makeWritable(events);
+
+    r.pipe(w);
+    r.on('data', () => events.push('data'));
+    w.on('finish', common.mustCall(() => {
+      assert.deepStrictEqual(events, ['write', 'data']);
+    }));
+  }
+
+  {
+    const events = [];
+    const r = R.from(['x']);
+    const w = makeWritable(events);
+
+    r.pipe(w);
+    r.prependListener('data', () => events.push('data'));
+    w.on('finish', common.mustCall(() => {
+      assert.deepStrictEqual(events, ['data', 'write']);
+    }));
+  }
+}
+
 
 [1, 2, 3, 4, 5, 6, 7, 8, 9].forEach(function(SPLIT) {
   // Verify unpipe

--- a/test/parallel/test-stream2-basic.js
+++ b/test/parallel/test-stream2-basic.js
@@ -192,6 +192,27 @@ class TestWriter extends EE {
       assert.deepStrictEqual(events, ['data', 'write']);
     }));
   }
+
+  {
+    const events = [];
+    const r = R.from(['a', 'b']);
+    const w = new W({
+      write: common.mustCall((chunk, enc, cb) => {
+        events.push(`write:${chunk}`);
+        if (String(chunk) === 'a') {
+          r.on('data', common.mustCall((chunk) => {
+            events.push(`data:${chunk}`);
+          }));
+        }
+        cb();
+      }, 2),
+    });
+
+    r.pipe(w);
+    w.on('finish', common.mustCall(() => {
+      assert.deepStrictEqual(events, ['write:a', 'write:b', 'data:b']);
+    }));
+  }
 }
 
 


### PR DESCRIPTION
Avoid EventEmitter dispatch for the internal `readable.pipe()` data handler
when it is the only `data` listener on the source stream.

If any additional `data` listener is present, the stream falls back to normal
`data` event emission so listener ordering is preserved.

Benchmark:

```console
                          confidence improvement accuracy (*)   (**)  (***)
streams/pipe.js n=5000000        ***     11.96 %       +/-2.00% +/-2.66% +/-3.47%
```

---

Assisted-by: openai:gpt-5.5