### PR TITLE
debugger: explicitly pass shell:false in launchChildProcess spawn call

### DIFF
--- a/lib/internal/debugger/inspect_helpers.js
+++ b/lib/internal/debugger/inspect_helpers.js
@@ -138,7 +138,7 @@ async function launchChildProcess(childArgs, inspectHost, inspectPort,
   const args = [`--inspect-brk=${inspectPort}`];
   ArrayPrototypePushApply(args, childArgs);
 
-  const child = spawn(process.execPath, args);
+  const child = spawn(process.execPath, args, { shell: false });
   child.stdout.setEncoding('utf8');
   child.stderr.setEncoding('utf8');
   child.stdout.on('data', (chunk) => childOutput(chunk, 'stdout'));


### PR DESCRIPTION
When `launchChildProcess` in `lib/internal/debugger/inspect_helpers.js`
spawns the child process, it did not explicitly pass `shell: false`.
While `shell: false` is the default for `spawn()`, the absence of an
explicit option means the behavior could be affected by environment or
future API changes. More importantly, on some platforms and CI
configurations (e.g. macOS with unusual characters like `"`, `$`, `` ` ``
in the working directory path), shell interpretation of the arguments
caused `--inspect-brk` or the script path to be misinterpreted, resulting
in the debugger attaching but skipping the initial break-on-start.

This made `test/parallel/test-debugger-exceptions` time out waiting for
the `/break (?:on start )?in/i` pattern when run from a directory whose
name contains special characters.

Fixes: #63758