### PR TITLE
stream: remove transform-writer handling in pipeTo

### DIFF
--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -946,11 +946,6 @@ function pull(source, ...args) {
 function pipeToSync(source, ...args) {
   const { transforms, writer, options } = parsePipeToArgs(args, 'writeSync');
 
-  // Handle transform-writer
-  if (isTransformObject(writer)) {
-    ArrayPrototypePush(transforms, writer);
-  }
-
   // Normalize source and create pipeline
   const normalized = fromSync(source);
   const pipeline = transforms.length > 0 ?
@@ -1015,11 +1010,6 @@ async function pipeTo(source, ...args) {
   const { transforms, writer, options } = parsePipeToArgs(args, 'write');
   if (options?.signal !== undefined) {
     validateAbortSignal(options.signal, 'options.signal');
-  }
-
-  // Handle transform-writer
-  if (isTransformObject(writer)) {
-    ArrayPrototypePush(transforms, writer);
   }
 
   const signal = options?.signal;

--- a/test/parallel/test-stream-iter-pipeto.js
+++ b/test/parallel/test-stream-iter-pipeto.js
@@ -141,6 +141,31 @@ async function testPipeToSyncWithTransforms() {
   assert.strictEqual(chunks.join(''), 'HELLO');
 }
 
+async function testPipeToWriterTransformMethodIgnored() {
+  const chunks = [];
+  const writer = {
+    transform: common.mustNotCall(),
+    write(chunk) { chunks.push(new TextDecoder().decode(chunk)); },
+  };
+
+  await pipeTo(from('hello'), writer);
+  assert.strictEqual(chunks.join(''), 'hello');
+}
+
+async function testPipeToSyncWriterTransformMethodIgnored() {
+  const chunks = [];
+  const writer = {
+    transform: common.mustNotCall(),
+    writeSync(chunk) {
+      chunks.push(new TextDecoder().decode(chunk));
+      return true;
+    },
+  };
+
+  pipeToSync(fromSync('hello'), writer);
+  assert.strictEqual(chunks.join(''), 'hello');
+}
+
 // PipeTo with writev writer
 async function testPipeToWithWritevWriter() {
   const allChunks = [];
@@ -301,6 +326,8 @@ Promise.all([
   testPipeToWithSignal(),
   testPipeToWithTransforms(),
   testPipeToSyncWithTransforms(),
+  testPipeToWriterTransformMethodIgnored(),
+  testPipeToSyncWriterTransformMethodIgnored(),
   testPipeToWithWritevWriter(),
   testPipeToSyncFallback(),
   testPipeToPreventFail(),


### PR DESCRIPTION
Remove unreachable transform-writer handling from `stream/iter` `pipeTo()` and
`pipeToSync()`.

The argument parser already requires the final non-options argument to be a
writer (`write` for `pipeTo()`, `writeSync` for `pipeToSync()`). Treating that
same object as a transform when it also has `transform()` does not match the
documented `pipeTo(source, ...transforms, writer, options?)` argument shape.

Fixes: https://github.com/nodejs/node/issues/63683

---

Assisted-by: openai:gpt-5.5