### PR TITLE
benchmark: add test runner hooks and options

### DIFF
--- a/benchmark/test_runner/hooks.js
+++ b/benchmark/test_runner/hooks.js
@@ -13,7 +13,7 @@ const {
 } = require('node:test');
 
 const bench = common.createBenchmark(main, {
-  n: [1, 10, 100, 1000],
+  n: [1000],
   hook: ['before', 'after', 'beforeEach', 'afterEach'],
 }, {
   // We don't want to test the reporter here.

--- a/benchmark/test_runner/hooks.js
+++ b/benchmark/test_runner/hooks.js
@@ -20,8 +20,6 @@ const bench = common.createBenchmark(main, {
   flags: ['--test-reporter=./benchmark/fixtures/empty-test-reporter.js'],
 });
 
-const noop = () => {};
-
 const hookList = {
   before: before,
   after: after,
@@ -32,7 +30,9 @@ const hookList = {
 function run(loopAmount, avoidV8Optimization, hookFn) {
   for (let i = 0; i < loopAmount; i++) {
     describe(`${i}`, () => {
-      hookFn(noop);
+      hookFn(() => {
+        avoidV8Optimization = i;
+      });
 
       it(`${i}`, () => {
         avoidV8Optimization = i;

--- a/benchmark/test_runner/hooks.js
+++ b/benchmark/test_runner/hooks.js
@@ -13,37 +13,26 @@ const {
 } = require('node:test');
 
 const bench = common.createBenchmark(main, {
-  n: [10, 100, 1000],
-  hook: ['none', 'before', 'after', 'beforeEach', 'afterEach'],
+  n: [1, 10, 100, 1000],
+  hook: ['before', 'after', 'beforeEach', 'afterEach'],
 }, {
   // We don't want to test the reporter here.
   flags: ['--test-reporter=./benchmark/fixtures/empty-test-reporter.js'],
 });
 
-async function run({ n, hook }) {
-  // eslint-disable-next-line no-unused-vars
-  let avoidV8Optimization;
+const noop = () => {};
 
-  const noop = () => {};
+const hookList = {
+  before: before,
+  after: after,
+  beforeEach: beforeEach,
+  afterEach: afterEach,
+};
 
-  for (let i = 0; i < n; i++) {
+function run(loopAmount, avoidV8Optimization, hookFn) {
+  for (let i = 0; i < loopAmount; i++) {
     describe(`${i}`, () => {
-      switch (hook) {
-        case 'before':
-          before(noop);
-          break;
-        case 'after':
-          after(noop);
-          break;
-        case 'beforeEach':
-          beforeEach(noop);
-          break;
-        case 'afterEach':
-          afterEach(noop);
-          break;
-        case 'none':
-          break;
-      }
+      hookFn(noop);
 
       it(`${i}`, () => {
         avoidV8Optimization = i;
@@ -51,13 +40,17 @@ async function run({ n, hook }) {
     });
   }
 
-  await finished(reporter);
+  return finished(reporter);
 }
 
 function main(params) {
+  // eslint-disable-next-line prefer-const
+  let avoidV8Optimization = 0;
+  const hookFn = hookList[params.hook];
+
   bench.start();
 
-  run(params).then(() => {
+  run(params.n, avoidV8Optimization, hookFn).then(() => {
     bench.end(params.n);
   });
 }

--- a/benchmark/test_runner/hooks.js
+++ b/benchmark/test_runner/hooks.js
@@ -1,0 +1,63 @@
+'use strict';
+
+const common = require('../common');
+const { finished } = require('node:stream/promises');
+const reporter = require('../fixtures/empty-test-reporter');
+const {
+  after,
+  afterEach,
+  before,
+  beforeEach,
+  describe,
+  it,
+} = require('node:test');
+
+const bench = common.createBenchmark(main, {
+  n: [10, 100, 1000],
+  hook: ['none', 'before', 'after', 'beforeEach', 'afterEach'],
+}, {
+  // We don't want to test the reporter here.
+  flags: ['--test-reporter=./benchmark/fixtures/empty-test-reporter.js'],
+});
+
+async function run({ n, hook }) {
+  // eslint-disable-next-line no-unused-vars
+  let avoidV8Optimization;
+
+  const noop = () => {};
+
+  for (let i = 0; i < n; i++) {
+    describe(`${i}`, () => {
+      switch (hook) {
+        case 'before':
+          before(noop);
+          break;
+        case 'after':
+          after(noop);
+          break;
+        case 'beforeEach':
+          beforeEach(noop);
+          break;
+        case 'afterEach':
+          afterEach(noop);
+          break;
+        case 'none':
+          break;
+      }
+
+      it(`${i}`, () => {
+        avoidV8Optimization = i;
+      });
+    });
+  }
+
+  await finished(reporter);
+}
+
+function main(params) {
+  bench.start();
+
+  run(params).then(() => {
+    bench.end(params.n);
+  });
+}

--- a/benchmark/test_runner/hooks.js
+++ b/benchmark/test_runner/hooks.js
@@ -27,16 +27,13 @@ const hookList = {
   afterEach: afterEach,
 };
 
-function run(loopAmount, avoidV8Optimization, hookFn) {
+const noop = () => {};
+
+function run(loopAmount, hookFn) {
   for (let i = 0; i < loopAmount; i++) {
     describe(`${i}`, () => {
-      hookFn(() => {
-        avoidV8Optimization = i;
-      });
-
-      it(`${i}`, () => {
-        avoidV8Optimization = i;
-      });
+      hookFn(noop);
+      it(`${i}`, noop);
     });
   }
 
@@ -44,13 +41,11 @@ function run(loopAmount, avoidV8Optimization, hookFn) {
 }
 
 function main(params) {
-  // eslint-disable-next-line prefer-const
-  let avoidV8Optimization = 0;
   const hookFn = hookList[params.hook];
 
   bench.start();
 
-  run(params.n, avoidV8Optimization, hookFn).then(() => {
+  run(params.n, hookFn).then(() => {
     bench.end(params.n);
   });
 }

--- a/benchmark/test_runner/test-options.js
+++ b/benchmark/test_runner/test-options.js
@@ -1,0 +1,94 @@
+'use strict';
+
+const common = require('../common');
+const { finished } = require('node:stream/promises');
+const reporter = require('../fixtures/empty-test-reporter');
+const { it } = require('node:test');
+
+const bench = common.createBenchmark(main, {
+  n: [100, 1000],
+  option: [
+    'none',
+    'skip',
+    'skip-with-message',
+    'skip-method',
+    'skip-method-with-message',
+    'todo',
+    'todo-with-message',
+    'todo-method',
+    'todo-method-with-message',
+  ],
+}, {
+  // We don't want to test the reporter here.
+  flags: ['--test-reporter=./benchmark/fixtures/empty-test-reporter.js'],
+});
+
+async function run({ n, option }) {
+  // eslint-disable-next-line no-unused-vars
+  let avoidV8Optimization;
+
+  for (let i = 0; i < n; i++) {
+    switch (option) {
+      case 'none':
+        it(`${i}`, () => {
+          avoidV8Optimization = i;
+        });
+        break;
+      case 'skip':
+        it(`${i}`, { skip: true }, () => {
+          throw new Error('This test should not run.');
+        });
+        break;
+      case 'skip-with-message':
+        it(`${i}`, { skip: 'skip reason' }, () => {
+          throw new Error('This test should not run.');
+        });
+        break;
+      case 'skip-method':
+        it(`${i}`, (t) => {
+          avoidV8Optimization = i;
+          t.skip();
+        });
+        break;
+      case 'skip-method-with-message':
+        it(`${i}`, (t) => {
+          avoidV8Optimization = i;
+          t.skip('skip reason');
+        });
+        break;
+      case 'todo':
+        it(`${i}`, { todo: true }, () => {
+          avoidV8Optimization = i;
+        });
+        break;
+      case 'todo-with-message':
+        it(`${i}`, { todo: 'todo reason' }, () => {
+          avoidV8Optimization = i;
+        });
+        break;
+      case 'todo-method':
+        it(`${i}`, (t) => {
+          avoidV8Optimization = i;
+          t.todo();
+        });
+        break;
+      case 'todo-method-with-message':
+        it(`${i}`, (t) => {
+          avoidV8Optimization = i;
+          t.todo('todo reason');
+        });
+        break;
+    }
+  }
+
+  await finished(reporter);
+  return n;
+}
+
+function main(params) {
+  bench.start();
+
+  run(params).then((ops) => {
+    bench.end(ops);
+  });
+}

--- a/benchmark/test_runner/test-options.js
+++ b/benchmark/test_runner/test-options.js
@@ -6,7 +6,7 @@ const reporter = require('../fixtures/empty-test-reporter');
 const { it } = require('node:test');
 
 const bench = common.createBenchmark(main, {
-  n: [1, 10, 100, 1000],
+  n: [10000],
   option: [
     'none',
     'skip',

--- a/benchmark/test_runner/test-options.js
+++ b/benchmark/test_runner/test-options.js
@@ -6,7 +6,7 @@ const reporter = require('../fixtures/empty-test-reporter');
 const { it } = require('node:test');
 
 const bench = common.createBenchmark(main, {
-  n: [100, 1000],
+  n: [1, 10, 100, 1000],
   option: [
     'none',
     'skip',
@@ -23,72 +23,102 @@ const bench = common.createBenchmark(main, {
   flags: ['--test-reporter=./benchmark/fixtures/empty-test-reporter.js'],
 });
 
-async function run({ n, option }) {
-  // eslint-disable-next-line no-unused-vars
-  let avoidV8Optimization;
-
-  for (let i = 0; i < n; i++) {
-    switch (option) {
-      case 'none':
-        it(`${i}`, () => {
-          avoidV8Optimization = i;
-        });
-        break;
-      case 'skip':
-        it(`${i}`, { skip: true }, () => {
-          throw new Error('This test should not run.');
-        });
-        break;
-      case 'skip-with-message':
-        it(`${i}`, { skip: 'skip reason' }, () => {
-          throw new Error('This test should not run.');
-        });
-        break;
-      case 'skip-method':
-        it(`${i}`, (t) => {
-          avoidV8Optimization = i;
-          t.skip();
-        });
-        break;
-      case 'skip-method-with-message':
-        it(`${i}`, (t) => {
-          avoidV8Optimization = i;
-          t.skip('skip reason');
-        });
-        break;
-      case 'todo':
-        it(`${i}`, { todo: true }, () => {
-          avoidV8Optimization = i;
-        });
-        break;
-      case 'todo-with-message':
-        it(`${i}`, { todo: 'todo reason' }, () => {
-          avoidV8Optimization = i;
-        });
-        break;
-      case 'todo-method':
-        it(`${i}`, (t) => {
-          avoidV8Optimization = i;
-          t.todo();
-        });
-        break;
-      case 'todo-method-with-message':
-        it(`${i}`, (t) => {
-          avoidV8Optimization = i;
-          t.todo('todo reason');
-        });
-        break;
+const allTests = {
+  'none': (loopAmount, avoidV8Optimization) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, () => {
+        avoidV8Optimization = i;
+      });
     }
-  }
 
-  await finished(reporter);
-  return n;
-}
+    return finished(reporter);
+  },
+  'skip': (loopAmount) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, { skip: true }, () => {
+        throw new Error('This test should not run.');
+      });
+    }
 
-function main(params) {
+    return finished(reporter);
+  },
+  'skip-with-message': (loopAmount) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, { skip: 'skip reason' }, () => {
+        throw new Error('This test should not run.');
+      });
+    }
+
+    return finished(reporter);
+  },
+  'skip-method': (loopAmount, avoidV8Optimization) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, (t) => {
+        avoidV8Optimization = i;
+        t.skip();
+      });
+    }
+
+    return finished(reporter);
+  },
+  'skip-method-with-message': (loopAmount, avoidV8Optimization) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, (t) => {
+        avoidV8Optimization = i;
+        t.skip('skip reason');
+      });
+    }
+
+    return finished(reporter);
+  },
+  'todo': (loopAmount, avoidV8Optimization) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, { todo: true }, () => {
+        avoidV8Optimization = i;
+      });
+    }
+
+    return finished(reporter);
+  },
+  'todo-with-message': (loopAmount, avoidV8Optimization) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, { todo: 'todo reason' }, () => {
+        avoidV8Optimization = i;
+      });
+    }
+
+    return finished(reporter);
+  },
+  'todo-method': (loopAmount, avoidV8Optimization) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, (t) => {
+        avoidV8Optimization = i;
+        t.todo();
+      });
+    }
+
+    return finished(reporter);
+  },
+  'todo-method-with-message': (loopAmount, avoidV8Optimization) => {
+    for (let i = 0; i < loopAmount; i++) {
+      it(`${i}`, (t) => {
+        avoidV8Optimization = i;
+        t.todo('todo reason');
+      });
+    }
+
+    return finished(reporter);
+  },
+};
+
+function main({ n, option }) {
+  // eslint-disable-next-line prefer-const
+  let avoidV8Optimization = 0;
+  const runOption = allTests[option];
+
   bench.start();
 
-  run(params).then((ops) => {
-    bench.end(ops);
+  runOption(n, avoidV8Optimization).then(() => {
+    bench.end(n);
   });
 }

--- a/benchmark/test_runner/test-options.js
+++ b/benchmark/test_runner/test-options.js
@@ -23,12 +23,12 @@ const bench = common.createBenchmark(main, {
   flags: ['--test-reporter=./benchmark/fixtures/empty-test-reporter.js'],
 });
 
+const noop = () => {};
+
 const allTests = {
-  'none': (loopAmount, avoidV8Optimization) => {
+  'none': (loopAmount) => {
     for (let i = 0; i < loopAmount; i++) {
-      it(`${i}`, () => {
-        avoidV8Optimization = i;
-      });
+      it(`${i}`, noop);
     }
 
     return finished(reporter);
@@ -51,58 +51,50 @@ const allTests = {
 
     return finished(reporter);
   },
-  'skip-method': (loopAmount, avoidV8Optimization) => {
+  'skip-method': (loopAmount) => {
     for (let i = 0; i < loopAmount; i++) {
       it(`${i}`, (t) => {
-        avoidV8Optimization = i;
         t.skip();
       });
     }
 
     return finished(reporter);
   },
-  'skip-method-with-message': (loopAmount, avoidV8Optimization) => {
+  'skip-method-with-message': (loopAmount) => {
     for (let i = 0; i < loopAmount; i++) {
       it(`${i}`, (t) => {
-        avoidV8Optimization = i;
         t.skip('skip reason');
       });
     }
 
     return finished(reporter);
   },
-  'todo': (loopAmount, avoidV8Optimization) => {
+  'todo': (loopAmount) => {
     for (let i = 0; i < loopAmount; i++) {
-      it(`${i}`, { todo: true }, () => {
-        avoidV8Optimization = i;
-      });
+      it(`${i}`, { todo: true }, noop);
     }
 
     return finished(reporter);
   },
-  'todo-with-message': (loopAmount, avoidV8Optimization) => {
+  'todo-with-message': (loopAmount) => {
     for (let i = 0; i < loopAmount; i++) {
-      it(`${i}`, { todo: 'todo reason' }, () => {
-        avoidV8Optimization = i;
-      });
+      it(`${i}`, { todo: 'todo reason' }, noop);
     }
 
     return finished(reporter);
   },
-  'todo-method': (loopAmount, avoidV8Optimization) => {
+  'todo-method': (loopAmount) => {
     for (let i = 0; i < loopAmount; i++) {
       it(`${i}`, (t) => {
-        avoidV8Optimization = i;
         t.todo();
       });
     }
 
     return finished(reporter);
   },
-  'todo-method-with-message': (loopAmount, avoidV8Optimization) => {
+  'todo-method-with-message': (loopAmount) => {
     for (let i = 0; i < loopAmount; i++) {
       it(`${i}`, (t) => {
-        avoidV8Optimization = i;
         t.todo('todo reason');
       });
     }
@@ -112,13 +104,11 @@ const allTests = {
 };
 
 function main({ n, option }) {
-  // eslint-disable-next-line prefer-const
-  let avoidV8Optimization = 0;
   const runOption = allTests[option];
 
   bench.start();
 
-  runOption(n, avoidV8Optimization).then(() => {
+  runOption(n).then(() => {
     bench.end(n);
   });
 }


### PR DESCRIPTION
Add benchmarks for node:test hooks and test options. The hooks benchmark covers before, after, beforeEach, and afterEach, with a none mode as the baseline. The test options benchmark covers skip and todo behavior. This adds coverage for part of the benchmark/test_runner gaps tracked in the issue.

Refs: https://github.com/nodejs/node/issues/55723

I eventually want to continue working on the Ref issue, and do the other benchmarks, but I decided to start with the simple ones that I can use [existing files as a reference](https://github.com/nodejs/node/blob/be7ea272e34b1f53f52d872649cb4140132e3bc4/benchmark/test_runner/suite-tests.js), get a feel for how the project works. Starting small and all of that. This will be my first (hopefully of many) contribution.

Please let me know if any changes or actions are required from me. I will wait for feedback before start tackling the other parts of the ref issue

Edit: I had some time today, and I started working on the other benchmarks, and I do have `only`, `mock.timers` and `mock.module` benchmarks ready too. I will await for feedback on the current code before pushing the other benchmarks. Please let me know if you prefer for me to push a different PR those since they have a bit more nuance, especially the mock.module one (Still nothing major tho)