### PR TITLE
stream: settle pending broadcast reads on return

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -165,6 +165,7 @@ class BroadcastImpl {
 
     function detach() {
       state.detached = true;
+      state.resolve?.({ __proto__: null, done: true, value: undefined });
       state.resolve = null;
       state.reject = null;
       if (self.#deleteConsumer(state)) {

--- a/test/parallel/test-stream-iter-broadcast-basic.js
+++ b/test/parallel/test-stream-iter-broadcast-basic.js
@@ -161,6 +161,18 @@ async function testCancelWithReason() {
   assert.strictEqual(result.message, 'cancelled');
 }
 
+async function testPendingNextSettlesAfterReturn() {
+  const { broadcast: bc } = broadcast();
+  const iter = bc.push()[Symbol.asyncIterator]();
+
+  const pendingNext = iter.next();
+  await iter.return();
+
+  const result = await pendingNext;
+  assert.strictEqual(result.done, true);
+  assert.strictEqual(result.value, undefined);
+}
+
 // =============================================================================
 // Writer fail detaches consumers
 // =============================================================================
@@ -254,6 +266,7 @@ Promise.all([
   testCancelWithoutReason(),
   testCancelWithReason(),
   testCancelWithFalsyReason(),
+  testPendingNextSettlesAfterReturn(),
   testFailDetachesConsumers(),
   testWriterFailIdempotent(),
   testLateJoinerSeesBufferedData(),


### PR DESCRIPTION
This updates broadcast async iterator cleanup so a pending
`next()` settles when the consumer is returned.

When a broadcast consumer has an outstanding `next()` and
`return()` is called before data arrives, the pending read is now
resolved with `{ done: true, value: undefined }` during detach.

Fixes: https://github.com/nodejs/node/issues/63519

---

Assisted-by: openai:gpt-5.5