### PR TITLE
doc: add examples for fs.StatFs properties

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -8004,6 +8004,14 @@ added:
 
 Free blocks available to unprivileged users.
 
+```mjs
+import { statfs } from 'node:fs/promises';
+
+const stats = await statfs('/');
+const availableSpaceInBytes = stats.bsize * stats.bavail;
+```
+
+
 #### `statfs.bfree`
 
 <!-- YAML
@@ -8015,6 +8023,14 @@ added:
 * Type: {number|bigint}
 
 Free blocks in file system.
+
+```mjs
+import { statfs } from 'node:fs/promises';
+
+const stats = await statfs('/');
+const freeSpaceInBytes = stats.bsize * stats.bfree;
+```
+
 
 #### `statfs.blocks`
 
@@ -8028,6 +8044,14 @@ added:
 
 Total data blocks in file system.
 
+```mjs
+import { statfs } from 'node:fs/promises';
+
+const stats = await statfs('/');
+const totalSpaceInBytes = stats.bsize * stats.blocks;
+```
+
+
 #### `statfs.bsize`
 
 <!-- YAML
@@ -8038,7 +8062,7 @@ added:
 
 * Type: {number|bigint}
 
-Optimal transfer block size.
+Optimal transfer block size in bytes.
 
 #### `statfs.frsize`
 
@@ -8087,6 +8111,8 @@ added:
 * Type: {number|bigint}
 
 Type of file system.
+
+This is an OS-dependent numeric value representing the file system type.
 
 ### Class: `fs.Utf8Stream`
 

--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -945,7 +945,34 @@ $ node other.js
 
 ## Dual CommonJS/ES module packages
 
-See [the package examples repository][] for details.
+Publishing packages with dual CommonJS and ESM sources, while having the benefits of supporting both CJS consumers and ESM-only platforms, can lead to the dual package hazard where Node.js might load both versions of the package, potentially causing issues with module state and identity.
+
+### Avoiding the dual package hazard
+
+When using conditional exports to provide both CommonJS and ESM entry points, consider using `"node"` and `"default"` conditions instead of `"require"` and `"import"` conditions:
+
+```json
+// package.json
+{
+  "name": "foo",
+  "exports": {
+    "node": "./foo.cjs",
+    "default": "./foo.mjs"
+  }
+}
+```
+
+This approach:
+
+* Avoids the dual package hazard in Node.js, because it only ever loads the CommonJS version
+* Avoids the dual package hazard in bundlers, because they only ever load either the Node version (if configured to target Node.js) or the default version (if configured to target other platforms)
+* Provides an ESM-only version for browsers while avoiding the hazard
+
+Using `"require"` and `"import"` conditions can lead to both the CommonJS and ESM versions being loaded in the same application, which may cause unexpected behavior if the package maintains internal state.
+
+For example, the [@babel/runtime][] package has successfully used this `"node"`/`"default"` pattern for years to provide an ESM-only version for browsers while avoiding the dual package hazard.
+
+See [the package examples repository][] for additional examples and patterns.
 
 ## Node.js `package.json` field definitions
 
@@ -1160,6 +1187,7 @@ Package imports permit mapping to external packages.
 
 This field defines [subpath imports][] for the current package.
 
+[@babel/runtime]: https://github.com/babel/babel/tree/main/packages/babel-runtime
 [CommonJS]: modules.md
 [Conditional exports]: #conditional-exports
 [ES module]: esm.md


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes: https://github.com/nodejs/node/issues/50749

This PR adds practical examples to `bavail`, `bfree`, and `blocks` demonstrating how to calculate actual space in bytes by multiplying with `bsize`. It explicitly documents that `bsize` represents bytes, and adds a brief description indicating that `type` is an OS-dependent numeric value identifying the file system.

This addresses all points requested in issue #50749.