### PR TITLE
debugger: await initialization after run and restart

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -945,6 +945,11 @@ function createRepl(inspector) {
     );
   });
 
+  async function runAndInit() {
+    await inspector.run();
+    await initAfterStart();
+  }
+
   function initializeContext(context) {
     ArrayPrototypeForEach(inspector.domainNames, (domain) => {
       ObjectDefineProperty(context, domain, {
@@ -962,7 +967,7 @@ function createRepl(inspector) {
       },
 
       get run() {
-        return inspector.run();
+        return runAndInit();
       },
 
       get kill() {
@@ -970,7 +975,7 @@ function createRepl(inspector) {
       },
 
       get restart() {
-        return inspector.run();
+        return runAndInit();
       },
 
       get cont() {
@@ -1195,9 +1200,6 @@ function createRepl(inspector) {
   return async function startRepl() {
     inspector.client.on('close', () => {
       resetOnStart();
-    });
-    inspector.client.on('ready', () => {
-      initAfterStart();
     });
 
     // Init once for the initial connection

--- a/test/parallel/test-debugger-run-restart-init.js
+++ b/test/parallel/test-debugger-run-restart-init.js
@@ -1,0 +1,119 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { EventEmitter } = require('events');
+const { PassThrough } = require('stream');
+const createRepl = require('internal/debugger/inspect_repl');
+
+function createGate() {
+  let resolve;
+  const promise = new Promise((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+function createAgent(domain, calls, gates) {
+  const agent = new EventEmitter();
+  const method = (name) => async () => {
+    calls.push(`${domain}.${name}`);
+    if (domain === 'Runtime' && name === 'runIfWaitingForDebugger') {
+      const gate = gates.shift();
+      if (gate) {
+        await gate.promise;
+      }
+    }
+  };
+
+  agent.enable = method('enable');
+  agent.setSamplingInterval = method('setSamplingInterval');
+  agent.setAsyncCallStackDepth = method('setAsyncCallStackDepth');
+  agent.setBlackboxPatterns = method('setBlackboxPatterns');
+  agent.setPauseOnExceptions = method('setPauseOnExceptions');
+  agent.runIfWaitingForDebugger = method('runIfWaitingForDebugger');
+  return agent;
+}
+
+function evalCommand(repl, command) {
+  return new Promise((resolve, reject) => {
+    repl.eval(
+      command,
+      repl.context,
+      'debugger-repl-test',
+      (error, result) => {
+        if (error) {
+          reject(error);
+        } else {
+          resolve(result);
+        }
+      },
+    );
+  });
+}
+
+async function assertCommandWaitsForInit(repl, command, gate, calls) {
+  let settled = false;
+  const promise = evalCommand(repl, command).then(() => {
+    settled = true;
+  });
+
+  await new Promise(setImmediate);
+  assert.strictEqual(
+    settled,
+    false,
+    `${command} resolved before post-connect initialization completed: ${calls}`,
+  );
+
+  gate.resolve();
+  await promise;
+  assert.strictEqual(settled, true);
+}
+
+(async () => {
+  const calls = [];
+  const runGate = createGate();
+  const restartGate = createGate();
+  const gates = [null, runGate, restartGate];
+  const inspector = {
+    client: new EventEmitter(),
+    domainNames: ['Debugger', 'HeapProfiler', 'Profiler', 'Runtime'],
+    stdin: new PassThrough(),
+    stdout: new PassThrough(),
+    run: common.mustCall(async () => {
+      calls.push('inspector.run');
+    }, 2),
+    suspendReplWhile(fn) {
+      return fn();
+    },
+  };
+
+  for (const domain of inspector.domainNames) {
+    inspector[domain] = createAgent(domain, calls, gates);
+  }
+
+  const repl = await createRepl(inspector)();
+
+  await assertCommandWaitsForInit(repl, 'run', runGate, calls);
+  await assertCommandWaitsForInit(repl, 'restart', restartGate, calls);
+
+  assert.deepStrictEqual(
+    calls.filter((call) => (
+      call === 'inspector.run' ||
+      call === 'Runtime.runIfWaitingForDebugger'
+    )),
+    [
+      'Runtime.runIfWaitingForDebugger',
+      'inspector.run',
+      'Runtime.runIfWaitingForDebugger',
+      'inspector.run',
+      'Runtime.runIfWaitingForDebugger',
+    ],
+  );
+
+  repl.close();
+})().then(common.mustCall());


### PR DESCRIPTION
Fix a debugger CLI synchronization race after `run` and `restart`.

Previously, these commands resolved once the inspector websocket connection
was established and `ok` was printed. The debugger initialization that enables
domains, restores breakpoints, and calls `Runtime.runIfWaitingForDebugger()`
was started from the `ready` event but not awaited.

That allowed the REPL prompt to be displayed before the restarted debuggee had
actually been released from `--inspect-brk` and reported the initial break. In
slow CI runs, this could make `parallel/test-debugger-run-after-quit-restart`
time out while waiting for the initial break message.

This changes `run` and `restart` to await the same post-connect initialization
path before resolving.

Observed in:
* https://github.com/nodejs/node/actions/runs/26499357103/job/78035468302
* https://github.com/nodejs/node/actions/runs/26555566216/job/78236783282
* https://github.com/nodejs/node/actions/runs/26561872119/job/78246617313

<details>
<summary>Error Log</summary>

```console
Path: parallel/test-debugger-run-after-quit-restart
Error: --- stderr ---
/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:92
        const timeoutErr = new Error(`Timeout (${TIMEOUT}) while waiting for ${pattern}`);
                           ^

Error: Timeout (15000) while waiting for /break (?:on start )?in/i
    at /Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:92:28
    at new Promise (<anonymous>)
    at Object.waitFor (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:67:14)
    at Object.waitForInitialBreak (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:116:18)
    at /Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/parallel/test-debugger-run-after-quit-restart.js:46:21
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5) {
  output: '< Debugger listening on ws://127.0.0.1:62843/a2167dba-9191-46bd-8b81-4245173caea4\n' +
    '< For help, see: [https://nodejs.org/learn/getting-started/debugging\n](https://nodejs.org/learn/getting-started/debugging/n)' +
    '< \n' +
    '\n' +
    'debug> connecting to 127.0.0.1:62843 ...\n' +
    '\n' +
    '< Debugger attached.\n' +
    '< \n' +
    '\n' +
    'debug> \n' +
    ' ok\n' +
    'debug> '
}
```

</details>

Refs: https://github.com/nodejs/node/issues/61762

---

Assisted-by: openai:gpt-5.5