### PR TITLE
debugger: defer probe pause handling until startup

### DIFF
--- a/lib/internal/debugger/inspect_probe.js
+++ b/lib/internal/debugger/inspect_probe.js
@@ -624,8 +624,9 @@ class ProbeInspectorSession {
 
   async handlePaused(params) {
     if (this.finished) { return; }
-    // Keep the initial --inspect-brk pause held until breakpoint setup is
-    // complete. `Runtime.runIfWaitingForDebugger` releases startup execution.
+    // Ignore pauses that arrive before breakpoint setup is complete. Once
+    // startup is marked complete, `Runtime.runIfWaitingForDebugger` may surface
+    // the initial --inspect-brk pause, which the normal resume path handles.
     if (!this.started) { return; }
 
     const hitBreakpoints = params.hitBreakpoints;

--- a/lib/internal/debugger/inspect_probe.js
+++ b/lib/internal/debugger/inspect_probe.js
@@ -624,6 +624,9 @@ class ProbeInspectorSession {
 
   async handlePaused(params) {
     if (this.finished) { return; }
+    // Keep the initial --inspect-brk pause held until breakpoint setup is
+    // complete. `Runtime.runIfWaitingForDebugger` releases startup execution.
+    if (!this.started) { return; }
 
     const hitBreakpoints = params.hitBreakpoints;
     if (hitBreakpoints === undefined || hitBreakpoints.length === 0) {
@@ -1025,5 +1028,6 @@ async function runProbeMode(stdout, probeOptions) {
 
 module.exports = {
   parseProbeTokens,
+  ProbeInspectorSession,
   runProbeMode,
 };

--- a/test/parallel/test-debugger-probe-startup-pause.js
+++ b/test/parallel/test-debugger-probe-startup-pause.js
@@ -1,0 +1,32 @@
+// Flags: --expose-internals
+// This tests that probe mode keeps the initial --inspect-brk pause held until
+// startup has finished binding breakpoints.
+'use strict';
+
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { ProbeInspectorSession } = require('internal/debugger/inspect_probe');
+
+const session = new ProbeInspectorSession({
+  probes: [],
+});
+
+const cdpCalls = [];
+session.client = {
+  callMethod: common.mustCall(async (method) => {
+    cdpCalls.push(method);
+  }),
+};
+
+async function testStartupPauseHandling() {
+  await session.handlePaused({});
+  assert.deepStrictEqual(cdpCalls, []);
+
+  session.started = true;
+  await session.handlePaused({});
+  assert.deepStrictEqual(cdpCalls, ['Debugger.resume']);
+}
+
+testStartupPauseHandling().then(common.mustCall());

--- a/test/parallel/test-debugger-probe-startup-pause.js
+++ b/test/parallel/test-debugger-probe-startup-pause.js
@@ -1,6 +1,6 @@
 // Flags: --expose-internals
-// This tests that probe mode keeps the initial --inspect-brk pause held until
-// startup has finished binding breakpoints.
+// This tests that probe mode ignores pauses until startup has finished binding
+// breakpoints.
 'use strict';
 
 const common = require('../common');


### PR DESCRIPTION
Fixes a race in debugger probe mode where the startup `--inspect-brk`
pause could be resumed before probe breakpoints were fully installed.

The generic `Debugger.paused` handler resumes pauses that do not match a
probe breakpoint. During startup, that can include the initial `--inspect-brk` pause.
If it is resumed before `bindBreakpoints()` finishes, a short target script can run 
past the probe location and the probe session times out.

This change ignores pause events until probe startup has completed, so the
main setup flow remains responsible for releasing the target after
breakpoints are bound.

Refs: https://github.com/nodejs/node/actions/runs/26482141780/job/77981519238

<details>
<summary>Error Log</summary>

```console
=== release test-debugger-probe-no-column-indent ===
Path: parallel/test-debugger-probe-no-column-indent
Error: --- stderr ---
[process 40660]: --- stderr ---

[process 40660]: --- stdout ---
{"v":2,"probes":[{"expr":"x","target":{"suffix":"probe-indented.js","line":6}}],"results":[{"event":"timeout","pending":[0],"error":{"code":"probe_timeout","message":"Timed out after 30000ms waiting for probes: probe-indented.js:6"}}]}

[process 40660]: status = 1, signal = null
/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/child_process.js:112
    throw error;
    ^

Error: - process terminated with status 1, expected 0
    at Object.<anonymous> (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/parallel/test-debugger-probe-no-column-indent.js:14:1)
    at Module._compile (node:internal/modules/cjs/loader:1879:14)
    at Object..js (node:internal/modules/cjs/loader:2019:10)
    at Module.load (node:internal/modules/cjs/loader:1602:32)
    at Module._load (node:internal/modules/cjs/loader:1404:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  options: {
    cwd: '/Users/runner/work/node/node/dir%20with $unusual"chars?\'åß∂ƒ©∆¬…`/test/fixtures/debugger'
  },
  command: '/Users/runner/work/node/node/dir%20with $unusual"chars?\'åß∂ƒ©∆¬…`/out/Release/node inspect --json --probe probe-indented.js:6 --expr x probe-indented.js'
}
```

</details>

---

Assisted-by: openai:gpt-5.5