### PR TITLE
deps: fix --no-string_slices flag being read-only

### DIFF
--- a/deps/v8/src/flags/flag-definitions.h
+++ b/deps/v8/src/flags/flag-definitions.h
@@ -1085,7 +1085,7 @@ DEFINE_BOOL_READONLY(internalize_on_the_fly, true,
 
 // Flags for data representation optimizations
 DEFINE_BOOL(unbox_double_arrays, true, "automatically unbox arrays of doubles")
-DEFINE_BOOL_READONLY(string_slices, true, "use string slices")
+DEFINE_BOOL(string_slices, true, "use string slices")
 
 // Tiering: Sparkplug / feedback vector allocation.
 DEFINE_INT(invocation_count_for_feedback_allocation, 8,


### PR DESCRIPTION
## Summary

Change `DEFINE_BOOL_READONLY` to `DEFINE_BOOL` for the `string_slices` V8 flag so that `--no-string_slices` can be set at runtime.

The flag was defined as read-only, making it impossible to disable string slices even though the code already contains fallback paths for when `string_slices` is false.

## Motivation

Long-running Node.js applications can experience memory issues caused by SlicedString retaining references to large parent strings. With this fix, users can pass `--no-string_slices` to force V8 to use copied substrings instead, avoiding the retention problem.

## Changes

- `deps/v8/src/flags/flag-definitions.h:1088` — `DEFINE_BOOL_READONLY` → `DEFINE_BOOL`

## Existing fallback paths (already in codebase)

- `deps/v8/src/heap/factory.cc:1143` — `if (!v8_flags.string_slices || ...)` → `NewCopiedSubstring`
- `deps/v8/src/builtins/builtins-string-gen.cc:2096` — `if (v8_flags.string_slices)` → skip SlicedString
- `deps/v8/src/codegen/code-stub-assembler.cc:9328` — `if (!v8_flags.string_slices || ...)` → expand SlicedString

## Impact

- Default value remains `true` — no behavior change unless `--no-string_slices` is explicitly passed
- Allows runtime mitigation of SlicedString-related memory issues

Refs: https://github.com/nicolo-ribaudo/v8/commit/1e2a395