### PR TITLE
crypto: runtime-deprecate calling digest() on HMAC more than once

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4562,12 +4562,15 @@ removed in a future version of Node.js.
 
 <!-- YAML
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: Runtime deprecation.
   - version: v26.2.0
     pr-url: https://github.com/nodejs/node/pull/63121
     description: Documentation-only deprecation.
 -->
 
-Type: Documentation-only
+Type: Runtime
 
 Calling `hmac.digest()` more than once returns an empty buffer instead of
 throwing an error. This behavior is inconsistent with `hash.digest()` and

--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -87,6 +87,13 @@ const maybeEmitDeprecationWarning = getDeprecationWarningEmitter(
   },
 );
 
+const emitHmacDigestDeprecation = getDeprecationWarningEmitter(
+  'DEP0206',
+  'Calling digest() on an already-finalized Hmac instance is deprecated.',
+  undefined,
+  false,
+);
+
 function Hash(algorithm, options) {
   if (!new.target)
     return new Hash(algorithm, options);
@@ -186,6 +193,7 @@ Hmac.prototype.digest = function digest(outputEncoding) {
   const state = this[kState];
 
   if (state[kFinalized]) {
+    emitHmacDigestDeprecation();
     const buf = Buffer.from('');
     if (outputEncoding && outputEncoding !== 'buffer')
       return buf.toString(outputEncoding);


### PR DESCRIPTION
## Description
Fixes #62838

Currently, calling `hmac.digest()` multiple times on a finalized HMAC instance returns an empty buffer instead of throwing `ERR_CRYPTO_HASH_FINALIZED` (which is what standard hashes do). As noted in the issue, this inconsistency represents a security footgun.

Following the documentation-only deprecation introduced in #63121, this patch formally implements the runtime deprecation warning via `emitDeprecationWarning('DEP0206')`.

## Testing
Verified correct usage of `getDeprecationWarningEmitter` mapping.