### PR TITLE
deps: V8: respect interceptors in lexical restricted-global check

### DIFF
--- a/deps/v8/include/v8-version.h
+++ b/deps/v8/include/v8-version.h
@@ -11,7 +11,7 @@
 #define V8_MAJOR_VERSION 14
 #define V8_MINOR_VERSION 6
 #define V8_BUILD_NUMBER 202
-#define V8_PATCH_LEVEL 34
+#define V8_PATCH_LEVEL 35
 
 // Use 1 for candidates and 0 otherwise.
 // (Boolean macro values are not supported by all preprocessors.)

--- a/deps/v8/src/execution/execution.cc
+++ b/deps/v8/src/execution/execution.cc
@@ -231,12 +231,12 @@ MaybeDirectHandle<Context> NewScriptContext(
 
     if (IsLexicalVariableMode(mode)) {
       LookupIterator lookup_it(isolate, global_object, name, global_object,
-                               LookupIterator::OWN_SKIP_INTERCEPTOR);
+                               LookupIterator::OWN);
       Maybe<PropertyAttributes> maybe =
           JSReceiver::GetPropertyAttributes(&lookup_it);
-      // Can't fail since the we looking up own properties on the global object
-      // skipping interceptors.
-      CHECK(!maybe.IsNothing());
+      // The interceptor query callback may throw, in which case propagate the
+      // pending exception instead of continuing.
+      if (maybe.IsNothing()) return MaybeDirectHandle<Context>();
       if ((maybe.FromJust() & DONT_DELETE) != 0) {
         // ES#sec-globaldeclarationinstantiation 5.a:
         // If envRec.HasVarDeclaration(name) is true, throw a SyntaxError

--- a/test/parallel/test-vm-global-property-interceptors.js
+++ b/test/parallel/test-vm-global-property-interceptors.js
@@ -127,3 +127,26 @@ assert.throws(() => vm.runInContext(`
 'use strict';
 Object.defineProperty(this, 'f', { value: 'newF' });
 `, ctx), /TypeError: Cannot redefine property: f/);
+
+{
+  const restrictedCtx = vm.createContext({});
+  vm.runInContext(
+    "Object.defineProperty(this, 'foo', { value: 1, configurable: false });",
+    restrictedCtx);
+  assert.throws(() => vm.runInContext('let foo;', restrictedCtx), {
+    name: 'SyntaxError',
+    message: /Identifier 'foo' has already been declared/,
+  });
+  assert.throws(() => vm.runInContext('const foo = 2;', restrictedCtx), {
+    name: 'SyntaxError',
+    message: /Identifier 'foo' has already been declared/,
+  });
+
+  // A configurable global property does not restrict a lexical declaration.
+  const configurableCtx = vm.createContext({});
+  vm.runInContext(
+    "Object.defineProperty(this, 'bar', { value: 1, configurable: true });",
+    configurableCtx);
+  assert.doesNotThrow(() => vm.runInContext('let bar = 9; bar;',
+                                            configurableCtx));
+}


### PR DESCRIPTION
fixes: https://github.com/nodejs/node/issues/63715

A top-level lexical declaration (`let`/`const`) that collides with a non-configurable ("restricted") own property on a `vm` context's global object is no longer rejected with a `SyntaxError`, violating ES#sec-globaldeclarationinstantiation step 5.d. 

This is a regression between v24.x and v26.x, found via the test262 case `language/global-code/script-decl-lex-restricted-global.js`.

```js
const vm = require('vm');
const context = vm.createContext({});
vm.runInContext(
  "Object.defineProperty(this, 'foo', { value: 1, configurable: false });",
  context);
vm.runInContext('let foo;', context);
// v24.12.0: SyntaxError: Identifier 'foo' has already been declared
// v26.3.0:  silently accepted  <-- bug
```

### Root cause

V8's `Execution::NewScriptContext` (`deps/v8/src/execution/execution.cc`) checks for a restricted global with `LookupIterator::OWN_SKIP_INTERCEPTOR`. `vm` globals are interceptor-backed and keep script-defined properties on a sandbox object, so skipping interceptors hides them and the collision goes undetected. The sibling `var`/function path in `runtime-scopes.cc` already keeps interceptors for the non-var case; the lexical path skipping them is the asymmetry that regressed.

### Fix

Switch that lookup to `LookupIterator::OWN` (interceptor-respecting) and propagate a possible pending exception instead of `CHECK`-ing. No-op for ordinary globals; restores correct behavior for vm contexts.

### Upstreaming

This is an interim floating patch; upstreaming to V8 is tracked/forthcoming

### Testing

- Added a regression test to `test/parallel/test-vm-global-property-interceptors.js`.
- The repro now throws `SyntaxError: Identifier 'foo' has already been declared`.
- All `test/parallel/test-vm-*` tests pass against a local release build.
