### PR TITLE
module: use file: URL as sourceURL for type-stripped CommonJS

### DIFF
--- a/lib/internal/modules/cjs/loader.js
+++ b/lib/internal/modules/cjs/loader.js
@@ -1830,7 +1830,8 @@ function wrapSafe(filename, content, cjsModuleInstance, format) {
  */
 Module.prototype._compile = function(content, filename, format) {
   if (format === 'commonjs-typescript' || format === 'module-typescript' || format === 'typescript') {
-    content = stripTypeScriptModuleTypes(content, filename);
+    this[kURL] ??= convertCJSFilenameToURL(filename);
+    content = stripTypeScriptModuleTypes(content, filename, this[kURL]);
     switch (format) {
       case 'commonjs-typescript': {
         format = 'commonjs';

--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -156,9 +156,10 @@ function stripTypeScriptTypesForCoverage(code) {
  * It is used by internal loaders.
  * @param {string} source TypeScript code to parse.
  * @param {string} filename The filename of the source code.
+ * @param {string} [sourceURL] The source URL of the source code. If not specified, use filename.
  * @returns {TransformOutput} The stripped TypeScript code.
  */
-function stripTypeScriptModuleTypes(source, filename) {
+function stripTypeScriptModuleTypes(source, filename, sourceURL) {
   assert(typeof source === 'string');
   if (isUnderNodeModules(filename)) {
     throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(filename);
@@ -178,7 +179,7 @@ function stripTypeScriptModuleTypes(source, filename) {
   const options = {
     mode: 'strip-only',
     sourceMap,
-    filename,
+    filename: sourceURL ?? filename,
   };
 
   const transpiled = processTypeScriptCode(source, options);

--- a/test/parallel/test-inspector-strip-types.js
+++ b/test/parallel/test-inspector-strip-types.js
@@ -1,23 +1,61 @@
+// Verifies that type-stripped TypeScript reports a file: URL as its script
+// sourceURL to the inspector across all module loading paths, hinting that it
+// is a generated source.
 'use strict';
 
 const common = require('../common');
+const { describe, it } = require('node:test');
 common.skipIfInspectorDisabled();
 if (!process.config.variables.node_use_amaro) common.skip('Requires Amaro');
 
 const { NodeInstance } = require('../common/inspector-helper.js');
 const fixtures = require('../common/fixtures');
 const assert = require('assert');
-const { pathToFileURL } = require('url');
 
-const scriptPath = fixtures.path('typescript/ts/test-typescript.ts');
-const scriptURL = pathToFileURL(scriptPath);
+const scenarios = [
+  {
+    // CommonJS: a .ts entry point.
+    entry: 'typescript/ts/test-typescript.ts',
+    expected: [
+      fixtures.fileURL('typescript/ts/test-typescript.ts').href,
+    ],
+  },
+  {
+    // CommonJS: a .ts entry that require()s a .cts dependency.
+    entry: 'typescript/ts/test-require-cts.ts',
+    expected: [
+      fixtures.fileURL('typescript/ts/test-require-cts.ts').href,
+      fixtures.fileURL('typescript/cts/test-cts-export-foo.cts').href,
+    ],
+  },
+  {
+    // CommonJS: a .ts entry that require()s a .mts dependency.
+    entry: 'typescript/ts/test-require-mts.ts',
+    expected: [
+      fixtures.fileURL('typescript/ts/test-require-mts.ts').href,
+      fixtures.fileURL('typescript/mts/test-mts-export-foo.mts').href,
+    ],
+  },
+  {
+    // ESM: a .mts entry that imports a .ts dependency.
+    entry: 'typescript/mts/test-import-ts-file.mts',
+    expected: [
+      fixtures.fileURL('typescript/mts/test-import-ts-file.mts').href,
+      fixtures.fileURL('typescript/mts/test-module-export.ts').href,
+    ],
+  },
+  {
+    // ESM: a .mts entry that imports a .cts dependency.
+    entry: 'typescript/mts/test-import-commonjs.mts',
+    expected: [
+      fixtures.fileURL('typescript/mts/test-import-commonjs.mts').href,
+      fixtures.fileURL('typescript/cts/test-cts-export-foo.cts').href,
+    ],
+  },
+];
 
-async function runTest() {
-  const child = new NodeInstance(
-    ['--inspect-brk=0'],
-    undefined,
-    scriptPath);
-
+async function collectParsedScripts(scriptPath) {
+  const child = new NodeInstance(['--inspect-brk=0'], undefined, scriptPath);
   const session = await child.connectInspectorSession();
 
   await session.send({ method: 'NodeRuntime.enable' });
@@ -29,18 +67,39 @@ async function runTest() {
   ]);
   await session.send({ method: 'NodeRuntime.disable' });
 
-  const scriptParsed = await session.waitForNotification((notification) => {
-    if (notification.method !== 'Debugger.scriptParsed') return false;
-
-    return notification.params.url === scriptPath || notification.params.url === scriptURL.href;
+  // Collect every parsed script while resuming through the break on start and
+  // any later pauses, until the main execution context is destroyed.
+  const scripts = new Map();
+  await session.waitForNotification((notification) => {
+    if (notification.method === 'Debugger.scriptParsed') {
+      const { url } = notification.params;
+      if (!url.startsWith('node:')) {
+        scripts.set(url, notification.params);
+      }
+    }
+    if (notification.method === 'Debugger.paused') {
+      session.send({ method: 'Debugger.resume' });
+    }
+    return notification.method === 'Runtime.executionContextDestroyed' &&
+      notification.params.executionContextId === 1;
   });
-  // Verify that the script has a sourceURL, hinting that it is a generated source.
-  assert(scriptParsed.params.hasSourceURL || common.isInsideDirWithUnusualChars);
-
-  await session.waitForPauseOnStart();
-  await session.runToCompletion();
+  await session.waitForDisconnect();
 
   assert.strictEqual((await child.expectShutdown()).exitCode, 0);
+  return scripts;
 }
 
-runTest().then(common.mustCall());
+describe('type stripping source URLs', { concurrency: !process.env.TEST_PARALLEL }, () => {
+  for (const { entry, expected } of scenarios) {
+    it(entry, async () => {
+      const scripts = await collectParsedScripts(fixtures.path(entry));
+      for (const href of expected) {
+        const params = scripts.get(href);
+        assert(params,
+               `expected ${entry} to report ${href} to the inspector, ` +
+               `got:\n- ${[...scripts.keys()].join('\n- ')}`);
+        assert(params.hasSourceURL);
+      }
+    });
+  }
+});


### PR DESCRIPTION
The CommonJS loader was passing the bare filesystem path as the `//# sourceURL` comment of type-stripped TypeScript, this leads to two problems:

1. It reports `hasSourceURL = false` if the path contains any whitespaces as this breaks V8's magic comment parser.
2. The inspector would incorrectly report a file path verbatim as the script's URL.

Pass the module's file: URL as the sourceURL so the reported URL is consistent across loaders and won't lead to an issue in inspector clients that actually except a real URL for the scripts.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
