### PR TITLE
stream: switch to internal `sleep` binding

### DIFF
--- a/lib/internal/streams/fast-utf8-stream.js
+++ b/lib/internal/streams/fast-utf8-stream.js
@@ -6,15 +6,14 @@
 
 const {
   ArrayPrototypePush,
-  AtomicsWait,
   Int32Array,
   MathMax,
-  Number,
   SymbolDispose,
 } = primordials;
 
 const {
   constructSharedArrayBuffer,
+  sleep,
 } = require('internal/util');
 
 const {
@@ -49,22 +48,6 @@ const {
 
 const BUSY_WRITE_TIMEOUT = 100;
 const kEmptyBuffer = Buffer.allocUnsafe(0);
-
-const kNil = new Int32Array(constructSharedArrayBuffer(4));
-
-function sleep(ms) {
-  // Also filters out NaN, non-number types, including empty strings, but allows bigints
-  const valid = ms > 0 && ms < Infinity;
-  if (valid === false) {
-    if (typeof ms !== 'number' && typeof ms !== 'bigint') {
-      throw new ERR_INVALID_ARG_TYPE('ms', ['number', 'bigint'], ms);
-    }
-    throw new ERR_INVALID_ARG_VALUE.RangeError('ms', ms,
-                                               'must be a number greater than 0 and less than Infinity');
-  }
-
-  AtomicsWait(kNil, 0, 0, Number(ms));
-}
 
 // 16 KB. Don't write more than docker buffer size.
 // https://github.com/moby/moby/blob/513ec73831269947d38a644c278ce3cac36783b2/daemon/logger/copier.go#L13

--- a/lib/internal/streams/fast-utf8-stream.js
+++ b/lib/internal/streams/fast-utf8-stream.js
@@ -6,13 +6,11 @@
 
 const {
   ArrayPrototypePush,
-  Int32Array,
   MathMax,
   SymbolDispose,
 } = primordials;
 
 const {
-  constructSharedArrayBuffer,
   sleep,
 } = require('internal/util');
 


### PR DESCRIPTION
I don't think there was any reason to maintain two duplicate implementations, my guess is that we simply forgot about the existing util.

https://github.com/nodejs/node/blob/8d0a3b84ff4b1e5bb1b0d54265ebd553bb29930e/lib/internal/util.js#L610-L617

The only limitation seems to be that the util only supports sleeping for 49 days