### PR TITLE
sqlite: validate maxSize argument in createTagStore()

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1044,10 +1044,23 @@ void DatabaseSync::CreateTagStore(const FunctionCallbackInfo<Value>& args) {
     return;
   }
   int capacity = 1000;
-  if (args.Length() > 0 && args[0]->IsNumber()) {
-    capacity = args[0].As<Number>()->Value();
+  if (args.Length() > 0 && !args[0]->IsUndefined()) {
+    if (!args[0]->IsNumber()) {
+      THROW_ERR_INVALID_ARG_TYPE(
+          env->isolate(),
+          "The \"maxSize\" argument must be a positive integer.");
+      return;
+    }
+    double val = args[0].As<Number>()->Value();
+    if (!std::isfinite(val) || std::floor(val) != val || val <= 0 ||
+        val > std::numeric_limits<int>::max()) {
+      THROW_ERR_OUT_OF_RANGE(
+          env->isolate(),
+          "The \"maxSize\" argument must be a positive integer.");
+      return;
+    }
+    capacity = static_cast<int>(val);
   }
-
   BaseObjectPtr<SQLTagStore> session =
       SQLTagStore::Create(env, BaseObjectWeakPtr<DatabaseSync>(db), capacity);
   if (!session) {

--- a/test/parallel/test-sqlite-template-tag.js
+++ b/test/parallel/test-sqlite-template-tag.js
@@ -112,6 +112,40 @@ test('TagStore capacity, size, and clear', () => {
   assert.strictEqual(sql.capacity, 10);
 });
 
+test('createTagStore throws on invalid maxSize', () => {
+  const db = new DatabaseSync(':memory:');
+
+  assert.throws(() => db.createTagStore(0), {
+    code: 'ERR_OUT_OF_RANGE',
+    message: /maxSize/,
+  });
+
+  assert.throws(() => db.createTagStore(-1), {
+    code: 'ERR_OUT_OF_RANGE',
+    message: /maxSize/,
+  });
+
+  assert.throws(() => db.createTagStore(NaN), {
+    code: 'ERR_OUT_OF_RANGE',
+    message: /maxSize/,
+  });
+
+  assert.throws(() => db.createTagStore(1.5), {
+    code: 'ERR_OUT_OF_RANGE',
+    message: /maxSize/,
+  });
+
+  assert.throws(() => db.createTagStore('abc'), {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: /maxSize/,
+  });
+
+  assert.throws(() => db.createTagStore(Number.MAX_SAFE_INTEGER), {
+    code: 'ERR_OUT_OF_RANGE',
+    message: /maxSize/,
+  });
+});
+
 test('sql.db returns the associated DatabaseSync instance', () => {
   assert.strictEqual(sql.db, db);
 });


### PR DESCRIPTION
Fixes: #63791

`database.createTagStore()` accepted invalid values for its `maxSize` argument without throwing. Negative integers caused integer overflow, NaN and floats produced garbage capacity values, and strings were silently ignored.

The `maxSize` parameter is documented as `{integer}` and represents a cache size, so negative values are meaningless.

This PR adds validation to reject:
- Non-integer values (NaN, floats, strings) with `ERR_INVALID_ARG_TYPE`
- Negative integers with `ERR_OUT_OF_RANGE`

