### PR TITLE
test: accept SIGILL aborts in async-hooks tests

### DIFF
--- a/test/async-hooks/test-emit-after-on-destroyed.js
+++ b/test/async-hooks/test-emit-after-on-destroyed.js
@@ -55,7 +55,7 @@ if (process.argv[2] === 'child') {
   child.on('close', common.mustCall((code, signal) => {
     if ((common.isAIX ||
          (common.isLinux && process.arch === 'x64')) &&
-         signal === 'SIGABRT') {
+        common.nodeProcessAborted(code, signal)) {
       // XXX: The child process could be aborted due to unknown reasons. Work around it.
     } else {
       assert.strictEqual(signal, null);

--- a/test/async-hooks/test-improper-order.js
+++ b/test/async-hooks/test-improper-order.js
@@ -53,8 +53,8 @@ if (process.argv[2] === 'child') {
 
   child.on('close', common.mustCall((code, signal) => {
     if ((common.isAIX ||
-        (common.isLinux && process.arch === 'x64')) &&
-        signal === 'SIGABRT') {
+         (common.isLinux && process.arch === 'x64')) &&
+        common.nodeProcessAborted(code, signal)) {
       // XXX: The child process could be aborted due to unknown reasons. Work around it.
     } else {
       assert.strictEqual(signal, null);

--- a/test/async-hooks/test-improper-unwind.js
+++ b/test/async-hooks/test-improper-unwind.js
@@ -58,7 +58,7 @@ if (process.argv[2] === 'child') {
   child.on('close', common.mustCall((code, signal) => {
     if ((common.isAIX ||
          (common.isLinux && process.arch === 'x64')) &&
-         signal === 'SIGABRT') {
+        common.nodeProcessAborted(code, signal)) {
       // XXX: The child process could be aborted due to unknown reasons. Work around it.
     } else {
       assert.strictEqual(signal, null);


### PR DESCRIPTION
Fixes flaky async-hooks stack corruption tests on AIX where the intentional
abort can be reported as `SIGILL` instead of `SIGABRT`.

The affected tests already allowed abort-style termination on AIX and Linux
x64, but only checked for `SIGABRT` directly. This updates them to use
`common.nodeProcessAborted(code, signal)`, matching Node’s shared handling for
abort results across platforms.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-06-01.md#jstest-failure

<details>
<summary>Example error log</summary>

```console
not ok 67 async-hooks/test-improper-order
  ---
  duration_ms: 389.11600
  severity: fail
  exitcode: 1
  stack: |-
    node:assert:152
      throw new AssertionError(obj);
      ^
    
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    
    'SIGILL' !== null
    
        at ChildProcess.<anonymous> (/home/iojs/build/workspace/node-test-commit-aix/nodes/aix72-power9/test/async-hooks/test-improper-order.js:60:14)
        at ChildProcess.<anonymous> (/home/iojs/build/workspace/node-test-commit-aix/nodes/aix72-power9/test/common/index.js:479:15)
        at ChildProcess.emit (node:events:509:28)
        at maybeClose (node:internal/child_process:1124:16)
        at ChildProcess._handle.onexit (node:internal/child_process:306:5) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: 'SIGILL',
      expected: null,
      operator: 'strictEqual',
      diff: 'simple'
    }
    
    Node.js v24.16.1-pre
  ...
```

</details>

--

Assisted-by: openai:gpt-5.5