### PR TITLE
vm: fix property queries for proxy sandboxes

### DIFF
--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -493,13 +493,13 @@ Intercepted ContextifyContext::PropertyQueryCallback(
 
   PropertyAttribute attr;
 
-  Maybe<bool> maybe_has = sandbox->HasRealNamedProperty(context, property);
+  Maybe<bool> maybe_has = sandbox->HasOwnProperty(context, property);
   if (maybe_has.IsNothing()) {
     return Intercepted::kNo;
   } else if (maybe_has.FromJust()) {
-    Maybe<PropertyAttribute> maybe_attr =
-        sandbox->GetRealNamedPropertyAttributes(context, property);
-    if (!maybe_attr.To(&attr)) {
+    Maybe<bool> maybe_attr =
+        sandbox->GetPropertyAttributes(context, property, &attr);
+    if (!maybe_attr.FromMaybe(false)) {
       return Intercepted::kNo;
     }
     args.GetReturnValue().Set(attr);

--- a/test/parallel/test-vm-proxy-sandbox-property-query.js
+++ b/test/parallel/test-vm-proxy-sandbox-property-query.js
@@ -1,0 +1,74 @@
+'use strict';
+
+require('../common');
+const assert = require('node:assert');
+const vm = require('node:vm');
+
+// This test ensures that Proxy-backed vm sandboxes report own properties
+// consistently across descriptor and membership queries.
+
+const sandbox = new Proxy({}, {});
+const ctx = vm.createContext(sandbox);
+
+vm.runInContext(`
+Object.defineProperty(this, 'foo', {
+  value: 42,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+Object.defineProperty(this, 'hidden', {
+  value: 1,
+  enumerable: false,
+  configurable: true,
+});
+Object.defineProperty(this, 'readonly', {
+  value: 2,
+  writable: false,
+  enumerable: true,
+  configurable: true,
+});
+`, ctx);
+
+const result = vm.runInContext(`({
+  value: foo,
+  descriptor: Object.getOwnPropertyDescriptor(globalThis, 'foo'),
+  ownNamesIncludes: Object.getOwnPropertyNames(globalThis).includes('foo'),
+  hasOwnProperty:
+    Object.prototype.hasOwnProperty.call(globalThis, 'foo'),
+  objectHasOwn: Object.hasOwn(globalThis, 'foo'),
+  inGlobalThis: 'foo' in globalThis,
+  reflectHas: Reflect.has(globalThis, 'foo'),
+  keysIncludesFoo: Object.keys(globalThis).includes('foo'),
+  keysIncludesHidden: Object.keys(globalThis).includes('hidden'),
+  hiddenIsEnumerable:
+    Object.prototype.propertyIsEnumerable.call(globalThis, 'hidden'),
+  readonlyDescriptor:
+    Object.getOwnPropertyDescriptor(globalThis, 'readonly'),
+  hasOwnToString: Object.hasOwn(globalThis, 'toString'),
+  toStringInGlobalThis: 'toString' in globalThis,
+})`, ctx);
+
+assert.strictEqual(result.value, 42);
+assert.deepStrictEqual({ ...result.descriptor }, {
+  value: 42,
+  writable: true,
+  enumerable: true,
+  configurable: true,
+});
+assert.strictEqual(result.ownNamesIncludes, true);
+assert.strictEqual(result.hasOwnProperty, true);
+assert.strictEqual(result.objectHasOwn, true);
+assert.strictEqual(result.inGlobalThis, true);
+assert.strictEqual(result.reflectHas, true);
+assert.strictEqual(result.keysIncludesFoo, true);
+assert.strictEqual(result.keysIncludesHidden, false);
+assert.strictEqual(result.hiddenIsEnumerable, false);
+assert.deepStrictEqual({ ...result.readonlyDescriptor }, {
+  value: 2,
+  writable: false,
+  enumerable: true,
+  configurable: true,
+});
+assert.strictEqual(result.hasOwnToString, false);
+assert.strictEqual(result.toStringInGlobalThis, true);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63739
Refs: https://github.com/nodejs/node/pull/63549

This updates the vm contextify named property query path to inspect own property descriptors on the sandbox object instead of using `HasRealNamedProperty()` for that sandbox lookup. The previous lookup cannot see properties through a JSProxy, which made Proxy-backed vm sandboxes report false for `hasOwnProperty`, `Object.hasOwn`, `in`, and `Reflect.has` even when the property was readable, listed, and had an own descriptor.

The fallback lookup on the real global proxy remains unchanged for properties that are not own properties of the sandbox.

Added a regression test for a Proxy sandbox with writable, non-enumerable, and readonly own properties, plus prototype fallback sanity checks.

Validation:
- `./configure --ninja --without-npm --without-inspector --without-sqlite --without-ffi --without-lief`
- `ninja -C out/Release -j12 node`
- `./out/Release/node test/parallel/test-vm-proxy-sandbox-property-query.js`
- `python3 tools/test.py -J --mode=release parallel/test-vm-proxy-sandbox-property-query parallel/test-vm-property-definer-interception parallel/test-vm-global-property-interceptors`
- `make lint-cpp`
- `make lint-js LINT_JS_TARGETS=test/parallel/test-vm-proxy-sandbox-property-query.js`
- External minimal repro: patched branch passes
- External Jest fake-timers repro: patched branch passes both tests
