### PR TITLE
stream: defer readable async iterator listener

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1380,6 +1380,7 @@ function streamToAsyncIterator(stream, options) {
 
 async function* createAsyncIterator(stream, options) {
   let callback = nop;
+  let isListening = false;
 
   function next(resolve) {
     if (this === stream) {
@@ -1390,14 +1391,17 @@ async function* createAsyncIterator(stream, options) {
     }
   }
 
-  stream.on('readable', next);
-
   let error;
   const cleanup = eos(stream, { writable: false }, (err) => {
     error = err ? aggregateTwoErrors(error, err) : null;
     callback();
     callback = nop;
   });
+
+  function setupReadable() {
+    isListening = true;
+    stream.on('readable', next);
+  }
 
   try {
     while (true) {
@@ -1409,6 +1413,9 @@ async function* createAsyncIterator(stream, options) {
       } else if (error === null) {
         return;
       } else {
+        if (!isListening) {
+          setupReadable();
+        }
         await new Promise(next);
       }
     }


### PR DESCRIPTION
This defers installing the `readable` listener for readable async
iteration until `read()` returns `null`.

The iterator still installs `eos()` up front, so existing error and close
handling is preserved. For the common path where chunks are already
buffered, this avoids listener dispatch while the iterator drains data.

Benchmark results are neutral-to-positive, with no statistically
significant regression observed:

```console
                                                       confidence improvement accuracy (*)   (**)  (***)
streams/readable-async-iterator.js sync='no' n=100000                  0.66 %       ±1.25% ±1.67% ±2.17%
streams/readable-async-iterator.js sync='yes' n=100000                 2.08 %       ±2.42% ±3.25% ±4.28%
```

---

Assisted-by: openai:gpt-5.5