### PR TITLE
crypto: add WebCrypto sync job fast paths

### DIFF
--- a/benchmark/crypto/_webcrypto_sync_fast_path_common.js
+++ b/benchmark/crypto/_webcrypto_sync_fast_path_common.js
@@ -15,6 +15,8 @@ const kThresholdSizeLabels = [
   'after-threshold',
 ];
 
+const kParallelism = 4;
+
 function ptn(size) {
   const buffer = Buffer.allocUnsafe(size);
   for (let i = 0; i < size; i++) {
@@ -98,11 +100,44 @@ function isSupported(operation, algorithm) {
 
 async function measureAsync(bench, n, mode, fn) {
   if (mode === 'parallel') {
-    const promises = new Array(n);
+    const parallelism = Math.min(kParallelism, n);
+    let started = 0;
+    let completed = 0;
     bench.start();
-    for (let i = 0; i < n; i++)
-      promises[i] = fn(i);
-    await Promise.all(promises);
+    await new Promise((resolve, reject) => {
+      let failed = false;
+      function fail(err) {
+        failed = true;
+        reject(err);
+      }
+
+      function launch() {
+        if (failed)
+          return;
+
+        const i = started++;
+        let promise;
+        try {
+          promise = fn(i);
+        } catch (err) {
+          fail(err);
+          return;
+        }
+
+        Promise.resolve(promise).then(() => {
+          if (failed)
+            return;
+          if (++completed === n) {
+            resolve();
+          } else if (started < n) {
+            launch();
+          }
+        }, fail);
+      }
+
+      for (let i = 0; i < parallelism; i++)
+        launch();
+    });
     bench.end(n);
     return;
   }

--- a/benchmark/crypto/_webcrypto_sync_fast_path_common.js
+++ b/benchmark/crypto/_webcrypto_sync_fast_path_common.js
@@ -1,0 +1,127 @@
+'use strict';
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const fixturesKeyDir = path.resolve(__dirname, '../../test/fixtures/keys/');
+
+const kWebCryptoSyncFastPathThreshold = 64 * 1024;
+
+const kThresholdSizeLabels = [
+  'minimal',
+  'middle',
+  'at-threshold',
+  'after-threshold',
+];
+
+function ptn(size) {
+  const buffer = Buffer.allocUnsafe(size);
+  for (let i = 0; i < size; i++) {
+    buffer[i] = i % 0xfb;
+  }
+  return buffer;
+}
+
+function thresholdSize(label, {
+  minimum = 1,
+  multiple = 1,
+  threshold = kWebCryptoSyncFastPathThreshold,
+} = {}) {
+  switch (label) {
+    case 'minimal':
+      return minimum;
+    case 'middle':
+      return roundDown(Math.max(minimum, threshold / 2), multiple);
+    case 'at-threshold':
+      return roundDown(Math.max(minimum, threshold), multiple);
+    case 'after-threshold':
+      return roundUp(Math.max(minimum, threshold + 1), multiple);
+  }
+  throw new Error(`Unknown threshold size label: ${label}`);
+}
+
+function roundDown(value, multiple) {
+  return Math.max(multiple, Math.floor(value / multiple) * multiple);
+}
+
+function roundUp(value, multiple) {
+  return Math.ceil(value / multiple) * multiple;
+}
+
+function readKey(name) {
+  return fs.readFileSync(path.resolve(fixturesKeyDir, `${name}.pem`), 'utf8');
+}
+
+function fixtureKeyPair(publicKeyName, privateKeyName) {
+  return {
+    publicKey: readKey(publicKeyName),
+    privateKey: readKey(privateKeyName),
+  };
+}
+
+function fixtureCryptoKeyPair(
+  publicKeyName,
+  privateKeyName,
+  algorithm,
+  publicUsages,
+  privateUsages,
+) {
+  return {
+    publicKey: crypto.createPublicKey(readKey(publicKeyName))
+      .toCryptoKey(algorithm, false, publicUsages),
+    privateKey: crypto.createPrivateKey(readKey(privateKeyName))
+      .toCryptoKey(algorithm, false, privateUsages),
+  };
+}
+
+async function importSecretKey({
+  algorithm,
+  usages,
+  length = 32,
+  format = 'raw-secret',
+  extractable = false,
+}) {
+  return globalThis.crypto.subtle.importKey(
+    format,
+    ptn(length),
+    algorithm,
+    extractable,
+    usages);
+}
+
+function isSupported(operation, algorithm) {
+  if (typeof SubtleCrypto.supports !== 'function')
+    return true;
+  return SubtleCrypto.supports(operation, algorithm);
+}
+
+async function measureAsync(bench, n, mode, fn) {
+  if (mode === 'parallel') {
+    const promises = new Array(n);
+    bench.start();
+    for (let i = 0; i < n; i++)
+      promises[i] = fn(i);
+    await Promise.all(promises);
+    bench.end(n);
+    return;
+  }
+
+  bench.start();
+  for (let i = 0; i < n; i++)
+    await fn(i);
+  bench.end(n);
+}
+
+module.exports = {
+  fixtureCryptoKeyPair,
+  fixtureKeyPair,
+  importSecretKey,
+  isSupported,
+  kThresholdSizeLabels,
+  kWebCryptoSyncFastPathThreshold,
+  measureAsync,
+  ptn,
+  readKey,
+  thresholdSize,
+};

--- a/benchmark/crypto/webcrypto-sync-fast-path-cipher.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-cipher.js
@@ -1,0 +1,122 @@
+'use strict';
+
+const common = require('../common.js');
+const {
+  importSecretKey,
+  isSupported,
+  kThresholdSizeLabels,
+  measureAsync,
+  ptn,
+  thresholdSize,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+const keyAlgorithms = {
+  'AES-CBC': { name: 'AES-CBC', length: 128 },
+  'AES-CTR': { name: 'AES-CTR', length: 128 },
+  'AES-GCM': { name: 'AES-GCM', length: 128 },
+  'AES-OCB': { name: 'AES-OCB', length: 128 },
+  'ChaCha20-Poly1305': { name: 'ChaCha20-Poly1305' },
+};
+
+function supportParams(algorithm) {
+  switch (algorithm) {
+    case 'AES-CBC':
+      return { name: algorithm, iv: new Uint8Array(16) };
+    case 'AES-CTR':
+      return { name: algorithm, counter: new Uint8Array(16), length: 64 };
+    case 'AES-GCM':
+      return { name: algorithm, iv: new Uint8Array(12) };
+    case 'AES-OCB':
+      return { name: algorithm, iv: new Uint8Array(15), tagLength: 128 };
+    case 'ChaCha20-Poly1305':
+      return { name: algorithm, iv: new Uint8Array(12), tagLength: 128 };
+  }
+  throw new Error(`Unknown cipher algorithm: ${algorithm}`);
+}
+
+const cipherAlgorithms = Object.keys(keyAlgorithms)
+  .filter((name) => isSupported('encrypt', supportParams(name)));
+
+if (cipherAlgorithms.length === 0) {
+  console.log('no supported WebCrypto cipher algorithms available');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  algorithm: cipherAlgorithms,
+  operation: ['encrypt', 'decrypt'],
+  size: kThresholdSizeLabels,
+  mode: ['serial', 'parallel'],
+  n: [1e3],
+});
+
+function cipherParams(algorithm, size) {
+  switch (algorithm) {
+    case 'AES-CBC':
+      return {
+        name: algorithm,
+        iv: ptn(16),
+      };
+    case 'AES-CTR':
+      return {
+        name: algorithm,
+        counter: ptn(16),
+        length: 64,
+      };
+    case 'AES-GCM':
+      return {
+        name: algorithm,
+        iv: ptn(12),
+        additionalData: ptn(16),
+        tagLength: 128,
+      };
+    case 'AES-OCB':
+      return {
+        name: algorithm,
+        iv: ptn(15),
+        additionalData: ptn(16),
+        tagLength: 128,
+      };
+    case 'ChaCha20-Poly1305':
+      return {
+        name: algorithm,
+        iv: ptn(12),
+        additionalData: ptn(16),
+        tagLength: 128,
+      };
+  }
+  throw new Error(`Unknown cipher algorithm: ${algorithm}`);
+}
+
+function dataSize(algorithm, size) {
+  switch (algorithm) {
+    case 'AES-CBC':
+      return thresholdSize(size, { minimum: 16, multiple: 16 });
+    default:
+      return thresholdSize(size);
+  }
+}
+
+async function setupCipherOperation(algorithm, operation, size) {
+  const key = await importSecretKey({
+    algorithm: keyAlgorithms[algorithm],
+    usages: ['encrypt', 'decrypt'],
+    length: algorithm === 'ChaCha20-Poly1305' ? 32 : 16,
+  });
+  const data = ptn(dataSize(algorithm, size));
+
+  const params = cipherParams(algorithm, size);
+  if (operation === 'encrypt') {
+    return () => subtle.encrypt(params, key, data);
+  }
+
+  const ciphertext = await subtle.encrypt(params, key, data);
+  return () => subtle.decrypt(params, key, ciphertext);
+}
+
+async function main({ n, algorithm, operation, size, mode }) {
+  const run = await setupCipherOperation(algorithm, operation, size);
+  await measureAsync(bench, n, mode, run);
+}

--- a/benchmark/crypto/webcrypto-sync-fast-path-cipher.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-cipher.js
@@ -5,6 +5,7 @@ const {
   importSecretKey,
   isSupported,
   kThresholdSizeLabels,
+  kWebCryptoSyncFastPathThreshold,
   measureAsync,
   ptn,
   thresholdSize,
@@ -19,6 +20,8 @@ const keyAlgorithms = {
   'AES-OCB': { name: 'AES-OCB', length: 128 },
   'ChaCha20-Poly1305': { name: 'ChaCha20-Poly1305' },
 };
+
+const kAesCbcCtrEncryptSyncFastPathThreshold = 32 * 1024;
 
 function supportParams(algorithm) {
   switch (algorithm) {
@@ -90,13 +93,36 @@ function cipherParams(algorithm, size) {
   throw new Error(`Unknown cipher algorithm: ${algorithm}`);
 }
 
-function dataSize(algorithm, size) {
+function syncFastPathThreshold(algorithm, operation) {
+  return operation === 'encrypt' &&
+    (algorithm === 'AES-CBC' || algorithm === 'AES-CTR') ?
+    kAesCbcCtrEncryptSyncFastPathThreshold :
+    kWebCryptoSyncFastPathThreshold;
+}
+
+function measuredInputOverhead(algorithm, operation) {
   switch (algorithm) {
-    case 'AES-CBC':
-      return thresholdSize(size, { minimum: 16, multiple: 16 });
+    case 'AES-GCM':
+    case 'AES-OCB':
+    case 'ChaCha20-Poly1305':
+      return operation === 'decrypt' ? 32 : 16;
     default:
-      return thresholdSize(size);
+      return 0;
   }
+}
+
+function dataSize(algorithm, operation, size) {
+  const minimum = algorithm === 'AES-CBC' ? 16 : 1;
+  if (size === 'minimal')
+    return minimum;
+
+  const overhead = measuredInputOverhead(algorithm, operation);
+  const multiple = algorithm === 'AES-CBC' ? 16 : 1;
+  return thresholdSize(size, {
+    minimum: minimum + overhead,
+    multiple,
+    threshold: syncFastPathThreshold(algorithm, operation),
+  }) - overhead;
 }
 
 async function setupCipherOperation(algorithm, operation, size) {
@@ -105,7 +131,7 @@ async function setupCipherOperation(algorithm, operation, size) {
     usages: ['encrypt', 'decrypt'],
     length: algorithm === 'ChaCha20-Poly1305' ? 32 : 16,
   });
-  const data = ptn(dataSize(algorithm, size));
+  const data = ptn(dataSize(algorithm, operation, size));
 
   const params = cipherParams(algorithm, size);
   if (operation === 'encrypt') {

--- a/benchmark/crypto/webcrypto-sync-fast-path-derive.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-derive.js
@@ -1,0 +1,65 @@
+'use strict';
+
+const common = require('../common.js');
+const {
+  fixtureCryptoKeyPair,
+  measureAsync,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+const keyFixtures = {
+  'ecdh-p256': {
+    publicKeyName: 'ec_p256_public',
+    privateKeyName: 'ec_p256_private',
+    keyAlgorithm: { name: 'ECDH', namedCurve: 'P-256' },
+    deriveAlgorithmName: 'ECDH',
+    length: 256,
+  },
+  'x25519': {
+    publicKeyName: 'x25519_public',
+    privateKeyName: 'x25519_private',
+    keyAlgorithm: { name: 'X25519' },
+    deriveAlgorithmName: 'X25519',
+    length: 256,
+  },
+};
+
+if (!process.features.openssl_is_boringssl) {
+  keyFixtures.x448 = {
+    publicKeyName: 'x448_public',
+    privateKeyName: 'x448_private',
+    keyAlgorithm: { name: 'X448' },
+    deriveAlgorithmName: 'X448',
+    length: 448,
+  };
+}
+
+const algorithms = Object.keys(keyFixtures);
+
+const bench = common.createBenchmark(main, {
+  algorithm: algorithms,
+  mode: ['serial', 'parallel'],
+  n: [1e3],
+});
+
+async function setupDeriveOperation(algorithm) {
+  const fixture = keyFixtures[algorithm];
+  const pair = fixtureCryptoKeyPair(
+    fixture.publicKeyName,
+    fixture.privateKeyName,
+    fixture.keyAlgorithm,
+    [],
+    ['deriveBits']);
+  const params = {
+    name: fixture.deriveAlgorithmName,
+    public: pair.publicKey,
+  };
+
+  return () => subtle.deriveBits(params, pair.privateKey, fixture.length);
+}
+
+async function main({ n, algorithm, mode }) {
+  const run = await setupDeriveOperation(algorithm);
+  await measureAsync(bench, n, mode, run);
+}

--- a/benchmark/crypto/webcrypto-sync-fast-path-digest.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-digest.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const common = require('../common.js');
+const {
+  isSupported,
+  kThresholdSizeLabels,
+  measureAsync,
+  ptn,
+  thresholdSize,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+function digestAlgorithm(name) {
+  switch (name) {
+    case 'cSHAKE128':
+      return { name, outputLength: 256 };
+    case 'cSHAKE256':
+      return { name, outputLength: 512 };
+    case 'TurboSHAKE128':
+      return { name, outputLength: 256 };
+    case 'TurboSHAKE256':
+      return { name, outputLength: 512 };
+    case 'KT128':
+      return { name, outputLength: 256 };
+    case 'KT256':
+      return { name, outputLength: 512 };
+    default:
+      return name;
+  }
+}
+
+const algorithms = [
+  'SHA-1',
+  'SHA-256',
+  'SHA-384',
+  'SHA-512',
+  'SHA3-256',
+  'SHA3-384',
+  'SHA3-512',
+  'cSHAKE128',
+  'cSHAKE256',
+  'TurboSHAKE128',
+  'TurboSHAKE256',
+  'KT128',
+  'KT256',
+].filter((name) => isSupported('digest', digestAlgorithm(name)));
+
+if (algorithms.length === 0) {
+  console.log('no supported WebCrypto digest algorithms available');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  algorithm: algorithms,
+  size: kThresholdSizeLabels,
+  mode: ['serial', 'parallel'],
+  n: [1e3],
+});
+
+async function main({ n, algorithm, size, mode }) {
+  const data = ptn(thresholdSize(size));
+  const params = digestAlgorithm(algorithm);
+
+  await measureAsync(bench, n, mode, () => subtle.digest(params, data));
+}

--- a/benchmark/crypto/webcrypto-sync-fast-path-kdf.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-kdf.js
@@ -4,13 +4,13 @@ const common = require('../common.js');
 const {
   importSecretKey,
   kThresholdSizeLabels,
-  kWebCryptoSyncFastPathThreshold,
   measureAsync,
   ptn,
 } = require('./_webcrypto_sync_fast_path_common.js');
 
 const { subtle } = globalThis.crypto;
 
+const kHkdfSyncFastPathThreshold = 16 * 1024;
 const kOutputBytes = 32;
 
 const bench = common.createBenchmark(main, {
@@ -25,11 +25,11 @@ function aggregateSize(label) {
     case 'minimal':
       return kOutputBytes;
     case 'middle':
-      return kWebCryptoSyncFastPathThreshold / 2;
+      return kHkdfSyncFastPathThreshold / 2;
     case 'at-threshold':
-      return kWebCryptoSyncFastPathThreshold;
+      return kHkdfSyncFastPathThreshold;
     case 'after-threshold':
-      return kWebCryptoSyncFastPathThreshold + 1;
+      return kHkdfSyncFastPathThreshold + 1;
   }
   throw new Error(`Unknown HKDF size label: ${label}`);
 }

--- a/benchmark/crypto/webcrypto-sync-fast-path-kdf.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-kdf.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const common = require('../common.js');
+const {
+  importSecretKey,
+  kThresholdSizeLabels,
+  kWebCryptoSyncFastPathThreshold,
+  measureAsync,
+  ptn,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+const kOutputBytes = 32;
+
+const bench = common.createBenchmark(main, {
+  algorithm: ['HKDF'],
+  size: kThresholdSizeLabels,
+  mode: ['serial', 'parallel'],
+  n: [1e3],
+});
+
+function aggregateSize(label) {
+  switch (label) {
+    case 'minimal':
+      return kOutputBytes;
+    case 'middle':
+      return kWebCryptoSyncFastPathThreshold / 2;
+    case 'at-threshold':
+      return kWebCryptoSyncFastPathThreshold;
+    case 'after-threshold':
+      return kWebCryptoSyncFastPathThreshold + 1;
+  }
+  throw new Error(`Unknown HKDF size label: ${label}`);
+}
+
+function hkdfParams(size) {
+  const aggregate = aggregateSize(size);
+  const infoLength = aggregate === kOutputBytes ? 0 : 16;
+  const saltLength = aggregate - infoLength - kOutputBytes;
+  return {
+    name: 'HKDF',
+    hash: 'SHA-256',
+    salt: ptn(saltLength),
+    info: ptn(infoLength),
+  };
+}
+
+async function main({ n, size, mode }) {
+  const key = await importSecretKey({
+    algorithm: 'HKDF',
+    usages: ['deriveBits'],
+    length: 32,
+  });
+  const params = hkdfParams(size);
+
+  await measureAsync(
+    bench,
+    n,
+    mode,
+    () => subtle.deriveBits(params, key, kOutputBytes * 8));
+}

--- a/benchmark/crypto/webcrypto-sync-fast-path-kem.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-kem.js
@@ -1,0 +1,80 @@
+'use strict';
+
+const common = require('../common.js');
+const { hasOpenSSL } = require('../../test/common/crypto.js');
+const {
+  fixtureCryptoKeyPair,
+  measureAsync,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+const keyFixtures = {};
+
+if (hasOpenSSL(3, 5)) {
+  keyFixtures['ml-kem-512'] = {
+    publicKeyName: 'ml_kem_512_public',
+    privateKeyName: 'ml_kem_512_private',
+    algorithm: { name: 'ML-KEM-512' },
+  };
+  keyFixtures['ml-kem-768'] = {
+    publicKeyName: 'ml_kem_768_public',
+    privateKeyName: 'ml_kem_768_private',
+    algorithm: { name: 'ML-KEM-768' },
+  };
+  keyFixtures['ml-kem-1024'] = {
+    publicKeyName: 'ml_kem_1024_public',
+    privateKeyName: 'ml_kem_1024_private',
+    algorithm: { name: 'ML-KEM-1024' },
+  };
+} else if (process.features.openssl_is_boringssl) {
+  keyFixtures['ml-kem-768'] = {
+    publicKeyName: 'ml_kem_768_public',
+    privateKeyName: 'ml_kem_768_private_seed_only',
+    algorithm: { name: 'ML-KEM-768' },
+  };
+  keyFixtures['ml-kem-1024'] = {
+    publicKeyName: 'ml_kem_1024_public',
+    privateKeyName: 'ml_kem_1024_private_seed_only',
+    algorithm: { name: 'ML-KEM-1024' },
+  };
+}
+
+const algorithms = Object.keys(keyFixtures);
+
+if (algorithms.length === 0) {
+  console.log('no supported WebCrypto ML-KEM algorithms available');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  algorithm: algorithms,
+  operation: ['encapsulateBits', 'decapsulateBits'],
+  mode: ['serial', 'parallel'],
+  n: [1e3],
+});
+
+async function setupKemOperation(algorithm, operation) {
+  const fixture = keyFixtures[algorithm];
+  const pair = fixtureCryptoKeyPair(
+    fixture.publicKeyName,
+    fixture.privateKeyName,
+    fixture.algorithm,
+    ['encapsulateBits'],
+    ['decapsulateBits']);
+
+  if (operation === 'encapsulateBits') {
+    return () => subtle.encapsulateBits(fixture.algorithm, pair.publicKey);
+  }
+
+  const { ciphertext } = await subtle.encapsulateBits(fixture.algorithm, pair.publicKey);
+  return () => subtle.decapsulateBits(
+    fixture.algorithm,
+    pair.privateKey,
+    ciphertext);
+}
+
+async function main({ n, algorithm, operation, mode }) {
+  const run = await setupKemOperation(algorithm, operation);
+  await measureAsync(bench, n, mode, run);
+}

--- a/benchmark/crypto/webcrypto-sync-fast-path-keygen.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-keygen.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const common = require('../common.js');
+const {
+  isSupported,
+  measureAsync,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+const keygenCases = {
+  'aes-cbc-128': {
+    algorithm: { name: 'AES-CBC', length: 128 },
+    usages: ['encrypt', 'decrypt'],
+  },
+  'aes-ctr-128': {
+    algorithm: { name: 'AES-CTR', length: 128 },
+    usages: ['encrypt', 'decrypt'],
+  },
+  'aes-gcm-128': {
+    algorithm: { name: 'AES-GCM', length: 128 },
+    usages: ['encrypt', 'decrypt'],
+  },
+  'aes-kw-128': {
+    algorithm: { name: 'AES-KW', length: 128 },
+    usages: ['wrapKey', 'unwrapKey'],
+  },
+  'aes-ocb-128': {
+    algorithm: { name: 'AES-OCB', length: 128 },
+    usages: ['encrypt', 'decrypt'],
+  },
+  'chacha20-poly1305': {
+    algorithm: { name: 'ChaCha20-Poly1305' },
+    usages: ['encrypt', 'decrypt'],
+  },
+  'hmac': {
+    algorithm: { name: 'HMAC', hash: 'SHA-256', length: 256 },
+    usages: ['sign', 'verify'],
+  },
+  'kmac128': {
+    algorithm: { name: 'KMAC128', length: 128 },
+    usages: ['sign', 'verify'],
+  },
+  'kmac256': {
+    algorithm: { name: 'KMAC256', length: 256 },
+    usages: ['sign', 'verify'],
+  },
+  'ecdsa-p256': {
+    algorithm: { name: 'ECDSA', namedCurve: 'P-256' },
+    usages: ['sign', 'verify'],
+  },
+  'ecdsa-p384': {
+    algorithm: { name: 'ECDSA', namedCurve: 'P-384' },
+    usages: ['sign', 'verify'],
+  },
+  'ecdsa-p521': {
+    algorithm: { name: 'ECDSA', namedCurve: 'P-521' },
+    usages: ['sign', 'verify'],
+  },
+  'ecdh-p256': {
+    algorithm: { name: 'ECDH', namedCurve: 'P-256' },
+    usages: ['deriveBits'],
+  },
+  'ecdh-p384': {
+    algorithm: { name: 'ECDH', namedCurve: 'P-384' },
+    usages: ['deriveBits'],
+  },
+  'ecdh-p521': {
+    algorithm: { name: 'ECDH', namedCurve: 'P-521' },
+    usages: ['deriveBits'],
+  },
+  'ed25519': {
+    algorithm: { name: 'Ed25519' },
+    usages: ['sign', 'verify'],
+  },
+  'ed448': {
+    algorithm: { name: 'Ed448' },
+    usages: ['sign', 'verify'],
+  },
+  'x25519': {
+    algorithm: { name: 'X25519' },
+    usages: ['deriveBits'],
+  },
+  'x448': {
+    algorithm: { name: 'X448' },
+    usages: ['deriveBits'],
+  },
+  'ml-dsa-44': {
+    algorithm: { name: 'ML-DSA-44' },
+    usages: ['sign', 'verify'],
+  },
+  'ml-dsa-65': {
+    algorithm: { name: 'ML-DSA-65' },
+    usages: ['sign', 'verify'],
+  },
+  'ml-dsa-87': {
+    algorithm: { name: 'ML-DSA-87' },
+    usages: ['sign', 'verify'],
+  },
+  'ml-kem-512': {
+    algorithm: { name: 'ML-KEM-512' },
+    usages: ['encapsulateBits', 'decapsulateBits'],
+  },
+  'ml-kem-768': {
+    algorithm: { name: 'ML-KEM-768' },
+    usages: ['encapsulateBits', 'decapsulateBits'],
+  },
+  'ml-kem-1024': {
+    algorithm: { name: 'ML-KEM-1024' },
+    usages: ['encapsulateBits', 'decapsulateBits'],
+  },
+};
+
+const algorithms = Object.keys(keygenCases)
+  .filter((name) => isSupported('generateKey', keygenCases[name].algorithm));
+
+if (algorithms.length === 0) {
+  console.log('no supported WebCrypto keygen algorithms available');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  algorithm: algorithms,
+  mode: ['serial', 'parallel'],
+  n: [1e3],
+});
+
+async function main({ n, algorithm, mode }) {
+  const { algorithm: keyAlgorithm, usages } = keygenCases[algorithm];
+  await measureAsync(
+    bench,
+    n,
+    mode,
+    () => subtle.generateKey(keyAlgorithm, false, usages));
+}

--- a/benchmark/crypto/webcrypto-sync-fast-path-mac.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-mac.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const common = require('../common.js');
+const {
+  importSecretKey,
+  isSupported,
+  kThresholdSizeLabels,
+  measureAsync,
+  ptn,
+  thresholdSize,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+const keyAlgorithms = {
+  HMAC: { name: 'HMAC', hash: 'SHA-256' },
+  KMAC128: { name: 'KMAC128' },
+  KMAC256: { name: 'KMAC256' },
+};
+
+const signAlgorithms = {
+  HMAC: { name: 'HMAC' },
+  KMAC128: { name: 'KMAC128', outputLength: 256 },
+  KMAC256: { name: 'KMAC256', outputLength: 256 },
+};
+
+const algorithms = Object.keys(keyAlgorithms)
+  .filter((name) => isSupported('sign', signAlgorithms[name]));
+
+if (algorithms.length === 0) {
+  console.log('no supported WebCrypto MAC algorithms available');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  algorithm: algorithms,
+  operation: ['sign', 'verify'],
+  size: kThresholdSizeLabels,
+  mode: ['serial', 'parallel'],
+  n: [1e3],
+});
+
+async function setupMacOperation(algorithm, operation, size) {
+  const key = await importSecretKey({
+    algorithm: keyAlgorithms[algorithm],
+    usages: ['sign', 'verify'],
+    length: 32,
+  });
+  const data = ptn(thresholdSize(size));
+  const params = signAlgorithms[algorithm];
+
+  if (operation === 'sign') {
+    return () => subtle.sign(params, key, data);
+  }
+
+  const signature = await subtle.sign(params, key, data);
+  return () => subtle.verify(params, key, signature, data);
+}
+
+async function main({ n, algorithm, operation, size, mode }) {
+  const run = await setupMacOperation(algorithm, operation, size);
+  await measureAsync(bench, n, mode, run);
+}

--- a/benchmark/crypto/webcrypto-sync-fast-path-mac.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-mac.js
@@ -5,6 +5,7 @@ const {
   importSecretKey,
   isSupported,
   kThresholdSizeLabels,
+  kWebCryptoSyncFastPathThreshold,
   measureAsync,
   ptn,
   thresholdSize,
@@ -24,6 +25,8 @@ const signAlgorithms = {
   KMAC256: { name: 'KMAC256', outputLength: 256 },
 };
 
+const kKmacSyncFastPathThreshold = 16 * 1024;
+
 const algorithms = Object.keys(keyAlgorithms)
   .filter((name) => isSupported('sign', signAlgorithms[name]));
 
@@ -40,13 +43,38 @@ const bench = common.createBenchmark(main, {
   n: [1e3],
 });
 
+function outputByteLength(algorithm) {
+  return algorithm === 'HMAC' ? 32 : signAlgorithms[algorithm].outputLength / 8;
+}
+
+function syncFastPathThreshold(algorithm) {
+  return algorithm === 'HMAC' ?
+    kWebCryptoSyncFastPathThreshold : kKmacSyncFastPathThreshold;
+}
+
+function dataSize(algorithm, operation, size) {
+  if (size === 'minimal')
+    return 1;
+
+  let overhead = 0;
+  if (operation === 'verify')
+    overhead += outputByteLength(algorithm);
+  if (algorithm !== 'HMAC')
+    overhead += outputByteLength(algorithm);
+
+  return thresholdSize(size, {
+    minimum: overhead + 1,
+    threshold: syncFastPathThreshold(algorithm),
+  }) - overhead;
+}
+
 async function setupMacOperation(algorithm, operation, size) {
   const key = await importSecretKey({
     algorithm: keyAlgorithms[algorithm],
     usages: ['sign', 'verify'],
     length: 32,
   });
-  const data = ptn(thresholdSize(size));
+  const data = ptn(dataSize(algorithm, operation, size));
   const params = signAlgorithms[algorithm];
 
   if (operation === 'sign') {

--- a/benchmark/crypto/webcrypto-sync-fast-path-rsa.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-rsa.js
@@ -1,0 +1,111 @@
+'use strict';
+
+const common = require('../common.js');
+const {
+  fixtureCryptoKeyPair,
+  kThresholdSizeLabels,
+  measureAsync,
+  ptn,
+  thresholdSize,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+const rsaKeySizes = [
+  'fixture-2048',
+  'fixture-4096',
+];
+
+const bench = common.createBenchmark(main, {
+  operation: [
+    'rsa-oaep-encrypt',
+    'rsa-oaep-decrypt',
+    'rsassa-pkcs1-v1_5-verify',
+    'rsa-pss-verify',
+  ],
+  keySize: rsaKeySizes,
+  size: kThresholdSizeLabels,
+  mode: ['serial', 'parallel'],
+  n: [500],
+}, {
+  combinationFilter({ operation, keySize, size }) {
+    if (operation === 'rsa-oaep-encrypt' || operation === 'rsa-oaep-decrypt')
+      return size === 'minimal';
+    return true;
+  },
+});
+
+function rsaAlgorithm(name) {
+  return {
+    name,
+    hash: 'SHA-256',
+  };
+}
+
+function fixtureNames(keySize) {
+  const bits = keySize.slice('fixture-'.length);
+  return {
+    publicKeyName: `rsa_public_${bits}`,
+    privateKeyName: `rsa_private_${bits}`,
+  };
+}
+
+async function rsaKeyPair(operation, keySize) {
+  const { publicKeyName, privateKeyName } = fixtureNames(keySize);
+  switch (operation) {
+    case 'rsa-oaep-encrypt':
+    case 'rsa-oaep-decrypt':
+      return fixtureCryptoKeyPair(
+        publicKeyName,
+        privateKeyName,
+        rsaAlgorithm('RSA-OAEP'),
+        ['encrypt'],
+        ['decrypt']);
+    case 'rsassa-pkcs1-v1_5-verify':
+      return fixtureCryptoKeyPair(
+        publicKeyName,
+        privateKeyName,
+        rsaAlgorithm('RSASSA-PKCS1-v1_5'),
+        ['verify'],
+        ['sign']);
+    case 'rsa-pss-verify':
+      return fixtureCryptoKeyPair(
+        publicKeyName,
+        privateKeyName,
+        rsaAlgorithm('RSA-PSS'),
+        ['verify'],
+        ['sign']);
+  }
+  throw new Error(`Unknown RSA operation: ${operation}`);
+}
+
+async function setupRsaOperation(operation, keySize, size) {
+  const pair = await rsaKeyPair(operation, keySize);
+
+  switch (operation) {
+    case 'rsa-oaep-encrypt': {
+      const data = ptn(32);
+      return () => subtle.encrypt('RSA-OAEP', pair.publicKey, data);
+    }
+    case 'rsa-oaep-decrypt': {
+      const data = ptn(32);
+      const ciphertext = await subtle.encrypt('RSA-OAEP', pair.publicKey, data);
+      return () => subtle.decrypt('RSA-OAEP', pair.privateKey, ciphertext);
+    }
+    case 'rsassa-pkcs1-v1_5-verify':
+    case 'rsa-pss-verify': {
+      const data = ptn(thresholdSize(size));
+      const signAlgorithm = operation === 'rsa-pss-verify' ?
+        { name: 'RSA-PSS', saltLength: 32 } :
+        { name: 'RSASSA-PKCS1-v1_5' };
+      const signature = await subtle.sign(signAlgorithm, pair.privateKey, data);
+      return () => subtle.verify(signAlgorithm, pair.publicKey, signature, data);
+    }
+  }
+  throw new Error(`Unknown RSA operation: ${operation}`);
+}
+
+async function main({ n, operation, keySize, size, mode }) {
+  const run = await setupRsaOperation(operation, keySize, size);
+  await measureAsync(bench, n, mode, run);
+}

--- a/benchmark/crypto/webcrypto-sync-fast-path-sign-verify.js
+++ b/benchmark/crypto/webcrypto-sync-fast-path-sign-verify.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const common = require('../common.js');
+const {
+  fixtureCryptoKeyPair,
+  isSupported,
+  kThresholdSizeLabels,
+  measureAsync,
+  ptn,
+  thresholdSize,
+} = require('./_webcrypto_sync_fast_path_common.js');
+
+const { subtle } = globalThis.crypto;
+
+const keyFixtures = {
+  'ecdsa-p256': {
+    publicKeyName: 'ec_p256_public',
+    privateKeyName: 'ec_p256_private',
+    keyAlgorithm: { name: 'ECDSA', namedCurve: 'P-256' },
+    signAlgorithm: { name: 'ECDSA', hash: 'SHA-256' },
+  },
+  'ed25519': {
+    publicKeyName: 'ed25519_public',
+    privateKeyName: 'ed25519_private',
+    keyAlgorithm: { name: 'Ed25519' },
+    signAlgorithm: { name: 'Ed25519' },
+  },
+  'ed448': {
+    publicKeyName: 'ed448_public',
+    privateKeyName: 'ed448_private',
+    keyAlgorithm: { name: 'Ed448' },
+    signAlgorithm: { name: 'Ed448' },
+  },
+};
+
+const algorithms = Object.keys(keyFixtures)
+  .filter((name) => isSupported('sign', keyFixtures[name].signAlgorithm));
+
+if (algorithms.length === 0) {
+  console.log('no supported WebCrypto sign/verify algorithms available');
+  process.exit(0);
+}
+
+const bench = common.createBenchmark(main, {
+  algorithm: algorithms,
+  operation: ['sign', 'verify'],
+  size: kThresholdSizeLabels,
+  mode: ['serial', 'parallel'],
+  n: [1e3],
+});
+
+async function setupSignVerifyOperation(algorithm, operation, size) {
+  const fixture = keyFixtures[algorithm];
+  const pair = fixtureCryptoKeyPair(
+    fixture.publicKeyName,
+    fixture.privateKeyName,
+    fixture.keyAlgorithm,
+    ['verify'],
+    ['sign']);
+  const data = ptn(thresholdSize(size));
+
+  if (operation === 'sign') {
+    return () => subtle.sign(fixture.signAlgorithm, pair.privateKey, data);
+  }
+
+  const signature = await subtle.sign(fixture.signAlgorithm, pair.privateKey, data);
+  return () => subtle.verify(fixture.signAlgorithm, pair.publicKey, signature, data);
+}
+
+async function main({ n, algorithm, operation, size, mode }) {
+  const run = await setupSignVerifyOperation(algorithm, operation, size);
+  await measureAsync(bench, n, mode, run);
+}

--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -7,7 +7,7 @@ const {
 
 const {
   AESCipherJob,
-  kCryptoJobSyncWebCrypto,
+  kCryptoJobWebCrypto,
   kKeyVariantAES_CTR_128,
   kKeyVariantAES_CBC_128,
   kKeyVariantAES_GCM_128,
@@ -28,9 +28,10 @@ const {
 
 const {
   getUsagesMask,
-  getWebCryptoJobModeForInputLength,
+  getWebCryptoJobMode,
   hasAnyNotIn,
   jobPromise,
+  kWebCryptoDefaultSyncThreshold,
 } = require('internal/crypto/util');
 
 const {
@@ -107,8 +108,10 @@ function getVariant(name, length) {
 }
 
 function asyncAesCtrCipher(mode, key, data, algorithm) {
+  const jobMode = data.byteLength <= kWebCryptoDefaultSyncThreshold ?
+    getWebCryptoJobMode() : kCryptoJobWebCrypto;
   return jobPromise(() => new AESCipherJob(
-    getWebCryptoJobModeForInputLength(data.byteLength),
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -118,8 +121,10 @@ function asyncAesCtrCipher(mode, key, data, algorithm) {
 }
 
 function asyncAesCbcCipher(mode, key, data, algorithm) {
+  const jobMode = data.byteLength <= kWebCryptoDefaultSyncThreshold ?
+    getWebCryptoJobMode() : kCryptoJobWebCrypto;
   return jobPromise(() => new AESCipherJob(
-    getWebCryptoJobModeForInputLength(data.byteLength),
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -128,8 +133,10 @@ function asyncAesCbcCipher(mode, key, data, algorithm) {
 }
 
 function asyncAesKwCipher(mode, key, data) {
+  const jobMode = data.byteLength <= kWebCryptoDefaultSyncThreshold ?
+    getWebCryptoJobMode() : kCryptoJobWebCrypto;
   return jobPromise(() => new AESCipherJob(
-    getWebCryptoJobModeForInputLength(data.byteLength),
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -140,10 +147,12 @@ function asyncAesGcmCipher(mode, key, data, algorithm) {
   const { tagLength = 128 } = algorithm;
   const tagByteLength = tagLength / 8;
   const additionalDataLength = algorithm.additionalData?.byteLength ?? 0;
+  const inputByteLength = data.byteLength + additionalDataLength;
+  const jobMode = inputByteLength <= kWebCryptoDefaultSyncThreshold ?
+    getWebCryptoJobMode() : kCryptoJobWebCrypto;
 
   return jobPromise(() => new AESCipherJob(
-    getWebCryptoJobModeForInputLength(
-      data.byteLength + additionalDataLength),
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -157,10 +166,12 @@ function asyncAesOcbCipher(mode, key, data, algorithm) {
   const { tagLength = 128 } = algorithm;
   const tagByteLength = tagLength / 8;
   const additionalDataLength = algorithm.additionalData?.byteLength ?? 0;
+  const inputByteLength = data.byteLength + additionalDataLength;
+  const jobMode = inputByteLength <= kWebCryptoDefaultSyncThreshold ?
+    getWebCryptoJobMode() : kCryptoJobWebCrypto;
 
   return jobPromise(() => new AESCipherJob(
-    getWebCryptoJobModeForInputLength(
-      data.byteLength + additionalDataLength),
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -199,8 +210,9 @@ function aesGenerateKey(algorithm, extractable, usages) {
       'SyntaxError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new SecretKeyGenJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     length,
     { name, length },
     getUsagesMask(usagesSet),

--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -8,6 +8,7 @@ const {
 const {
   AESCipherJob,
   kCryptoJobWebCrypto,
+  kWebCryptoCipherEncrypt,
   kKeyVariantAES_CTR_128,
   kKeyVariantAES_CBC_128,
   kKeyVariantAES_GCM_128,
@@ -33,6 +34,8 @@ const {
   jobPromise,
   kWebCryptoDefaultSyncThreshold,
 } = require('internal/crypto/util');
+
+const kWebCryptoAesCbcCtrEncryptSyncThreshold = 32 * 1024;
 
 const {
   lazyDOMException,
@@ -108,7 +111,10 @@ function getVariant(name, length) {
 }
 
 function asyncAesCtrCipher(mode, key, data, algorithm) {
-  const jobMode = data.byteLength <= kWebCryptoDefaultSyncThreshold ?
+  const threshold = mode === kWebCryptoCipherEncrypt ?
+    kWebCryptoAesCbcCtrEncryptSyncThreshold :
+    kWebCryptoDefaultSyncThreshold;
+  const jobMode = data.byteLength <= threshold ?
     getWebCryptoJobMode() : kCryptoJobWebCrypto;
   return jobPromise(() => new AESCipherJob(
     jobMode,
@@ -121,7 +127,10 @@ function asyncAesCtrCipher(mode, key, data, algorithm) {
 }
 
 function asyncAesCbcCipher(mode, key, data, algorithm) {
-  const jobMode = data.byteLength <= kWebCryptoDefaultSyncThreshold ?
+  const threshold = mode === kWebCryptoCipherEncrypt ?
+    kWebCryptoAesCbcCtrEncryptSyncThreshold :
+    kWebCryptoDefaultSyncThreshold;
+  const jobMode = data.byteLength <= threshold ?
     getWebCryptoJobMode() : kCryptoJobWebCrypto;
   return jobPromise(() => new AESCipherJob(
     jobMode,

--- a/lib/internal/crypto/aes.js
+++ b/lib/internal/crypto/aes.js
@@ -7,7 +7,7 @@ const {
 
 const {
   AESCipherJob,
-  kCryptoJobWebCrypto,
+  kCryptoJobSyncWebCrypto,
   kKeyVariantAES_CTR_128,
   kKeyVariantAES_CBC_128,
   kKeyVariantAES_GCM_128,
@@ -28,6 +28,7 @@ const {
 
 const {
   getUsagesMask,
+  getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
 } = require('internal/crypto/util');
@@ -107,7 +108,7 @@ function getVariant(name, length) {
 
 function asyncAesCtrCipher(mode, key, data, algorithm) {
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(data.byteLength),
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -118,7 +119,7 @@ function asyncAesCtrCipher(mode, key, data, algorithm) {
 
 function asyncAesCbcCipher(mode, key, data, algorithm) {
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(data.byteLength),
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -128,7 +129,7 @@ function asyncAesCbcCipher(mode, key, data, algorithm) {
 
 function asyncAesKwCipher(mode, key, data) {
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(data.byteLength),
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -138,9 +139,11 @@ function asyncAesKwCipher(mode, key, data) {
 function asyncAesGcmCipher(mode, key, data, algorithm) {
   const { tagLength = 128 } = algorithm;
   const tagByteLength = tagLength / 8;
+  const additionalDataLength = algorithm.additionalData?.byteLength ?? 0;
 
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(
+      data.byteLength + additionalDataLength),
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -153,9 +156,11 @@ function asyncAesGcmCipher(mode, key, data, algorithm) {
 function asyncAesOcbCipher(mode, key, data, algorithm) {
   const { tagLength = 128 } = algorithm;
   const tagByteLength = tagLength / 8;
+  const additionalDataLength = algorithm.additionalData?.byteLength ?? 0;
 
   return jobPromise(() => new AESCipherJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(
+      data.byteLength + additionalDataLength),
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -195,7 +200,7 @@ function aesGenerateKey(algorithm, extractable, usages) {
   }
 
   return jobPromise(() => new SecretKeyGenJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     length,
     { name, length },
     getUsagesMask(usagesSet),

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -8,7 +8,6 @@ const {
 
 const {
   SignJob,
-  kCryptoJobSyncWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
   kSignJobModeSign,
@@ -26,6 +25,7 @@ const {
 const {
   getUsagesMask,
   getUsagesUnion,
+  getWebCryptoJobMode,
   getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
@@ -131,8 +131,9 @@ function cfrgGenerateKey(algorithm, extractable, usages) {
       'SyntaxError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new NidKeyPairGenJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     nid,
     keyAlgorithm,
     getUsagesMask(publicUsages),
@@ -239,8 +240,9 @@ function eddsaSignVerify(key, data, algorithm, signature) {
   if (getCryptoKeyType(key) !== type)
     throw lazyDOMException(`Key must be a ${type} key`, 'InvalidAccessError');
 
+  const jobMode = getWebCryptoJobModeForInputLength(data.byteLength);
   return jobPromise(() => new SignJob(
-    getWebCryptoJobModeForInputLength(data.byteLength),
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     undefined,

--- a/lib/internal/crypto/cfrg.js
+++ b/lib/internal/crypto/cfrg.js
@@ -8,7 +8,7 @@ const {
 
 const {
   SignJob,
-  kCryptoJobWebCrypto,
+  kCryptoJobSyncWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
   kSignJobModeSign,
@@ -26,6 +26,7 @@ const {
 const {
   getUsagesMask,
   getUsagesUnion,
+  getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
 } = require('internal/crypto/util');
@@ -131,7 +132,7 @@ function cfrgGenerateKey(algorithm, extractable, usages) {
   }
 
   return jobPromise(() => new NidKeyPairGenJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     nid,
     keyAlgorithm,
     getUsagesMask(publicUsages),
@@ -239,7 +240,7 @@ function eddsaSignVerify(key, data, algorithm, signature) {
     throw lazyDOMException(`Key must be a ${type} key`, 'InvalidAccessError');
 
   return jobPromise(() => new SignJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(data.byteLength),
     mode,
     getCryptoKeyHandle(key),
     undefined,

--- a/lib/internal/crypto/chacha20_poly1305.js
+++ b/lib/internal/crypto/chacha20_poly1305.js
@@ -6,15 +6,16 @@ const {
 
 const {
   ChaCha20Poly1305CipherJob,
+  kCryptoJobWebCrypto,
   SecretKeyGenJob,
-  kCryptoJobSyncWebCrypto,
 } = internalBinding('crypto');
 
 const {
   getUsagesMask,
-  getWebCryptoJobModeForInputLength,
+  getWebCryptoJobMode,
   hasAnyNotIn,
   jobPromise,
+  kWebCryptoDefaultSyncThreshold,
 } = require('internal/crypto/util');
 
 const {
@@ -40,9 +41,11 @@ function validateKeyLength(length) {
 
 function c20pCipher(mode, key, data, algorithm) {
   const additionalDataLength = algorithm.additionalData?.byteLength ?? 0;
+  const inputByteLength = data.byteLength + additionalDataLength;
+  const jobMode = inputByteLength <= kWebCryptoDefaultSyncThreshold ?
+    getWebCryptoJobMode() : kCryptoJobWebCrypto;
   return jobPromise(() => new ChaCha20Poly1305CipherJob(
-    getWebCryptoJobModeForInputLength(
-      data.byteLength + additionalDataLength),
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -67,8 +70,9 @@ function c20pGenerateKey(algorithm, extractable, usages) {
       'SyntaxError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new SecretKeyGenJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     256,
     { name },
     getUsagesMask(usagesSet),

--- a/lib/internal/crypto/chacha20_poly1305.js
+++ b/lib/internal/crypto/chacha20_poly1305.js
@@ -7,11 +7,12 @@ const {
 const {
   ChaCha20Poly1305CipherJob,
   SecretKeyGenJob,
-  kCryptoJobWebCrypto,
+  kCryptoJobSyncWebCrypto,
 } = internalBinding('crypto');
 
 const {
   getUsagesMask,
+  getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
 } = require('internal/crypto/util');
@@ -38,8 +39,10 @@ function validateKeyLength(length) {
 }
 
 function c20pCipher(mode, key, data, algorithm) {
+  const additionalDataLength = algorithm.additionalData?.byteLength ?? 0;
   return jobPromise(() => new ChaCha20Poly1305CipherJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(
+      data.byteLength + additionalDataLength),
     mode,
     getCryptoKeyHandle(key),
     data,
@@ -65,7 +68,7 @@ function c20pGenerateKey(algorithm, extractable, usages) {
   }
 
   return jobPromise(() => new SecretKeyGenJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     256,
     { name },
     getUsagesMask(usagesSet),

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -19,6 +19,7 @@ const {
   ECDHConvertKey: _ECDHConvertKey,
   kCryptoJobAsync,
   kCryptoJobSync,
+  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
 } = internalBinding('crypto');
 
@@ -351,8 +352,14 @@ function ecdhDeriveBits(algorithm, baseKey, length) {
     throw lazyDOMException('Named curve mismatch', 'InvalidAccessError');
   }
 
+  const jobMode =
+    keyAlgorithm.name === 'X25519' ||
+    keyAlgorithm.name === 'X448' ||
+    (keyAlgorithm.name === 'ECDH' && keyAlgorithm.namedCurve === 'P-256') ?
+      kCryptoJobSyncWebCrypto : kCryptoJobWebCrypto;
+
   const bits = jobPromise(() => new DHBitsJob(
-    kCryptoJobWebCrypto,
+    jobMode,
     getCryptoKeyHandle(key),
     undefined,
     undefined,

--- a/lib/internal/crypto/diffiehellman.js
+++ b/lib/internal/crypto/diffiehellman.js
@@ -19,7 +19,6 @@ const {
   ECDHConvertKey: _ECDHConvertKey,
   kCryptoJobAsync,
   kCryptoJobSync,
-  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
 } = internalBinding('crypto');
 
@@ -58,6 +57,7 @@ const {
 
 const {
   getArrayBufferOrView,
+  getWebCryptoJobMode,
   jobPromise,
   jobPromiseThen,
   toBuf,
@@ -356,7 +356,7 @@ function ecdhDeriveBits(algorithm, baseKey, length) {
     keyAlgorithm.name === 'X25519' ||
     keyAlgorithm.name === 'X448' ||
     (keyAlgorithm.name === 'ECDH' && keyAlgorithm.namedCurve === 'P-256') ?
-      kCryptoJobSyncWebCrypto : kCryptoJobWebCrypto;
+      getWebCryptoJobMode() : kCryptoJobWebCrypto;
 
   const bits = jobPromise(() => new DHBitsJob(
     jobMode,

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -10,6 +10,7 @@ const {
   EcKeyPairGenJob,
   KeyObjectHandle,
   SignJob,
+  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
@@ -31,6 +32,7 @@ const {
 const {
   getUsagesMask,
   getUsagesUnion,
+  getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
   normalizeHashName,
@@ -120,7 +122,7 @@ function ecGenerateKey(algorithm, extractable, usages) {
   }
 
   return jobPromise(() => new EcKeyPairGenJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     namedCurve,
     undefined,
     keyAlgorithm,
@@ -267,8 +269,13 @@ function ecdsaSignVerify(key, data, { name, hash }, signature) {
   if (getCryptoKeyType(key) !== type)
     throw lazyDOMException(`Key must be a ${type} key`, 'InvalidAccessError');
 
+  const { namedCurve } = getCryptoKeyAlgorithm(key);
+  const jobMode = namedCurve === 'P-256' ?
+    getWebCryptoJobModeForInputLength(data.byteLength) :
+    kCryptoJobWebCrypto;
+
   return jobPromise(() => new SignJob(
-    kCryptoJobWebCrypto,
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     undefined,

--- a/lib/internal/crypto/ec.js
+++ b/lib/internal/crypto/ec.js
@@ -10,7 +10,6 @@ const {
   EcKeyPairGenJob,
   KeyObjectHandle,
   SignJob,
-  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
@@ -32,6 +31,7 @@ const {
 const {
   getUsagesMask,
   getUsagesUnion,
+  getWebCryptoJobMode,
   getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
@@ -121,8 +121,9 @@ function ecGenerateKey(algorithm, extractable, usages) {
       'SyntaxError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new EcKeyPairGenJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     namedCurve,
     undefined,
     keyAlgorithm,

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -12,13 +12,13 @@ const {
   Hash: _Hash,
   HashJob,
   Hmac: _Hmac,
-  kCryptoJobWebCrypto,
   oneShotDigest,
   TurboShakeJob,
   KangarooTwelveJob,
 } = internalBinding('crypto');
 
 const {
+  getWebCryptoJobModeForInputLength,
   getStringOption,
   jobPromise,
   normalizeHashName,
@@ -202,6 +202,9 @@ Hmac.prototype._transform = Hash.prototype._transform;
 
 function asyncDigest(algorithm, data) {
   validateMaxBufferLength(data, 'data');
+  const outputByteLength = (algorithm.outputLength ?? 0) / 8;
+  const jobMode =
+    getWebCryptoJobModeForInputLength(data.byteLength + outputByteLength);
 
   switch (algorithm.name) {
     case 'SHA-1':
@@ -222,7 +225,7 @@ function asyncDigest(algorithm, data) {
       // Fall through
     case 'cSHAKE256':
       return jobPromise(() => new HashJob(
-        kCryptoJobWebCrypto,
+        jobMode,
         normalizeHashName(algorithm.name),
         data,
         algorithm.outputLength));
@@ -230,7 +233,7 @@ function asyncDigest(algorithm, data) {
       // Fall through
     case 'TurboSHAKE256':
       return jobPromise(() => new TurboShakeJob(
-        kCryptoJobWebCrypto,
+        jobMode,
         algorithm.name,
         algorithm.domainSeparation ?? 0x1f,
         algorithm.outputLength / 8,
@@ -239,7 +242,7 @@ function asyncDigest(algorithm, data) {
       // Fall through
     case 'KT256':
       return jobPromise(() => new KangarooTwelveJob(
-        kCryptoJobWebCrypto,
+        jobMode,
         algorithm.name,
         algorithm.customization,
         algorithm.outputLength / 8,

--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -10,7 +10,6 @@ const {
   HKDFJob,
   kCryptoJobAsync,
   kCryptoJobSync,
-  kCryptoJobWebCrypto,
 } = internalBinding('crypto');
 
 const {
@@ -22,6 +21,7 @@ const {
 const { kMaxLength } = require('buffer');
 
 const {
+  getWebCryptoJobModeForInputLength,
   jobPromise,
   normalizeHashName,
   toBuf,
@@ -157,7 +157,8 @@ function hkdfDeriveBits(algorithm, baseKey, length) {
     return PromiseResolve(new ArrayBuffer(0));
 
   return jobPromise(() => new HKDFJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(
+      salt.byteLength + info.byteLength + length / 8),
     normalizeHashName(hash.name),
     getCryptoKeyHandle(baseKey),
     salt,

--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -23,6 +23,7 @@ const { kMaxLength } = require('buffer');
 const {
   getWebCryptoJobModeForInputLength,
   jobPromise,
+  kWebCryptoHkdfSyncThreshold,
   normalizeHashName,
   toBuf,
   validateByteSource,
@@ -157,7 +158,8 @@ function hkdfDeriveBits(algorithm, baseKey, length) {
     return PromiseResolve(new ArrayBuffer(0));
 
   const jobMode = getWebCryptoJobModeForInputLength(
-    salt.byteLength + info.byteLength + length / 8);
+    salt.byteLength + info.byteLength + length / 8,
+    kWebCryptoHkdfSyncThreshold);
   return jobPromise(() => new HKDFJob(
     jobMode,
     normalizeHashName(hash.name),

--- a/lib/internal/crypto/hkdf.js
+++ b/lib/internal/crypto/hkdf.js
@@ -156,9 +156,10 @@ function hkdfDeriveBits(algorithm, baseKey, length) {
   if (length === 0)
     return PromiseResolve(new ArrayBuffer(0));
 
+  const jobMode = getWebCryptoJobModeForInputLength(
+    salt.byteLength + info.byteLength + length / 8);
   return jobPromise(() => new HKDFJob(
-    getWebCryptoJobModeForInputLength(
-      salt.byteLength + info.byteLength + length / 8),
+    jobMode,
     normalizeHashName(hash.name),
     getCryptoKeyHandle(baseKey),
     salt,

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -8,7 +8,7 @@ const {
 const {
   HmacJob,
   KmacJob,
-  kCryptoJobWebCrypto,
+  kCryptoJobSyncWebCrypto,
   kSignJobModeSign,
   kSignJobModeVerify,
   SecretKeyGenJob,
@@ -17,6 +17,7 @@ const {
 const {
   getBlockSize,
   getUsagesMask,
+  getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
   normalizeHashName,
@@ -60,7 +61,7 @@ function hmacGenerateKey(algorithm, extractable, usages) {
   }
 
   return jobPromise(() => new SecretKeyGenJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     length,
     { name, length, hash },
     getUsagesMask(usageSet),
@@ -90,7 +91,7 @@ function kmacGenerateKey(algorithm, extractable, usages) {
   }
 
   return jobPromise(() => new SecretKeyGenJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     length,
     { name, length },
     getUsagesMask(usageSet),
@@ -175,8 +176,9 @@ function macImportKey(
 
 function hmacSignVerify(key, data, algorithm, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
+  const signatureLength = signature?.byteLength ?? 0;
   return jobPromise(() => new HmacJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(data.byteLength + signatureLength),
     mode,
     normalizeHashName(getCryptoKeyAlgorithm(key).hash.name),
     getCryptoKeyHandle(key),
@@ -186,8 +188,11 @@ function hmacSignVerify(key, data, algorithm, signature) {
 
 function kmacSignVerify(key, data, algorithm, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
+  const signatureLength = signature?.byteLength ?? 0;
+  const outputByteLength = algorithm.outputLength / 8;
   return jobPromise(() => new KmacJob(
-    kCryptoJobWebCrypto,
+    getWebCryptoJobModeForInputLength(
+      data.byteLength + signatureLength + outputByteLength),
     mode,
     getCryptoKeyHandle(key),
     algorithm.name,

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -8,7 +8,6 @@ const {
 const {
   HmacJob,
   KmacJob,
-  kCryptoJobSyncWebCrypto,
   kSignJobModeSign,
   kSignJobModeVerify,
   SecretKeyGenJob,
@@ -17,6 +16,7 @@ const {
 const {
   getBlockSize,
   getUsagesMask,
+  getWebCryptoJobMode,
   getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
@@ -60,8 +60,9 @@ function hmacGenerateKey(algorithm, extractable, usages) {
       'SyntaxError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new SecretKeyGenJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     length,
     { name, length, hash },
     getUsagesMask(usageSet),
@@ -90,8 +91,9 @@ function kmacGenerateKey(algorithm, extractable, usages) {
       'SyntaxError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new SecretKeyGenJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     length,
     { name, length },
     getUsagesMask(usageSet),
@@ -177,8 +179,10 @@ function macImportKey(
 function hmacSignVerify(key, data, algorithm, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   const signatureLength = signature?.byteLength ?? 0;
+  const jobMode = getWebCryptoJobModeForInputLength(
+    data.byteLength + signatureLength);
   return jobPromise(() => new HmacJob(
-    getWebCryptoJobModeForInputLength(data.byteLength + signatureLength),
+    jobMode,
     mode,
     normalizeHashName(getCryptoKeyAlgorithm(key).hash.name),
     getCryptoKeyHandle(key),
@@ -190,9 +194,10 @@ function kmacSignVerify(key, data, algorithm, signature) {
   const mode = signature === undefined ? kSignJobModeSign : kSignJobModeVerify;
   const signatureLength = signature?.byteLength ?? 0;
   const outputByteLength = algorithm.outputLength / 8;
+  const jobMode = getWebCryptoJobModeForInputLength(
+    data.byteLength + signatureLength + outputByteLength);
   return jobPromise(() => new KmacJob(
-    getWebCryptoJobModeForInputLength(
-      data.byteLength + signatureLength + outputByteLength),
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     algorithm.name,

--- a/lib/internal/crypto/mac.js
+++ b/lib/internal/crypto/mac.js
@@ -20,6 +20,7 @@ const {
   getWebCryptoJobModeForInputLength,
   hasAnyNotIn,
   jobPromise,
+  kWebCryptoKmacSyncThreshold,
   normalizeHashName,
 } = require('internal/crypto/util');
 
@@ -195,7 +196,8 @@ function kmacSignVerify(key, data, algorithm, signature) {
   const signatureLength = signature?.byteLength ?? 0;
   const outputByteLength = algorithm.outputLength / 8;
   const jobMode = getWebCryptoJobModeForInputLength(
-    data.byteLength + signatureLength + outputByteLength);
+    data.byteLength + signatureLength + outputByteLength,
+    kWebCryptoKmacSyncThreshold);
   return jobPromise(() => new KmacJob(
     jobMode,
     mode,

--- a/lib/internal/crypto/ml_dsa.js
+++ b/lib/internal/crypto/ml_dsa.js
@@ -9,6 +9,7 @@ const {
 
 const {
   SignJob,
+  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
@@ -88,7 +89,7 @@ function mlDsaGenerateKey(algorithm, extractable, usages) {
   }
 
   return jobPromise(() => new NidKeyPairGenJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     nid,
     keyAlgorithm,
     getUsagesMask(publicUsages),

--- a/lib/internal/crypto/ml_dsa.js
+++ b/lib/internal/crypto/ml_dsa.js
@@ -9,7 +9,6 @@ const {
 
 const {
   SignJob,
-  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
   kKeyFormatDER,
   kKeyFormatRawPublic,
@@ -28,6 +27,7 @@ const {
 const {
   getUsagesMask,
   getUsagesUnion,
+  getWebCryptoJobMode,
   hasAnyNotIn,
   jobPromise,
 } = require('internal/crypto/util');
@@ -88,8 +88,9 @@ function mlDsaGenerateKey(algorithm, extractable, usages) {
       'SyntaxError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new NidKeyPairGenJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     nid,
     keyAlgorithm,
     getUsagesMask(publicUsages),

--- a/lib/internal/crypto/ml_kem.js
+++ b/lib/internal/crypto/ml_kem.js
@@ -8,7 +8,6 @@ const {
 } = primordials;
 
 const {
-  kCryptoJobSyncWebCrypto,
   KEMDecapsulateJob,
   KEMEncapsulateJob,
   kKeyFormatDER,
@@ -26,6 +25,7 @@ const {
 const {
   getUsagesMask,
   getUsagesUnion,
+  getWebCryptoJobMode,
   hasAnyNotIn,
   jobPromise,
 } = require('internal/crypto/util');
@@ -79,8 +79,9 @@ function mlKemGenerateKey(algorithm, extractable, usages) {
       'SyntaxError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new NidKeyPairGenJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     nid,
     keyAlgorithm,
     getUsagesMask(publicUsages),
@@ -211,8 +212,9 @@ function mlKemEncapsulate(encapsulationKey) {
     throw lazyDOMException(`Key must be a public key`, 'InvalidAccessError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new KEMEncapsulateJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     getCryptoKeyHandle(encapsulationKey),
     undefined,
     undefined,
@@ -225,8 +227,9 @@ function mlKemDecapsulate(decapsulationKey, ciphertext) {
     throw lazyDOMException(`Key must be a private key`, 'InvalidAccessError');
   }
 
+  const jobMode = getWebCryptoJobMode();
   return jobPromise(() => new KEMDecapsulateJob(
-    kCryptoJobSyncWebCrypto,
+    jobMode,
     getCryptoKeyHandle(decapsulationKey),
     undefined,
     undefined,

--- a/lib/internal/crypto/ml_kem.js
+++ b/lib/internal/crypto/ml_kem.js
@@ -8,7 +8,7 @@ const {
 } = primordials;
 
 const {
-  kCryptoJobWebCrypto,
+  kCryptoJobSyncWebCrypto,
   KEMDecapsulateJob,
   KEMEncapsulateJob,
   kKeyFormatDER,
@@ -80,7 +80,7 @@ function mlKemGenerateKey(algorithm, extractable, usages) {
   }
 
   return jobPromise(() => new NidKeyPairGenJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     nid,
     keyAlgorithm,
     getUsagesMask(publicUsages),
@@ -212,7 +212,7 @@ function mlKemEncapsulate(encapsulationKey) {
   }
 
   return jobPromise(() => new KEMEncapsulateJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     getCryptoKeyHandle(encapsulationKey),
     undefined,
     undefined,
@@ -226,7 +226,7 @@ function mlKemDecapsulate(decapsulationKey, ciphertext) {
   }
 
   return jobPromise(() => new KEMDecapsulateJob(
-    kCryptoJobWebCrypto,
+    kCryptoJobSyncWebCrypto,
     getCryptoKeyHandle(decapsulationKey),
     undefined,
     undefined,

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -10,6 +10,7 @@ const {
 const {
   RSACipherJob,
   SignJob,
+  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
   kKeyFormatDER,
   kSignJobModeSign,
@@ -30,10 +31,12 @@ const {
 const {
   bigIntArrayToUnsignedInt,
   getDigestSizeInBytes,
+  getWebCryptoJobModeForInputLength,
   getUsagesMask,
   getUsagesUnion,
   hasAnyNotIn,
   jobPromise,
+  kWebCryptoRsaSyncMaxModulusLength,
   normalizeHashName,
   validateMaxBufferLength,
 } = require('internal/crypto/util');
@@ -95,13 +98,19 @@ function rsaOaepCipher(mode, key, data, algorithm) {
       'InvalidAccessError');
   }
 
+  const keyAlgorithm = getCryptoKeyAlgorithm(key);
+  const jobMode =
+    mode === kWebCryptoCipherEncrypt &&
+    keyAlgorithm.modulusLength <= kWebCryptoRsaSyncMaxModulusLength ?
+      kCryptoJobSyncWebCrypto : kCryptoJobWebCrypto;
+
   return jobPromise(() => new RSACipherJob(
-    kCryptoJobWebCrypto,
+    jobMode,
     mode,
     getCryptoKeyHandle(key),
     data,
     kKeyVariantRSA_OAEP,
-    normalizeHashName(getCryptoKeyAlgorithm(key).hash.name),
+    normalizeHashName(keyAlgorithm.hash.name),
     algorithm.label));
 }
 
@@ -299,9 +308,15 @@ function rsaSignVerify(key, data, { saltLength }, signature) {
     }
   }
 
+  const jobMode =
+    mode === kSignJobModeVerify &&
+    algorithm.modulusLength <= kWebCryptoRsaSyncMaxModulusLength ?
+      getWebCryptoJobModeForInputLength(data.byteLength) :
+      kCryptoJobWebCrypto;
+
   return jobPromise(() => new SignJob(
-    kCryptoJobWebCrypto,
-    signature === undefined ? kSignJobModeSign : kSignJobModeVerify,
+    jobMode,
+    mode,
     getCryptoKeyHandle(key),
     undefined,
     undefined,

--- a/lib/internal/crypto/rsa.js
+++ b/lib/internal/crypto/rsa.js
@@ -10,7 +10,6 @@ const {
 const {
   RSACipherJob,
   SignJob,
-  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
   kKeyFormatDER,
   kSignJobModeSign,
@@ -31,6 +30,7 @@ const {
 const {
   bigIntArrayToUnsignedInt,
   getDigestSizeInBytes,
+  getWebCryptoJobMode,
   getWebCryptoJobModeForInputLength,
   getUsagesMask,
   getUsagesUnion,
@@ -102,7 +102,7 @@ function rsaOaepCipher(mode, key, data, algorithm) {
   const jobMode =
     mode === kWebCryptoCipherEncrypt &&
     keyAlgorithm.modulusLength <= kWebCryptoRsaSyncMaxModulusLength ?
-      kCryptoJobSyncWebCrypto : kCryptoJobWebCrypto;
+      getWebCryptoJobMode() : kCryptoJobWebCrypto;
 
   return jobPromise(() => new RSACipherJob(
     jobMode,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -695,6 +695,8 @@ function cleanupWebCryptoResult(value) {
 }
 
 const kWebCryptoDefaultSyncThreshold = 64 * 1024;
+const kWebCryptoHkdfSyncThreshold = 16 * 1024;
+const kWebCryptoKmacSyncThreshold = 16 * 1024;
 const kWebCryptoRsaSyncMaxModulusLength = 4096;
 const kWebCryptoMaxSyncJobsPerTurn = 1;
 const kWebCryptoParallelPressureAsyncJobs = 1024;
@@ -733,8 +735,11 @@ function getWebCryptoJobMode() {
     kCryptoJobSyncWebCrypto : kCryptoJobWebCrypto;
 }
 
-function getWebCryptoJobModeForInputLength(byteLength) {
-  return byteLength <= kWebCryptoDefaultSyncThreshold ?
+function getWebCryptoJobModeForInputLength(
+  byteLength,
+  threshold = kWebCryptoDefaultSyncThreshold,
+) {
+  return byteLength <= threshold ?
     getWebCryptoJobMode() : kCryptoJobWebCrypto;
 }
 
@@ -1012,6 +1017,8 @@ module.exports = {
   kNamedCurveAliases,
   kSupportedAlgorithms,
   kWebCryptoDefaultSyncThreshold,
+  kWebCryptoHkdfSyncThreshold,
+  kWebCryptoKmacSyncThreshold,
   kWebCryptoRsaSyncMaxModulusLength,
   getWebCryptoJobMode,
   getWebCryptoJobModeForInputLength,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -49,6 +49,10 @@ const {
   KmacJob,
 } = internalBinding('crypto');
 
+const {
+  enqueueMicrotask,
+} = internalBinding('task_queue');
+
 const { getOptionValue } = require('internal/options');
 
 const {
@@ -692,10 +696,46 @@ function cleanupWebCryptoResult(value) {
 
 const kWebCryptoDefaultSyncThreshold = 64 * 1024;
 const kWebCryptoRsaSyncMaxModulusLength = 4096;
+const kWebCryptoMaxSyncJobsPerTurn = 1;
+const kWebCryptoParallelPressureAsyncJobs = 1024;
+
+let webCryptoParallelPressure = 0;
+let webCryptoSyncJobsThisTurn = 0;
+let webCryptoSyncJobResetScheduled = false;
+
+function resetWebCryptoSyncJobsThisTurn() {
+  webCryptoSyncJobsThisTurn = 0;
+  webCryptoSyncJobResetScheduled = false;
+}
+
+function reserveWebCryptoSyncJob() {
+  if (webCryptoParallelPressure > 0) {
+    webCryptoParallelPressure--;
+    return false;
+  }
+
+  if (webCryptoSyncJobsThisTurn >= kWebCryptoMaxSyncJobsPerTurn) {
+    webCryptoParallelPressure = kWebCryptoParallelPressureAsyncJobs;
+    return false;
+  }
+
+  webCryptoSyncJobsThisTurn++;
+  if (!webCryptoSyncJobResetScheduled) {
+    webCryptoSyncJobResetScheduled = true;
+    enqueueMicrotask(resetWebCryptoSyncJobsThisTurn);
+  }
+
+  return true;
+}
+
+function getWebCryptoJobMode() {
+  return reserveWebCryptoSyncJob() ?
+    kCryptoJobSyncWebCrypto : kCryptoJobWebCrypto;
+}
 
 function getWebCryptoJobModeForInputLength(byteLength) {
   return byteLength <= kWebCryptoDefaultSyncThreshold ?
-    kCryptoJobSyncWebCrypto : kCryptoJobWebCrypto;
+    getWebCryptoJobMode() : kCryptoJobWebCrypto;
 }
 
 // CryptoJob constructors can synchronously throw while running their native
@@ -973,6 +1013,7 @@ module.exports = {
   kSupportedAlgorithms,
   kWebCryptoDefaultSyncThreshold,
   kWebCryptoRsaSyncMaxModulusLength,
+  getWebCryptoJobMode,
   getWebCryptoJobModeForInputLength,
   normalizeAlgorithm,
   normalizeHashName,

--- a/lib/internal/crypto/util.js
+++ b/lib/internal/crypto/util.js
@@ -36,6 +36,8 @@ const {
   secureHeapUsed: _secureHeapUsed,
   getCachedAliases,
   getOpenSSLSecLevelCrypto: getOpenSSLSecLevel,
+  kCryptoJobSyncWebCrypto,
+  kCryptoJobWebCrypto,
   EVP_PKEY_ML_DSA_44,
   EVP_PKEY_ML_DSA_65,
   EVP_PKEY_ML_DSA_87,
@@ -668,19 +670,6 @@ const validateByteSource = hideStackFrames((val, name) => {
     val);
 });
 
-// CryptoJob constructors can synchronously throw while running their native
-// AdditionalConfig hook. WebCrypto needs those operation-specific setup
-// failures to reject with an OperationError.
-function jobPromise(getJob) {
-  try {
-    return getJob().run();
-  } catch (err) {
-    return PromiseReject(lazyDOMException(
-      'The operation failed for an operation-specific reason',
-      { name: 'OperationError', cause: err }));
-  }
-}
-
 // Temporarily shadow inherited then accessors on WebCrypto result objects.
 // Promise resolution reads "then" synchronously for thenable assimilation.
 // Returning an own undefined data property keeps that lookup from reaching
@@ -699,6 +688,27 @@ function prepareWebCryptoResult(value) {
 // Remove the temporary then property installed by prepareWebCryptoResult().
 function cleanupWebCryptoResult(value) {
   delete value.then;
+}
+
+const kWebCryptoDefaultSyncThreshold = 64 * 1024;
+const kWebCryptoRsaSyncMaxModulusLength = 4096;
+
+function getWebCryptoJobModeForInputLength(byteLength) {
+  return byteLength <= kWebCryptoDefaultSyncThreshold ?
+    kCryptoJobSyncWebCrypto : kCryptoJobWebCrypto;
+}
+
+// CryptoJob constructors can synchronously throw while running their native
+// AdditionalConfig hook. WebCrypto needs those operation-specific setup
+// failures to reject with an OperationError.
+function jobPromise(getJob) {
+  try {
+    return getJob().run();
+  } catch (err) {
+    return PromiseReject(lazyDOMException(
+      'The operation failed for an operation-specific reason',
+      { name: 'OperationError', cause: err }));
+  }
 }
 
 // Resolve a WebCrypto promise while inherited then accessors are shadowed.
@@ -961,6 +971,9 @@ module.exports = {
 
   kNamedCurveAliases,
   kSupportedAlgorithms,
+  kWebCryptoDefaultSyncThreshold,
+  kWebCryptoRsaSyncMaxModulusLength,
+  getWebCryptoJobModeForInputLength,
   normalizeAlgorithm,
   normalizeHashName,
   hasAnyNotIn,

--- a/src/crypto/README.md
+++ b/src/crypto/README.md
@@ -252,21 +252,99 @@ If the `CryptoJob` is processed as a Web Crypto API job, then
 `run()` returns a Promise. `kCryptoJobWebCrypto` dispatches the
 work to the libuv threadpool. `kCryptoJobSyncWebCrypto` performs
 the work synchronously on the current thread but still resolves or
-rejects the Promise using Web Crypto API semantics. This sync
-Web Crypto mode is used for selected small-input operations and
-selected low-cost public-key operations, plus Web Crypto symmetric
-and non-RSA asymmetric key generation. Sync Web Crypto selection is
-also limited by a small per-turn JavaScript budget so that sequential
-`await` usage can take the fast path while same-turn fanout falls back
-to asynchronous jobs.
-Operation-specific failures are rejected with an `OperationError`,
-and successful jobs resolve with the Web Crypto API result shape
-expected by the JavaScript implementation.
+rejects the Promise using Web Crypto API semantics. Operation-specific
+failures are rejected with an `OperationError`, and successful jobs
+resolve with the Web Crypto API result shape expected by the
+JavaScript implementation.
 
-The JavaScript Web Crypto layer keeps the thresholds close to the
-operation-specific call sites. The default small-input threshold is
-64 KiB. RSA public-key operations are only selected for sync Web Crypto
-mode with moduli up to 4096 bits.
+The JavaScript Web Crypto layer decides between `kCryptoJobWebCrypto`
+and `kCryptoJobSyncWebCrypto` before the native job is constructed.
+The decision must be made at that point because async jobs need
+threadsafe copies of BufferSource input, while sync Web Crypto jobs can
+borrow the caller's input for the duration of the immediate operation.
+A native job cannot safely start as sync and later fall back to async
+after it has been configured with sync-only input references.
+
+No Web Crypto operation is unconditionally sync. The sync path is only
+a fast-path candidate. A candidate still becomes async when its input
+is too large, when an operation-specific public-key limit rejects it,
+or when the same JavaScript turn has already consumed the sync budget.
+
+The default small-input threshold is 64 KiB. Call sites may use lower
+operation-specific thresholds when benchmarks show that parallel
+throughput is more sensitive to the synchronous first job. Current
+thresholds are:
+
+* 64 KiB by default.
+* 32 KiB for AES-CBC and AES-CTR encrypt.
+* 16 KiB for HKDF deriveBits.
+* 16 KiB for KMAC sign and verify.
+
+The byte length being compared is the amount of operation input that
+best predicts the native cost, not always a single Web Crypto argument:
+
+* Digest uses input data length plus output length.
+* AES-CBC, AES-CTR, and AES-KW use input data length.
+* AES-GCM, AES-OCB, and ChaCha20-Poly1305 use input data length plus
+  additional authenticated data length. For decrypt, input data already
+  includes the authentication tag.
+* HMAC uses input data length plus signature length for verify.
+* KMAC uses input data length plus signature length plus output length.
+* HKDF uses salt length plus info length plus derived output length.
+* ECDSA, EdDSA, and RSA verify use input data length.
+
+RSA public-key candidates are additionally limited to moduli up to
+4096 bits. RSA-OAEP encrypt can be a sync candidate under that modulus
+limit. RSA-OAEP decrypt, RSA sign, and RSA key generation remain
+async.
+
+Some candidates do not have a byte-size threshold because their input
+size is fixed or otherwise bounded by the operation. These include
+Web Crypto symmetric key generation, non-RSA asymmetric key generation,
+ML-KEM encapsulation and decapsulation, ECDH P-256 deriveBits, X25519
+deriveBits, X448 deriveBits, and RSA-OAEP encrypt with an allowed
+modulus size. These are still only sync candidates; same-turn fanout
+can force them async.
+
+The sync budget is intentionally small: at most one sync Web Crypto
+candidate is allowed in a JavaScript turn. Here "turn" means the
+continuous JavaScript execution slice before the next microtask
+checkpoint. When the first candidate reserves the sync slot, Node.js
+queues a microtask that resets the per-turn counter. Sequential
+`await` usage yields to the microtask queue between operations, so it
+can keep taking the sync fast path:
+
+```js
+await subtle.digest('SHA-256', data);
+await subtle.digest('SHA-256', data);
+```
+
+Same-turn fanout does not give the reset microtask a chance to run
+between job creations:
+
+```js
+const a = subtle.digest('SHA-256', data);
+const b = subtle.digest('SHA-256', data);
+await Promise.all([a, b]);
+```
+
+In that case the first eligible job may run sync, the second eligible
+job runs async, and a short async pressure window is enabled. The
+pressure window forces the next 1024 eligible candidates to async. If a
+single synchronous burst creates more jobs than that, the per-turn sync
+counter is still used, so the pressure window is re-armed instead of
+letting another sync job through.
+
+The pressure window is a heuristic, not a Web Crypto API requirement.
+It exists because a replenished Promise pipeline can otherwise run one
+sync job from each Promise reaction while still trying to measure or
+use parallel throughput. Once same-turn fanout has been observed, the
+workload is treated as throughput-oriented for a while and candidates
+are sent to the threadpool. This protects parallel throughput without
+requiring precise active-job accounting in the native layer, but it
+also means that a small fanout can make later otherwise-eligible jobs
+async until the pressure counter drains. Changes to this policy should
+be justified with serial and parallel Web Crypto benchmarks.
 
 For `CipherJob` types, the output is always an `ArrayBuffer`.
 

--- a/src/crypto/README.md
+++ b/src/crypto/README.md
@@ -187,7 +187,9 @@ are built around the `CryptoJob` class.
 
 A `CryptoJob` encapsulates a single crypto operation that can be
 invoked synchronously, asynchronously, or as a Web Crypto API
-Promise-based job.
+Promise-based job. Web Crypto API jobs can run either asynchronously
+on the libuv threadpool or synchronously on the current thread while
+still returning a Promise to the JavaScript layer.
 
 The `CryptoJob` class itself is a C++ template that takes a single
 `CryptoJobTraits` struct as a parameter. The `CryptoJobTraits`
@@ -247,10 +249,21 @@ or `undefined`, and the second is the result of the operation
 if successful.
 
 If the `CryptoJob` is processed as a Web Crypto API job, then
-`run()` returns a Promise. Operation-specific failures are
-rejected with an `OperationError`, and successful jobs resolve
-with the Web Crypto API result shape expected by the JavaScript
-implementation.
+`run()` returns a Promise. `kCryptoJobWebCrypto` dispatches the
+work to the libuv threadpool. `kCryptoJobSyncWebCrypto` performs
+the work synchronously on the current thread but still resolves or
+rejects the Promise using Web Crypto API semantics. This sync
+Web Crypto mode is used for selected small-input operations and
+selected low-cost public-key operations, plus Web Crypto symmetric
+and non-RSA asymmetric key generation.
+Operation-specific failures are rejected with an `OperationError`,
+and successful jobs resolve with the Web Crypto API result shape
+expected by the JavaScript implementation.
+
+The JavaScript Web Crypto layer keeps the thresholds close to the
+operation-specific call sites. The default small-input threshold is
+64 KiB. RSA public-key operations are only selected for sync Web Crypto
+mode with moduli up to 4096 bits.
 
 For `CipherJob` types, the output is always an `ArrayBuffer`.
 
@@ -322,6 +335,10 @@ operations use the traditional Node.js callback pattern, as
 illustrated in the previous `randomFill()` example. In the
 Web Crypto API (accessible via `globalThis.crypto`),
 all asynchronous single-call operations are Promise-based.
+Some Web Crypto API Promise-based operations can still execute
+their crypto work synchronously on the current thread for small
+inputs. Those operations continue to return Promises and use Web
+Crypto API result and error semantics.
 
 ```js
 // Example Web Crypto API asynchronous single-call operation
@@ -336,9 +353,9 @@ subtle.generateKeys({ name: 'HMAC', length: 256 }, true, ['sign'])
   });
 ```
 
-In nearly every case, asynchronous single-call operations make use
-of the libuv threadpool to perform crypto operations off the main
-event loop thread.
+Most asynchronous single-call operations make use of the libuv
+threadpool to perform crypto operations off the main event loop
+thread.
 
 Stream-oriented operations use an object to maintain state
 over multiple individual synchronous steps. The steps themselves

--- a/src/crypto/README.md
+++ b/src/crypto/README.md
@@ -255,7 +255,10 @@ the work synchronously on the current thread but still resolves or
 rejects the Promise using Web Crypto API semantics. This sync
 Web Crypto mode is used for selected small-input operations and
 selected low-cost public-key operations, plus Web Crypto symmetric
-and non-RSA asymmetric key generation.
+and non-RSA asymmetric key generation. Sync Web Crypto selection is
+also limited by a small per-turn JavaScript budget so that sequential
+`await` usage can take the fast path while same-turn fanout falls back
+to asynchronous jobs.
 Operation-specific failures are rejected with an `OperationError`,
 and successful jobs resolve with the Web Crypto API result shape
 expected by the JavaScript implementation.

--- a/src/crypto/crypto_kem.cc
+++ b/src/crypto/crypto_kem.cc
@@ -174,7 +174,7 @@ MaybeLocal<Value> KEMEncapsulateTraits::EncodeOutput(
     return MaybeLocal<Value>();
   }
 
-  if (params.job_mode == kCryptoJobWebCrypto) {
+  if (IsCryptoJobWebCrypto(params.job_mode)) {
     Local<Object> result = Object::New(env->isolate());
     if (!result
              ->DefineOwnProperty(env->context(),

--- a/src/crypto/crypto_keygen.h
+++ b/src/crypto/crypto_keygen.h
@@ -63,7 +63,7 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
     }
 
     WebCryptoKeyGenConfig config;
-    if (mode == kCryptoJobWebCrypto) {
+    if (IsCryptoJobWebCrypto(mode)) {
       if constexpr (KeyGenTraits::kWebCryptoKeyPair) {
         CHECK(args[offset]->IsObject());
         CHECK(args[offset + 1]->IsUint32());
@@ -132,7 +132,7 @@ class KeyGenJob final : public CryptoJob<KeyGenTraits> {
     if (status_ == KeyGenJobStatus::OK) {
       v8::TryCatch try_catch(env->isolate());
       v8::MaybeLocal<v8::Value> encoded =
-          CryptoJob<KeyGenTraits>::mode() == kCryptoJobWebCrypto
+          IsCryptoJobWebCrypto(CryptoJob<KeyGenTraits>::mode())
               ? EncodeWebCryptoKey(env, params)
               : KeyGenTraits::EncodeKey(env, params);
       if (encoded.ToLocal(result)) {
@@ -235,7 +235,7 @@ struct KeyPairGenTraits final {
       return v8::Nothing<void>();
     }
 
-    if (mode == kCryptoJobWebCrypto) return v8::JustVoid();
+    if (IsCryptoJobWebCrypto(mode)) return v8::JustVoid();
 
     if (!KeyObjectData::GetPublicKeyEncodingFromJs(
              args, offset, kKeyContextGenerate)

--- a/src/crypto/crypto_util.cc
+++ b/src/crypto/crypto_util.cc
@@ -713,12 +713,16 @@ Maybe<void> SetEncodedValue(Environment* env,
 CryptoJobMode GetCryptoJobMode(v8::Local<v8::Value> args) {
   CHECK(args->IsUint32());
   uint32_t mode = args.As<v8::Uint32>()->Value();
-  CHECK_LE(mode, kCryptoJobWebCrypto);
+  CHECK_LE(mode, kCryptoJobSyncWebCrypto);
   return static_cast<CryptoJobMode>(mode);
 }
 
 bool IsCryptoJobAsync(CryptoJobMode mode) {
   return mode == kCryptoJobAsync || mode == kCryptoJobWebCrypto;
+}
+
+bool IsCryptoJobWebCrypto(CryptoJobMode mode) {
+  return mode == kCryptoJobWebCrypto || mode == kCryptoJobSyncWebCrypto;
 }
 
 MaybeLocal<Value> CreateWebCryptoJobError(Environment* env,
@@ -839,6 +843,7 @@ void Initialize(Environment* env, Local<Object> target) {
   NODE_DEFINE_CONSTANT(target, kCryptoJobAsync);
   NODE_DEFINE_CONSTANT(target, kCryptoJobSync);
   NODE_DEFINE_CONSTANT(target, kCryptoJobWebCrypto);
+  NODE_DEFINE_CONSTANT(target, kCryptoJobSyncWebCrypto);
 
   SetMethod(context, target, "secureBuffer", SecureBuffer);
   SetMethodNoSideEffect(context, target, "secureHeapUsed", SecureHeapUsed);

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -249,10 +249,16 @@ class ByteSource final {
       : data_(data), allocated_data_(allocated_data), size_(size) {}
 };
 
-enum CryptoJobMode { kCryptoJobAsync, kCryptoJobSync, kCryptoJobWebCrypto };
+enum CryptoJobMode {
+  kCryptoJobAsync,
+  kCryptoJobSync,
+  kCryptoJobWebCrypto,
+  kCryptoJobSyncWebCrypto,
+};
 
 CryptoJobMode GetCryptoJobMode(v8::Local<v8::Value> args);
 bool IsCryptoJobAsync(CryptoJobMode mode);
+bool IsCryptoJobWebCrypto(CryptoJobMode mode);
 
 v8::MaybeLocal<v8::Value> CreateWebCryptoJobError(Environment* env,
                                                   v8::Local<v8::Value> cause);
@@ -274,9 +280,11 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
         ThreadPoolWork(env, "crypto"),
         mode_(mode),
         params_(std::move(params)) {
-    // If the CryptoJob is async, then the instance will be
-    // cleaned up when AfterThreadPoolWork is called.
-    if (mode == kCryptoJobSync) MakeWeak();
+    // Async CryptoJobs are cleaned up when AfterThreadPoolWork is called.
+    // Sync jobs can be collected after run() returns.
+    if (mode == kCryptoJobSync || mode == kCryptoJobSyncWebCrypto) {
+      MakeWeak();
+    }
   }
 
   bool IsNotIndicativeOfMemoryLeakAtExit() const override {
@@ -399,6 +407,49 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
       args.GetReturnValue().Set(resolver->GetPromise());
 
       return job->ScheduleWork();
+    }
+
+    if (job->mode() == kCryptoJobSyncWebCrypto) {
+      v8::Local<v8::Promise::Resolver> resolver;
+      if (!v8::Promise::Resolver::New(env->context()).ToLocal(&resolver)) {
+        return;
+      }
+
+      CHECK(job->resolver_.IsEmpty());
+      job->resolver_.Reset(env->isolate(), resolver);
+      args.GetReturnValue().Set(resolver->GetPromise());
+
+      v8::Local<v8::Value> err;
+      v8::Local<v8::Value> result;
+      {
+        node::errors::TryCatchScope try_catch(env);
+        job->DoThreadPoolWork();
+        if (job->ToResult(&err, &result).IsNothing()) {
+          CHECK(try_catch.HasCaught());
+          CHECK(try_catch.CanContinue());
+          err = try_catch.Exception();
+        }
+      }
+
+      if (!err.IsEmpty() && !err->IsUndefined()) {
+        job->RejectWebCrypto(err);
+        return;
+      }
+
+      CHECK(!result.IsEmpty());
+      v8::Local<v8::Value> webcrypto_result;
+      {
+        node::errors::TryCatchScope try_catch(env);
+        if (!ToWebCryptoJobResult(env, result).ToLocal(&webcrypto_result)) {
+          CHECK(try_catch.HasCaught());
+          CHECK(try_catch.CanContinue());
+          job->RejectWebCrypto(try_catch.Exception());
+          return;
+        }
+      }
+
+      job->ResolveWebCrypto(webcrypto_result);
+      return;
     }
 
     if (job->mode() == kCryptoJobAsync)

--- a/src/crypto/crypto_util.h
+++ b/src/crypto/crypto_util.h
@@ -409,48 +409,8 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
       return job->ScheduleWork();
     }
 
-    if (job->mode() == kCryptoJobSyncWebCrypto) {
-      v8::Local<v8::Promise::Resolver> resolver;
-      if (!v8::Promise::Resolver::New(env->context()).ToLocal(&resolver)) {
-        return;
-      }
-
-      CHECK(job->resolver_.IsEmpty());
-      job->resolver_.Reset(env->isolate(), resolver);
-      args.GetReturnValue().Set(resolver->GetPromise());
-
-      v8::Local<v8::Value> err;
-      v8::Local<v8::Value> result;
-      {
-        node::errors::TryCatchScope try_catch(env);
-        job->DoThreadPoolWork();
-        if (job->ToResult(&err, &result).IsNothing()) {
-          CHECK(try_catch.HasCaught());
-          CHECK(try_catch.CanContinue());
-          err = try_catch.Exception();
-        }
-      }
-
-      if (!err.IsEmpty() && !err->IsUndefined()) {
-        job->RejectWebCrypto(err);
-        return;
-      }
-
-      CHECK(!result.IsEmpty());
-      v8::Local<v8::Value> webcrypto_result;
-      {
-        node::errors::TryCatchScope try_catch(env);
-        if (!ToWebCryptoJobResult(env, result).ToLocal(&webcrypto_result)) {
-          CHECK(try_catch.HasCaught());
-          CHECK(try_catch.CanContinue());
-          job->RejectWebCrypto(try_catch.Exception());
-          return;
-        }
-      }
-
-      job->ResolveWebCrypto(webcrypto_result);
-      return;
-    }
+    if (V8_UNLIKELY(job->mode() == kCryptoJobSyncWebCrypto))
+      return RunSyncWebCrypto(job, env, args);
 
     if (job->mode() == kCryptoJobAsync)
       return job->ScheduleWork();
@@ -464,6 +424,51 @@ class CryptoJob : public AsyncWrap, public ThreadPoolWork {
       args.GetReturnValue().Set(
           v8::Array::New(env->isolate(), ret, arraysize(ret)));
     }
+  }
+
+  static V8_NOINLINE void RunSyncWebCrypto(
+      CryptoJob<CryptoJobTraits>* job,
+      Environment* env,
+      const v8::FunctionCallbackInfo<v8::Value>& args) {
+    v8::Local<v8::Promise::Resolver> resolver;
+    if (!v8::Promise::Resolver::New(env->context()).ToLocal(&resolver)) {
+      return;
+    }
+
+    CHECK(job->resolver_.IsEmpty());
+    job->resolver_.Reset(env->isolate(), resolver);
+    args.GetReturnValue().Set(resolver->GetPromise());
+
+    v8::Local<v8::Value> err;
+    v8::Local<v8::Value> result;
+    {
+      node::errors::TryCatchScope try_catch(env);
+      job->DoThreadPoolWork();
+      if (job->ToResult(&err, &result).IsNothing()) {
+        CHECK(try_catch.HasCaught());
+        CHECK(try_catch.CanContinue());
+        err = try_catch.Exception();
+      }
+    }
+
+    if (!err.IsEmpty() && !err->IsUndefined()) {
+      job->RejectWebCrypto(err);
+      return;
+    }
+
+    CHECK(!result.IsEmpty());
+    v8::Local<v8::Value> webcrypto_result;
+    {
+      node::errors::TryCatchScope try_catch(env);
+      if (!ToWebCryptoJobResult(env, result).ToLocal(&webcrypto_result)) {
+        CHECK(try_catch.HasCaught());
+        CHECK(try_catch.CanContinue());
+        job->RejectWebCrypto(try_catch.Exception());
+        return;
+      }
+    }
+
+    job->ResolveWebCrypto(webcrypto_result);
   }
 
   static void Initialize(

--- a/test/parallel/test-webcrypto-crypto-job-mode.js
+++ b/test/parallel/test-webcrypto-crypto-job-mode.js
@@ -14,6 +14,8 @@ const {
   getCryptoKeyHandle,
 } = require('internal/crypto/keys');
 const {
+  getWebCryptoJobModeForInputLength,
+  kWebCryptoDefaultSyncThreshold,
   getUsagesMask,
 } = require('internal/crypto/util');
 const {
@@ -25,6 +27,7 @@ const {
   EcKeyPairGenJob,
   HashJob,
   SecretKeyGenJob,
+  kCryptoJobSyncWebCrypto,
   kCryptoJobWebCrypto,
   kKeyVariantAES_CBC_128,
   kWebCryptoCipherEncrypt,
@@ -62,6 +65,15 @@ async function withObjectPrototypeSetters(names, fn) {
 
 (async function() {
   {
+    assert.strictEqual(
+      getWebCryptoJobModeForInputLength(kWebCryptoDefaultSyncThreshold),
+      kCryptoJobSyncWebCrypto);
+    assert.strictEqual(
+      getWebCryptoJobModeForInputLength(kWebCryptoDefaultSyncThreshold + 1),
+      kCryptoJobWebCrypto);
+  }
+
+  {
     const promise = new HashJob(
       kCryptoJobWebCrypto,
       'sha256',
@@ -74,6 +86,26 @@ async function withObjectPrototypeSetters(names, fn) {
     promise.then(common.mustCall(() => { settled = true; }));
     await Promise.resolve();
     assert.strictEqual(settled, false);
+
+    const digest = await promise;
+    assert(digest instanceof ArrayBuffer);
+    assert.strictEqual(digest.byteLength, 32);
+    assert.strictEqual(Object.hasOwn(digest, 'then'), false);
+  }
+
+  {
+    const promise = new HashJob(
+      kCryptoJobSyncWebCrypto,
+      'sha256',
+      Buffer.from('hello'),
+      undefined).run();
+
+    assert.strictEqual(Object.getPrototypeOf(promise), Promise.prototype);
+
+    let settled = false;
+    promise.then(common.mustCall(() => { settled = true; }));
+    await Promise.resolve();
+    assert.strictEqual(settled, true);
 
     const digest = await promise;
     assert(digest instanceof ArrayBuffer);
@@ -97,6 +129,29 @@ async function withObjectPrototypeSetters(names, fn) {
   }
 
   {
+    const promise = new SecretKeyGenJob(
+      kCryptoJobSyncWebCrypto,
+      128,
+      { name: 'AES-CBC', length: 128 },
+      getUsagesMask(new Set(['encrypt'])),
+      true).run();
+
+    assert.strictEqual(Object.getPrototypeOf(promise), Promise.prototype);
+
+    let settled = false;
+    promise.then(common.mustCall(() => { settled = true; }));
+    await Promise.resolve();
+    assert.strictEqual(settled, true);
+
+    const key = await promise;
+    assert(isCryptoKey(key));
+    assert(key instanceof CryptoKey);
+    assert.strictEqual(key.type, 'secret');
+    assert.strictEqual(key.extractable, true);
+    assert.deepStrictEqual(key.usages, ['encrypt']);
+  }
+
+  {
     const pair = await withObjectPrototypeSetters(
       ['publicKey', 'privateKey'],
       () => new EcKeyPairGenJob(
@@ -108,6 +163,36 @@ async function withObjectPrototypeSetters(names, fn) {
         getUsagesMask(new Set(['sign'])),
         true).run());
 
+    assert.strictEqual(Object.getPrototypeOf(pair), Object.prototype);
+    assert.strictEqual(Object.hasOwn(pair, 'then'), false);
+    assert(isCryptoKey(pair.publicKey));
+    assert(isCryptoKey(pair.privateKey));
+    assert(pair.publicKey instanceof CryptoKey);
+    assert(pair.privateKey instanceof CryptoKey);
+    assert.strictEqual(pair.publicKey.type, 'public');
+    assert.strictEqual(pair.privateKey.type, 'private');
+    assert.deepStrictEqual(pair.publicKey.usages, ['verify']);
+    assert.deepStrictEqual(pair.privateKey.usages, ['sign']);
+  }
+
+  {
+    const promise = new EcKeyPairGenJob(
+      kCryptoJobSyncWebCrypto,
+      'P-256',
+      undefined,
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      getUsagesMask(new Set(['verify'])),
+      getUsagesMask(new Set(['sign'])),
+      true).run();
+
+    assert.strictEqual(Object.getPrototypeOf(promise), Promise.prototype);
+
+    let settled = false;
+    promise.then(common.mustCall(() => { settled = true; }));
+    await Promise.resolve();
+    assert.strictEqual(settled, true);
+
+    const pair = await promise;
     assert.strictEqual(Object.getPrototypeOf(pair), Object.prototype);
     assert.strictEqual(Object.hasOwn(pair, 'then'), false);
     assert(isCryptoKey(pair.publicKey));
@@ -190,25 +275,6 @@ async function withObjectPrototypeSetters(names, fn) {
     assert.strictEqual(
       typeof await subtle.verify('HMAC', key, signature, data),
       'boolean');
-  }
-
-  {
-    Object.defineProperty(CryptoKey.prototype, 'then', {
-      __proto__: null,
-      configurable: true,
-      get: common.mustNotCall('CryptoKey.prototype.then getter'),
-    });
-
-    try {
-      const key = await subtle.generateKey(
-        { name: 'AES-CBC', length: 128 },
-        true,
-        ['encrypt']);
-      assert(isCryptoKey(key));
-      assert.strictEqual(Object.hasOwn(key, 'then'), false);
-    } finally {
-      delete CryptoKey.prototype.then;
-    }
   }
 
   if (hasOpenSSL(3, 5) || process.features.openssl_is_boringssl) {

--- a/test/parallel/test-webcrypto-promise-prototype-pollution.mjs
+++ b/test/parallel/test-webcrypto-promise-prototype-pollution.mjs
@@ -23,12 +23,23 @@ if (!common.hasCrypto) common.skip('missing crypto');
 // The registry assertions at the bottom make missing updates fail loudly.
 
 const require = createRequire(import.meta.url);
-const { kSupportedAlgorithms } = require('internal/crypto/util');
+const {
+  kSupportedAlgorithms,
+  kWebCryptoDefaultSyncThreshold,
+} = require('internal/crypto/util');
 const { subtle } = globalThis.crypto;
 
 Promise.prototype.then = common.mustNotCall('Promise.prototype.then');
 
 const data = new TextEncoder().encode('prototype pollution');
+const asyncData = new Uint8Array(kWebCryptoDefaultSyncThreshold + 1);
+asyncData.set(data);
+const asyncAesKwKeyData = new Uint8Array(kWebCryptoDefaultSyncThreshold + 8);
+
+let plaintextAssertionCount = 0;
+let verificationAssertionCount = 0;
+let assertPlaintextEquals;
+let assertVerified;
 
 // WebCrypto methods return native promises. Re-wrapping a promise with
 // PromiseResolve() or chaining it with Promise.prototype.then can read
@@ -369,6 +380,35 @@ async function getKeyToWrap() {
   return getKeyToWrap.key;
 }
 
+async function getLargeKeyToWrap() {
+  if (getLargeKeyToWrap.key === undefined) {
+    getLargeKeyToWrap.key = await subtle.importKey(
+      'raw-secret',
+      asyncAesKwKeyData,
+      algorithm('HMAC', { hash: 'SHA-256' }),
+      true,
+      ['sign']);
+  }
+  return getLargeKeyToWrap.key;
+}
+
+async function getRawSecretWrapTargets() {
+  return [
+    {
+      jobMode: 'sync',
+      key: await getKeyToWrap(),
+      importAlgorithm: algorithm('AES-CBC', { length: 128 }),
+      usages: ['encrypt'],
+    },
+    {
+      jobMode: 'async',
+      key: await getLargeKeyToWrap(),
+      importAlgorithm: algorithm('HMAC', { hash: 'SHA-256' }),
+      usages: ['sign'],
+    },
+  ];
+}
+
 function addCommonKeyExportTests(fixture) {
   fixture.exportKey = async (ctx) => {
     if (fixture.rawFormat !== undefined)
@@ -399,7 +439,7 @@ function secretKeyFixture(options) {
   const fixture = {
     ...options,
     generateKey: async (ctx) => {
-      ctx.key = await assertNoPromiseConstructorAccess(`generateKey ${options.name}`, () =>
+      ctx.key = await assertCryptoKeyResult(`generateKey ${options.name}`, () =>
         subtle.generateKey(options.generateAlgorithm, true, options.usages));
     },
   };
@@ -407,33 +447,86 @@ function secretKeyFixture(options) {
   addCommonKeyExportTests(fixture);
 
   if (options.encryptAlgorithm !== undefined) {
+    plaintextAssertionCount += 2;
     fixture.encrypt = async (ctx) => {
-      ctx.ciphertext = await assertNoPromiseConstructorAccess(`encrypt ${options.name}`, () =>
-        subtle.encrypt(options.encryptAlgorithm, ctx.key, data));
+      ctx.ciphertexts = { __proto__: null };
+      for (const [jobMode, input] of [
+        ['sync', data],
+        ['async', asyncData],
+      ]) {
+        ctx.ciphertexts[jobMode] = await assertNoInheritedArrayBufferThenAccess(
+          `encrypt ${options.name} ${jobMode}`,
+          () => assertNoPromiseConstructorAccess(
+            `encrypt ${options.name} ${jobMode}`,
+            () => subtle.encrypt(options.encryptAlgorithm, ctx.key, input)));
+      }
     };
     fixture.decrypt = async (ctx) => {
-      await assertNoPromiseConstructorAccess(`decrypt ${options.name}`, () =>
-        subtle.decrypt(options.encryptAlgorithm, ctx.key, ctx.ciphertext));
+      for (const [jobMode, input] of [
+        ['sync', data],
+        ['async', asyncData],
+      ]) {
+        const plaintext = await assertNoInheritedArrayBufferThenAccess(
+          `decrypt ${options.name} ${jobMode}`,
+          () => assertNoPromiseConstructorAccess(
+            `decrypt ${options.name} ${jobMode}`,
+            () => subtle.decrypt(
+              options.encryptAlgorithm,
+              ctx.key,
+              ctx.ciphertexts[jobMode])));
+        assertPlaintextEquals(plaintext, input);
+      }
     };
   }
 
   if (options.signAlgorithm !== undefined) {
+    verificationAssertionCount += 2;
     fixture.sign = async (ctx) => {
-      ctx.signature = await assertNoPromiseConstructorAccess(`sign ${options.name}`, () =>
-        subtle.sign(options.signAlgorithm, ctx.key, data));
+      ctx.signatures = { __proto__: null };
+      for (const [jobMode, input] of [
+        ['sync', data],
+        ['async', asyncData],
+      ]) {
+        ctx.signatures[jobMode] = await assertNoInheritedArrayBufferThenAccess(
+          `sign ${options.name} ${jobMode}`,
+          () => assertNoPromiseConstructorAccess(
+            `sign ${options.name} ${jobMode}`,
+            () => subtle.sign(options.signAlgorithm, ctx.key, input)));
+      }
     };
     fixture.verify = async (ctx) => {
-      await assertNoPromiseConstructorAccess(`verify ${options.name}`, () =>
-        subtle.verify(options.signAlgorithm, ctx.key, ctx.signature, data));
+      for (const [jobMode, input] of [
+        ['sync', data],
+        ['async', asyncData],
+      ]) {
+        assertVerified(await assertNoPromiseConstructorAccess(
+          `verify ${options.name} ${jobMode}`,
+          () => subtle.verify(
+            options.signAlgorithm,
+            ctx.key,
+            ctx.signatures[jobMode],
+            input)));
+      }
     };
   }
 
   if (options.wrapAlgorithm !== undefined) {
     fixture.wrapKey = async (ctx) => {
-      const keyToWrap = await getKeyToWrap();
-      ctx.wrappedRawSecret = await assertNoPromiseConstructorAccess(
-        `wrapKey raw-secret ${options.name}`,
-        () => subtle.wrapKey('raw-secret', keyToWrap, ctx.key, options.wrapAlgorithm));
+      ctx.rawSecretWrapTargets = await getRawSecretWrapTargets();
+      ctx.wrappedRawSecrets = { __proto__: null };
+      for (const { jobMode, key } of ctx.rawSecretWrapTargets) {
+        ctx.wrappedRawSecrets[jobMode] =
+          await assertNoInheritedArrayBufferThenAccess(
+            `wrapKey raw-secret ${options.name} ${jobMode}`,
+            () => assertNoPromiseConstructorAccess(
+              `wrapKey raw-secret ${options.name} ${jobMode}`,
+              () => subtle.wrapKey(
+                'raw-secret',
+                key,
+                ctx.key,
+                options.wrapAlgorithm)));
+      }
+      const keyToWrap = ctx.rawSecretWrapTargets[0].key;
       ctx.wrappedJwk = await assertNoInheritedJwkPropertyAccess(
         `wrapKey jwk ${options.name}`,
         () => assertNoInheritedToJSONAccess(
@@ -444,16 +537,22 @@ function secretKeyFixture(options) {
                 subtle.wrapKey('jwk', keyToWrap, ctx.key, options.wrapAlgorithm)))));
     };
     fixture.unwrapKey = async (ctx) => {
-      await assertNoInheritedArrayBufferThenAccess(`unwrapKey raw-secret ${options.name}`, () =>
-        assertCryptoKeyResult(`unwrapKey raw-secret ${options.name} result`, () =>
-          subtle.unwrapKey(
+      for (const {
+        jobMode,
+        importAlgorithm,
+        usages,
+      } of ctx.rawSecretWrapTargets) {
+        await assertCryptoKeyResult(
+          `unwrapKey raw-secret ${options.name} ${jobMode} result`,
+          () => subtle.unwrapKey(
             'raw-secret',
-            ctx.wrappedRawSecret,
+            ctx.wrappedRawSecrets[jobMode],
             ctx.key,
             options.wrapAlgorithm,
-            algorithm('AES-CBC', { length: 128 }),
+            importAlgorithm,
             true,
-            ['encrypt'])));
+            usages));
+      }
       await assertNoUserMutableDecodeAccess(`unwrapKey jwk ${options.name}`, () =>
         assertNoInheritedArrayBufferThenAccess(`unwrapKey jwk ${options.name}`, () =>
           assertCryptoKeyResult(`unwrapKey jwk ${options.name} result`, () =>
@@ -475,8 +574,14 @@ function pairKeyFixture(options) {
   const fixture = {
     ...options,
     generateKey: async (ctx) => {
-      ctx.keyPair = await assertNoPromiseConstructorAccess(`generateKey ${options.name}`, () =>
-        subtle.generateKey(options.generateAlgorithm, true, options.usages));
+      ctx.keyPair = await assertNoInheritedObjectThenAccess(
+        `generateKey ${options.name}`,
+        () => assertNoPromiseConstructorAccess(
+          `generateKey ${options.name}`,
+          () => subtle.generateKey(
+            options.generateAlgorithm,
+            true,
+            options.usages)));
     },
     exportKey: async (ctx) => {
       if (options.spki !== false) {
@@ -552,12 +657,35 @@ function pairKeyFixture(options) {
 
   if (options.signAlgorithm !== undefined) {
     fixture.sign = async (ctx) => {
-      ctx.signature = await assertNoPromiseConstructorAccess(`sign ${options.name}`, () =>
-        subtle.sign(options.signAlgorithm, ctx.keyPair.privateKey, data));
+      ctx.signatures = { __proto__: null };
+      const inputs = options.thresholdSignVerify === true ?
+        [
+          ['sync', data],
+          ['async', asyncData],
+        ] :
+        [['default', data]];
+      for (const [jobMode, input] of inputs) {
+        ctx.signatures[jobMode] = await assertNoInheritedArrayBufferThenAccess(
+          `sign ${options.name} ${jobMode}`,
+          () => assertNoPromiseConstructorAccess(`sign ${options.name} ${jobMode}`, () =>
+            subtle.sign(options.signAlgorithm, ctx.keyPair.privateKey, input)));
+      }
     };
     fixture.verify = async (ctx) => {
-      await assertNoPromiseConstructorAccess(`verify ${options.name}`, () =>
-        subtle.verify(options.signAlgorithm, ctx.keyPair.publicKey, ctx.signature, data));
+      const inputs = options.thresholdSignVerify === true ?
+        [
+          ['sync', data],
+          ['async', asyncData],
+        ] :
+        [['default', data]];
+      for (const [jobMode, input] of inputs) {
+        await assertNoPromiseConstructorAccess(`verify ${options.name} ${jobMode}`, () =>
+          subtle.verify(
+            options.signAlgorithm,
+            ctx.keyPair.publicKey,
+            ctx.signatures[jobMode],
+            input));
+      }
     };
   }
 
@@ -621,18 +749,31 @@ function kdfFixture(options) {
         ['deriveBits', 'deriveKey']);
     },
     deriveBits: async (ctx) => {
-      await assertNoPromiseConstructorAccess(`deriveBits ${options.name}`, () =>
-        subtle.deriveBits(options.deriveAlgorithm, ctx.key, 256));
+      const deriveAlgorithms = options.deriveAlgorithms ?? [
+        ['default', options.deriveAlgorithm],
+      ];
+      for (const [jobMode, deriveAlgorithm] of deriveAlgorithms) {
+        await assertNoInheritedArrayBufferThenAccess(
+          `deriveBits ${options.name} ${jobMode}`,
+          () => assertNoPromiseConstructorAccess(
+            `deriveBits ${options.name} ${jobMode}`,
+            () => subtle.deriveBits(deriveAlgorithm, ctx.key, 256)));
+      }
     },
     extra: async (ctx) => {
-      await assertNoInheritedArrayBufferThenAccess(`deriveKey ${options.name}`, () =>
-        assertCryptoKeyResult(`deriveKey ${options.name} result`, () =>
-          subtle.deriveKey(
-            options.deriveAlgorithm,
-            ctx.key,
-            algorithm('AES-CBC', { length: 128 }),
-            true,
-            ['encrypt'])));
+      const deriveAlgorithms = options.deriveAlgorithms ?? [
+        ['default', options.deriveAlgorithm],
+      ];
+      for (const [jobMode, deriveAlgorithm] of deriveAlgorithms) {
+        await assertNoInheritedArrayBufferThenAccess(`deriveKey ${options.name} ${jobMode}`, () =>
+          assertCryptoKeyResult(`deriveKey ${options.name} ${jobMode} result`, () =>
+            subtle.deriveKey(
+              deriveAlgorithm,
+              ctx.key,
+              algorithm('AES-CBC', { length: 128 }),
+              true,
+              ['encrypt'])));
+      }
     },
   };
 }
@@ -653,9 +794,10 @@ function kemFixture(options) {
   });
 
   fixture.encapsulate = async (ctx) => {
-    ctx.encapsulatedBits = await assertNoPromiseConstructorAccess(
-      `encapsulateBits ${options.name}`, () =>
-        subtle.encapsulateBits(algorithm(options.name), ctx.keyPair.publicKey));
+    ctx.encapsulatedBits = await assertNoRawSharedKeyObjectThenAccess(
+      `encapsulateBits ${options.name}`,
+      () => assertNoPromiseConstructorAccess(`encapsulateBits ${options.name}`, () =>
+        subtle.encapsulateBits(algorithm(options.name), ctx.keyPair.publicKey)));
     ctx.encapsulatedKey = await assertNoRawSharedKeyObjectThenAccess(
       `encapsulateKey ${options.name}`,
       () => assertNoPromiseConstructorAccess(`encapsulateKey ${options.name}`, () =>
@@ -775,6 +917,7 @@ for (const name of ['RSASSA-PKCS1-v1_5', 'RSA-PSS']) {
     signAlgorithm: name === 'RSA-PSS' ?
       algorithm(name, { saltLength: 32 }) :
       algorithm(name),
+    thresholdSignVerify: true,
   }));
 }
 
@@ -797,6 +940,7 @@ addFixture('ECDSA', pairKeyFixture({
   privateUsages: ['sign'],
   rawPublic: true,
   signAlgorithm: algorithm('ECDSA', { hash: 'SHA-256' }),
+  thresholdSignVerify: true,
 }));
 
 addFixture('ECDH', pairKeyFixture({
@@ -821,6 +965,7 @@ for (const name of ['Ed25519', 'Ed448']) {
     privateUsages: ['sign'],
     rawPublic: true,
     signAlgorithm: algorithm(name),
+    thresholdSignVerify: true,
   }));
 }
 
@@ -880,6 +1025,18 @@ for (const name of ['HKDF', 'PBKDF2']) {
         salt: new Uint8Array(8),
         iterations: 1,
       }),
+    deriveAlgorithms: name === 'HKDF' ? [
+      ['sync', algorithm(name, {
+        hash: 'SHA-256',
+        salt: new Uint8Array(8),
+        info: new Uint8Array(8),
+      })],
+      ['async', algorithm(name, {
+        hash: 'SHA-256',
+        salt: new Uint8Array(kWebCryptoDefaultSyncThreshold + 1),
+        info: new Uint8Array(8),
+      })],
+    ] : undefined,
   }));
 }
 
@@ -931,8 +1088,16 @@ for (const name of [
   addFixture(name, {
     name,
     digest: async () => {
-      await assertNoPromiseConstructorAccess(`digest ${name}`, () =>
-        subtle.digest(digestAlgorithm(name), data));
+      for (const [jobMode, input] of [
+        ['sync', data],
+        ['async', asyncData],
+      ]) {
+        await assertNoInheritedArrayBufferThenAccess(
+          `digest ${name} ${jobMode}`,
+          () => assertNoPromiseConstructorAccess(
+            `digest ${name} ${jobMode}`,
+            () => subtle.digest(digestAlgorithm(name), input)));
+      }
     },
   });
 }
@@ -1024,6 +1189,13 @@ for (const operation of Object.keys(kSupportedAlgorithms)) {
 }
 
 const supportedAlgorithms = getSupportedAlgorithmOperations();
+assertPlaintextEquals = common.mustCall((actual, expected) => {
+  assert.deepStrictEqual(new Uint8Array(actual), expected);
+}, plaintextAssertionCount);
+assertVerified = common.mustCall((actual) => {
+  assert.strictEqual(actual, true);
+}, verificationAssertionCount);
+
 for (const [name, operations] of supportedAlgorithms) {
   const fixture = fixtures.get(name);
   assert(fixture, `missing prototype pollution fixture for ${name}`);


### PR DESCRIPTION
> [!NOTE]
> This is a work in progress, i just need a PR to use benchmark-node-micro-benchmarks

TL;DR A WebCrypto sync operation candidate runs synchronously only when it passes its operation-specific limits and no other candidate has used the sync slot since the last microtask checkpoint; otherwise, fanout before the next checkpoint or the async pressure window sends it to the threadpool.

<details>
<summary>Benchmark</summary>

```
FILTER='--filter webcrypto-sync-fast-path'
RUNS='--runs 10'                                                                                                                                                confidence improvement accuracy (*)     (**)    (***)
                                                                                                                                                confidence improvement accuracy (*)     (**)    (***)
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='decrypt' algorithm='AES-CBC'                                -3.81 %      ±16.73%  ±22.93%  ±31.24%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='decrypt' algorithm='AES-CTR'                                -4.29 %      ±13.06%  ±17.90%  ±24.39%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='decrypt' algorithm='AES-GCM'                                -3.43 %      ±12.78%  ±17.51%  ±23.86%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='decrypt' algorithm='AES-OCB'                               -10.85 %      ±12.58%  ±17.28%  ±23.61%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='decrypt' algorithm='ChaCha20-Poly1305'                      -1.49 %       ±9.69%  ±13.31%  ±18.23%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='encrypt' algorithm='AES-CBC'                                 1.04 %      ±11.39%  ±15.61%  ±21.27%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='encrypt' algorithm='AES-CTR'                               -13.39 %      ±14.50%  ±19.87%  ±27.07%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='encrypt' algorithm='AES-GCM'                                 4.48 %      ±14.99%  ±20.55%  ±28.02%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='encrypt' algorithm='AES-OCB'                                -8.13 %      ±11.86%  ±16.39%  ±22.65%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='after-threshold' operation='encrypt' algorithm='ChaCha20-Poly1305'                       0.64 %      ±10.00%  ±13.71%  ±18.69%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='decrypt' algorithm='AES-CBC'                                    5.90 %      ±15.14%  ±20.76%  ±28.32%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='decrypt' algorithm='AES-CTR'                                   -0.05 %      ±15.62%  ±21.43%  ±29.25%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='decrypt' algorithm='AES-GCM'                                   -5.86 %      ±12.12%  ±16.60%  ±22.62%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='decrypt' algorithm='AES-OCB'                                    1.86 %      ±11.82%  ±16.19%  ±22.06%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='decrypt' algorithm='ChaCha20-Poly1305'                         -2.33 %      ±11.92%  ±16.33%  ±22.26%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='encrypt' algorithm='AES-CBC'                                   -2.84 %      ±16.11%  ±22.07%  ±30.07%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='encrypt' algorithm='AES-CTR'                                    0.16 %      ±15.36%  ±21.07%  ±28.77%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='encrypt' algorithm='AES-GCM'                                   -2.68 %      ±17.22%  ±23.61%  ±32.20%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='encrypt' algorithm='AES-OCB'                                   10.68 %      ±13.88%  ±19.06%  ±26.06%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='at-threshold' operation='encrypt' algorithm='ChaCha20-Poly1305'                          4.33 %      ±15.81%  ±21.68%  ±29.58%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='decrypt' algorithm='AES-CBC'                                         -6.98 %      ±15.91%  ±21.82%  ±29.77%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='decrypt' algorithm='AES-CTR'                                          6.04 %      ±18.55%  ±25.47%  ±34.82%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='decrypt' algorithm='AES-GCM'                                        -11.97 %      ±16.06%  ±22.04%  ±30.10%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='decrypt' algorithm='AES-OCB'                                        -10.27 %      ±14.07%  ±19.29%  ±26.33%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='decrypt' algorithm='ChaCha20-Poly1305'                        **    -16.52 %      ±11.93%  ±16.36%  ±22.32%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='encrypt' algorithm='AES-CBC'                                          5.97 %      ±17.52%  ±24.24%  ±33.55%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='encrypt' algorithm='AES-CTR'                                         14.27 %      ±21.09%  ±29.03%  ±39.85%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='encrypt' algorithm='AES-GCM'                                        -14.03 %      ±15.24%  ±20.89%  ±28.48%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='encrypt' algorithm='AES-OCB'                                          3.71 %      ±16.14%  ±22.15%  ±30.27%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='middle' operation='encrypt' algorithm='ChaCha20-Poly1305'                              -13.51 %      ±15.93%  ±21.94%  ±30.16%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='decrypt' algorithm='AES-CBC'                                        -0.11 %      ±25.53%  ±35.09%  ±48.06%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='decrypt' algorithm='AES-CTR'                                        -3.54 %      ±20.57%  ±28.30%  ±38.81%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='decrypt' algorithm='AES-GCM'                                         5.96 %      ±24.07%  ±32.99%  ±44.97%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='decrypt' algorithm='AES-OCB'                                         2.50 %      ±21.78%  ±29.85%  ±40.70%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='decrypt' algorithm='ChaCha20-Poly1305'                               3.17 %      ±16.45%  ±22.61%  ±30.96%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='encrypt' algorithm='AES-CBC'                                        -0.54 %      ±17.81%  ±24.42%  ±33.30%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='encrypt' algorithm='AES-CTR'                                        -4.27 %      ±21.31%  ±29.20%  ±39.79%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='encrypt' algorithm='AES-GCM'                                       -16.50 %      ±19.22%  ±26.44%  ±36.27%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='encrypt' algorithm='AES-OCB'                                        -2.00 %      ±22.88%  ±31.52%  ±43.32%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='parallel' size='minimal' operation='encrypt' algorithm='ChaCha20-Poly1305'                             -17.84 %      ±17.84%  ±24.58%  ±33.77%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='decrypt' algorithm='AES-CBC'                                  -9.03 %      ±29.32%  ±40.28%  ±55.14%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='decrypt' algorithm='AES-CTR'                                  14.93 %      ±38.30%  ±52.56%  ±71.80%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='decrypt' algorithm='AES-GCM'                                  -4.27 %      ±33.67%  ±46.17%  ±62.99%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='decrypt' algorithm='AES-OCB'                                   2.25 %      ±27.72%  ±38.05%  ±51.99%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='decrypt' algorithm='ChaCha20-Poly1305'                       -17.43 %      ±35.86%  ±49.93%  ±69.81%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='encrypt' algorithm='AES-CBC'                                  21.41 %      ±56.10%  ±77.08% ±105.50%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='encrypt' algorithm='AES-CTR'                                   6.14 %      ±21.17%  ±29.07%  ±39.76%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='encrypt' algorithm='AES-GCM'                                 -10.90 %      ±32.97%  ±45.17%  ±61.55%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='encrypt' algorithm='AES-OCB'                                   1.11 %      ±31.12%  ±42.65%  ±58.13%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='after-threshold' operation='encrypt' algorithm='ChaCha20-Poly1305'                        56.55 %      ±63.35%  ±86.88% ±118.54%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='decrypt' algorithm='AES-CBC'                                    -25.54 %      ±34.02%  ±46.71%  ±63.85%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='decrypt' algorithm='AES-CTR'                             ***     81.75 %      ±20.17%  ±28.69%  ±41.49%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='decrypt' algorithm='AES-GCM'                             ***     65.43 %      ±21.40%  ±30.39%  ±43.90%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='decrypt' algorithm='AES-OCB'                             ***    130.40 %      ±31.67%  ±44.84%  ±64.39%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='decrypt' algorithm='ChaCha20-Poly1305'                   ***    197.77 %      ±23.91%  ±33.99%  ±49.14%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='encrypt' algorithm='AES-CBC'                             ***    126.13 %      ±28.69%  ±40.44%  ±57.68%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='encrypt' algorithm='AES-CTR'                             ***     86.06 %      ±14.87%  ±20.44%  ±28.00%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='encrypt' algorithm='AES-GCM'                             ***    104.56 %      ±31.79%  ±44.99%  ±64.58%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='encrypt' algorithm='AES-OCB'                             ***    101.93 %      ±23.19%  ±32.98%  ±47.71%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='at-threshold' operation='encrypt' algorithm='ChaCha20-Poly1305'                   ***    166.17 %      ±33.96%  ±48.54%  ±70.81%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='decrypt' algorithm='AES-CBC'                                   ***     85.50 %      ±17.77%  ±24.58%  ±34.01%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='decrypt' algorithm='AES-CTR'                                   ***     51.36 %      ±12.20%  ±16.72%  ±22.79%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='decrypt' algorithm='AES-GCM'                                   ***     60.91 %      ±21.75%  ±29.81%  ±40.61%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='decrypt' algorithm='AES-OCB'                                   ***     46.56 %      ±15.58%  ±21.38%  ±29.22%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='decrypt' algorithm='ChaCha20-Poly1305'                         ***    100.38 %      ±34.33%  ±48.37%  ±68.91%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='encrypt' algorithm='AES-CBC'                                   ***     62.30 %      ±21.66%  ±29.84%  ±41.00%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='encrypt' algorithm='AES-CTR'                                   ***     79.34 %      ±19.05%  ±26.31%  ±36.31%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='encrypt' algorithm='AES-GCM'                                   ***     65.24 %      ±16.68%  ±23.12%  ±32.11%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='encrypt' algorithm='AES-OCB'                                   ***     62.40 %      ±16.99%  ±23.42%  ±32.21%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='middle' operation='encrypt' algorithm='ChaCha20-Poly1305'                         ***    113.11 %      ±33.13%  ±47.01%  ±67.77%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='decrypt' algorithm='AES-CBC'                                    *     39.57 %      ±34.63%  ±48.40%  ±68.09%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='decrypt' algorithm='AES-CTR'                                   **     32.77 %      ±19.87%  ±27.25%  ±37.18%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='decrypt' algorithm='AES-GCM'                                  ***     32.42 %      ±15.72%  ±21.54%  ±29.34%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='decrypt' algorithm='AES-OCB'                                  ***     47.34 %      ±20.20%  ±27.86%  ±38.33%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='decrypt' algorithm='ChaCha20-Poly1305'                        ***     47.99 %      ±22.01%  ±30.76%  ±43.26%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='encrypt' algorithm='AES-CBC'                                   **     50.66 %      ±28.07%  ±39.20%  ±55.05%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='encrypt' algorithm='AES-CTR'                                   **     54.53 %      ±28.28%  ±39.29%  ±54.71%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='encrypt' algorithm='AES-GCM'                                   **     46.61 %      ±24.72%  ±34.45%  ±48.25%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='encrypt' algorithm='AES-OCB'                                  ***     49.15 %      ±23.49%  ±32.74%  ±45.84%
crypto/webcrypto-sync-fast-path-cipher.js n=1000 mode='serial' size='minimal' operation='encrypt' algorithm='ChaCha20-Poly1305'                         **     37.56 %      ±22.29%  ±30.75%  ±42.34%
crypto/webcrypto-sync-fast-path-derive.js n=1000 mode='parallel' algorithm='ecdh-p256'                                                                          7.69 %      ±10.47%  ±14.35%  ±19.55%
crypto/webcrypto-sync-fast-path-derive.js n=1000 mode='parallel' algorithm='x25519'                                                                            -3.42 %      ±13.55%  ±18.69%  ±25.76%
crypto/webcrypto-sync-fast-path-derive.js n=1000 mode='parallel' algorithm='x448'                                                                              -0.94 %       ±7.77%  ±10.74%  ±14.85%
crypto/webcrypto-sync-fast-path-derive.js n=1000 mode='serial' algorithm='ecdh-p256'                                                                   ***    180.86 %      ±42.88%  ±61.51%  ±90.27%
crypto/webcrypto-sync-fast-path-derive.js n=1000 mode='serial' algorithm='x25519'                                                                      ***    114.69 %      ±25.19%  ±35.68%  ±51.27%
crypto/webcrypto-sync-fast-path-derive.js n=1000 mode='serial' algorithm='x448'                                                                        ***    226.56 %      ±47.51%  ±68.24% ±100.35%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='cSHAKE128'                                                   1.28 %       ±9.29%  ±12.73%  ±17.35%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='cSHAKE256'                                                  -0.69 %       ±6.66%   ±9.13%  ±12.44%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='KT128'                                                       0.48 %       ±7.64%  ±10.52%  ±14.42%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='KT256'                                                      10.90 %      ±11.16%  ±15.35%  ±21.04%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='SHA-1'                                                       8.02 %      ±13.77%  ±18.96%  ±26.06%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='SHA-256'                                                     4.02 %       ±7.94%  ±11.12%  ±15.73%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='SHA-384'                                                    -6.97 %       ±7.13%   ±9.97%  ±14.01%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='SHA-512'                                                     3.60 %       ±9.78%  ±13.54%  ±18.77%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='SHA3-256'                                                   -1.15 %       ±7.89%  ±10.90%  ±15.07%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='SHA3-384'                                                   -2.71 %       ±6.00%   ±8.40%  ±11.85%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='SHA3-512'                                                   -1.18 %       ±3.28%   ±4.50%   ±6.14%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='TurboSHAKE128'                                               5.16 %       ±9.13%  ±12.56%  ±17.23%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='after-threshold' algorithm='TurboSHAKE256'                                               1.07 %      ±10.76%  ±14.75%  ±20.10%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='cSHAKE128'                                                      8.07 %       ±9.19%  ±12.60%  ±17.18%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='cSHAKE256'                                                     -3.18 %       ±6.26%   ±8.58%  ±11.70%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='KT128'                                                         -0.13 %      ±11.74%  ±16.09%  ±21.93%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='KT256'                                                         -2.19 %      ±10.82%  ±14.83%  ±20.21%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='SHA-1'                                                          1.58 %       ±9.64%  ±13.22%  ±18.03%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='SHA-256'                                                       -8.09 %      ±10.77%  ±14.80%  ±20.28%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='SHA-384'                                                        2.52 %       ±8.06%  ±11.06%  ±15.11%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='SHA-512'                                                        1.32 %       ±7.79%  ±10.70%  ±14.64%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='SHA3-256'                                                      -0.43 %       ±6.12%   ±8.44%  ±11.62%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='SHA3-384'                                                       1.77 %       ±3.74%   ±5.15%   ±7.07%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='SHA3-512'                                                       1.07 %       ±2.97%   ±4.09%   ±5.61%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='TurboSHAKE128'                                                  0.96 %      ±11.53%  ±15.85%  ±21.71%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='at-threshold' algorithm='TurboSHAKE256'                                                  0.12 %      ±10.04%  ±13.76%  ±18.76%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='cSHAKE128'                                                            7.99 %      ±13.05%  ±17.90%  ±24.42%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='cSHAKE256'                                                            4.69 %      ±10.44%  ±14.32%  ±19.56%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='KT128'                                                               -1.29 %      ±11.51%  ±15.82%  ±21.65%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='KT256'                                                                4.65 %      ±15.15%  ±20.94%  ±28.93%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='SHA-1'                                                               -8.93 %      ±14.08%  ±19.33%  ±26.42%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='SHA-256'                                                             -0.70 %      ±15.60%  ±21.41%  ±29.27%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='SHA-384'                                                             -6.99 %      ±10.36%  ±14.44%  ±20.23%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='SHA-512'                                                             -5.64 %       ±8.94%  ±12.25%  ±16.69%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='SHA3-256'                                                      *     -7.86 %       ±7.45%  ±10.21%  ±13.92%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='SHA3-384'                                                             4.08 %       ±5.48%   ±7.55%  ±10.38%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='SHA3-512'                                                            -2.20 %       ±5.04%   ±6.90%   ±9.42%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='TurboSHAKE128'                                                       -0.76 %      ±16.11%  ±22.31%  ±30.94%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='middle' algorithm='TurboSHAKE256'                                                       -0.96 %       ±9.32%  ±12.92%  ±17.92%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='cSHAKE128'                                                          -0.94 %      ±21.77%  ±29.84%  ±40.69%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='cSHAKE256'                                                          10.20 %      ±21.72%  ±29.77%  ±40.58%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='KT128'                                                        *     26.19 %      ±21.77%  ±30.41%  ±42.73%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='KT256'                                                               1.14 %      ±24.63%  ±34.31%  ±48.00%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='SHA-1'                                                              -4.60 %      ±17.82%  ±24.41%  ±33.26%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='SHA-256'                                                      *    -16.53 %      ±14.78%  ±20.28%  ±27.68%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='SHA-384'                                                      *    -14.98 %      ±13.15%  ±18.22%  ±25.26%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='SHA-512'                                                      *    -10.14 %       ±8.55%  ±11.72%  ±15.99%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='SHA3-256'                                                     *    -15.48 %      ±13.23%  ±18.19%  ±24.94%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='SHA3-384'                                                     *    -18.24 %      ±13.86%  ±18.99%  ±25.89%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='SHA3-512'                                                           -5.67 %      ±13.68%  ±18.75%  ±25.56%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='TurboSHAKE128'                                               **     36.79 %      ±22.19%  ±30.95%  ±43.40%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='parallel' size='minimal' algorithm='TurboSHAKE256'                                                      13.71 %      ±24.41%  ±33.68%  ±46.42%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='cSHAKE128'                                                     3.20 %      ±74.67% ±102.41% ±139.76%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='cSHAKE256'                                                   -10.67 %      ±74.86% ±102.71% ±140.25%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='KT128'                                                       -10.99 %      ±57.59%  ±79.02% ±107.90%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='KT256'                                                       -10.35 %      ±58.11%  ±80.13% ±110.28%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='SHA-1'                                                       -15.16 %      ±37.79%  ±52.01%  ±71.36%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='SHA-256'                                                     -22.86 %      ±41.51%  ±57.44%  ±79.51%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='SHA-384'                                                     -14.91 %      ±50.20%  ±70.15%  ±98.65%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='SHA-512'                                                      53.41 %      ±65.49%  ±93.17% ±134.87%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='SHA3-256'                                                     27.45 %      ±77.01% ±105.66% ±144.25%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='SHA3-384'                                                    -13.38 %      ±58.83%  ±80.99% ±111.16%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='SHA3-512'                                                     14.90 %      ±46.56%  ±63.97%  ±87.53%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='TurboSHAKE128'                                                47.44 %      ±73.78% ±102.12% ±141.41%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='after-threshold' algorithm='TurboSHAKE256'                                                 2.94 %      ±67.89%  ±93.02% ±126.73%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='cSHAKE128'                                                      -14.90 %      ±55.85%  ±76.88% ±105.55%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='cSHAKE256'                                                       29.33 %      ±76.83% ±106.18% ±146.69%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='KT128'                                                           61.01 %      ±69.24%  ±96.04% ±133.46%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='KT256'                                                     *    118.97 %      ±98.87% ±141.59% ±207.24%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='SHA-1'                                                   ***    128.93 %      ±27.12%  ±38.91%  ±57.09%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='SHA-256'                                                 ***    104.93 %      ±35.98%  ±51.64%  ±75.87%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='SHA-384'                                                 ***    335.33 %      ±34.93%  ±50.09%  ±73.47%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='SHA-512'                                                 ***    242.99 %      ±48.22%  ±69.24% ±101.79%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='SHA3-256'                                                ***    327.20 %      ±55.96%  ±80.37% ±118.16%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='SHA3-384'                                                ***    264.68 %      ±38.40%  ±55.14%  ±81.05%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='SHA3-512'                                                ***    301.45 %      ±22.57%  ±32.42%  ±47.66%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='TurboSHAKE128'                                                   13.91 %      ±65.65%  ±89.95% ±122.55%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='at-threshold' algorithm='TurboSHAKE256'                                                   -2.43 %      ±57.20%  ±78.39% ±106.83%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='cSHAKE128'                                                     ***    131.66 %      ±35.19%  ±50.35%  ±73.56%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='cSHAKE256'                                                     ***    238.28 %      ±45.22%  ±64.90%  ±95.32%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='KT128'                                                         ***    193.99 %      ±26.36%  ±36.85%  ±51.83%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='KT256'                                                         ***    122.88 %      ±40.03%  ±56.99%  ±82.62%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='SHA-1'                                                         ***    130.61 %      ±21.10%  ±28.96%  ±39.58%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='SHA-256'                                                       ***     66.89 %      ±26.45%  ±37.85%  ±55.34%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='SHA-384'                                                       ***    153.81 %      ±25.82%  ±37.03%  ±54.31%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='SHA-512'                                                       ***    167.45 %      ±36.34%  ±52.11%  ±76.42%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='SHA3-256'                                                      ***    363.76 %      ±20.80%  ±29.57%  ±42.74%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='SHA3-384'                                                      ***    367.04 %      ±23.56%  ±33.69%  ±49.21%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='SHA3-512'                                                      ***    256.95 %      ±44.90%  ±64.48%  ±94.81%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='TurboSHAKE128'                                                 ***    115.53 %      ±34.94%  ±49.60%  ±71.58%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='middle' algorithm='TurboSHAKE256'                                                 ***    219.04 %      ±28.69%  ±40.34%  ±57.30%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='cSHAKE128'                                                     **     56.91 %      ±30.17%  ±42.14%  ±59.18%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='cSHAKE256'                                                    ***     65.43 %      ±29.69%  ±41.52%  ±58.44%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='KT128'                                                         **     45.30 %      ±24.92%  ±34.47%  ±47.67%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='KT256'                                                         **     38.21 %      ±25.98%  ±35.96%  ±49.80%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='SHA-1'                                                        ***    107.69 %      ±28.18%  ±39.16%  ±54.59%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='SHA-256'                                                      ***     88.61 %      ±24.46%  ±34.00%  ±47.38%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='SHA-384'                                                      ***    103.23 %      ±14.57%  ±19.96%  ±27.20%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='SHA-512'                                                      ***     90.16 %      ±19.65%  ±27.44%  ±38.53%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='SHA3-256'                                                     ***     91.90 %      ±12.65%  ±17.37%  ±23.74%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='SHA3-384'                                                     ***     91.62 %      ±20.94%  ±28.90%  ±39.82%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='SHA3-512'                                                     ***     80.88 %       ±3.79%   ±5.29%   ±7.42%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='TurboSHAKE128'                                                 **     56.40 %      ±33.53%  ±47.18%  ±67.09%
crypto/webcrypto-sync-fast-path-digest.js n=1000 mode='serial' size='minimal' algorithm='TurboSHAKE256'                                                  *     46.55 %      ±34.85%  ±48.96%  ±69.46%
crypto/webcrypto-sync-fast-path-kdf.js n=1000 mode='parallel' size='after-threshold' algorithm='HKDF'                                                          -0.95 %      ±14.42%  ±19.81%  ±27.09%
crypto/webcrypto-sync-fast-path-kdf.js n=1000 mode='parallel' size='at-threshold' algorithm='HKDF'                                                            -10.95 %      ±11.01%  ±15.22%  ±21.03%
crypto/webcrypto-sync-fast-path-kdf.js n=1000 mode='parallel' size='middle' algorithm='HKDF'                                                             *    -20.99 %      ±18.56%  ±26.03%  ±36.80%
crypto/webcrypto-sync-fast-path-kdf.js n=1000 mode='parallel' size='minimal' algorithm='HKDF'                                                                  -4.34 %      ±22.48%  ±30.81%  ±42.02%
crypto/webcrypto-sync-fast-path-kdf.js n=1000 mode='serial' size='after-threshold' algorithm='HKDF'                                                           -11.42 %      ±18.55%  ±25.43%  ±34.68%
crypto/webcrypto-sync-fast-path-kdf.js n=1000 mode='serial' size='at-threshold' algorithm='HKDF'                                                       ***     42.61 %      ±16.16%  ±22.46%  ±31.33%
crypto/webcrypto-sync-fast-path-kdf.js n=1000 mode='serial' size='middle' algorithm='HKDF'                                                             ***     52.21 %      ±18.78%  ±25.76%  ±35.17%
crypto/webcrypto-sync-fast-path-kdf.js n=1000 mode='serial' size='minimal' algorithm='HKDF'                                                            ***     46.45 %      ±19.52%  ±27.03%  ±37.45%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='parallel' operation='decapsulateBits' algorithm='ml-kem-1024'                                              -1.60 %      ±10.57%  ±14.48%  ±19.73%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='parallel' operation='decapsulateBits' algorithm='ml-kem-512'                                               -1.75 %      ±16.32%  ±22.36%  ±30.47%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='parallel' operation='decapsulateBits' algorithm='ml-kem-768'                                         *     -7.50 %       ±7.16%   ±9.90%  ±13.71%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='parallel' operation='encapsulateBits' algorithm='ml-kem-1024'                                        *     -9.30 %       ±7.45%  ±10.37%  ±14.49%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='parallel' operation='encapsulateBits' algorithm='ml-kem-512'                                               -2.48 %      ±12.25%  ±16.85%  ±23.10%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='parallel' operation='encapsulateBits' algorithm='ml-kem-768'                                                1.14 %      ±11.74%  ±16.34%  ±22.84%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='serial' operation='decapsulateBits' algorithm='ml-kem-1024'                                        ***    241.37 %      ±14.93%  ±21.39%  ±31.34%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='serial' operation='decapsulateBits' algorithm='ml-kem-512'                                         ***     42.64 %      ±10.27%  ±14.75%  ±21.68%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='serial' operation='decapsulateBits' algorithm='ml-kem-768'                                         ***     86.19 %      ±20.91%  ±29.82%  ±43.35%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='serial' operation='encapsulateBits' algorithm='ml-kem-1024'                                        ***     48.17 %       ±8.16%  ±11.29%  ±15.65%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='serial' operation='encapsulateBits' algorithm='ml-kem-512'                                          **     30.55 %      ±17.08%  ±24.53%  ±36.08%
crypto/webcrypto-sync-fast-path-kem.js n=1000 mode='serial' operation='encapsulateBits' algorithm='ml-kem-768'                                         ***     22.90 %       ±4.80%   ±6.57%   ±8.95%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='aes-cbc-128'                                                                       18.40 %      ±23.85%  ±32.84%  ±45.10%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='aes-ctr-128'                                                                       -9.27 %      ±20.53%  ±28.13%  ±38.34%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='aes-gcm-128'                                                                       -3.19 %      ±22.77%  ±31.21%  ±42.56%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='aes-kw-128'                                                                        -7.80 %      ±21.17%  ±29.03%  ±39.60%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='aes-ocb-128'                                                                       -7.06 %      ±16.03%  ±22.44%  ±31.66%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='chacha20-poly1305'                                                                 -5.81 %      ±13.57%  ±18.60%  ±25.36%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ecdh-p256'                                                                         -3.46 %      ±15.52%  ±21.31%  ±29.16%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ecdh-p384'                                                                         -0.84 %       ±1.93%   ±2.68%   ±3.74%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ecdh-p521'                                                                         -0.17 %       ±0.79%   ±1.08%   ±1.47%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ecdsa-p256'                                                                        11.00 %      ±13.07%  ±18.14%  ±25.22%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ecdsa-p384'                                                                         1.20 %       ±2.09%   ±2.92%   ±4.10%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ecdsa-p521'                                                                        -0.35 %       ±0.62%   ±0.86%   ±1.19%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ed25519'                                                                            4.01 %      ±14.54%  ±20.03%  ±27.55%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ed448'                                                                             -5.18 %      ±10.25%  ±14.07%  ±19.22%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='hmac'                                                                               7.86 %      ±17.48%  ±24.19%  ±33.47%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='kmac128'                                                                          -13.77 %      ±14.09%  ±19.53%  ±27.13%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='kmac256'                                                                           -1.62 %      ±21.98%  ±30.11%  ±41.02%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ml-dsa-44'                                                                         -7.20 %       ±9.89%  ±13.82%  ±19.43%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ml-dsa-65'                                                                          2.70 %       ±4.31%   ±5.90%   ±8.04%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ml-dsa-87'                                                                          1.64 %       ±4.20%   ±5.76%   ±7.86%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ml-kem-1024'                                                                       -3.68 %       ±7.55%  ±10.38%  ±14.23%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ml-kem-512'                                                                        -3.28 %      ±14.98%  ±20.69%  ±28.57%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='ml-kem-768'                                                                        -8.58 %       ±9.52%  ±13.09%  ±17.93%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='x25519'                                                                             2.60 %       ±9.56%  ±13.10%  ±17.85%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='parallel' algorithm='x448'                                                                               2.33 %       ±9.79%  ±13.43%  ±18.33%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='aes-cbc-128'                                                                  **     35.93 %      ±19.96%  ±27.55%  ±38.00%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='aes-ctr-128'                                                                  **     45.37 %      ±26.82%  ±37.26%  ±51.93%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='aes-gcm-128'                                                                 ***     75.38 %      ±21.20%  ±29.67%  ±41.80%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='aes-kw-128'                                                                  ***     66.93 %      ±25.69%  ±35.92%  ±50.54%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='aes-ocb-128'                                                                 ***     57.50 %      ±27.95%  ±39.28%  ±55.75%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='chacha20-poly1305'                                                           ***     44.75 %      ±16.15%  ±22.52%  ±31.56%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ecdh-p256'                                                                   ***     57.72 %      ±22.18%  ±31.29%  ±44.69%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ecdh-p384'                                                                   ***    242.79 %      ±51.79%  ±74.40% ±109.43%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ecdh-p521'                                                                   ***    128.53 %      ±27.93%  ±40.12%  ±59.02%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ecdsa-p256'                                                                  ***     70.60 %      ±30.92%  ±43.09%  ±60.32%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ecdsa-p384'                                                                  ***    140.74 %      ±33.34%  ±47.89%  ±70.45%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ecdsa-p521'                                                                  ***    104.44 %      ±38.94%  ±55.94%  ±82.30%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ed25519'                                                                     ***    126.96 %      ±34.39%  ±49.24%  ±72.02%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ed448'                                                                       ***    182.02 %      ±33.99%  ±48.81%  ±71.77%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='hmac'                                                                         **     44.85 %      ±26.46%  ±36.88%  ±51.67%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='kmac128'                                                                     ***     56.87 %      ±27.02%  ±37.75%  ±53.07%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='kmac256'                                                                     ***     66.14 %      ±28.69%  ±40.27%  ±57.02%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ml-dsa-44'                                                                   ***    217.23 %      ±45.94%  ±65.89%  ±96.64%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ml-dsa-65'                                                                   ***    260.86 %      ±38.62%  ±55.45%  ±81.51%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ml-dsa-87'                                                                   ***    463.09 %       ±8.57%  ±12.29%  ±18.01%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ml-kem-1024'                                                                 ***    171.74 %      ±35.50%  ±50.97%  ±74.93%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ml-kem-512'                                                                  ***     62.34 %      ±25.31%  ±36.15%  ±52.67%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='ml-kem-768'                                                                  ***    181.54 %      ±35.00%  ±49.93%  ±72.64%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='x25519'                                                                      ***    138.77 %      ±33.33%  ±47.83%  ±70.24%
crypto/webcrypto-sync-fast-path-keygen.js n=1000 mode='serial' algorithm='x448'                                                                        ***    163.32 %      ±37.45%  ±53.78%  ±79.05%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='after-threshold' operation='sign' algorithm='HMAC'                                         -4.13 %       ±9.13%  ±12.52%  ±17.07%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='after-threshold' operation='sign' algorithm='KMAC128'                                      -6.86 %      ±13.49%  ±18.52%  ±25.30%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='after-threshold' operation='sign' algorithm='KMAC256'                                      -8.42 %      ±14.84%  ±20.34%  ±27.72%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='after-threshold' operation='verify' algorithm='HMAC'                                        1.68 %       ±9.58%  ±13.16%  ±18.02%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='after-threshold' operation='verify' algorithm='KMAC128'                                     4.78 %      ±17.76%  ±24.39%  ±33.33%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='after-threshold' operation='verify' algorithm='KMAC256'                                    -3.57 %      ±16.61%  ±22.82%  ±31.24%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='at-threshold' operation='sign' algorithm='HMAC'                                             3.86 %      ±11.80%  ±16.17%  ±22.04%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='at-threshold' operation='sign' algorithm='KMAC128'                                         -7.44 %      ±15.47%  ±21.24%  ±29.04%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='at-threshold' operation='sign' algorithm='KMAC256'                                         -9.45 %      ±11.73%  ±16.09%  ±21.96%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='at-threshold' operation='verify' algorithm='HMAC'                                         -11.29 %      ±14.95%  ±20.51%  ±28.00%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='at-threshold' operation='verify' algorithm='KMAC128'                                       -6.70 %      ±14.79%  ±20.42%  ±28.17%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='at-threshold' operation='verify' algorithm='KMAC256'                                        3.49 %      ±14.76%  ±20.22%  ±27.55%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='middle' operation='sign' algorithm='HMAC'                                                  -0.64 %      ±13.89%  ±19.05%  ±25.97%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='middle' operation='sign' algorithm='KMAC128'                                                0.88 %      ±23.02%  ±31.55%  ±43.00%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='middle' operation='sign' algorithm='KMAC256'                                               -1.39 %      ±17.00%  ±23.55%  ±32.66%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='middle' operation='verify' algorithm='HMAC'                                                -9.18 %      ±15.80%  ±21.73%  ±29.77%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='middle' operation='verify' algorithm='KMAC128'                                             17.63 %      ±27.33%  ±38.63%  ±55.34%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='middle' operation='verify' algorithm='KMAC256'                                             -7.77 %      ±16.93%  ±23.38%  ±32.28%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='minimal' operation='sign' algorithm='HMAC'                                                  2.52 %      ±15.78%  ±21.73%  ±29.87%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='minimal' operation='sign' algorithm='KMAC128'                                               6.80 %      ±15.12%  ±21.06%  ±29.47%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='minimal' operation='sign' algorithm='KMAC256'                                              -8.69 %      ±19.49%  ±26.71%  ±36.39%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='minimal' operation='verify' algorithm='HMAC'                                                0.88 %      ±18.23%  ±24.99%  ±34.07%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='minimal' operation='verify' algorithm='KMAC128'                                            25.79 %      ±28.82%  ±40.87%  ±58.85%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='parallel' size='minimal' operation='verify' algorithm='KMAC256'                                             6.34 %      ±28.14%  ±38.55%  ±52.53%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='after-threshold' operation='sign' algorithm='HMAC'                                          -31.92 %      ±41.02%  ±57.60%  ±81.61%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='after-threshold' operation='sign' algorithm='KMAC128'                                       -11.75 %      ±37.20%  ±50.99%  ±69.52%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='after-threshold' operation='sign' algorithm='KMAC256'                                        34.91 %      ±50.41%  ±69.07%  ±94.12%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='after-threshold' operation='verify' algorithm='HMAC'                                          7.35 %      ±49.47%  ±67.97%  ±93.04%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='after-threshold' operation='verify' algorithm='KMAC128'                                      11.54 %      ±49.70%  ±68.13%  ±92.91%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='after-threshold' operation='verify' algorithm='KMAC256'                                      25.66 %      ±53.01%  ±74.20% ±104.61%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='at-threshold' operation='sign' algorithm='HMAC'                                      ***    208.53 %      ±40.06%  ±57.46%  ±84.31%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='at-threshold' operation='sign' algorithm='KMAC128'                                   ***     95.63 %      ±32.55%  ±46.46%  ±67.62%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='at-threshold' operation='sign' algorithm='KMAC256'                                   ***    145.71 %      ±21.33%  ±30.07%  ±42.91%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='at-threshold' operation='verify' algorithm='HMAC'                                    ***    155.19 %      ±44.04%  ±63.20%  ±92.80%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='at-threshold' operation='verify' algorithm='KMAC128'                                 ***    139.22 %      ±35.00%  ±49.52%  ±71.05%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='at-threshold' operation='verify' algorithm='KMAC256'                                 ***    148.99 %      ±40.07%  ±57.04%  ±82.66%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='middle' operation='sign' algorithm='HMAC'                                            ***     88.87 %      ±29.23%  ±41.64%  ±60.41%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='middle' operation='sign' algorithm='KMAC128'                                         ***    111.55 %      ±30.12%  ±41.52%  ±57.14%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='middle' operation='sign' algorithm='KMAC256'                                         ***     74.84 %      ±31.25%  ±43.88%  ±62.21%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='middle' operation='verify' algorithm='HMAC'                                          ***    109.23 %      ±28.81%  ±41.01%  ±59.44%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='middle' operation='verify' algorithm='KMAC128'                                       ***    130.98 %      ±21.88%  ±30.00%  ±40.93%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='middle' operation='verify' algorithm='KMAC256'                                       ***     92.61 %      ±33.29%  ±45.89%  ±63.15%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='minimal' operation='sign' algorithm='HMAC'                                           ***     82.55 %      ±11.58%  ±16.10%  ±22.47%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='minimal' operation='sign' algorithm='KMAC128'                                         **     45.28 %      ±26.91%  ±37.34%  ±51.93%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='minimal' operation='sign' algorithm='KMAC256'                                         **     36.43 %      ±24.31%  ±33.39%  ±45.69%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='minimal' operation='verify' algorithm='HMAC'                                         ***     94.89 %       ±9.44%  ±12.97%  ±17.77%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='minimal' operation='verify' algorithm='KMAC128'                                       **     53.37 %      ±27.85%  ±39.03%  ±55.15%
crypto/webcrypto-sync-fast-path-mac.js n=1000 mode='serial' size='minimal' operation='verify' algorithm='KMAC256'                                       **     42.09 %      ±26.67%  ±36.95%  ±51.25%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='after-threshold' keySize='fixture-2048' operation='rsa-pss-verify'                           9.01 %      ±19.00%  ±26.05%  ±35.54%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='after-threshold' keySize='fixture-2048' operation='rsassa-pkcs1-v1_5-verify'                 1.44 %      ±10.26%  ±14.07%  ±19.20%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='after-threshold' keySize='fixture-4096' operation='rsa-pss-verify'                          -2.59 %      ±16.29%  ±22.55%  ±31.23%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='after-threshold' keySize='fixture-4096' operation='rsassa-pkcs1-v1_5-verify'                 2.25 %      ±14.33%  ±19.68%  ±26.92%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='at-threshold' keySize='fixture-2048' operation='rsa-pss-verify'                       *    -18.31 %      ±15.65%  ±21.55%  ±29.60%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='at-threshold' keySize='fixture-2048' operation='rsassa-pkcs1-v1_5-verify'                    0.02 %      ±20.73%  ±28.42%  ±38.77%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='at-threshold' keySize='fixture-4096' operation='rsa-pss-verify'                              9.83 %      ±12.46%  ±17.19%  ±23.68%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='at-threshold' keySize='fixture-4096' operation='rsassa-pkcs1-v1_5-verify'                    6.08 %      ±13.60%  ±18.65%  ±25.46%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='middle' keySize='fixture-2048' operation='rsa-pss-verify'                                   -6.70 %      ±17.06%  ±23.58%  ±32.58%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='middle' keySize='fixture-2048' operation='rsassa-pkcs1-v1_5-verify'                          1.06 %      ±14.54%  ±19.99%  ±27.37%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='middle' keySize='fixture-4096' operation='rsa-pss-verify'                            **    -19.18 %      ±13.38%  ±18.62%  ±26.04%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='middle' keySize='fixture-4096' operation='rsassa-pkcs1-v1_5-verify'                          1.87 %      ±15.38%  ±21.09%  ±28.77%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='minimal' keySize='fixture-2048' operation='rsa-oaep-decrypt'                                 4.22 %      ±57.90%  ±79.40% ±108.36%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='minimal' keySize='fixture-2048' operation='rsa-oaep-encrypt'                                -1.78 %      ±22.74%  ±31.27%  ±42.86%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='minimal' keySize='fixture-2048' operation='rsa-pss-verify'                                 -19.14 %      ±25.20%  ±34.55%  ±47.12%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='minimal' keySize='fixture-2048' operation='rsassa-pkcs1-v1_5-verify'                        -7.58 %      ±15.84%  ±21.71%  ±29.58%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='minimal' keySize='fixture-4096' operation='rsa-oaep-decrypt'                               -11.03 %      ±53.13%  ±72.79%  ±99.17%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='minimal' keySize='fixture-4096' operation='rsa-oaep-encrypt'                                23.69 %      ±38.74%  ±53.07%  ±72.31%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='minimal' keySize='fixture-4096' operation='rsa-pss-verify'                                  -9.09 %      ±18.67%  ±25.58%  ±34.86%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='parallel' size='minimal' keySize='fixture-4096' operation='rsassa-pkcs1-v1_5-verify'                       -10.44 %      ±12.75%  ±17.91%  ±25.38%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='after-threshold' keySize='fixture-2048' operation='rsa-pss-verify'                            16.18 %      ±30.20%  ±41.86%  ±58.10%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='after-threshold' keySize='fixture-2048' operation='rsassa-pkcs1-v1_5-verify'                  19.97 %      ±61.02%  ±84.61% ±117.51%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='after-threshold' keySize='fixture-4096' operation='rsa-pss-verify'                           -14.03 %      ±50.99%  ±70.00%  ±95.66%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='after-threshold' keySize='fixture-4096' operation='rsassa-pkcs1-v1_5-verify'                   1.72 %      ±52.32%  ±72.55% ±100.76%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='at-threshold' keySize='fixture-2048' operation='rsa-pss-verify'                       ***    257.19 %      ±26.92%  ±37.53%  ±52.56%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='at-threshold' keySize='fixture-2048' operation='rsassa-pkcs1-v1_5-verify'             ***    295.59 %      ±19.23%  ±26.63%  ±36.90%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='at-threshold' keySize='fixture-4096' operation='rsa-pss-verify'                       ***    196.17 %      ±41.74%  ±59.54%  ±86.59%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='at-threshold' keySize='fixture-4096' operation='rsassa-pkcs1-v1_5-verify'             ***    338.23 %      ±38.21%  ±54.07%  ±77.62%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='middle' keySize='fixture-2048' operation='rsa-pss-verify'                             ***     84.75 %      ±28.21%  ±40.09%  ±57.91%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='middle' keySize='fixture-2048' operation='rsassa-pkcs1-v1_5-verify'                   ***    138.09 %      ±37.29%  ±52.79%  ±75.82%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='middle' keySize='fixture-4096' operation='rsa-pss-verify'                             ***    329.50 %      ±21.85%  ±29.95%  ±40.83%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='middle' keySize='fixture-4096' operation='rsassa-pkcs1-v1_5-verify'                   ***    216.95 %      ±42.70%  ±60.70%  ±87.75%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='minimal' keySize='fixture-2048' operation='rsa-oaep-decrypt'                                 -29.50 %      ±43.52%  ±60.20%  ±83.25%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='minimal' keySize='fixture-2048' operation='rsa-oaep-encrypt'                           **     34.57 %      ±19.33%  ±26.55%  ±36.30%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='minimal' keySize='fixture-2048' operation='rsa-pss-verify'                            ***     53.05 %      ±21.47%  ±29.65%  ±40.93%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='minimal' keySize='fixture-2048' operation='rsassa-pkcs1-v1_5-verify'                  ***     82.15 %      ±32.49%  ±45.12%  ±62.81%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='minimal' keySize='fixture-4096' operation='rsa-oaep-decrypt'                                   9.35 %      ±42.22%  ±57.87%  ±78.92%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='minimal' keySize='fixture-4096' operation='rsa-oaep-encrypt'                          ***    187.18 %      ±28.07%  ±38.74%  ±53.39%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='minimal' keySize='fixture-4096' operation='rsa-pss-verify'                            ***    211.12 %      ±51.21%  ±72.80% ±105.28%
crypto/webcrypto-sync-fast-path-rsa.js n=500 mode='serial' size='minimal' keySize='fixture-4096' operation='rsassa-pkcs1-v1_5-verify'                  ***    247.03 %      ±29.56%  ±40.82%  ±56.32%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='after-threshold' operation='sign' algorithm='ecdsa-p256'                            3.76 %       ±9.97%  ±13.65%  ±18.60%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='after-threshold' operation='sign' algorithm='ed25519'                               1.92 %       ±4.86%   ±6.74%   ±9.38%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='after-threshold' operation='sign' algorithm='ed448'                                 1.02 %       ±3.64%   ±5.06%   ±7.05%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='after-threshold' operation='verify' algorithm='ecdsa-p256'                         -1.94 %       ±9.11%  ±12.52%  ±17.13%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='after-threshold' operation='verify' algorithm='ed25519'                             5.12 %       ±5.71%   ±7.94%  ±11.08%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='after-threshold' operation='verify' algorithm='ed448'                               0.87 %       ±3.56%   ±4.89%   ±6.68%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='at-threshold' operation='sign' algorithm='ecdsa-p256'                        *     12.19 %       ±9.56%  ±13.11%  ±17.87%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='at-threshold' operation='sign' algorithm='ed25519'                                 -0.03 %       ±4.54%   ±6.22%   ±8.49%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='at-threshold' operation='sign' algorithm='ed448'                                    0.15 %       ±2.56%   ±3.51%   ±4.79%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='at-threshold' operation='verify' algorithm='ecdsa-p256'                            -3.54 %       ±7.05%   ±9.77%  ±13.54%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='at-threshold' operation='verify' algorithm='ed25519'                               -0.84 %       ±4.09%   ±5.61%   ±7.67%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='at-threshold' operation='verify' algorithm='ed448'                                  0.71 %       ±3.51%   ±4.82%   ±6.62%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='middle' operation='sign' algorithm='ecdsa-p256'                                     3.17 %      ±14.99%  ±20.61%  ±28.22%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='middle' operation='sign' algorithm='ed25519'                                       -0.95 %       ±6.37%   ±8.82%  ±12.23%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='middle' operation='sign' algorithm='ed448'                                         -0.82 %       ±5.32%   ±7.28%   ±9.92%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='middle' operation='verify' algorithm='ecdsa-p256'                                  -2.48 %       ±7.67%  ±10.53%  ±14.40%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='middle' operation='verify' algorithm='ed25519'                                      0.49 %       ±7.25%  ±10.04%  ±13.93%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='middle' operation='verify' algorithm='ed448'                                        0.55 %       ±5.22%   ±7.18%   ±9.85%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='minimal' operation='sign' algorithm='ecdsa-p256'                                   -0.76 %      ±19.26%  ±26.39%  ±35.96%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='minimal' operation='sign' algorithm='ed25519'                                      -4.96 %      ±14.88%  ±20.42%  ±27.90%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='minimal' operation='sign' algorithm='ed448'                                        -7.33 %      ±16.82%  ±23.05%  ±31.44%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='minimal' operation='verify' algorithm='ecdsa-p256'                                 -0.28 %      ±12.79%  ±17.52%  ±23.88%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='minimal' operation='verify' algorithm='ed25519'                                     0.68 %       ±8.36%  ±11.51%  ±15.81%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='parallel' size='minimal' operation='verify' algorithm='ed448'                                      -5.39 %       ±6.89%   ±9.43%  ±12.85%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='after-threshold' operation='sign' algorithm='ecdsa-p256'                              4.90 %      ±62.53%  ±85.81% ±117.21%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='after-threshold' operation='sign' algorithm='ed25519'                                23.89 %      ±81.40% ±111.54% ±151.99%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='after-threshold' operation='sign' algorithm='ed448'                                  24.52 %      ±38.65%  ±53.54%  ±74.24%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='after-threshold' operation='verify' algorithm='ecdsa-p256'                           56.44 %      ±77.22% ±110.78% ±162.59%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='after-threshold' operation='verify' algorithm='ed25519'                               8.32 %      ±31.19%  ±42.99%  ±59.15%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='after-threshold' operation='verify' algorithm='ed448'                                28.74 %      ±80.39% ±110.99% ±153.06%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='at-threshold' operation='sign' algorithm='ecdsa-p256'                        ***    189.29 %      ±38.92%  ±55.87%  ±82.10%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='at-threshold' operation='sign' algorithm='ed25519'                           ***    460.91 %      ±19.09%  ±27.38%  ±40.14%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='at-threshold' operation='sign' algorithm='ed448'                             ***    280.43 %      ±23.76%  ±34.11%  ±50.12%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='at-threshold' operation='verify' algorithm='ecdsa-p256'                      ***    290.94 %      ±51.76%  ±74.27% ±109.01%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='at-threshold' operation='verify' algorithm='ed25519'                         ***    273.55 %      ±54.77%  ±78.68% ±115.74%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='at-threshold' operation='verify' algorithm='ed448'                           ***    304.89 %      ±24.28%  ±34.85%  ±51.19%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='middle' operation='sign' algorithm='ecdsa-p256'                              ***    202.76 %      ±35.36%  ±50.56%  ±73.79%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='middle' operation='sign' algorithm='ed25519'                                 ***    238.69 %      ±63.24%  ±90.82% ±133.54%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='middle' operation='sign' algorithm='ed448'                                   ***    434.42 %      ±13.38%  ±19.01%  ±27.44%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='middle' operation='verify' algorithm='ecdsa-p256'                            ***    282.00 %      ±40.19%  ±57.61%  ±84.44%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='middle' operation='verify' algorithm='ed25519'                               ***    283.47 %      ±42.60%  ±61.18%  ±89.98%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='middle' operation='verify' algorithm='ed448'                                 ***    253.78 %      ±35.17%  ±50.50%  ±74.20%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='minimal' operation='sign' algorithm='ecdsa-p256'                             ***    104.55 %      ±34.38%  ±48.65%  ±69.81%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='minimal' operation='sign' algorithm='ed25519'                                ***    138.15 %      ±29.21%  ±41.96%  ±61.70%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='minimal' operation='sign' algorithm='ed448'                                  ***    191.58 %      ±29.96%  ±42.59%  ±61.59%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='minimal' operation='verify' algorithm='ecdsa-p256'                           ***    242.45 %      ±57.14%  ±81.94% ±120.16%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='minimal' operation='verify' algorithm='ed25519'                              ***    266.59 %      ±30.83%  ±44.26%  ±65.04%
crypto/webcrypto-sync-fast-path-sign-verify.js n=1000 mode='serial' size='minimal' operation='verify' algorithm='ed448'                                ***    234.28 %      ±48.08%  ±69.01% ±101.37%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 396 comparisons, you can thus
expect the following amount of false-positive results:
  19.80 false positives, when considering a   5% risk acceptance (*, **, ***),
  3.96 false positives, when considering a   1% risk acceptance (**, ***),
  0.40 false positives, when considering a 0.1% risk acceptance (***)
```

</details>

---

This adds a WebCrypto-specific synchronous CryptoJob fast path for selected low-cost operations while preserving Promise-based WebCrypto semantics.

The existing WebCrypto implementation always dispatched these jobs to the libuv threadpool. For small inputs and low-cost key operations, the threadpool orchestration cost can dominate the native crypto work. This change adds `kCryptoJobSyncWebCrypto`, which performs the native work on the current thread while still resolving or rejecting the returned Promise using WebCrypto result and error semantics.

The JavaScript WebCrypto layer now chooses between async and sync WebCrypto job modes before constructing the native job. The selection is limited to explicit sync candidates and is guarded by operation-specific thresholds, RSA modulus limits, and a small per-turn sync budget. This lets sequential `await` usage take the fast path while same-turn fanout falls back to async jobs for parallel throughput.

Sync candidates include selected small-input digest, cipher, MAC, HKDF, RSA verify, ECDSA, and EdDSA operations, selected ECDH operations, ML-KEM encapsulation/decapsulation, and WebCrypto symmetric and non-RSA asymmetric key generation. No WebCrypto operation is unconditionally sync; the sync path is always a candidate path and can still fall back to async mode.