### PR TITLE
lib: remove source map deadcode in type stripping

### DIFF
--- a/lib/internal/modules/typescript.js
+++ b/lib/internal/modules/typescript.js
@@ -18,9 +18,7 @@ const {
   ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING,
   ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX,
 } = require('internal/errors').codes;
-const { getOptionValue } = require('internal/options');
 const assert = require('internal/assert');
-const { Buffer } = require('buffer');
 const {
   getCompileCacheEntry,
   saveCompileCacheEntry,
@@ -117,26 +115,18 @@ function stripTypeScriptTypes(code, options = kEmptyObject) {
 }
 
 /**
- * @typedef {'strip-only' | 'transform'} TypeScriptMode
  * @typedef {object} TypeScriptOptions
- * @property {TypeScriptMode} mode Mode.
- * @property {boolean} sourceMap Whether to generate source maps.
  * @property {string|undefined} filename Filename.
  */
 
 /**
- * Processes TypeScript code by stripping types or transforming.
- * Handles source maps if needed.
+ * Processes TypeScript code by stripping types.
  * @param {string} code TypeScript code to process.
  * @param {TypeScriptOptions} options The configuration object.
  * @returns {string} The processed code.
  */
 function processTypeScriptCode(code, options) {
-  const { code: transformedCode, map } = parseTypeScript(code, options);
-
-  if (map) {
-    return addSourceMap(transformedCode, map);
-  }
+  const { code: transformedCode } = parseTypeScript(code, options);
 
   if (options.filename) {
     return `${transformedCode}\n\n//# sourceURL=${options.filename}`;
@@ -164,8 +154,6 @@ function stripTypeScriptModuleTypes(source, filename, sourceURL) {
   if (isUnderNodeModules(filename)) {
     throw new ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING(filename);
   }
-  const sourceMap = getOptionValue('--enable-source-maps');
-
   // Get a compile cache entry into the native compile cache store,
   // keyed by the filename. If the cache can already be loaded on disk,
   // cached.transpiled contains the cached string. Otherwise we should do
@@ -178,7 +166,6 @@ function stripTypeScriptModuleTypes(source, filename, sourceURL) {
 
   const options = {
     mode: 'strip-only',
-    sourceMap,
     filename: sourceURL ?? filename,
   };
 
@@ -192,20 +179,6 @@ function stripTypeScriptModuleTypes(source, filename, sourceURL) {
     saveCompileCacheEntry(cached.external, transpiled);
   }
   return transpiled;
-}
-
-/**
- *
- * @param {string} code The compiled code.
- * @param {string} sourceMap The source map.
- * @returns {string} The code with the source map attached.
- */
-function addSourceMap(code, sourceMap) {
-  // The base64 encoding should be https://datatracker.ietf.org/doc/html/rfc4648#section-4,
-  // not base64url https://datatracker.ietf.org/doc/html/rfc4648#section-5. See data url
-  // spec https://tools.ietf.org/html/rfc2397#section-2.
-  const base64SourceMap = Buffer.from(sourceMap).toString('base64');
-  return `${code}\n\n//# sourceMappingURL=data:application/json;base64,${base64SourceMap}`;
 }
 
 module.exports = {


### PR DESCRIPTION
`processTypeScriptCode` does not produce source maps at all for type
stripping. Given that the transform mode was removed, there is no need
to keep the source map support around it.

Refs: https://github.com/nodejs/node/pull/61803
