### PR TITLE
sqlite: fix undefined behaviour in `Session::Changeset()`

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -3836,7 +3836,9 @@ void Session::Changeset(const FunctionCallbackInfo<Value>& args) {
   auto freeChangeset = OnScopeLeave([&] { sqlite3_free(pChangeset); });
 
   Local<ArrayBuffer> buffer = ArrayBuffer::New(env->isolate(), nChangeset);
-  std::memcpy(buffer->GetBackingStore()->Data(), pChangeset, nChangeset);
+  if (nChangeset > 0) {
+    std::memcpy(buffer->GetBackingStore()->Data(), pChangeset, nChangeset);
+  }
   Local<Uint8Array> uint8Array = Uint8Array::New(buffer, 0, nChangeset);
 
   args.GetReturnValue().Set(uint8Array);


### PR DESCRIPTION
If `nChangeset == 0`, the pointer `pChangeset` may be nullptr. Passing a nullptr to `memcpy()` is undefined behaviour. This can be triggered by running the test suite under UBSAN.

```
../src/node_sqlite.cc:3342:42: runtime error: null pointer passed as argument 1, which is declared to never be null
/usr/include/string.h:44:28: note: nonnull attribute specified here
    #0 0x64b18916cde5 in void node::sqlite::Session::Changeset<&sqlite3session_changeset>(v8::FunctionCallbackInfo<v8::Value> const&) /work/node/out/../src/node_sqlite.cc:3342:3
    #1 0x7c81ae412f8c in Builtins_CallApiCallbackGeneric embedded.o
    #2 0x7c818e751ff0  (<unknown module>)
```

Note: this was found by a static-dynamic analyser I'm developing.