### PR TITLE
doc: clarify QUIC stream state wording

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1280,8 +1280,8 @@ added: v23.8.0
   * `body` {string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView |
     Blob | FileHandle | AsyncIterable | Iterable | Promise | null}
     The outbound body source. See [`stream.setBody()`][] for details on
-    supported types. When omitted, the stream starts half-closed (writable
-    side open, no body queued).
+    supported types. When omitted, the stream's outgoing side remains
+    writable with no body queued; no FIN is sent immediately.
   * `headers` {Object} Initial request or response headers to send. Only
     used when the session supports headers (e.g. HTTP/3). If `body` is not
     specified and `headers` is provided, the stream is treated as
@@ -1308,7 +1308,8 @@ added: v23.8.0
 * Returns: {Promise} for a {quic.QuicStream}
 
 Open a new bidirectional stream. If the `body` option is not specified,
-the outgoing stream will be half-closed. The `priority` and `incremental`
+the stream's outgoing side remains writable and no FIN is sent
+immediately. The `priority` and `incremental`
 options are only used when the session supports priority (e.g. HTTP/3).
 The `headers`, `onheaders`, `ontrailers`, `oninfo`, and `onwanttrailers`
 options are only used when the session supports headers (e.g. HTTP/3).
@@ -1323,7 +1324,8 @@ added: v23.8.0
   * `body` {string | ArrayBuffer | SharedArrayBuffer | ArrayBufferView |
     Blob | FileHandle | AsyncIterable | Iterable | Promise | null}
     The outbound body source. See [`stream.setBody()`][] for details on
-    supported types. When omitted, the stream is closed immediately.
+    supported types. When omitted, the stream's outgoing side remains
+    writable with no body queued; no FIN is sent immediately.
   * `headers` {Object} Initial request headers to send.
   * `priority` {string} The priority level of the stream. One of `'high'`,
     `'default'`, or `'low'`. **Default:** `'default'`.
@@ -1345,7 +1347,8 @@ added: v23.8.0
 * Returns: {Promise} for a {quic.QuicStream}
 
 Open a new unidirectional stream. If the `body` option is not specified,
-the outgoing stream will be closed. The `priority` and `incremental`
+the stream's outgoing side remains writable and no FIN is sent
+immediately. The `priority` and `incremental`
 options are only used when the session supports priority (e.g. HTTP/3).
 
 ### `session.path`


### PR DESCRIPTION
## Summary
- describe `createBidirectionalStream()` without a body as half-open instead of half-closed
- make the same clarification for `createUnidirectionalStream()`
- note explicitly that omitting `body` does not send a FIN immediately

Fixes #63655

## Validation
- `node tools/lint-md/lint-md.mjs doc/api/quic.md`