### PR TITLE
crypto: deduplicate X509 subject matching logic

### DIFF
--- a/src/crypto/crypto_x509.cc
+++ b/src/crypto/crypto_x509.cc
@@ -477,81 +477,64 @@ void CheckPublicKey(const FunctionCallbackInfo<Value>& args) {
       cert->view().checkPublicKey(key->Data().GetAsymmetricKey()));
 }
 
-void CheckHost(const FunctionCallbackInfo<Value>& args) {
+template <typename F>
+void CheckX509Subject(const FunctionCallbackInfo<Value>& args, F check) {
   Environment* env = Environment::GetCurrent(args);
   X509Certificate* cert;
   ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
 
-  CHECK(args[0]->IsString());  // name
+  CHECK(args[0]->IsString());  // subject
   CHECK(args[1]->IsUint32());  // flags
 
-  Utf8Value name(env->isolate(), args[0]);
+  Utf8Value subject(env->isolate(), args[0]);
   uint32_t flags = args[1].As<Uint32>()->Value();
-  DataPointer peername;
 
-  switch (cert->view().checkHost(name.ToStringView(), flags, &peername)) {
-    case X509View::CheckMatch::MATCH: {  // Match!
+  DataPointer matched_subject;
+  X509View view = cert->view();
+  auto result = check(view, subject.ToStringView(), flags, &matched_subject);
+  switch (result) {
+    case X509View::CheckMatch::MATCH: {
       Local<Value> ret = args[0];
-      if (peername) {
+      if (matched_subject) {
         ret = OneByteString(env->isolate(),
-                            static_cast<const char*>(peername.get()),
-                            peername.size());
+                            matched_subject.get<const char>(),
+                            matched_subject.size());
       }
       return args.GetReturnValue().Set(ret);
     }
-    case X509View::CheckMatch::NO_MATCH:  // No Match!
-      return;  // No return value is set
-    case X509View::CheckMatch::INVALID_NAME:  // Error!
+    case X509View::CheckMatch::NO_MATCH:
+      break;  // No return value is set.
+    case X509View::CheckMatch::INVALID_NAME:
       return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid name");
-    default:  // Error!
+    default:
       return THROW_ERR_CRYPTO_OPERATION_FAILED(env);
   }
+}
+
+void CheckHost(const FunctionCallbackInfo<Value>& args) {
+  CheckX509Subject(
+      args,
+      [](X509View& cert,
+         std::string_view subject,
+         uint32_t flags,
+         DataPointer* match) { return cert.checkHost(subject, flags, match); });
 }
 
 void CheckEmail(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
-
-  CHECK(args[0]->IsString());  // name
-  CHECK(args[1]->IsUint32());  // flags
-
-  Utf8Value name(env->isolate(), args[0]);
-  uint32_t flags = args[1].As<Uint32>()->Value();
-
-  switch (cert->view().checkEmail(name.ToStringView(), flags)) {
-    case X509View::CheckMatch::MATCH:  // Match!
-      return args.GetReturnValue().Set(args[0]);
-    case X509View::CheckMatch::NO_MATCH:  // No Match!
-      return;  // No return value is set
-    case X509View::CheckMatch::INVALID_NAME:  // Error!
-      return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid name");
-    default:  // Error!
-      return THROW_ERR_CRYPTO_OPERATION_FAILED(env);
-  }
+  CheckX509Subject(
+      args,
+      [](X509View& cert,
+         std::string_view subject,
+         uint32_t flags,
+         DataPointer*) { return cert.checkEmail(subject, flags); });
 }
 
 void CheckIP(const FunctionCallbackInfo<Value>& args) {
-  Environment* env = Environment::GetCurrent(args);
-  X509Certificate* cert;
-  ASSIGN_OR_RETURN_UNWRAP(&cert, args.This());
-
-  CHECK(args[0]->IsString());  // IP
-  CHECK(args[1]->IsUint32());  // flags
-
-  Utf8Value name(env->isolate(), args[0]);
-  uint32_t flags = args[1].As<Uint32>()->Value();
-
-  switch (cert->view().checkIp(name.ToStringView(), flags)) {
-    case X509View::CheckMatch::MATCH:  // Match!
-      return args.GetReturnValue().Set(args[0]);
-    case X509View::CheckMatch::NO_MATCH:  // No Match!
-      return;  // No return value is set
-    case X509View::CheckMatch::INVALID_NAME:  // Error!
-      return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid IP");
-    default:  // Error!
-      return THROW_ERR_CRYPTO_OPERATION_FAILED(env);
-  }
+  CheckX509Subject(args,
+                   [](X509View& cert,
+                      std::string_view subject,
+                      uint32_t flags,
+                      DataPointer*) { return cert.checkIp(subject, flags); });
 }
 
 void GetIssuerCert(const FunctionCallbackInfo<Value>& args) {


### PR DESCRIPTION
`CheckHost()`, `CheckEmail()`, and `CheckIP()` all do very similar things. Extract the common logic into a helper function `CheckX509Subject()` to avoid duplication.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
