### PR TITLE
stream: use data listener for compose forwarding

### DIFF
--- a/benchmark/streams/compose.js
+++ b/benchmark/streams/compose.js
@@ -9,16 +9,35 @@ const {
 } = require('node:stream');
 
 const bench = common.createBenchmark(main, {
-  n: [1e3],
+  type: ['creation', 'throughput'],
+  n: [1, 1e3],
+  streams: [100],
+  chunks: [1e4],
+}, {
+  combinationFilter({ type, n }) {
+    return type === 'creation' ? n === 1e3 : n === 1;
+  },
+  test: {
+    n: [1, 1e3],
+    type: ['creation', 'throughput'],
+  },
 });
 
-function main({ n }) {
+function main({ type, n, streams, chunks }) {
+  switch (type) {
+    case 'creation':
+      return benchCreation(n, streams);
+    case 'throughput':
+      return benchThroughput(n, streams, chunks);
+  }
+}
+
+function benchCreation(n, numberOfPassThroughs) {
   const cachedPassThroughs = [];
   const cachedReadables = [];
   const cachedWritables = [];
 
   for (let i = 0; i < n; i++) {
-    const numberOfPassThroughs = 100;
     const passThroughs = [];
 
     for (let i = 0; i < numberOfPassThroughs; i++) {
@@ -39,4 +58,42 @@ function main({ n }) {
     composed.end();
   }
   bench.end(n);
+}
+
+function benchThroughput(n, numberOfPassThroughs, chunks) {
+  const chunk = Buffer.alloc(1024);
+
+  let i = 0;
+  bench.start();
+
+  function run() {
+    if (i++ === n) {
+      bench.end(n * chunks);
+      return;
+    }
+
+    const passThroughs = [];
+    for (let i = 0; i < numberOfPassThroughs; i++) {
+      passThroughs.push(new PassThrough());
+    }
+
+    let remaining = chunks;
+    const composed = compose(...passThroughs);
+    composed.on('data', () => {});
+    composed.on('end', run);
+
+    write();
+
+    function write() {
+      while (remaining-- > 0) {
+        if (!composed.write(chunk)) {
+          composed.once('drain', write);
+          return;
+        }
+      }
+      composed.end();
+    }
+  }
+
+  run();
 }

--- a/lib/internal/streams/compose.js
+++ b/lib/internal/streams/compose.js
@@ -82,7 +82,6 @@ module.exports = function compose(...streams) {
 
   let ondrain;
   let onfinish;
-  let onreadable;
   let onclose;
   let d;
 
@@ -184,31 +183,19 @@ module.exports = function compose(...streams) {
 
   if (readable) {
     if (isNodeStream(tail)) {
-      tail.on('readable', function() {
-        if (onreadable) {
-          const cb = onreadable;
-          onreadable = null;
-          cb();
+      d._read = function() {
+        tail.resume();
+      };
+
+      tail.on('data', function(chunk) {
+        if (!d.push(chunk)) {
+          tail.pause();
         }
       });
 
       tail.on('end', function() {
         d.push(null);
       });
-
-      d._read = function() {
-        while (true) {
-          const buf = tail.read();
-          if (buf === null) {
-            onreadable = d._read;
-            return;
-          }
-
-          if (!d.push(buf)) {
-            return;
-          }
-        }
-      };
     } else if (isWebStream(tail)) {
       const readable = isTransformStream(tail) ? tail.readable : tail;
       const reader = readable.getReader();
@@ -238,7 +225,6 @@ module.exports = function compose(...streams) {
       err = new AbortError();
     }
 
-    onreadable = null;
     ondrain = null;
     onfinish = null;
 


### PR DESCRIPTION
Use a pipe-style `data` listener for `stream.compose()` Node.js tail
forwarding instead of manually waiting on `readable` and draining with
`read()`.

The forwarding path is structurally similar to `pipe()`: each chunk read
from the composed tail is pushed to the outer duplex, and backpressure is
handled with `pause()` / `resume()`.

Benchmark:

```console
                                                                  confidence improvement accuracy (*)   (**)  (***)
streams/compose.js chunks=10000 streams=100 n=1 type='throughput'                  3.01 %       ±3.14% ±4.18% ±5.45%
streams/compose.js chunks=10000 streams=100 n=1000 type='creation'                 1.42 %       ±2.36% ±3.16% ±4.15%
```

---

Assisted-by: openai:gpt-5.5