### PR TITLE
ci: fix expression injection in notify-on-review-wanted workflow


### DIFF
--- a/.github/workflows/notify-on-review-wanted.yml
+++ b/.github/workflows/notify-on-review-wanted.yml
@@ -20,14 +20,16 @@ jobs:
         env:
           TITLE_ISSUE: ${{ github.event.issue.title }}
           TITLE_PR: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         run: |
-          if [[ -n "${{ github.event.pull_request.number }}" ]]; then
-            number="${{ github.event.pull_request.number }}"
+          if [[ -n "$PR_NUMBER" ]]; then
+            number="$PR_NUMBER"
             link="https://github.com/${{ github.repository }}/pull/$number"
             echo "message=The PR (#$number) requires review from Node.js maintainers. See: $link" >> "$GITHUB_OUTPUT"
             echo "title=$TITLE_PR" >> "$GITHUB_OUTPUT"
           else
-            number="${{ github.event.issue.number }}"
+            number="$ISSUE_NUMBER"
             link="https://github.com/${{ github.repository }}/issues/$number"
             echo "message=The issue (#$number) requires review from Node.js maintainers. See: $link" >> "$GITHUB_OUTPUT"
             echo "title=$TITLE_ISSUE" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
The `.github/workflows/notify-on-review-wanted.yml` workflow injects GitHub Actions expressions directly into a shell run step. This is flagged by zizmor/actionlint and violates GitHub's security hardening guidelines. Fix: use env vars instead of inline expressions.
