### PR TITLE
fs: do not treat EPERM as ENOTEMPTY on Windows

### DIFF
--- a/lib/internal/fs/rimraf.js
+++ b/lib/internal/fs/rimraf.js
@@ -24,7 +24,9 @@ const {
 const { sep } = require('path');
 const { setTimeout } = require('timers');
 const { isWindows } = require('internal/util');
-const notEmptyErrorCodes = new SafeSet(['ENOTEMPTY', 'EEXIST', 'EPERM']);
+const notEmptyErrorCodes = isWindows ?
+  new SafeSet(['ENOTEMPTY', 'EEXIST']) :
+  new SafeSet(['ENOTEMPTY', 'EEXIST', 'EPERM']);
 const retryErrorCodes = new SafeSet(
   ['EBUSY', 'EMFILE', 'ENFILE', 'ENOTEMPTY', 'EPERM']);
 const epermHandler = isWindows ? fixWinEPERM : _rmdir;

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -567,5 +567,67 @@ if (isGitPresent) {
         makeDirectoryWritable(middle);
       }
     }
+
+    if (common.isWindows) {
+      // On Windows, EPERM from rmdir on a directory that cannot be deleted
+      // due to permissions must not be treated as ENOTEMPTY (which would
+      // cause rimraf to recurse into and delete the directory's children).
+      const dirname = nextDirPath();
+      const parent = path.join(dirname, 'parent');
+      const child = path.join(parent, 'child');
+      const childFile = path.join(child, 'childFile.txt');
+      fs.mkdirSync(child, common.mustNotMutateObjectDeep({ recursive: true }));
+      fs.writeFileSync(childFile, 'hello');
+
+      // (DC) denies deleting children; (DE) denies deleting the directory
+      // itself. Combined denies on each layer guarantee rmdir returns EPERM.
+      execSync(`icacls "${dirname}" /deny "everyone:(DC)"`);
+      execSync(`icacls "${parent}" /deny "everyone:(DE,DC)"`);
+      execSync(`icacls "${child}" /deny "everyone:(DE)"`);
+
+      const cleanup = () => {
+        try {
+          execSync(`icacls "${child}" /remove:d "everyone"`);
+        } catch {
+          // Best-effort cleanup; ignore failures (e.g. already cleared).
+        }
+        try {
+          execSync(`icacls "${parent}" /remove:d "everyone"`);
+        } catch {
+          // Best-effort cleanup; ignore failures.
+        }
+        try {
+          execSync(`icacls "${dirname}" /remove:d "everyone"`);
+        } catch {
+          // Best-effort cleanup; ignore failures.
+        }
+        try {
+          fs.rmSync(dirname, common.mustNotMutateObjectDeep({
+            recursive: true,
+            force: true,
+          }));
+        } catch {
+          // Best-effort cleanup; ignore failures.
+        }
+      };
+      process.on('exit', cleanup);
+
+      fs.rm(dirname, common.mustNotMutateObjectDeep({ recursive: true }),
+            common.mustCall((err) => {
+              try {
+                assert.ok(err, 'expected EPERM error');
+                assert.strictEqual(err.code, 'EPERM');
+                assert.strictEqual(err.syscall, 'rmdir');
+                assert.ok(err.path.endsWith('\\parent'));
+                assert.ok(
+                  fs.existsSync(child),
+                  'EPERM from rmdir must propagate without recursing into children',
+                );
+              } finally {
+                process.removeListener('exit', cleanup);
+                cleanup();
+              }
+            }));
+    }
   }
 }


### PR DESCRIPTION
## Changes

`fs.rm(..., { recursive: true })` on Windows treats `EPERM` from `rmdir` as "directory not empty" and recurses into children. That's wrong, because on Windows, `EPERM` means "no permission to delete", not "still has contents".

Windows now uses its own `notEmptyErrorCodes` set that excludes `EPERM`.

## Safety
The `EPERM` treatment as non-empty traces to rimraf 2.2:  ([changelog](https://app.unpkg.com/rimraf@3.0.2/files/CHANGELOG.md), [commit](https://github.com/isaacs/rimraf/commit/bd19df7f9a05f0a780a86ea0480cacd9a778116b)):

> As per http://sourceforge.net/mailarchive/message.php?msg_id=31240176 sshfs-mounted directories return EPERM on rmdir called with non-empty dir. Hence removing non-empty directories mounted through sshfs didn't work with rimraf, and this change makes it work.

This does not apply to Windows, so `EPERM` is safely removed from `notEmptyErrorCodes` and is kept for other platforms.

## Before/After

JS Script used as `rm.js`:
```JavaScript
import { rmSync } from "fs";
import { rm } from "fs/promises";
const parentPath = "C:\\Users\\dev\\permissions\\folders";

await rm(parentPath, {recursive: true});
```

### Before
```powershell
PS C:\Users\dev\permissions> node.exe --max-old-space-size=30 .\rm.js

<--- Last few GCs --->
.6[25312:000001C3A99BC000]      515 ms: Mark-Compact 24.7 (87.4) -> 23.3 (89.4) MB, pooled: 0 MB, 2.46 / 0.00 ms  (+ 1.4 ms in 71 steps since start of marking, biggest step 0.1 ms, walltime since start of marking 9 ms) (average mu = 0.736, current mu = 0.70[25312:000001C3A99BC000]      592 ms: Mark-Compact 38.7 (89.4) -> 30.8 (96.4) MB, pooled: 0 MB, 10.28 / 0.00 ms  (+ 0.8 ms in 66 steps since start of marking, biggest step 0.2 ms, walltime since start of marking 20 ms) (average mu = 0.833, current mu = 0.
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

### After
```powershell
PS C:\Users\dev\permissions> ..\node_projects\node\Release\node.exe --max-old-space-size=30 .\rm.js
node:internal/modules/run_main:107
    triggerUncaughtException(
    ^

[Error: EPERM: operation not permitted, rmdir 'C:\Users\kirill\dev\permissions\folders\00'] {
  errno: -4048,
  code: 'EPERM',
  syscall: 'rmdir',
  path: 'C:\\Users\\dev\\permissions\\folders\\00'
}

Node.js v27.0.0-pre
```

Fixes: https://github.com/nodejs/node/issues/56433
