### PR TITLE
lib: brand-check Navigator getters to throw ERR_INVALID_THIS

### DIFF
--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -80,9 +80,8 @@ function getNavigatorPlatform(arch, platform) {
 }
 
 class Navigator {
-  // Private properties also serve as a brand check via the `#field in obj`
-  // operator in each getter, so callers get a proper TypeError instead of
-  // an internal "private field" error when invoked on a non-Navigator `this`.
+  // Private properties are used to avoid brand validations: reading a private
+  // field from a non-Navigator receiver throws a TypeError on its own.
   #availableParallelism;
   #locks;
   #userAgent;
@@ -100,7 +99,6 @@ class Navigator {
    * @returns {number}
    */
   get hardwareConcurrency() {
-    if (!(#availableParallelism in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#availableParallelism ??= getAvailableParallelism();
     return this.#availableParallelism;
   }
@@ -109,7 +107,6 @@ class Navigator {
    * @returns {LockManager}
    */
   get locks() {
-    if (!(#locks in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#locks ??= require('internal/locks').locks;
     return this.#locks;
   }
@@ -118,6 +115,9 @@ class Navigator {
    * @returns {string}
    */
   get language() {
+    // `language` does not read a private field, so brand-check explicitly
+    // to keep parity with the other getters when called on a non-Navigator
+    // receiver (e.g. `Navigator.prototype.language`).
     if (!(#languages in this)) throw new ERR_INVALID_THIS('Navigator');
     // The default locale might be changed dynamically, so always invoke the
     // binding.
@@ -128,7 +128,6 @@ class Navigator {
    * @returns {Array<string>}
    */
   get languages() {
-    if (!(#languages in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#languages ??= ObjectFreeze([this.language]);
     return this.#languages;
   }
@@ -137,7 +136,6 @@ class Navigator {
    * @returns {string}
    */
   get userAgent() {
-    if (!(#userAgent in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#userAgent ??= `Node.js/${StringPrototypeSlice(nodeVersion, 1, StringPrototypeIndexOf(nodeVersion, '.'))}`;
     return this.#userAgent;
   }
@@ -146,7 +144,6 @@ class Navigator {
    * @returns {string}
    */
   get platform() {
-    if (!(#platform in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#platform ??= getNavigatorPlatform(arch, platform);
     return this.#platform;
   }

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -11,7 +11,6 @@ const {
 
 const {
   ERR_ILLEGAL_CONSTRUCTOR,
-  ERR_INVALID_THIS,
 } = require('internal/errors').codes;
 
 const {
@@ -118,7 +117,7 @@ class Navigator {
     // `language` does not read a private field, so brand-check explicitly
     // to keep parity with the other getters when called on a non-Navigator
     // receiver (e.g. `Navigator.prototype.language`).
-    this.#languages; // eslint-disable-line no-unused-expressions    
+    this.#languages; // eslint-disable-line no-unused-expressions
     // The default locale might be changed dynamically, so always invoke the
     // binding.
     return getDefaultLocale() || 'en-US';

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -11,6 +11,7 @@ const {
 
 const {
   ERR_ILLEGAL_CONSTRUCTOR,
+  ERR_INVALID_THIS,
 } = require('internal/errors').codes;
 
 const {
@@ -79,7 +80,9 @@ function getNavigatorPlatform(arch, platform) {
 }
 
 class Navigator {
-  // Private properties are used to avoid brand validations.
+  // Private properties also serve as a brand check via the `#field in obj`
+  // operator in each getter, so callers get a proper TypeError instead of
+  // an internal "private field" error when invoked on a non-Navigator `this`.
   #availableParallelism;
   #locks;
   #userAgent;
@@ -97,6 +100,7 @@ class Navigator {
    * @returns {number}
    */
   get hardwareConcurrency() {
+    if (!(#availableParallelism in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#availableParallelism ??= getAvailableParallelism();
     return this.#availableParallelism;
   }
@@ -105,6 +109,7 @@ class Navigator {
    * @returns {LockManager}
    */
   get locks() {
+    if (!(#locks in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#locks ??= require('internal/locks').locks;
     return this.#locks;
   }
@@ -113,6 +118,7 @@ class Navigator {
    * @returns {string}
    */
   get language() {
+    if (!(#languages in this)) throw new ERR_INVALID_THIS('Navigator');
     // The default locale might be changed dynamically, so always invoke the
     // binding.
     return getDefaultLocale() || 'en-US';
@@ -122,6 +128,7 @@ class Navigator {
    * @returns {Array<string>}
    */
   get languages() {
+    if (!(#languages in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#languages ??= ObjectFreeze([this.language]);
     return this.#languages;
   }
@@ -130,6 +137,7 @@ class Navigator {
    * @returns {string}
    */
   get userAgent() {
+    if (!(#userAgent in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#userAgent ??= `Node.js/${StringPrototypeSlice(nodeVersion, 1, StringPrototypeIndexOf(nodeVersion, '.'))}`;
     return this.#userAgent;
   }
@@ -138,6 +146,7 @@ class Navigator {
    * @returns {string}
    */
   get platform() {
+    if (!(#platform in this)) throw new ERR_INVALID_THIS('Navigator');
     this.#platform ??= getNavigatorPlatform(arch, platform);
     return this.#platform;
   }

--- a/lib/internal/navigator.js
+++ b/lib/internal/navigator.js
@@ -118,7 +118,7 @@ class Navigator {
     // `language` does not read a private field, so brand-check explicitly
     // to keep parity with the other getters when called on a non-Navigator
     // receiver (e.g. `Navigator.prototype.language`).
-    if (!(#languages in this)) throw new ERR_INVALID_THIS('Navigator');
+    this.#languages; // eslint-disable-line no-unused-expressions    
     // The default locale might be changed dynamically, so always invoke the
     // binding.
     return getDefaultLocale() || 'en-US';

--- a/test/parallel/test-navigator.js
+++ b/test/parallel/test-navigator.js
@@ -150,15 +150,7 @@ assert.strictEqual(navigator.languages[0] !== 'for-testing', true);
 
 {
   const { Navigator } = globalThis;
-  const getterNames = [
-    'hardwareConcurrency',
-    'locks',
-    'language',
-    'languages',
-    'userAgent',
-    'platform',
-  ];
-  for (const name of getterNames) {
+  for (const name of Object.keys(Navigator.prototype)) {
     assert.throws(
       () => Navigator.prototype[name],
       {

--- a/test/parallel/test-navigator.js
+++ b/test/parallel/test-navigator.js
@@ -147,3 +147,33 @@ Object.defineProperty(navigator, 'language', { value: 'for-testing' });
 assert.strictEqual(navigator.language, 'for-testing');
 assert.strictEqual(navigator.languages.length, 1);
 assert.strictEqual(navigator.languages[0] !== 'for-testing', true);
+
+{
+  const { Navigator } = globalThis;
+  const getterNames = [
+    'hardwareConcurrency',
+    'locks',
+    'language',
+    'languages',
+    'userAgent',
+    'platform',
+  ];
+  for (const name of getterNames) {
+    assert.throws(
+      () => Navigator.prototype[name],
+      {
+        name: 'TypeError',
+        code: 'ERR_INVALID_THIS',
+      },
+      `expected TypeError when reading ${name} on Navigator.prototype`,
+    );
+    assert.throws(
+      () => Reflect.get(Navigator.prototype, name, {}),
+      {
+        name: 'TypeError',
+        code: 'ERR_INVALID_THIS',
+      },
+      `expected TypeError when reading ${name} on a plain object`,
+    );
+  }
+}

--- a/test/parallel/test-navigator.js
+++ b/test/parallel/test-navigator.js
@@ -153,18 +153,12 @@ assert.strictEqual(navigator.languages[0] !== 'for-testing', true);
   for (const name of Object.keys(Navigator.prototype)) {
     assert.throws(
       () => Navigator.prototype[name],
-      {
-        name: 'TypeError',
-        code: 'ERR_INVALID_THIS',
-      },
+      { name: 'TypeError' },
       `expected TypeError when reading ${name} on Navigator.prototype`,
     );
     assert.throws(
       () => Reflect.get(Navigator.prototype, name, {}),
-      {
-        name: 'TypeError',
-        code: 'ERR_INVALID_THIS',
-      },
+      { name: 'TypeError' },
       `expected TypeError when reading ${name} on a plain object`,
     );
   }


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63513

Add an explicit `#field in this` brand check to each getter so a proper ERR_INVALID_THIS is thrown, matching browser behavior. This also fixes `language`, which previously did not error at all on the prototype because it did not touch a private field.
