### PR TITLE
quic: add missing documentation for stream.stopSending() and stream.r…

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -2266,6 +2266,72 @@ The following body source types are supported:
 Throws `ERR_INVALID_STATE` if the outbound is already configured or if
 the writer has been accessed.
 
+### `stream.resetStream([code])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `code` {number|bigint} The application error code to include in the
+  `RESET_STREAM` frame sent to the peer. Numbers are coerced to `BigInt`.
+  **Default:** `0n`.
+
+Sends a `RESET_STREAM` frame to the peer, signalling that this end will
+not send any more data on this stream. This half-closes the stream in the
+WRITE direction only — the readable side (if any) is unaffected and can
+continue receiving data from the peer.
+
+If the stream has already been destroyed, this is a no-op.
+
+This is useful for WebTransport and other application protocols that need
+independent half-closing per direction without tearing down the entire
+stream.
+
+```mjs
+import { connect } from 'node:quic';
+
+const session = await connect('localhost:4567', { alpn: 'myproto' });
+const stream = await session.createBidirectionalStream();
+
+// Abort the writable side with application error code 42.
+stream.resetStream(42n);
+```
+
+See [Aborting a stream][] for an overview of all stream-abort APIs.
+
+### `stream.stopSending([code])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `code` {number|bigint} The application error code to include in the
+  `STOP_SENDING` frame sent to the peer. Numbers are coerced to `BigInt`.
+  **Default:** `0n`.
+
+Sends a `STOP_SENDING` frame to the peer, requesting that the peer stop
+sending data on this stream. This half-closes the stream in the READ
+direction only — the writable side (if any) is unaffected and can
+continue sending data to the peer.
+
+If the stream has already been destroyed, this is a no-op.
+
+This is useful for WebTransport and other application protocols that need
+independent half-closing per direction without tearing down the entire
+stream.
+
+```mjs
+import { connect } from 'node:quic';
+
+const session = await connect('localhost:4567', { alpn: 'myproto' });
+const stream = await session.createBidirectionalStream();
+
+// Tell the peer to stop sending with application error code 7.
+stream.stopSending(7n);
+```
+
+See [Aborting a stream][] for an overview of all stream-abort APIs.
+
 ### `stream.session`
 
 <!-- YAML
@@ -4447,6 +4513,8 @@ throughput issues caused by flow control.
 [`sessionOptions.sni`]: #sessionoptionssni-server-only
 [`sessionOptions.token`]: #sessionoptionstoken-client-only
 [`stream.destroy()`]: #streamdestroyerror-options
+[`stream.resetStream()`]: #streamresetstreamcode
+[`stream.stopSending()`]: #streamstopsendingcode
 [`stream.headers`]: #streamheaders
 [`stream.onerror`]: #streamonerror
 [`stream.onwanttrailers`]: #streamonwanttrailers

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -2284,7 +2284,7 @@ the writer has been accessed.
 ### `stream.resetStream([code])`
 
 <!-- YAML
-added: REPLACEME
+added: v26.2.0
 -->
 
 * `code` {number|bigint} The application error code to include in the
@@ -2312,12 +2312,26 @@ const stream = await session.createBidirectionalStream();
 stream.resetStream(42n);
 ```
 
+```cjs
+const { connect } = require('node:quic');
+
+async function main() {
+  const session = await connect('localhost:4567', { alpn: 'myproto' });
+  const stream = await session.createBidirectionalStream();
+
+  // Abort the writable side with application error code 42.
+  stream.resetStream(42n);
+}
+
+main();
+```
+
 See [Aborting a stream][] for an overview of all stream-abort APIs.
 
 ### `stream.stopSending([code])`
 
 <!-- YAML
-added: REPLACEME
+added: v26.2.0
 -->
 
 * `code` {number|bigint} The application error code to include in the
@@ -2343,6 +2357,20 @@ const stream = await session.createBidirectionalStream();
 
 // Tell the peer to stop sending with application error code 7.
 stream.stopSending(7n);
+```
+
+```cjs
+const { connect } = require('node:quic');
+
+async function main() {
+  const session = await connect('localhost:4567', { alpn: 'myproto' });
+  const stream = await session.createBidirectionalStream();
+
+  // Tell the peer to stop sending with application error code 7.
+  stream.stopSending(7n);
+}
+
+main();
 ```
 
 See [Aborting a stream][] for an overview of all stream-abort APIs.

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -2269,7 +2269,7 @@ the writer has been accessed.
 ### `stream.resetStream([code])`
 
 <!-- YAML
-added: REPLACEME
+added: v26.2.0
 -->
 
 * `code` {number|bigint} The application error code to include in the
