### PR TITLE
crypto: runtime-deprecate calling hmac.digest() multiple times

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -87,6 +87,13 @@ const maybeEmitDeprecationWarning = getDeprecationWarningEmitter(
   },
 );
 
+const maybeEmitHMACMultipleDigestDeprecationWarning =
+  getDeprecationWarningEmitter(
+    'DEP0208',
+    'Calling hmac.digest() multiple times without re-initialization is ' +
+    'deprecated and will throw an error in a future version.',
+  );
+
 function Hash(algorithm, options) {
   if (!new.target)
     return new Hash(algorithm, options);
@@ -186,6 +193,7 @@ Hmac.prototype.digest = function digest(outputEncoding) {
   const state = this[kState];
 
   if (state[kFinalized]) {
+    maybeEmitHMACMultipleDigestDeprecationWarning();
     const buf = Buffer.from('');
     if (outputEncoding && outputEncoding !== 'buffer')
       return buf.toString(outputEncoding);


### PR DESCRIPTION
This is an independent contribution and is not associated with any hackathon or competition.

## Summary

Runtime-deprecate calling `hmac.digest()` multiple times without re-initialization. Unlike `Hash.prototype.digest()` which throws `ERR_CRYPTO_HASH_FINALIZED` on second call, `Hmac.prototype.digest()` silently returned an empty buffer, creating a potential security footgun.

## Root Cause

The `Hmac.prototype.digest()` method did not emit any deprecation warning when called after the HMAC instance was already finalized. Instead, it silently returned an empty `Buffer`. This behavior differs from `Hash.prototype.digest()` which throws an error, and creates a security risk where callers may inadvertently reuse the same HMAC instance thinking it produces valid output.

## Fix

Added a runtime deprecation warning (DEP0208) that emits when `Hmac.prototype.digest()` is called after the HMAC instance has already been finalized. The existing behavior (returning empty buffer) is preserved for backward compatibility. In a future version, this will throw an error matching the behavior of `Hash.prototype.digest()`.

## Testing

Existing tests in `test/parallel/test-crypto-hmac.js` that call `.digest()` multiple times continue to pass. The deprecation warning is emitted to stderr but does not change return values, maintaining backward compatibility.

Closes #62838
