### PR TITLE
src: fix external reference registration for new CFunction lifetime

### DIFF
--- a/src/node_external_reference.h
+++ b/src/node_external_reference.h
@@ -42,6 +42,8 @@ class ExternalReferenceRegistry {
   // Registers both the underlying function pointer
   // and the corresponding CFunctionInfo.
   void Register(const v8::CFunction& c_func) {
+    RegisterT(&c_func);
+    // TODO(joyeecheung): remove below when V8 14.8 lands.
     RegisterT(c_func.GetAddress());
     RegisterT(c_func.GetTypeInfo());
   }

--- a/src/node_wasi.cc
+++ b/src/node_wasi.cc
@@ -234,7 +234,7 @@ void WASI::New(const FunctionCallbackInfo<Value>& args) {
 template <typename FT, FT F, typename R, typename... Args>
 void WASI::WasiFunction<FT, F, R, Args...>::SetFunction(
     Environment* env, const char* name, Local<FunctionTemplate> tmpl) {
-  auto c_function = CFunction::Make(FastCallback);
+  static auto c_function = CFunction::Make(FastCallback);
   Local<FunctionTemplate> t =
       FunctionTemplate::New(env->isolate(),
                             SlowCallback,


### PR DESCRIPTION
This fix will be needed by v8 14.8 upgrade, which makes the CFunction the canonical external reference to mitigate a security issue in browsers, and to keep serialization working, requires CFunction to outlive the FunctionTemplateInfo (in Node.js the simplest way to make it so is to use static storage, we have been doing this for most CFunction except WASI, which is fixed in this PR).

This fix has been floated in v8/node (https://github.com/v8/node/pull/254), the 14.8 upgrade PR (https://github.com/nodejs/node/pull/62572) and the canary-base branch of this repository. Electron also now floats a similar fix as they link Node.js with a newer version of V8. (https://github.com/electron/electron/pull/51703). Since it can be modified in a form that works both with 14.6 on the main branch and 14.8 (with a TODO to remove the obsolete parts after 14.8 lands), opening a PR against the main branch with the modified version to reduce the amount of floats everywhere.

Refs: https://chromium-review.googlesource.com/c/v8/v8/+/7828135

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
