### PR TITLE
url: fix URLSearchParams(null)  per spec

### DIFF
--- a/lib/internal/url.js
+++ b/lib/internal/url.js
@@ -337,9 +337,9 @@ class URLSearchParams {
   constructor(init = undefined) {
     markTransferMode(this, false, false);
 
-    if (init == null) {
+    if (init === undefined) {
       // Do nothing
-    } else if (typeof init === 'object' || typeof init === 'function') {
+    } else if (init !== null && (typeof init === 'object' || typeof init === 'function')) {
       const method = init[SymbolIterator];
       if (method === this[SymbolIterator] && #searchParams in init) {
         // While the spec does not have this branch, we can use it as a

--- a/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
+++ b/test/parallel/test-whatwg-url-custom-searchparams-constructor.js
@@ -28,8 +28,14 @@ function makeIterableFunc(array) {
   let params;
   params = new URLSearchParams(undefined);
   assert.strictEqual(params.toString(), '');
+  // Per WebIDL union resolution, null is coerced to the USVString "null".
+  // Refs: https://url.spec.whatwg.org/#interface-urlsearchparams
   params = new URLSearchParams(null);
-  assert.strictEqual(params.toString(), '');
+  assert.strictEqual(params.toString(), 'null=');
+  params = new URLSearchParams(false);
+  assert.strictEqual(params.toString(), 'false=');
+  params = new URLSearchParams(0);
+  assert.strictEqual(params.toString(), '0=');
   params = new URLSearchParams(
     makeIterableFunc([['key', 'val'], ['key2', 'val2']])
   );


### PR DESCRIPTION
## url: fix URLSearchParams(null) to produce "null=" per spec

Per the [WHATWG URL spec][spec], the `URLSearchParams` constructor accepts a `(sequence<sequence<USVString>> or record<USVString, USVString> or USVString)` union. `null` is not a sequence or record, so WebIDL union resolution falls through to `USVString`, where `ToString(null)` is `"null"`.

Here we short-circuited on `init == null`, treating `null` the same as `undefined` and producing an empty string.

Before:

```js
new URLSearchParams(null).toString() // ''
```

After (matches Chrome and Deno):

```js
new URLSearchParams(null).toString() // 'null='
```

Fixes: https://github.com/nodejs/node/issues/63559

[spec]: https://url.spec.whatwg.org/#interface-urlsearchparams