### PR TITLE
tools: refine `v8.nix` source definition

### DIFF
--- a/tools/nix/v8.nix
+++ b/tools/nix/v8.nix
@@ -57,10 +57,24 @@ let
         ../../tools/icu/icutrim.py
         ../../tools/icu/no-op.cc
       ];
+      potentiallyAlreadyRemovedFiles =
+        # Files that are removed in the release tarball (see Makefile $(TARBALL) target)
+        [ (fileset.difference ../../deps/v8/test ../../deps/v8/test/torque) ]
+        ++ (builtins.filter builtins.pathExists [
+          ../../deps/v8/samples
+          ../../deps/v8/tools/profviz
+          ../../deps/v8/tools/run-tests.py
+          ../../deps/v8/third_party/ittapi
+        ]);
+      trackedFiles =
+        ({
+          # This line is being modified by Makefile $(TARBALL) target, any change to it should be sync
+          fileset = fileset.intersection (fileset.gitTracked root) (fileset.unions files);
+        }).fileset;
     in
     fileset.toSource {
       inherit root;
-      fileset = fileset.intersection (fileset.gitTracked root) (fileset.unions files);
+      fileset = fileset.difference trackedFiles (fileset.unions potentiallyAlreadyRemovedFiles);
     };
   v8Dir = "${src}/deps/v8";
 in


### PR DESCRIPTION
I've noticed while working on https://github.com/nodejs/node/pull/60293 that there was some discrepancy between the build based on the tarball and the git repo