### PR TITLE
test_runner: report ignored branches as covered in lcov output

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -263,14 +263,18 @@ class TestCoverage {
           ObjectAssign(range, mapRangeToLines(range, lines));
 
           if (isBlockCoverage) {
+            // If all lines in this range are ignored, report the branch as
+            // covered (count=1) instead of its actual V8 count. This matches
+            // the behavior of c8 and ensures the lcov output does not contain
+            // uncovered BRDA entries for ignored branches.
+            const count = range.ignoredLines === range.lines.length ? 1 : range.count;
             ArrayPrototypePush(branchReports, {
               __proto__: null,
               line: range.lines[0]?.line,
-              count: range.count,
+              count,
             });
 
-            if (range.count !== 0 ||
-                range.ignoredLines === range.lines.length) {
+            if (count !== 0) {
               branchesCovered++;
             }
 


### PR DESCRIPTION
This is an independent contribution and is not affiliated with, endorsed by, or related to any hackathon or competition.

## Summary

When `/* node:coverage ignore next */` is used to exclude a branch return from coverage, the DA (line coverage) entry is correctly excluded from the lcov output but the BRDA (branch coverage) entry remains as uncovered (`BRDA:4,2,0,0`). This causes branch coverage to report lower than expected.

## Root Cause

In `lib/internal/test_runner/coverage.js`, branch coverage ranges are added to `branchReports` with the raw V8 count (0 for uncovered branches). While `coveredBranchCount` correctly handles ignored branches (counting them as covered), the individual branch report still carries count=0, which the lcov reporter outputs as an uncovered branch.

## Fix

When a branch range spans entirely ignored lines (`range.ignoredLines === range.lines.length`), report it with count=1 instead of the raw V8 count. This matches the behavior of `c8` and ensures lcov output correctly represents ignored branches as covered.

## Testing

Existing coverage tests continue to pass. Manual verification against the reproduction case from the issue confirms:
- `DA` entries for ignored lines are excluded (unchanged behavior)
- `BRDA` entries for ignored branches now appear as covered (count=1)
- Branch coverage summary reports 100% as expected

Fixes #61586