### PR TITLE
test: add closed-library assertions for getFunctions and getSymbols

### DIFF
--- a/test/ffi/test-ffi-dynamic-library.js
+++ b/test/ffi/test-ffi-dynamic-library.js
@@ -149,6 +149,8 @@ test('closed libraries reject subsequent operations', () => {
   assert.throws(() => functions.add_i32(1, 2), /Library is closed/);
   assert.throws(() => lib.getFunction('add_i32', fixtureSymbols.add_i32), /Library is closed/);
   assert.throws(() => lib.getSymbol('add_i32'), /Library is closed/);
+  assert.throws(() => lib.getFunctions({ add_i32: fixtureSymbols.add_i32 }), /Library is closed/);
+  assert.throws(() => lib.getSymbols(), /Library is closed/);
 });
 
 test('DynamicLibrary supports Symbol.dispose', () => {


### PR DESCRIPTION
The 'closed libraries reject subsequent operations' test verified that getFunction and getSymbol throw after close, but getFunctions and getSymbols were not covered. Both methods check handle_ == nullptr and throw ERR_FFI_LIBRARY_CLOSED, so they belong in the same test.