### PR TITLE
fs: normalize encoding before utf8 fast path check

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -94,6 +94,7 @@ const {
   SideEffectFreeRegExpPrototypeExec,
   defineLazyProperties,
   isWindows,
+  normalizeEncoding,
   isMacOS,
 } = require('internal/util');
 const {
@@ -489,7 +490,8 @@ function readFileSync(path, options) {
   }
   options = getOptions(options, { flag: 'r' });
 
-  if (options.encoding === 'utf8' || options.encoding === 'utf-8') {
+  const encoding = normalizeEncoding(options.encoding) || options.encoding;
+  if (encoding === 'utf8') {
     if (!isInt32(path)) {
       path = getValidatedPath(path);
     }
@@ -2845,7 +2847,8 @@ function writeFileSync(path, data, options) {
   const flag = options.flag || 'w';
 
   // C++ fast path for string data and UTF8 encoding
-  if (typeof data === 'string' && (options.encoding === 'utf8' || options.encoding === 'utf-8')) {
+  const encoding = normalizeEncoding(options.encoding) || options.encoding;
+  if (typeof data === 'string' && encoding === 'utf8') {
     if (!isInt32(path)) {
       path = getValidatedPath(path);
     }

--- a/lib/fs.js
+++ b/lib/fs.js
@@ -490,8 +490,7 @@ function readFileSync(path, options) {
   }
   options = getOptions(options, { flag: 'r' });
 
-  const encoding = normalizeEncoding(options.encoding) || options.encoding;
-  if (encoding === 'utf8') {
+  if (options.encoding && normalizeEncoding(options.encoding) === 'utf8') {
     if (!isInt32(path)) {
       path = getValidatedPath(path);
     }
@@ -2847,8 +2846,7 @@ function writeFileSync(path, data, options) {
   const flag = options.flag || 'w';
 
   // C++ fast path for string data and UTF8 encoding
-  const encoding = normalizeEncoding(options.encoding) || options.encoding;
-  if (typeof data === 'string' && encoding === 'utf8') {
+  if (typeof data === 'string' && options.encoding && normalizeEncoding(options.encoding) === 'utf8') {
     if (!isInt32(path)) {
       path = getValidatedPath(path);
     }


### PR DESCRIPTION
The fs.readFileSync and fs.writeFileSync fast paths for utf8 encoding only checked for 'utf8' and 'utf-8', but normalizeEncoding also accepts 'UTF8' and 'UTF-8'. This meant that using those encodings would bypass the fast path and go through the slower generic path.

Fix by normalizing the encoding before checking if it's utf8.

Fixes: https://github.com/nodejs/node/issues/49888