### PR TITLE
test_runner: do not read from process.argv and process.cwd() in run()

### DIFF
--- a/lib/internal/main/test_runner.js
+++ b/lib/internal/main/test_runner.js
@@ -30,6 +30,9 @@ if (isUsingInspector() && options.isolation === 'process') {
   options.inspectPort = process.debugPort;
 }
 
+// Capture process state before passing to run() to avoid reading from
+// process.cwd() and process.argv inside run()
+options.cwd = process.cwd();
 options.globPatterns = ArrayPrototypeSlice(process.argv, 1);
 
 debug('test runner configuration:', options);

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -1109,7 +1109,7 @@ function run(options = kEmptyObject) {
       await root.harness.bootstrapPromise;
     }
     if (typeof setup === 'function') {
-      await setup(root.reporter);
+      await setup(root.reporter, cwd);
     }
 
     await runFiles();

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -223,7 +223,7 @@ function parsePreviousRuns(rerunFailuresFilePath) {
   return JSONParse(data);
 }
 
-async function getReportersMap(reporters, destinations) {
+async function getReportersMap(reporters, destinations, cwd) {
   return SafePromiseAllReturnArrayLike(reporters, async (name, i) => {
     const destination = kBuiltinDestinations.get(destinations[i]) ??
       createWriteStream(destinations[i], { __proto__: null, flush: true });
@@ -235,7 +235,7 @@ async function getReportersMap(reporters, destinations) {
       let parentURL;
 
       try {
-        parentURL = pathToFileURL(process.cwd() + '/').href;
+        parentURL = pathToFileURL((cwd ?? process.cwd()) + '/').href;
       } catch {
         parentURL = 'file:///';
       }
@@ -426,8 +426,8 @@ function parseCommandLine() {
     randomize = true;
   }
 
-  const setup = reporterScope.bind(async (rootReporter) => {
-    const reportersMap = await getReportersMap(reporters, destinations);
+  const setup = reporterScope.bind(async (rootReporter, cwd) => {
+    const reportersMap = await getReportersMap(reporters, destinations, cwd);
     for (let i = 0; i < reportersMap.length; i++) {
       const { reporter, destination } = reportersMap[i];
       compose(rootReporter, reporter).pipe(destination);


### PR DESCRIPTION
## Summary

Fixes #53867

Currently, `run()` in `lib/internal/test_runner/runner.js` reads from `process.argv` and `process.cwd()` directly, even though they are accessible at the call site in `lib/internal/main/test_runner.js`.

This is problematic because:
- `run()` is also exposed as a public API for end users
- Any user calling `run()` has no way to override or isolate the `cwd` used internally for reporter URL resolution

### Changes

- **`lib/internal/main/test_runner.js`**: Capture `process.cwd()` into `options.cwd` before calling `run()`, so the value is passed explicitly rather than read lazily inside `run()`.
- **`lib/internal/test_runner/runner.js`**: Pass `cwd` down to `setup(root.reporter, cwd)` so it flows through to reporter setup.
- **`lib/internal/test_runner/utils.js`**: Update `getReportersMap(reporters, destinations, cwd)` to accept `cwd` and use `cwd ?? process.cwd()` as fallback, maintaining backwards compatibility. Update the `setup` closure to accept and forward `cwd`.

### Backwards Compatibility

No breaking changes. The `cwd ?? process.cwd()` fallback preserves existing behaviour when `cwd` is not provided (e.g. when `run()` is called directly by users without specifying a `cwd` option).

## Test Plan

- [ ] Existing test suite for `test_runner` passes
- [ ] Manual verification: `node --test` still correctly resolves reporter paths

Refs: #53867