### PR TITLE
sqlite: fix stack-use-after-scope with function callback

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -2254,6 +2254,8 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
+  Local<Function> conflictFunc;
+  Local<Function> filterFunc;
   if (args.Length() > 1 && !args[1]->IsUndefined()) {
     if (!args[1]->IsObject()) {
       THROW_ERR_INVALID_ARG_TYPE(env->isolate(),
@@ -2276,7 +2278,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
             "The \"options.onConflict\" argument must be a function.");
         return;
       }
-      Local<Function> conflictFunc = conflictValue.As<Function>();
+      conflictFunc = conflictValue.As<Function>();
       context.conflictCallback = [env, conflictFunc](int conflictType) -> int {
         Local<Value> argv[] = {Integer::New(env->isolate(), conflictType)};
         TryCatch try_catch(env->isolate());
@@ -2313,7 +2315,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
         return;
       }
 
-      Local<Function> filterFunc = filterValue.As<Function>();
+      filterFunc = filterValue.As<Function>();
 
       context.filterCallback =
           [env, db, filterFunc](std::string_view item) -> bool {

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -2279,7 +2279,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
         return;
       }
       conflictFunc = conflictValue.As<Function>();
-      context.conflictCallback = [env, conflictFunc](int conflictType) -> int {
+      context.conflictCallback = [env, &conflictFunc](int conflictType) -> int {
         Local<Value> argv[] = {Integer::New(env->isolate(), conflictType)};
         TryCatch try_catch(env->isolate());
         Local<Value> result =
@@ -2318,7 +2318,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
       filterFunc = filterValue.As<Function>();
 
       context.filterCallback =
-          [env, db, filterFunc](std::string_view item) -> bool {
+          [env, db, &filterFunc](std::string_view item) -> bool {
         // If there was an error in the previous call to the filter's
         // callback, we skip calling it again.
         if (db->ignore_next_sqlite_error_) {


### PR DESCRIPTION
The `hasIt` block has `Local<Function>`s, but it's capture in the lambda, yet the lambda is used after the locals go out of scope.

This can be triggered by just running the test suite under ASAN.

ASAN report:
```
==202109==ERROR: AddressSanitizer: stack-use-after-scope on address 0x71bcb8cc6b40 at pc 0x5e562e3d0bfe bp 0x7fff740e23e0 sp 0x7fff740e23d8
READ of size 8 at 0x71bcb8cc6b40 thread T0
    #0 0x5e562e3d0bfd in v8::Function* v8::api_internal::IndirectHandleBase::value<v8::Function, false>() const /work/node/out/../deps/v8/include/v8-handle-base.h:90:62
    #1 0x5e562e3c9ee2 in v8::Local<v8::Function>::operator->() const /work/node/out/../deps/v8/include/v8-local-handle.h:382:59
    #2 0x5e562f5603cd in node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&)::$_1::operator()(std::basic_string_view<char, std::char_traits<char>>) const /work/node/out/../src/node_sqlite.cc:1907:14
    #3 0x5e562f55fd42 in bool std::__invoke_impl<bool, node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&)::$_1&, std::basic_string_view<char, std::char_traits<char>>>(std::__invoke_other, node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&)::$_1&, std::basic_string_view<char, std::char_traits<char>>&&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:61:14
    #4 0x5e562f55fc3c in std::enable_if<is_invocable_r_v<bool, node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&)::$_1&, std::basic_string_view<char, std::char_traits<char>>>, bool>::type std::__invoke_r<bool, node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&)::$_1&, std::basic_string_view<char, std::char_traits<char>>>(node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&)::$_1&, std::basic_string_view<char, std::char_traits<char>>&&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/invoke.h:114:9
    #5 0x5e562f55f8b4 in std::_Function_handler<bool (std::basic_string_view<char, std::char_traits<char>>), node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&)::$_1>::_M_invoke(std::_Any_data const&, std::basic_string_view<char, std::char_traits<char>>&&) /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:290:9
    #6 0x5e562f57745b in std::function<bool (std::basic_string_view<char, std::char_traits<char>>)>::operator()(std::basic_string_view<char, std::char_traits<char>>) const /usr/lib/gcc/x86_64-linux-gnu/13/../../../../include/c++/13/bits/std_function.h:591:9
    #7 0x5e562f53c8bb in node::sqlite::xFilter(void*, char const*) /work/node/out/../src/node_sqlite.cc:1814:10
    #8 0x71bcbb3dbf3a  (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xdaf3a) (BuildId: ac2bec9c45eec6feab0928b3b1373b467aa51339)
    #9 0x71bcbb3dc9f6 in sqlite3changeset_apply (/lib/x86_64-linux-gnu/libsqlite3.so.0+0xdb9f6) (BuildId: ac2bec9c45eec6feab0928b3b1373b467aa51339)
    #10 0x5e562f53c035 in node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&) /work/node/out/../src/node_sqlite.cc:1919:11
    #11 0x71bc99ad2f8c in Builtins_CallApiCallbackGeneric embedded.o

Address 0x71bcb8cc6b40 is located in stack of thread T0 at offset 832 in frame
    #0 0x5e562f53ad3f in node::sqlite::DatabaseSync::ApplyChangeset(v8::FunctionCallbackInfo<v8::Value> const&) /work/node/out/../src/node_sqlite.cc:1817
```

Note: this was found by a static-dynamic analyser I'm developing.