### PR TITLE
crypto: runtime-deprecate calling digest() on HMAC more than once

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4562,12 +4562,15 @@ removed in a future version of Node.js.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: REPLACEME
+    description: Runtime deprecation.
   - version: v26.2.0
     pr-url: https://github.com/nodejs/node/pull/63121
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Calling `hmac.digest()` more than once returns an empty buffer instead of
 throwing an error. This behavior is inconsistent with `hash.digest()` and

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -87,6 +87,13 @@ const maybeEmitDeprecationWarning = getDeprecationWarningEmitter(
   },
 );
 
+const maybeEmitHmacFinalizedDeprecationWarning = getDeprecationWarningEmitter(
+  'DEP0206',
+  'Calling digest() on an already-finalized Hmac instance is deprecated.',
+  undefined,
+  false,
+);
+
 function Hash(algorithm, options) {
   if (!new.target)
     return new Hash(algorithm, options);
@@ -186,6 +193,7 @@ Hmac.prototype.digest = function digest(outputEncoding) {
   const state = this[kState];
 
   if (state[kFinalized]) {
+    maybeEmitHmacFinalizedDeprecationWarning();
     const buf = Buffer.from('');
     if (outputEncoding && outputEncoding !== 'buffer')
       return buf.toString(outputEncoding);

--- a/test/parallel/test-crypto-hmac.js
+++ b/test/parallel/test-crypto-hmac.js
@@ -417,6 +417,12 @@ assert.strictEqual(
       '\u0010\u0041\u0052\u00c5\u00bf\u00dc\u00a0\u007b\u00c6\u0033' +
       '\u00ee\u00bd\u0046\u0019\u009f\u0002\u0055\u00c9\u00f4\u009d';
   {
+    common.expectWarning({
+      DeprecationWarning: [
+        ['Calling digest() on an already-finalized Hmac instance is deprecated.',
+         'DEP0206'],
+      ],
+    });
     const h = crypto.createHmac('sha1', 'key').update('data');
     assert.deepStrictEqual(h.digest('buffer'), Buffer.from(expected, 'latin1'));
     assert.deepStrictEqual(h.digest('buffer'), Buffer.from(''));


### PR DESCRIPTION
Calling `digest()` on an already-finalized `Hmac` instance now emits a
runtime deprecation warning with code `DEP0206`. Previously it silently
returned an empty buffer, which is inconsistent with `Hash` behavior and
could lead to security issues.

This changes DEP0206 from a documentation-only deprecation to a runtime
deprecation. The existing behavior (returning an empty buffer) is
preserved for now but will be changed to throw an error in a future
version.

Fixes: https://github.com/nodejs/node/issues/62838

Refs: https://github.com/nodejs/node/pull/63121