### PR TITLE
doc: fix AES-OCB IV length in SubtleCrypto.supports example

### DIFF
--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -500,7 +500,7 @@ const key = await crypto.subtle.deriveKey(
   ['encrypt', 'decrypt'],
 );
 const plaintext = 'Hello, world!';
-const iv = crypto.getRandomValues(new Uint8Array(16));
+const iv = crypto.getRandomValues(new Uint8Array(12));
 const encrypted = await crypto.subtle.encrypt(
   { name: encryptionAlg, iv },
   key,


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63713
The example uses a 16-byte IV for AES-OCB, but AES-OCB requires at most 15 bytes, causing a DOMException when run. Fix by using 12 bytes, which satisfies both AES-OCB and AES-GCM constraints.

