### PR TITLE
path: remove StringPrototypeCharCodeAt from more posix methods

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -1378,15 +1378,15 @@ const posix = {
     let lastCommonSep = -1;
     let i = 0;
     for (; i < length; i++) {
-      const fromCode = StringPrototypeCharCodeAt(from, fromStart + i);
-      if (fromCode !== StringPrototypeCharCodeAt(to, toStart + i))
+      const fromChar = from[fromStart + i];
+      if (fromChar !== to[toStart + i])
         break;
-      else if (fromCode === CHAR_FORWARD_SLASH)
+      else if (fromChar === '/')
         lastCommonSep = i;
     }
     if (i === length) {
       if (toLen > length) {
-        if (StringPrototypeCharCodeAt(to, toStart + i) === CHAR_FORWARD_SLASH) {
+        if (to[toStart + i] === '/') {
           // We get here if `from` is the exact base path for `to`.
           // For example: from='/foo/bar'; to='/foo/bar/baz'
           return StringPrototypeSlice(to, toStart + i + 1);
@@ -1397,8 +1397,7 @@ const posix = {
           return StringPrototypeSlice(to, toStart + i);
         }
       } else if (fromLen > length) {
-        if (StringPrototypeCharCodeAt(from, fromStart + i) ===
-            CHAR_FORWARD_SLASH) {
+        if (from[fromStart + i] === '/') {
           // We get here if `to` is the exact base path for `from`.
           // For example: from='/foo/bar/baz'; to='/foo/bar'
           lastCommonSep = i;
@@ -1414,8 +1413,7 @@ const posix = {
     // Generate the relative path based on the path difference between `to`
     // and `from`.
     for (i = fromStart + lastCommonSep + 1; i <= fromEnd; ++i) {
-      if (i === fromEnd ||
-          StringPrototypeCharCodeAt(from, i) === CHAR_FORWARD_SLASH) {
+      if (i === fromEnd || from[i] === '/') {
         out += out.length === 0 ? '..' : '/..';
       }
     }
@@ -1442,11 +1440,11 @@ const posix = {
     validateString(path, 'path');
     if (path.length === 0)
       return '.';
-    const hasRoot = StringPrototypeCharCodeAt(path, 0) === CHAR_FORWARD_SLASH;
+    const hasRoot = path[0] === '/';
     let end = -1;
     let matchedSlash = true;
     for (let i = path.length - 1; i >= 1; --i) {
-      if (StringPrototypeCharCodeAt(path, i) === CHAR_FORWARD_SLASH) {
+      if (path[i] === '/') {
         if (!matchedSlash) {
           end = i;
           break;
@@ -1484,8 +1482,8 @@ const posix = {
       let extIdx = suffix.length - 1;
       let firstNonSlashEnd = -1;
       for (let i = path.length - 1; i >= 0; --i) {
-        const code = StringPrototypeCharCodeAt(path, i);
-        if (code === CHAR_FORWARD_SLASH) {
+        const char = path[i];
+        if (char === '/') {
           // If we reached a path separator that was not part of a set of path
           // separators at the end of the string, stop now
           if (!matchedSlash) {
@@ -1501,7 +1499,7 @@ const posix = {
           }
           if (extIdx >= 0) {
             // Try to match the explicit extension
-            if (code === StringPrototypeCharCodeAt(suffix, extIdx)) {
+            if (char === suffix[extIdx]) {
               if (--extIdx === -1) {
                 // We matched the extension, so mark this as the end of our path
                 // component
@@ -1524,7 +1522,7 @@ const posix = {
       return StringPrototypeSlice(path, start, end);
     }
     for (let i = path.length - 1; i >= 0; --i) {
-      if (StringPrototypeCharCodeAt(path, i) === CHAR_FORWARD_SLASH) {
+      if (path[i] === '/') {
         // If we reached a path separator that was not part of a set of path
         // separators at the end of the string, stop now
         if (!matchedSlash) {


### PR DESCRIPTION
## Summary

Extends the optimization landed in #54546 (`posix.extname`) to the remaining POSIX path methods still using `StringPrototypeCharCodeAt`. #54668 covers `resolve`/`normalize`/`parse`; this PR covers `dirname`, `basename`, and `relative`.

## What changed

Replaced `StringPrototypeCharCodeAt(path, i) === CHAR_FORWARD_SLASH` with `path[i] === '/'` in three POSIX methods. Diff: +12 / −14 lines in `lib/path.js`.

## Benchmark

Apple M1, 30 runs via `benchmark/compare.js`. Showing significant cases:

### dirname-posix
| path | delta | sig |
|---|---:|---|
| `/foo` | +12.45% | *** |
| `/foo/bar/baz/asdf/quux` | +8.82% | *** |
| `/foo/bar` | +8.82% | *** |
| `foo` | +6.34% | * |
| `foo/bar` | +2.26% | * |

### basename-posix
| pathext | delta | sig |
|---|---:|---|
| `/foo/bar/baz/asdf/quux.html\|.html` | +8.38% | *** |
| `/foo/.bar.baz\|.baz` | +8.25% | *** |
| `/foo/.bar.baz` | +6.90% | *** |
| `foo/bar.` | +5.94% | *** |
| `foo` | +5.78% | * |

### relative-posix
| paths | delta | sig |
|---|---:|---|
| `/var\|/bin` | +3.28% | ** |

### Methodology validation

Control benchmark on `extname-posix` (unchanged in this PR) shows ±2% deltas without statistical significance, confirming methodology. No regressions on Win32 paths (slow path untouched).

## Test plan

- [x] `parallel/test-path*` — all 17 pass
- [x] `parallel/test-url-*` — all 15 pass
- [x] `parallel/test-fs-readfile/stat/realpath` — pass
- [x] `parallel/test-module-*` — all 32 pass
- [x] Fuzz: 425 input cases identical to baseline
- [x] `make lint-js` — clean

Refs: #54546, #54668