@@ -2297,12 +2297,26 @@ const stream = await session.createBidirectionalStream();
 stream.resetStream(42n);
 ```
 
+```cjs
+const { connect } = require('node:quic');
+
+async function main() {
+  const session = await connect('localhost:4567', { alpn: 'myproto' });
+  const stream = await session.createBidirectionalStream();
+
+  // Abort the writable side with application error code 42.
+  stream.resetStream(42n);
+}
+
+main();
+```
+
 See [Aborting a stream][] for an overview of all stream-abort APIs.
 
 ### `stream.stopSending([code])`
 
 <!-- YAML
-added: REPLACEME
+added: v26.2.0
 -->
 
 * `code` {number|bigint} The application error code to include in the
@@ -2328,6 +2342,20 @@ const stream = await session.createBidirectionalStream();
 
 // Tell the peer to stop sending with application error code 7.
 stream.stopSending(7n);
+```
+
+```cjs
+const { connect } = require('node:quic');
+
+async function main() {
+  const session = await connect('localhost:4567', { alpn: 'myproto' });
+  const stream = await session.createBidirectionalStream();
+
+  // Tell the peer to stop sending with application error code 7.
+  stream.stopSending(7n);
+}
+
+main();
 ```
 
 See [Aborting a stream][] for an overview of all stream-abort APIs.

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -2281,6 +2281,72 @@ The following body source types are supported:
 Throws `ERR_INVALID_STATE` if the outbound is already configured or if
 the writer has been accessed.
 
+### `stream.resetStream([code])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `code` {number|bigint} The application error code to include in the
+  `RESET_STREAM` frame sent to the peer. Numbers are coerced to `BigInt`.
+  **Default:** `0n`.
+
+Sends a `RESET_STREAM` frame to the peer, signalling that this end will
+not send any more data on this stream. This half-closes the stream in the
+WRITE direction only — the readable side (if any) is unaffected and can
+continue receiving data from the peer.
+
+If the stream has already been destroyed, this is a no-op.
+
+This is useful for WebTransport and other application protocols that need
+independent half-closing per direction without tearing down the entire
+stream.
+
+```mjs
+import { connect } from 'node:quic';
+
+const session = await connect('localhost:4567', { alpn: 'myproto' });
+const stream = await session.createBidirectionalStream();
+
+// Abort the writable side with application error code 42.
+stream.resetStream(42n);
+```
+
+See [Aborting a stream][] for an overview of all stream-abort APIs.
+
+### `stream.stopSending([code])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `code` {number|bigint} The application error code to include in the
+  `STOP_SENDING` frame sent to the peer. Numbers are coerced to `BigInt`.
+  **Default:** `0n`.
+
+Sends a `STOP_SENDING` frame to the peer, requesting that the peer stop
+sending data on this stream. This half-closes the stream in the READ
+direction only — the writable side (if any) is unaffected and can
+continue sending data to the peer.
+
+If the stream has already been destroyed, this is a no-op.
+
+This is useful for WebTransport and other application protocols that need
+independent half-closing per direction without tearing down the entire
+stream.
+
+```mjs
+import { connect } from 'node:quic';
+
+const session = await connect('localhost:4567', { alpn: 'myproto' });
+const stream = await session.createBidirectionalStream();
+
+// Tell the peer to stop sending with application error code 7.
+stream.stopSending(7n);
+```
+
+See [Aborting a stream][] for an overview of all stream-abort APIs.
+
 ### `stream.session`
 
 <!-- YAML
@@ -4462,6 +4528,8 @@ throughput issues caused by flow control.
 [`sessionOptions.sni`]: #sessionoptionssni-server-only
 [`sessionOptions.token`]: #sessionoptionstoken-client-only
 [`stream.destroy()`]: #streamdestroyerror-options
+[`stream.resetStream()`]: #streamresetstreamcode
+[`stream.stopSending()`]: #streamstopsendingcode
 [`stream.headers`]: #streamheaders
 [`stream.onerror`]: #streamonerror
 [`stream.onwanttrailers`]: #streamonwanttrailers


### PR DESCRIPTION
## quic: add missing documentation for `stream.stopSending()` and `stream.resetStream()`

Fixes #63680

---

### What this PR does

Adds missing documentation for two `QuicStream` methods that are implemented in the source but not documented:

- `stream.stopSending(code)` — sends a `STOP_SENDING` frame to abort the **readable** side of the stream (half-close for incoming data)
- `stream.resetStream(code)` — sends a `RESET_STREAM` frame to abort the **writable** side of the stream (half-close for outgoing data)

Both methods are important for protocols like WebTransport that require half-closing streams independently.

### Why this matters

Without documentation, developers implementing WebTransport or other QUIC-based protocols had no way to discover or correctly use these methods from the official Node.js docs.

### Changes made

- Added `stream.stopSending(code)` entry to `doc/api/quic.md` under the `QuicStream` class section
- Added `stream.resetStream(code)` entry to `doc/api/quic.md` under the `QuicStream` class section
- Both entries follow the existing Node.js documentation format with YAML metadata, parameter types, and description

**File changed:** `doc/api/quic.md`

---

### Checklist
- [x] `make lint` passes
- [x] Documentation only — no source code modified
- [x] Follows the Node.js [documentation style guide](https://github.com/nodejs/node/blob/main/doc/contributing/writing-and-running-benchmarks.md)
- [x] Added `added: REPLACEME` version metadata as required for new doc entries