### PR TITLE
test_runner: avoid recompiling coverage globs for every file

### DIFF
--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -947,5 +947,6 @@ function matchGlobPattern(path, pattern, windows = isWindows) {
 module.exports = {
   __proto__: null,
   Glob,
+  createMatcher,
   matchGlobPattern,
 };

--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -37,7 +37,7 @@ const {
     ERR_SOURCE_MAP_MISSING_SOURCE,
   },
 } = require('internal/errors');
-const { matchGlobPattern } = require('internal/fs/glob');
+const { createMatcher } = require('internal/fs/glob');
 const { constants: { kMockSearchParam } } = require('internal/test_runner/mock/loader');
 
 const kCoverageFileRegex = /^coverage-(\d+)-(\d{13})-(\d+)\.json$/;
@@ -86,6 +86,8 @@ class TestCoverage {
   #sourceLines = new SafeMap();
   #typeScriptLines = new SafeSet();
   #skipCache = new SafeMap();
+  #excludeMatchers = null;
+  #includeMatchers = null;
 
   getLines(fileUrl, source) {
     // Split the file source into lines. Make sure the lines maintain their
@@ -550,28 +552,27 @@ class TestCoverage {
 
     const absolutePath = fileURLToPath(url);
     const relativePath = relative(this.options.cwd, absolutePath);
-    const {
-      coverageExcludeGlobs: excludeGlobs,
-      coverageIncludeGlobs: includeGlobs,
-    } = this.options;
+    // The exclude/include globs are fixed for the lifetime of this
+    // TestCoverage instance, so compile each glob to a matcher once and reuse
+    // it for every file. Building a fresh Minimatch per call (the previous
+    // behavior) dominated the coverage report time, scaling with
+    // files * globs.
+    this.#excludeMatchers ??= ArrayPrototypeMap(
+      this.options.coverageExcludeGlobs ?? [], (pattern) => createMatcher(pattern));
+    this.#includeMatchers ??= ArrayPrototypeMap(
+      this.options.coverageIncludeGlobs ?? [], (pattern) => createMatcher(pattern));
 
     // This check filters out files that match the exclude globs.
-    if (excludeGlobs?.length > 0) {
-      for (let i = 0; i < excludeGlobs.length; ++i) {
-        if (
-          matchGlobPattern(relativePath, excludeGlobs[i]) ||
-          matchGlobPattern(absolutePath, excludeGlobs[i])
-        ) return true;
-      }
+    for (let i = 0; i < this.#excludeMatchers.length; ++i) {
+      const matcher = this.#excludeMatchers[i];
+      if (matcher.match(relativePath) || matcher.match(absolutePath)) return true;
     }
 
     // This check filters out files that do not match the include globs.
-    if (includeGlobs?.length > 0) {
-      for (let i = 0; i < includeGlobs.length; ++i) {
-        if (
-          matchGlobPattern(relativePath, includeGlobs[i]) ||
-          matchGlobPattern(absolutePath, includeGlobs[i])
-        ) return false;
+    if (this.#includeMatchers.length > 0) {
+      for (let i = 0; i < this.#includeMatchers.length; ++i) {
+        const matcher = this.#includeMatchers[i];
+        if (matcher.match(relativePath) || matcher.match(absolutePath)) return false;
       }
       return true;
     }

--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -85,6 +85,7 @@ class TestCoverage {
 
   #sourceLines = new SafeMap();
   #typeScriptLines = new SafeSet();
+  #skipCache = new SafeMap();
 
   getLines(fileUrl, source) {
     // Split the file source into lines. Make sure the lines maintain their
@@ -534,6 +535,14 @@ class TestCoverage {
   }
 
   shouldSkipFileCoverage(url) {
+    const cached = this.#skipCache.get(url);
+    if (cached !== undefined) return cached;
+    const result = this.#computeShouldSkipFileCoverage(url);
+    this.#skipCache.set(url, result);
+    return result;
+  }
+
+  #computeShouldSkipFileCoverage(url) {
     // This check filters out core modules, which start with 'node:' in
     // coverage reports, as well as any invalid coverages which have been
     // observed on Windows.


### PR DESCRIPTION
This speeds up the `--experimental-test-coverage` **report** phase by removing redundant glob work in `shouldSkipFileCoverage()`. Refs: https://github.com/nodejs/node/issues/55103 (the report-generation half of that issue).

### Background

When building the coverage report, `shouldSkipFileCoverage(url)` runs once per covered file to decide whether the file belongs in the report (e.g. test files are excluded by default). For each exclude/include glob it calls `matchGlobPattern(path, pattern)`, and `matchGlobPattern()` constructs a **fresh `Minimatch`** — a full glob parse + regexp compile — on **every call** (`lib/internal/fs/glob.js`).

The exclude/include globs don't change during a run, so the same patterns are recompiled once per file. cpu-profiling a coverage run shows this glob compilation (`shouldSkipFileCoverage` → `matchGlobPattern` → minimatch `make`/`parse`/regexp compile) as the dominant cost of the report path.

### Changes

Two commits:

**1. `test_runner: avoid recompiling coverage globs for every file`** — the main change.
The globs are fixed for the lifetime of a `TestCoverage` instance, so compile each to a matcher **once** and reuse it for every file instead of recompiling per call.
- `internal/fs/glob`: export the existing `createMatcher()` helper (already used internally by `Glob` to precompile patterns).
- `test_runner/coverage`: build `#excludeMatchers` / `#includeMatchers` once, then match with `matcher.match(path)`.

No behavior change — same patterns, same options, same match results.

**2. `test_runner: cache shouldSkipFileCoverage result per URL`** — complementary.
Memoizes the per-URL skip *decision*. Under `isolation: 'process'` the same script URL is reported by every worker, so this dedups the computes, while commit 1 makes each compute cheap. The result depends only on the URL plus the instance's fixed options (cwd, exclude/include globs), so it is safe to cache for the instance lifetime.

### Measurements

Synthetic project: 200 test files importing 80 shared `src` modules, `--experimental-test-coverage`, default exclude glob, `--test-isolation=none`, cpu-prof of the report-generating process. Median of 3 runs; before/after measured on the same build (the glob commit reverted via `git stash` + rebuild):

| metric | before | after |
| --- | --- | --- |
| `shouldSkipFileCoverage` (inclusive, incl. minimatch) | ~117 ms | ~11 ms |
| minimatch self-time (glob compile) | ~111 ms | ~11 ms |

The saving is independent of test weight and scales with `files × globs`, so it grows on large suites (which are the ones that notice the report lag) and is negligible on small ones.

### Correctness

Existing coverage tests pass, including `test/parallel/test-runner-coverage-default-exclusion` (which exercises the default exclude behavior) and the rest of `test-runner-coverage*` / `test-runner-run-coverage`.
