### PR TITLE
util: remove style caches from styleText slow path

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -129,6 +129,16 @@ function getHexStyleCache() {
   return hexStyleCache;
 }
 
+function codesToStyle(codes) {
+  const openNum = codes[0];
+  return {
+    __proto__: null,
+    openSeq: kEscape + openNum + kEscapeEnd,
+    closeSeq: kEscape + codes[1] + kEscapeEnd,
+    keepClose: openNum === kDimCode || openNum === kBoldCode,
+  };
+}
+
 function getStyleCache() {
   if (styleCache === undefined) {
     styleCache = { __proto__: null };
@@ -136,14 +146,7 @@ function getStyleCache() {
     for (const key of ObjectGetOwnPropertyNames(colors)) {
       const codes = colors[key];
       if (codes) {
-        const openNum = codes[0];
-        const closeNum = codes[1];
-        styleCache[key] = {
-          __proto__: null,
-          openSeq: kEscape + openNum + kEscapeEnd,
-          closeSeq: kEscape + closeNum + kEscapeEnd,
-          keepClose: openNum === kDimCode || openNum === kBoldCode,
-        };
+        styleCache[key] = codesToStyle(codes);
       }
     }
   }
@@ -241,10 +244,10 @@ function rgbToAnsi24Bit(r, g, b) {
  */
 function styleText(format, text, options) {
   const validateStream = options?.validateStream ?? true;
-  const cache = getStyleCache();
 
   // Fast path: single format string with validateStream=false
   if (!validateStream && typeof format === 'string' && typeof text === 'string') {
+    const cache = getStyleCache();
     if (format === 'none') return text;
     const style = cache[format];
     if (style !== undefined) {
@@ -284,6 +287,7 @@ function styleText(format, text, options) {
   }
 
   const formatArray = ArrayIsArray(format) ? format : [format];
+  const colors = inspect.colors;
 
   let openCodes = '';
   let closeCodes = '';
@@ -293,30 +297,27 @@ function styleText(format, text, options) {
     if (key === 'none') continue;
 
     if (typeof key === 'string' && key[0] === '#') {
-      let hexStyle = getHexStyleCache().get(key);
-      if (hexStyle === undefined) {
-        if (RegExpPrototypeExec(hexColorRegExp, key) === null) {
-          throw new ERR_INVALID_ARG_VALUE('format', key,
-                                          'must be a valid hex color (#RGB or #RRGGBB)');
-        }
-        if (skipColorize) continue;
-        hexStyle = getHexStyle(key);
-      } else if (skipColorize) {
-        continue;
+      if (RegExpPrototypeExec(hexColorRegExp, key) === null) {
+        throw new ERR_INVALID_ARG_VALUE('format', key,
+                                        'must be a valid hex color (#RGB or #RRGGBB)');
       }
-      openCodes += hexStyle.openSeq;
-      closeCodes = hexStyle.closeSeq + closeCodes;
-      processedText = replaceCloseCode(processedText, hexStyle.closeSeq, hexStyle.openSeq, false);
+      if (skipColorize) continue;
+      const { 0: r, 1: g, 2: b } = hexToRgb(key);
+      const hexOpenSeq = kEscape + rgbToAnsi24Bit(r, g, b) + kEscapeEnd;
+      openCodes += hexOpenSeq;
+      closeCodes = kHexCloseSeq + closeCodes;
+      processedText = replaceCloseCode(processedText, kHexCloseSeq, hexOpenSeq, false);
       continue;
     }
 
-    const style = cache[key];
-    if (style === undefined) {
+    const codes = colors[key];
+    if (!codes) {
       validateOneOf(key, 'format', ObjectGetOwnPropertyNames(inspect.colors));
     }
-    openCodes += style.openSeq;
-    closeCodes = style.closeSeq + closeCodes;
-    processedText = replaceCloseCode(processedText, style.closeSeq, style.openSeq, style.keepClose);
+    const { openSeq, closeSeq, keepClose } = codesToStyle(codes);
+    openCodes += openSeq;
+    closeCodes = closeSeq + closeCodes;
+    processedText = replaceCloseCode(processedText, closeSeq, openSeq, keepClose);
   }
 
   if (skipColorize) return text;


### PR DESCRIPTION
Remove the caches from the slow path since they don't improve performance there. validation dominates the cost, making the lookup savings negligible

```
util/style-text.js n=1000 validateStream=0 format='#ff0000' messageType='boolean'                  -0.36 %       ±2.99% ±4.02% ±5.32%
util/style-text.js n=1000 validateStream=0 format='#ff0000' messageType='invalid'                   0.40 %       ±2.49% ±3.34% ±4.39%
util/style-text.js n=1000 validateStream=0 format='#ff0000' messageType='number'            **      2.27 %       ±1.68% ±2.24% ±2.91%
util/style-text.js n=1000 validateStream=0 format='#ff0000' messageType='string'                    0.82 %       ±2.93% ±3.90% ±5.07%
util/style-text.js n=1000 validateStream=0 format='#rotating' messageType='boolean'          *      1.25 %       ±1.23% ±1.64% ±2.14%
util/style-text.js n=1000 validateStream=0 format='#rotating' messageType='invalid'                -0.71 %       ±5.57% ±7.50% ±9.94%
util/style-text.js n=1000 validateStream=0 format='#rotating' messageType='number'           *      2.59 %       ±2.08% ±2.77% ±3.61%
util/style-text.js n=1000 validateStream=0 format='#rotating' messageType='string'                 -2.07 %       ±3.62% ±4.83% ±6.33%
util/style-text.js n=1000 validateStream=0 format='invalid' messageType='boolean'          ***      2.36 %       ±1.28% ±1.71% ±2.24%
util/style-text.js n=1000 validateStream=0 format='invalid' messageType='invalid'           **      1.57 %       ±0.99% ±1.31% ±1.71%
util/style-text.js n=1000 validateStream=0 format='invalid' messageType='number'            **      3.25 %       ±2.35% ±3.13% ±4.08%
util/style-text.js n=1000 validateStream=0 format='invalid' messageType='string'                    2.07 %       ±2.89% ±3.89% ±5.15%
util/style-text.js n=1000 validateStream=0 format='italic' messageType='boolean'             *      1.62 %       ±1.41% ±1.87% ±2.43%
util/style-text.js n=1000 validateStream=0 format='italic' messageType='invalid'           ***      2.00 %       ±0.79% ±1.05% ±1.36%
util/style-text.js n=1000 validateStream=0 format='italic' messageType='number'              *      3.90 %       ±3.08% ±4.15% ±5.50%
util/style-text.js n=1000 validateStream=0 format='italic' messageType='string'                    -1.52 %       ±4.73% ±6.31% ±8.24%
util/style-text.js n=1000 validateStream=0 format='red' messageType='boolean'                       1.68 %       ±1.93% ±2.56% ±3.33%
util/style-text.js n=1000 validateStream=0 format='red' messageType='invalid'               **      2.29 %       ±1.42% ±1.90% ±2.47%
util/style-text.js n=1000 validateStream=0 format='red' messageType='number'                **      2.72 %       ±1.93% ±2.57% ±3.34%
util/style-text.js n=1000 validateStream=0 format='red' messageType='string'                       -0.34 %       ±3.61% ±4.82% ±6.30%
util/style-text.js n=1000 validateStream=1 format='#ff0000' messageType='boolean'                   0.14 %       ±3.35% ±4.51% ±5.96%
util/style-text.js n=1000 validateStream=1 format='#ff0000' messageType='invalid'          ***      1.91 %       ±0.62% ±0.83% ±1.08%
util/style-text.js n=1000 validateStream=1 format='#ff0000' messageType='number'             *      2.08 %       ±1.72% ±2.29% ±2.98%
util/style-text.js n=1000 validateStream=1 format='#ff0000' messageType='string'           ***      2.24 %       ±0.82% ±1.09% ±1.42%
util/style-text.js n=1000 validateStream=1 format='#rotating' messageType='boolean'          *      1.73 %       ±1.31% ±1.75% ±2.28%
util/style-text.js n=1000 validateStream=1 format='#rotating' messageType='invalid'                 0.64 %       ±2.20% ±2.95% ±3.88%
util/style-text.js n=1000 validateStream=1 format='#rotating' messageType='number'         ***      2.98 %       ±1.39% ±1.86% ±2.43%
util/style-text.js n=1000 validateStream=1 format='#rotating' messageType='string'                  0.30 %       ±2.50% ±3.36% ±4.45%
util/style-text.js n=1000 validateStream=1 format='invalid' messageType='boolean'           **      2.27 %       ±1.40% ±1.87% ±2.44%
util/style-text.js n=1000 validateStream=1 format='invalid' messageType='invalid'          ***      1.86 %       ±0.94% ±1.25% ±1.62%
util/style-text.js n=1000 validateStream=1 format='invalid' messageType='number'            **      3.84 %       ±2.81% ±3.75% ±4.91%
util/style-text.js n=1000 validateStream=1 format='invalid' messageType='string'           ***      2.26 %       ±1.28% ±1.71% ±2.24%
util/style-text.js n=1000 validateStream=1 format='italic' messageType='boolean'           ***      2.72 %       ±1.51% ±2.02% ±2.64%
util/style-text.js n=1000 validateStream=1 format='italic' messageType='invalid'           ***      2.01 %       ±0.97% ±1.29% ±1.68%
util/style-text.js n=1000 validateStream=1 format='italic' messageType='number'              *      2.19 %       ±1.76% ±2.34% ±3.06%
util/style-text.js n=1000 validateStream=1 format='italic' messageType='string'                     3.53 %       ±3.78% ±5.10% ±6.75%
util/style-text.js n=1000 validateStream=1 format='red' messageType='boolean'                       1.32 %       ±1.68% ±2.25% ±2.95%
util/style-text.js n=1000 validateStream=1 format='red' messageType='invalid'              ***      1.97 %       ±1.08% ±1.44% ±1.88%
util/style-text.js n=1000 validateStream=1 format='red' messageType='number'                 *      2.37 %       ±1.80% ±2.40% ±3.13%
util/style-text.js n=1000 validateStream=1 format='red' messageType='string'                        2.26 %       ±2.31% ±3.09% ±4.07%

Be aware that when doing many comparisons the risk of a false-positive
result increases. In this case, there are 40 comparisons, you can thus
expect the following amount of false-positive results:
  2.00 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.40 false positives, when considering a   1% risk acceptance (**, ***),
  0.04 false positives, when considering a 0.1% risk acceptance (***)
```