### PR TITLE
fs: ignore deleted dirs in recursive watch scan

### DIFF
--- a/lib/internal/fs/recursive_watch.js
+++ b/lib/internal/fs/recursive_watch.js
@@ -157,7 +157,9 @@ class FSWatcher extends EventEmitter {
         }
       }
     } catch (error) {
-      this.emit('error', error);
+      if (error.code !== 'ENOENT') {
+        this.emit('error', error);
+      }
     }
   }
 

--- a/test/parallel/test-fs-watch-recursive-delete-race.js
+++ b/test/parallel/test-fs-watch-recursive-delete-race.js
@@ -1,0 +1,44 @@
+// Flags: --expose-internals
+'use strict';
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { kFSWatchStart } = require('internal/fs/watchers');
+const { FSWatcher } = require('internal/fs/recursive_watch');
+
+if (common.isIBMi)
+  common.skip('IBMi does not support `fs.watch()`');
+
+tmpdir.refresh();
+
+const parent = tmpdir.resolve('parent');
+const child = path.join(parent, 'child');
+fs.mkdirSync(child, { recursive: true });
+fs.writeFileSync(path.join(child, 'test.tmp'), 'test');
+
+const watch = fs.watch;
+let deletedChild = false;
+fs.watch = function(filename, ...args) {
+  const watcher = Reflect.apply(watch, this, [filename, ...args]);
+
+  if (filename === child) {
+    fs.rmSync(child, { recursive: true });
+    deletedChild = true;
+  }
+
+  return watcher;
+};
+
+const watcher = new FSWatcher({ recursive: true });
+watcher.on('error', common.mustNotCall());
+
+try {
+  watcher[kFSWatchStart](parent);
+  assert.strictEqual(deletedChild, true);
+} finally {
+  watcher.close();
+  fs.watch = watch;
+}


### PR DESCRIPTION
Fixes a race in the non-native recursive `fs.watch()` implementation.

When a directory is removed recursively, the watcher can observe the child
directory from the parent watcher and then attempt to scan it after it has
already been deleted. In that case, `readdirSync()` throws `ENOENT`, which was
emitted as a watcher error and could crash tests with an unhandled `error`
event.

This treats `ENOENT` during the recursive directory scan as a normal deletion
race, while preserving existing error reporting for other failures.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-06-01.md#jstest-failure

<details>
<summary>Example Error log</summary>

```console
not ok 1330 parallel/test-fs-watch-recursive-delete
  ---
  duration_ms: 826.25800
  severity: fail
  exitcode: 1
  stack: |-
    node:events:487
          throw er; // Unhandled 'error' event
          ^
    
    Error: ENOENT: no such file or directory, scandir '/home/iojs/node-tmp/.tmp.1329/parent/child'
        at readdirSync (node:fs:1554:26)
        at #watchFolder (node:internal/fs/recursive_watch:122:21)
        at FSWatcher.<anonymous> (node:internal/fs/recursive_watch:208:26)
        at FSWatcher.emit (node:events:509:20)
        at FSWatcher._handle.onchange (node:internal/fs/watchers:279:12)
    Emitted 'error' event on FSWatcher instance at:
        at #watchFolder (node:internal/fs/recursive_watch:160:12)
        at FSWatcher.<anonymous> (node:internal/fs/recursive_watch:208:26)
        at FSWatcher.emit (node:events:509:20)
        at FSWatcher._handle.onchange (node:internal/fs/watchers:279:12) {
      errno: -2,
      code: 'ENOENT',
      syscall: 'scandir',
      path: '/home/iojs/node-tmp/.tmp.1329/parent/child'
    }
    
    Node.js v27.0.0-pre
  ...
```

</details>

---

Assisted-by: openai:gpt-5.5