### PR TITLE
doc: clarify fromReadable() duck-typed contract

### DIFF
--- a/doc/api/stream_iter.md
+++ b/doc/api/stream_iter.md
@@ -1469,7 +1469,7 @@ added: v26.1.0
 > Stability: 1 - Experimental
 
 * `readable` {stream.Readable|Object} A classic Readable stream or any object
-  with `read()` and `on()` methods.
+  with `read()`, `on()`, and `off()` methods.
 * Returns: {AsyncIterable\<Uint8Array\[]>} A stream/iter async iterable source.
 
 Converts a classic Readable stream (or duck-typed equivalent) into a
@@ -1478,8 +1478,8 @@ stream/iter async iterable source that can be passed to [`from()`][],
 
 If the object implements the [`toAsyncStreamable`][] protocol (as
 `stream.Readable` does), that protocol is used. Otherwise, the function
-duck-types on `read()` and `on()` (EventEmitter) and wraps the stream with
-a batched async iterator.
+duck-types on `read()`, `on()`, and `off()` (EventEmitter) and wraps the
+stream with a batched async iterator.
 
 The result is cached per instance -- calling `fromReadable()` twice with the
 same stream returns the same iterable.


### PR DESCRIPTION
Clarify the documented duck-typed contract for `stream/iter` `fromReadable()`.

The implementation removes its internal `readable` listener with `off()` during
cleanup, so duck-typed readable inputs need to provide `off()` in addition to
`read()` and `on()`.

Source code: https://github.com/nodejs/node/blob/9e58d9d244126ebd6f086e0dc2dab63719ff1bc6/lib/internal/streams/iter/classic.js#L195