### PR TITLE
ffi: port semi-colon fix for riscv64 (and others)

### DIFF
--- a/deps/libffi/src/loongarch64/ffitarget.h
+++ b/deps/libffi/src/loongarch64/ffitarget.h
@@ -77,6 +77,6 @@ typedef enum ffi_abi
 #define FFI_NATIVE_RAW_API 0
 #define FFI_EXTRA_CIF_FIELDS \
   unsigned loongarch_nfixedargs; \
-  unsigned loongarch_unused;
+  unsigned loongarch_unused
 #define FFI_TARGET_SPECIFIC_VARIADIC
 #endif

--- a/deps/libffi/src/or1k/ffitarget.h
+++ b/deps/libffi/src/or1k/ffitarget.h
@@ -52,7 +52,7 @@ typedef enum ffi_abi {
 #define FFI_TRAMPOLINE_SIZE (24)
 
 #define FFI_TARGET_SPECIFIC_VARIADIC 1
-#define FFI_EXTRA_CIF_FIELDS unsigned nfixedargs;
+#define FFI_EXTRA_CIF_FIELDS unsigned nfixedargs
 
 #endif
 

--- a/deps/libffi/src/riscv/ffitarget.h
+++ b/deps/libffi/src/riscv/ffitarget.h
@@ -62,7 +62,7 @@ typedef enum ffi_abi {
 #define FFI_GO_CLOSURES 1
 #define FFI_TRAMPOLINE_SIZE 24
 #define FFI_NATIVE_RAW_API 0
-#define FFI_EXTRA_CIF_FIELDS unsigned riscv_nfixedargs; unsigned riscv_unused;
+#define FFI_EXTRA_CIF_FIELDS unsigned riscv_nfixedargs; unsigned riscv_unused
 #define FFI_TARGET_SPECIFIC_VARIADIC
 
 #endif


### PR DESCRIPTION
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This PR pulls across the fix which has been accepted upstream at https://github.com/libffi/libffi/pull/968 and will therefore be in any future versions of libffi that we take.

@ShogunPanda I'm not sure if we have implemented any specific rules/restrictions on taking fixes like this so hopefully this is ok to go in as a patch since I had it merged upstream before raising this.

Fixes https://github.com/nodejs/unofficial-builds/issues/235 which has the explanation of when and why it occurs.

While this includes all platforms which would have the same issue I'll note that loongarch does not show the problem in the unofficial builds on that platform but that is likely because it is using `gcc` and node `clang`. Also noting that we have `loongarch64` in this PR as opposed to the upstream `loongarch` directory - that is because of [this upstream change](https://github.com/libffi/libffi/pull/957) where the directory was renamed.

FYI @nodejs/platform-loong64 @nodejs/platform-riscv64 