### PR TITLE
debugger: add more logs to probe mode

### DIFF
--- a/lib/internal/debugger/inspect_probe.js
+++ b/lib/internal/debugger/inspect_probe.js
@@ -505,6 +505,7 @@ class ProbeInspectorSession {
 
   onChildOutput(text, which) {
     if (which !== 'stderr') { return; }
+    debug('child stderr: %j', text);
 
     this.childStderr += text;
 
@@ -512,6 +513,7 @@ class ProbeInspectorSession {
     // Detect the disconnect sentinel.
     if (this.connected &&
         StringPrototypeIncludes(combined, kProbeDisconnectSentinel)) {
+      debug('disconnect sentinel detected, resetting client');
       this.disconnectRequested = true;
       this.client.reset();
     }
@@ -587,6 +589,7 @@ class ProbeInspectorSession {
   }
 
   onPaused(params) {
+    debug('paused: finished=%d, reason=%s hitBreakpoints=%j', this.finished, params.reason, params.hitBreakpoints);
     this.handlePaused(params).catch((error) => {
       if (error === kInspectorFailedSentinel) { return; }
       this.recordInspectorFailure({
@@ -837,6 +840,9 @@ class ProbeInspectorSession {
   }
 
   onScriptParsed(params) {
+    if (params.url && !StringPrototypeStartsWith(params.url, 'node:')) {
+      debug('scriptParsed: scriptId=%s url=%s, length=%d', params.scriptId, params.url, params.length);
+    }
     // This map grows by the number of scripts parsed, which is limited, and is just a
     // small string -> string map. The lifetime is bounded by probe timeout etc. so cleanup is overkill.
     this.scriptIdToUrl.set(params.scriptId, params.url);
@@ -879,6 +885,8 @@ class ProbeInspectorSession {
       }
 
       const result = await this.callCdp('Debugger.setBreakpointByUrl', params);
+      debug('breakpoint set: id=%s urlRegex=%s locations=%j',
+            result.breakpointId, params.urlRegex, result.locations);
       this.breakpointDefinitions.set(result.breakpointId, { probeIndices });
     }
   }

--- a/test/parallel/test-debugger-probe-bound-never-hit.js
+++ b/test/parallel/test-debugger-probe-bound-never-hit.js
@@ -16,7 +16,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'probe-bound-never-hit.js:4',
   '--expr', '1',
   'probe-bound-never-hit.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-child-inspect-port-zero.js
+++ b/test/parallel/test-debugger-probe-child-inspect-port-zero.js
@@ -19,7 +19,7 @@ spawnSyncAndAssert(process.execPath, [
   '--',
   '--inspect-port=0',
   'probe.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-explicit-column.js
+++ b/test/parallel/test-debugger-probe-explicit-column.js
@@ -24,7 +24,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'probe-multi-statement.js:5:29',
   '--expr', 'acc.length',
   'probe-multi-statement.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-expression-throws.js
+++ b/test/parallel/test-debugger-probe-expression-throws.js
@@ -23,7 +23,7 @@ spawnSyncAndExit(process.execPath, [
   '--probe', `${fixture}:16`, '--expr', probes[0].expr,
   '--probe', `${fixture}:17`, '--expr', probes[1].expr,
   fixture,
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   status: 0,
   signal: null,
   stdout(output) {

--- a/test/parallel/test-debugger-probe-failure-hang-during-evaluate.js
+++ b/test/parallel/test-debugger-probe-failure-hang-during-evaluate.js
@@ -24,7 +24,7 @@ spawnSyncAndExit(process.execPath, [
   '--probe', `${fixture}:10`, '--expr', probes[0].expr,
   '--probe', `${fixture}:11`, '--expr', probes[1].expr,
   fixture,
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   status: 1,
   signal: null,
   stdout(output) {

--- a/test/parallel/test-debugger-probe-failure-process-exit.js
+++ b/test/parallel/test-debugger-probe-failure-process-exit.js
@@ -18,7 +18,7 @@ spawnSyncAndExit(process.execPath, [
   'inspect', '--json',
   '--probe', `${fixture}:8`, '--expr', probes[0].expr,
   fixture,
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   status: 1,
   signal: null,
   stdout(output) {

--- a/test/parallel/test-debugger-probe-global-option-order.js
+++ b/test/parallel/test-debugger-probe-global-option-order.js
@@ -17,7 +17,7 @@ spawnSyncAndAssert(process.execPath, [
   '--expr', 'finalValue',
   '--json',
   'probe.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-json-preview.js
+++ b/test/parallel/test-debugger-probe-json-preview.js
@@ -24,7 +24,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', probeArg,
   '--expr', 'errorValue',
   'probe-types.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-json-special-values.js
+++ b/test/parallel/test-debugger-probe-json-special-values.js
@@ -39,7 +39,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', probeArg,
   '--expr', 'errorValue',
   'probe-types.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-json.js
+++ b/test/parallel/test-debugger-probe-json.js
@@ -23,7 +23,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'probe.js:12',
   '--expr', 'finalValue',
   'probe.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-late-resolution.js
+++ b/test/parallel/test-debugger-probe-late-resolution.js
@@ -21,7 +21,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'probe-late-target.cjs:5',
   '--expr', 'value',
   'probe-late-entry.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-launch.js
+++ b/test/parallel/test-debugger-probe-launch.js
@@ -17,7 +17,7 @@ spawnSyncAndExit(process.execPath, [
   '--',
   '--not-a-real-node-flag',
   'probe.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   signal: null,
   status: 1,
   stderr(output) {

--- a/test/parallel/test-debugger-probe-miss.js
+++ b/test/parallel/test-debugger-probe-miss.js
@@ -15,7 +15,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'probe-miss.js:99',
   '--expr', '42',
   'probe-miss.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-missing-expr.js
+++ b/test/parallel/test-debugger-probe-missing-expr.js
@@ -13,7 +13,7 @@ spawnSyncAndExit(process.execPath, [
   'inspect',
   '--probe', 'probe.js:12',
   'probe.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   signal: null,
   status: 9,
   stderr: /Each --probe must be followed immediately by --expr/,

--- a/test/parallel/test-debugger-probe-multi-location.js
+++ b/test/parallel/test-debugger-probe-multi-location.js
@@ -19,7 +19,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'utils.js:5',
   '--expr', 'b',
   'probe-multi-entry.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-narrow-suffix.js
+++ b/test/parallel/test-debugger-probe-narrow-suffix.js
@@ -17,7 +17,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'probe-multi-a/utils.js:5',
   '--expr', 'b',
   'probe-multi-entry.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-no-column-indent.js
+++ b/test/parallel/test-debugger-probe-no-column-indent.js
@@ -17,7 +17,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'probe-indented.js:6',  // No `:col`
   '--expr', 'x',
   'probe-indented.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeJson(output, {
       v: 2,

--- a/test/parallel/test-debugger-probe-requires-separator.js
+++ b/test/parallel/test-debugger-probe-requires-separator.js
@@ -15,7 +15,7 @@ spawnSyncAndExit(process.execPath, [
   '--expr', 'finalValue',
   '--inspect-port=0',
   'probe.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   signal: null,
   status: 9,
   stderr: /Use -- before child Node\.js flags in probe mode/,

--- a/test/parallel/test-debugger-probe-script-throws.js
+++ b/test/parallel/test-debugger-probe-script-throws.js
@@ -33,7 +33,7 @@ spawnSyncAndExit(process.execPath, [
   '--probe', `${fixture}:7`, '--expr', probes[0].expr,
   '--probe', `${fixture}:4`, '--expr', probes[1].expr,
   fixture,
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   // probe_target_exit: probing process exits 0 (hits trustworthy).
   status: 0,
   signal: null,

--- a/test/parallel/test-debugger-probe-target-syntax-error.js
+++ b/test/parallel/test-debugger-probe-target-syntax-error.js
@@ -27,7 +27,7 @@ spawnSyncAndExit(process.execPath, [
   'inspect', '--json',
   '--probe', `${fixture}:3`, '--expr', probes[0].expr,
   fixture,
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   // probe_target_exit: probing process exits 0.
   status: 0,
   signal: null,

--- a/test/parallel/test-debugger-probe-text-special-values.js
+++ b/test/parallel/test-debugger-probe-text-special-values.js
@@ -36,7 +36,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', probeArg,
   '--expr', 'errorValue',
   'probe-types.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeText(output, [
       `Hit 1 at ${hitText}`,

--- a/test/parallel/test-debugger-probe-text.js
+++ b/test/parallel/test-debugger-probe-text.js
@@ -15,7 +15,7 @@ spawnSyncAndAssert(process.execPath, [
   '--probe', 'probe.js:12',
   '--expr', 'finalValue',
   'probe.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   stdout(output) {
     assertProbeText(output,
                     `Hit 1 at ${probeUrl}:12:1\n` +

--- a/test/parallel/test-debugger-probe-timeout.js
+++ b/test/parallel/test-debugger-probe-timeout.js
@@ -17,7 +17,7 @@ spawnSyncAndExit(process.execPath, [
   '--probe', 'probe-timeout.js:99',
   '--expr', '1',
   'probe-timeout.js',
-], { cwd }, {
+], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   signal: null,
   status: 1,
   stdout(output) {


### PR DESCRIPTION
Add more log points in the probe mode and enable the debuglog int the probe mode tests, so we can have more information if they flake.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
