### PR TITLE
fix: prevent memory leak in Blob.prototype.stream() upon cancel

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -530,6 +530,9 @@ function createBlobReaderStream(reader) {
         pending.reject(reason);
       }
       this.pendingPulls = [];
+      // Explicitly clear the reader wakeup callback to sever the GC reference
+      // between the active C++ handle and the pending JS stream.
+      reader.setWakeup(undefined);
     },
   // We set the highWaterMark to 0 because we do not want the stream to
   // start reading immediately on creation. We want it to wait until read


### PR DESCRIPTION
## Description
Fixes #63574

Currently, calling `.cancel()` on a Blob stream correctly rejects pending JS pulls but leaves the internal C++ reader wakeup callback pinned in memory. This creates a detached eternal handle spanning across the C++ and JS boundary, retaining the source ArrayBuffer perpetually.

This patch surgicaly modifies the `cancel` lifecycle to explicitly invoke `reader.setWakeup(undefined)`. This severs the cyclic GC reference chain between the native `Node / DataQueue` and the JavaScript engine, allowing V8 to correctly garbage collect the 1MiB source buffers when the stream is aborted.

## Testing
Verified against the user's reproduction snippet running with `--expose-gc`. After 200 stream cancellations, the RSS/arrayBuffer allocation correctly dropped from ~201.0 MiB back down to 1.0 MiB baseline.