### PR TITLE
debugger: avoid probe timeouts on target throws

### DIFF
--- a/lib/internal/debugger/inspect_probe.js
+++ b/lib/internal/debugger/inspect_probe.js
@@ -944,6 +944,7 @@ class ProbeInspectorSession {
       try {
         await this.callCdp('Runtime.enable');
         await this.callCdp('Debugger.enable');
+        await this.callCdp('Debugger.setPauseOnExceptions', { state: 'none' });
         await this.bindBreakpoints();
         this.started = true;
         this.startTimeout();


### PR DESCRIPTION
Fixes a flaky `test-debugger-probe-script-throws` timeout.

Probe mode now explicitly disables exception pauses after enabling the
debugger. This keeps uncaught target exceptions flowing to process exit,
so probe mode reports `probe_target_exit` instead of leaving the target
paused until the probe timeout.

Refs: https://github.com/nodejs/node/actions/runs/26599014755/job/78377475548

<details>
<summary>Error Log</summary>

```console
Path: parallel/test-debugger-probe-script-throws
Error: --- stderr ---
[process 39453]: --- stderr ---

[process 39453]: --- stdout ---
{"v":2,"probes":[{"expr":"'before-throw'","target":{"suffix":"probe-script-throws.js","line":7}},{"expr":"99","target":{"suffix":"probe-script-throws.js","line":4}}],"results":[{"event":"timeout","pending":[0,1],"error":{"code":"probe_timeout","message":"Timed out after 30000ms waiting for probes: probe-script-throws.js:7, probe-script-throws.js:4"}}]}

[process 39453]: status = 1, signal = null
/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/child_process.js:112
    throw error;
    ^

Error: - process terminated with status 1, expected 0
    at Object.<anonymous> (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/parallel/test-debugger-probe-script-throws.js:31:1)
    at Module._compile (node:internal/modules/cjs/loader:1879:14)
    at Object..js (node:internal/modules/cjs/loader:2019:10)
    at Module.load (node:internal/modules/cjs/loader:1602:32)
    at Module._load (node:internal/modules/cjs/loader:1404:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:255:19)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  options: {
    cwd: '/Users/runner/work/node/node/dir%20with $unusual"chars?\'åß∂ƒ©∆¬…`/test/fixtures/debugger'
  },
  command: '/Users/runner/work/node/node/dir%20with $unusual"chars?\'åß∂ƒ©∆¬…`/out/Release/node inspect --json --probe probe-script-throws.js:7 --expr \'before-throw\' --probe probe-script-throws.js:4 --expr 99 probe-script-throws.js'
}
```

</details>

---

Assisted-by: openai:gpt-5.5