### PR TITLE
doc: fix incorrect test runner mock examples

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1248,7 +1248,7 @@ test('setTime does not execute timers', (context) => {
 const assert = require('node:assert');
 const { test } = require('node:test');
 
-test('runs timers as setTime passes ticks', (context) => {
+test('setTime does not execute timers', (context) => {
   // Optionally choose what to mock
   context.mock.timers.enable({ apis: ['setTimeout', 'Date'] });
   const fn = context.mock.fn();
@@ -1260,7 +1260,10 @@ test('runs timers as setTime passes ticks', (context) => {
   assert.strictEqual(Date.now(), 800);
 
   context.mock.timers.setTime(1200);
-  // Timer is executed as the time is now reached
+  // Timer is still not executed
+  assert.strictEqual(fn.mock.callCount(), 0);
+  // Advance in time to execute the timer
+  context.mock.timers.tick(0);
   assert.strictEqual(fn.mock.callCount(), 1);
   assert.strictEqual(Date.now(), 1200);
 });
@@ -2730,8 +2733,8 @@ test('mocks a builtin module in both module systems', async (t) => {
   // cursorTo() is an export of the original 'node:readline' module.
   assert.strictEqual(esmImpl.cursorTo, undefined);
   assert.strictEqual(cjsImpl.cursorTo, undefined);
-  assert.strictEqual(esmImpl.fn(), 42);
-  assert.strictEqual(cjsImpl.fn(), 42);
+  assert.strictEqual(esmImpl.foo(), 42);
+  assert.strictEqual(cjsImpl.foo(), 42);
 
   mock.restore();
 
@@ -2741,8 +2744,8 @@ test('mocks a builtin module in both module systems', async (t) => {
 
   assert.strictEqual(typeof esmImpl.cursorTo, 'function');
   assert.strictEqual(typeof cjsImpl.cursorTo, 'function');
-  assert.strictEqual(esmImpl.fn, undefined);
-  assert.strictEqual(cjsImpl.fn, undefined);
+  assert.strictEqual(esmImpl.foo, undefined);
+  assert.strictEqual(cjsImpl.foo, undefined);
 });
 ```
 


### PR DESCRIPTION
Two examples in the test runner mocking docs were wrong and would throw if run:

- The CJS `mock.timers.setTime` example asserted `callCount() === 1` right after `setTime(1200)` with no `tick()` call. That contradicts the sentence just above it ("Timers scheduled in the past will **not** run when you call `setTime()`") and the ESM version of the same example, which keeps the count at 0 and calls `tick(0)` to execute the timer. Aligned the CJS version with the ESM one (and its test name).
- The `mock.module` example mocks an export named `foo` but then calls `esmImpl.fn()` / `cjsImpl.fn()`, so it throws on an undefined `fn`. Changed the four `.fn` references to `.foo`.