### PR TITLE
test_runner: fix watch cwd with isolation none

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -12,7 +12,6 @@ const {
   ArrayPrototypePush,
   ArrayPrototypePushApply,
   ArrayPrototypeShift,
-  ArrayPrototypeSlice,
   ArrayPrototypeSome,
   ArrayPrototypeSort,
   MathMax,
@@ -185,6 +184,9 @@ function getRunArgs(path, { forceExit,
                             testSkipPatterns,
                             testTagFilterExpressions,
                             only,
+                            hasFiles,
+                            testFiles,
+                            globPatterns,
                             argv: suppliedArgs,
                             execArgv,
                             rerunFailuresFilePath,
@@ -245,7 +247,8 @@ function getRunArgs(path, { forceExit,
 
   if (path === kIsolatedProcessName) {
     ArrayPrototypePush(runArgs, '--test');
-    ArrayPrototypePushApply(runArgs, ArrayPrototypeSlice(process.argv, 1));
+    ArrayPrototypePush(runArgs, '--test-isolation=none');
+    ArrayPrototypePushApply(runArgs, hasFiles ? testFiles : globPatterns ?? []);
   } else {
     ArrayPrototypePush(runArgs, path);
   }
@@ -986,6 +989,7 @@ function run(options = kEmptyObject) {
     workerIdPool: isolation === 'process' ? workerIdPool : null,
     randomize,
     randomSeed,
+    testFiles,
   };
 
   if (isolation === 'process') {

--- a/test/test-runner/test-run-watch-cwd-isolation-none-argv.mjs
+++ b/test/test-runner/test-run-watch-cwd-isolation-none-argv.mjs
@@ -1,0 +1,43 @@
+// Test run({ watch: true, cwd, isolation: 'none' }) does not reuse the
+// parent process argv when spawning the watch child.
+import * as common from '../common/index.mjs';
+import assert from 'node:assert';
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { run } from 'node:test';
+import tmpdir from '../common/tmpdir.js';
+import { skipIfNoWatch } from '../common/watch.js';
+
+skipIfNoWatch();
+tmpdir.refresh();
+
+const marker = join(tmpdir.path, 'marker');
+writeFileSync(join(tmpdir.path, 'test.js'), `
+const test = require('node:test');
+const { writeFileSync } = require('node:fs');
+
+test('test ran from cwd', () => {
+  writeFileSync(${JSON.stringify(marker)}, 'ran');
+});
+`);
+
+const controller = new AbortController();
+const stream = run({
+  cwd: tmpdir.path,
+  watch: true,
+  signal: controller.signal,
+  isolation: 'none',
+}).on('data', function({ type }) {
+  if (type === 'test:watch:drained') {
+    stream.removeAllListeners('test:fail');
+    stream.removeAllListeners('test:pass');
+    controller.abort();
+  }
+});
+
+stream.on('test:fail', common.mustNotCall());
+stream.on('test:pass', common.mustCall(1));
+// eslint-disable-next-line no-unused-vars
+for await (const _ of stream);
+
+assert.strictEqual(readFileSync(marker, 'utf8'), 'ran');


### PR DESCRIPTION
When `run({ watch: true, cwd, isolation: 'none' })` spawned the watch child,
it reused the parent process argv while changing the child process cwd. That
could make the child run the outer test file, recurse, or miss the test file
that was discovered under the configured cwd.

This updates the isolation-none watch path to spawn the child test runner with
the current run's explicit files or glob patterns instead of `process.argv`.
A regression test verifies that the cwd-scoped test file actually runs.

Fixes: https://github.com/nodejs/node/issues/63689

---

Fixes a flaky failure in `test-runner/test-run-watch-cwd-isolation-none`.
Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-06-01.md#jstest-failure

<details>
<summary>Example error log</summary>

```console
not ok 5115 test-runner/test-run-watch-cwd-isolation-none
  ---
  duration_ms: 1588.88400
  severity: fail
  exitcode: 1
  stack: |-
  ...
```

</details>

---

Assisted-by: openai:gpt-5.5