### PR TITLE
test: mark SEA tests flaky on linux arm debug

### DIFF
--- a/test/sea/sea.status
+++ b/test/sea/sea.status
@@ -21,6 +21,11 @@ test-build-sea*: SKIP
 test-single-executable-application*: SKIP
 test-build-sea*: SKIP
 
+[$system==linux && $arch==arm && $mode==debug]
+# LIEF-based --build-sea can be killed on arm debug CI.
+test-single-executable-application*: PASS, FLAKY
+test-build-sea*: PASS, FLAKY
+
 [$system==win32]
 # https://github.com/nodejs/node/issues/49630
 test-single-executable-application-snapshot: PASS, FLAKY

--- a/test/sea/sea.status
+++ b/test/sea/sea.status
@@ -22,7 +22,7 @@ test-single-executable-application*: SKIP
 test-build-sea*: SKIP
 
 [$system==linux && $arch==arm && $mode==debug]
-# LIEF-based --build-sea can be killed on arm debug CI.
+# https://github.com/nodejs/node/issues/63749
 test-single-executable-application*: PASS, FLAKY
 test-build-sea*: PASS, FLAKY
 


### PR DESCRIPTION
The LIEF-based --build-sea tests can be killed by the OS on the
linux arm debug CI worker while rebuilding the ELF binary. The failures
all happen after SEA serialization succeeds, when the injector enters
LIEF::ELF::Builder::build(), and report SIGKILL instead of a test
assertion failure.

Mark the affected SEA build and application test families as flaky only
on linux arm debug, matching the node-test-commit-arm-debug job
where the flakes have been observed.

Refs:
* https://github.com/nodejs/reliability/blob/main/reports/2026-06-10.md
* https://github.com/nodejs/reliability/blob/main/reports/2026-06-09.md
* https://github.com/nodejs/reliability/blob/main/reports/2026-06-08.md
* https://github.com/nodejs/reliability/blob/main/reports/2026-06-07.md
* https://github.com/nodejs/reliability/blob/main/reports/2026-06-06.md
* https://github.com/nodejs/reliability/blob/main/reports/2026-06-05.md
* https://github.com/nodejs/reliability/blob/main/reports/2026-06-04.md
* https://github.com/nodejs/reliability/blob/main/reports/2026-06-03.md