### PR TITLE
zlib: validate flush kind for brotli streams

### DIFF
--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -268,6 +268,7 @@ function ZlibBase(opts, mode, handle, { flush, finishFlush, fullFlush }) {
   this._defaultFlushFlag = flush;
   this._finishFlushFlag = finishFlush;
   this._defaultFullFlushFlag = fullFlush;
+  this._flushBoundIdx = flushBoundIdx;
   this._info = opts?.info;
   this._maxOutputLength = maxOutputLength;
 
@@ -347,6 +348,18 @@ ZlibBase.prototype.flush = function(kind, callback) {
   if (typeof kind === 'function' || (kind === undefined && !callback)) {
     callback = kind;
     kind = this._defaultFullFlushFlag;
+  }
+
+  // Reject kinds outside the brotli operation range. Otherwise the fake-chunk
+  // path forwards an unsupported flush flag to the native encoder/decoder,
+  // which spins at 100% CPU without making progress (see #63701).
+  if (this._flushBoundIdx === FLUSH_BOUND_IDX_BROTLI) {
+    const min = FLUSH_BOUND[FLUSH_BOUND_IDX_BROTLI][0];
+    const max = FLUSH_BOUND[FLUSH_BOUND_IDX_BROTLI][1];
+    if (typeof kind !== 'number' || NumberIsNaN(kind) ||
+        kind < min || kind > max) {
+      throw new ERR_OUT_OF_RANGE('kind', `>= ${min} and <= ${max}`, kind);
+    }
   }
 
   if (this.writableFinished) {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -350,17 +350,10 @@ ZlibBase.prototype.flush = function(kind, callback) {
     kind = this._defaultFullFlushFlag;
   }
 
-  // Reject kinds outside the brotli operation range. Otherwise the fake-chunk
-  // path forwards an unsupported flush flag to the native encoder/decoder,
-  // which spins at 100% CPU without making progress (see #63701).
-  if (this._flushBoundIdx === FLUSH_BOUND_IDX_BROTLI) {
-    const min = FLUSH_BOUND[FLUSH_BOUND_IDX_BROTLI][0];
-    const max = FLUSH_BOUND[FLUSH_BOUND_IDX_BROTLI][1];
-    if (typeof kind !== 'number' || NumberIsNaN(kind) ||
-        kind < min || kind > max) {
-      throw new ERR_OUT_OF_RANGE('kind', `>= ${min} and <= ${max}`, kind);
-    }
-  }
+  kind = checkRangesOrGetDefault(
+    kind, 'kind',
+    FLUSH_BOUND[this._flushBoundIdx][0], FLUSH_BOUND[this._flushBoundIdx][1],
+    this._defaultFullFlushFlag);
 
   if (this.writableFinished) {
     if (callback)

--- a/test/parallel/test-zlib-brotli-flush-invalid-kind.js
+++ b/test/parallel/test-zlib-brotli-flush-invalid-kind.js
@@ -1,0 +1,69 @@
+'use strict';
+// Regression test for https://github.com/nodejs/node/issues/63701
+// BrotliCompress/BrotliDecompress.flush(kind) used to spin at 100% CPU when
+// kind was outside the brotli operation range (0..3) — e.g. Z_FINISH (4) or
+// Z_BLOCK (5). It must now throw ERR_OUT_OF_RANGE before reaching the native
+// layer.
+
+require('../common');
+const assert = require('assert');
+const zlib = require('zlib');
+
+const {
+  BROTLI_OPERATION_PROCESS,
+  BROTLI_OPERATION_FLUSH,
+  BROTLI_OPERATION_FINISH,
+  BROTLI_OPERATION_EMIT_METADATA,
+  Z_BLOCK,
+  Z_FINISH,
+} = zlib.constants;
+
+// Brotli operations 0..3 are valid and must not throw synchronously from
+// flush(). Some operations (e.g. FINISH on a decoder with no input) emit a
+// Z_BUF_ERROR asynchronously — that's expected and unrelated to the input
+// validation under test, so we attach a noop error handler.
+for (const validKind of [
+  BROTLI_OPERATION_PROCESS,
+  BROTLI_OPERATION_FLUSH,
+  BROTLI_OPERATION_FINISH,
+  BROTLI_OPERATION_EMIT_METADATA,
+]) {
+  const c = zlib.createBrotliCompress();
+  c.on('error', () => {});
+  c.flush(validKind);
+
+  const d = zlib.createBrotliDecompress();
+  d.on('error', () => {});
+  d.flush(validKind);
+}
+
+// Values outside [0, 3] must throw ERR_OUT_OF_RANGE for both compress and
+// decompress streams. Z_FINISH (4) and Z_BLOCK (5) previously hung at 100% CPU.
+const outOfRange = [-1, Z_FINISH, Z_BLOCK, 6, 7, 100];
+
+for (const factory of [zlib.createBrotliCompress, zlib.createBrotliDecompress]) {
+  for (const kind of outOfRange) {
+    assert.throws(
+      () => factory().flush(kind),
+      { code: 'ERR_OUT_OF_RANGE', name: 'RangeError' },
+    );
+  }
+}
+
+// Non-number kinds must also throw, instead of silently triggering the
+// fake-chunk path with an undefined buffer.
+for (const factory of [zlib.createBrotliCompress, zlib.createBrotliDecompress]) {
+  for (const kind of ['foobar', null, {}, NaN]) {
+    assert.throws(
+      () => factory().flush(kind),
+      { code: 'ERR_OUT_OF_RANGE' },
+    );
+  }
+}
+
+// flush() with no arguments (or with only a callback) must still work —
+// it uses the stream's _defaultFullFlushFlag, which is a valid brotli op.
+zlib.createBrotliCompress().flush();
+zlib.createBrotliCompress().flush(() => {});
+zlib.createBrotliDecompress().flush();
+zlib.createBrotliDecompress().flush(() => {});

--- a/test/parallel/test-zlib-brotli-flush-invalid-kind.js
+++ b/test/parallel/test-zlib-brotli-flush-invalid-kind.js
@@ -1,9 +1,7 @@
 'use strict';
-// Regression test for https://github.com/nodejs/node/issues/63701
-// BrotliCompress/BrotliDecompress.flush(kind) used to spin at 100% CPU when
-// kind was outside the brotli operation range (0..3) — e.g. Z_FINISH (4) or
-// Z_BLOCK (5). It must now throw ERR_OUT_OF_RANGE before reaching the native
-// layer.
+// Regression test for https://github.com/nodejs/node/issues/63701.
+// Invalid Brotli flush kinds used to spin in native code. flush(kind) should
+// reject invalid kinds before writing the fake flush chunk.
 
 require('../common');
 const assert = require('assert');
@@ -14,56 +12,81 @@ const {
   BROTLI_OPERATION_FLUSH,
   BROTLI_OPERATION_FINISH,
   BROTLI_OPERATION_EMIT_METADATA,
+  Z_NO_FLUSH,
   Z_BLOCK,
   Z_FINISH,
+  ZSTD_e_continue,
+  ZSTD_e_flush,
+  ZSTD_e_end,
 } = zlib.constants;
 
-// Brotli operations 0..3 are valid and must not throw synchronously from
-// flush(). Some operations (e.g. FINISH on a decoder with no input) emit a
-// Z_BUF_ERROR asynchronously — that's expected and unrelated to the input
-// validation under test, so we attach a noop error handler.
-for (const validKind of [
-  BROTLI_OPERATION_PROCESS,
-  BROTLI_OPERATION_FLUSH,
-  BROTLI_OPERATION_FINISH,
-  BROTLI_OPERATION_EMIT_METADATA,
-]) {
-  const c = zlib.createBrotliCompress();
-  c.on('error', () => {});
-  c.flush(validKind);
+const noop = () => {};
 
-  const d = zlib.createBrotliDecompress();
-  d.on('error', () => {});
-  d.flush(validKind);
-}
+const flushKindTestCases = [
+  {
+    factories: [zlib.createGzip],
+    validKinds: [Z_NO_FLUSH, Z_FINISH, Z_BLOCK],
+    invalidKinds: [-1, 6, 100],
+  },
+  {
+    factories: [zlib.createBrotliCompress, zlib.createBrotliDecompress],
+    validKinds: [
+      BROTLI_OPERATION_PROCESS,
+      BROTLI_OPERATION_FLUSH,
+      BROTLI_OPERATION_FINISH,
+      BROTLI_OPERATION_EMIT_METADATA,
+    ],
+    invalidKinds: [-1, Z_FINISH, Z_BLOCK, 6, 100],
+  },
+  {
+    factories: [zlib.createZstdCompress, zlib.createZstdDecompress],
+    validKinds: [ZSTD_e_continue, ZSTD_e_flush, ZSTD_e_end],
+    invalidKinds: [-1, 3, Z_FINISH, Z_BLOCK, 100],
+  },
+];
 
-// Values outside [0, 3] must throw ERR_OUT_OF_RANGE for both compress and
-// decompress streams. Z_FINISH (4) and Z_BLOCK (5) previously hung at 100% CPU.
-const outOfRange = [-1, Z_FINISH, Z_BLOCK, 6, 7, 100];
-
-for (const factory of [zlib.createBrotliCompress, zlib.createBrotliDecompress]) {
-  for (const kind of outOfRange) {
-    assert.throws(
-      () => factory().flush(kind),
-      { code: 'ERR_OUT_OF_RANGE', name: 'RangeError' },
-    );
+for (const { factories, validKinds } of flushKindTestCases) {
+  for (const factory of factories) {
+    for (const kind of validKinds) {
+      const stream = factory();
+      stream.on('error', noop);
+      stream.flush(kind);
+    }
   }
 }
 
-// Non-number kinds must also throw, instead of silently triggering the
-// fake-chunk path with an undefined buffer.
-for (const factory of [zlib.createBrotliCompress, zlib.createBrotliDecompress]) {
-  for (const kind of ['foobar', null, {}, NaN]) {
-    assert.throws(
-      () => factory().flush(kind),
-      { code: 'ERR_OUT_OF_RANGE' },
-    );
+for (const { factories, invalidKinds } of flushKindTestCases) {
+  for (const factory of factories) {
+    for (const kind of invalidKinds) {
+      assert.throws(
+        () => factory().flush(kind),
+        { code: 'ERR_OUT_OF_RANGE', name: 'RangeError' },
+      );
+    }
   }
 }
 
-// flush() with no arguments (or with only a callback) must still work —
-// it uses the stream's _defaultFullFlushFlag, which is a valid brotli op.
-zlib.createBrotliCompress().flush();
-zlib.createBrotliCompress().flush(() => {});
-zlib.createBrotliDecompress().flush();
-zlib.createBrotliDecompress().flush(() => {});
+for (const { factories } of flushKindTestCases) {
+  for (const factory of factories) {
+    for (const kind of ['foobar', null, {}]) {
+      assert.throws(
+        () => factory().flush(kind),
+        { code: 'ERR_INVALID_ARG_TYPE', name: 'TypeError' },
+      );
+    }
+  }
+}
+
+for (const { factories } of flushKindTestCases) {
+  for (const factory of factories) {
+    for (const kind of [undefined, NaN]) {
+      const stream = factory();
+      stream.on('error', noop);
+      stream.flush(kind);
+    }
+
+    const stream = factory();
+    stream.on('error', noop);
+    stream.flush(noop);
+  }
+}


### PR DESCRIPTION
### Summary

`BrotliCompress.flush(kind)` and `BrotliDecompress.flush(kind)` accepted numeric `kind` values that are not valid Brotli operations and forwarded them to the native Brotli encoder/decoder.

Passing zlib flush constants such as `Z_FINISH` (`4`) or `Z_BLOCK` (`5`) could make the process spin at 100% CPU indefinitely, because Brotli only supports operation values in the range `0..3`.

This PR validates `kind` for Brotli streams before queuing the fake flush chunk. Numeric values outside the Brotli operation range now throw `ERR_OUT_OF_RANGE`, matching the existing `options.flush` and `options.finishFlush` validation path.

### Scope

The validation is intentionally limited to Brotli streams. zlib and zstd stream `flush()` behavior is unchanged.

Valid Brotli operations continue to work:

- `BROTLI_OPERATION_PROCESS` (`0`)
- `BROTLI_OPERATION_FLUSH` (`1`)
- `BROTLI_OPERATION_FINISH` (`2`)
- `BROTLI_OPERATION_EMIT_METADATA` (`3`)

### Observable behavior changes

| Call | Before | After |
| --- | --- | --- |
| `flush(4)` / `Z_FINISH` | Hangs / spins at 100% CPU | Throws `ERR_OUT_OF_RANGE` |
| `flush(5)` / `Z_BLOCK` | Hangs / spins at 100% CPU | Throws `ERR_OUT_OF_RANGE` |
| `flush(6)` | Throws incidentally from the fake-chunk path | Throws `ERR_OUT_OF_RANGE` during validation |
| `flush(0..3)` | Works | Works |
| `flush()` / `flush(cb)` | Works, uses default Brotli flush operation | Works, uses default Brotli flush operation |

### Error type

`ERR_OUT_OF_RANGE` is intentional for invalid numeric values: `kind` has the correct JavaScript type, but the value is outside the valid Brotli operation range. Non-number values should continue to use the existing type-validation behavior.

### Cross-runtime note

Bun is fixing the same bug on their side ([oven-sh/bun#31505](https://github.com/oven-sh/bun/pull/31505)) but plans to throw `ERR_INVALID_ARG_TYPE` to match the current incidental behaviour of `flush(6)` on Node. This PR chooses `ERR_OUT_OF_RANGE` for internal consistency with the `checkRangesOrGetDefault` validation already used elsewhere in `lib/zlib.js`.

Fixes: https://github.com/nodejs/node/issues/63701