### PR TITLE
tools: update the llhttp updater script

### DIFF
--- a/tools/dep_updaters/update-llhttp.sh
+++ b/tools/dep_updaters/update-llhttp.sh
@@ -8,12 +8,14 @@ DEPS_DIR="${BASE_DIR}/deps"
 
 [ -z "$NODE" ] && NODE="$BASE_DIR/out/Release/node"
 [ -x "$NODE" ] || NODE=$(command -v node)
+NPM_DIR="$DEPS_DIR/npm/bin"
+NPM="$NPM_DIR/npm-cli.js"
 
 # shellcheck disable=SC1091
 . "$BASE_DIR/tools/dep_updaters/utils.sh"
 
 if [ -n "$LOCAL_COPY" ]; then
-  NEW_VERSION=$(node -e "console.log(JSON.parse(require('fs').readFileSync('$LOCAL_COPY/package.json', 'utf-8')).version)")
+  NEW_VERSION=$(PACKAGE_JSON="$LOCAL_COPY/package.json" node -p "require(process.env.PACKAGE_JSON).version")
 else
   NEW_VERSION="$("$NODE" --input-type=module <<'EOF'
   const res = await fetch('https://api.github.com/repos/nodejs/llhttp/releases/latest',
@@ -47,51 +49,27 @@ echo "Making temporary workspace ..."
 WORKSPACE=$(mktemp -d 2> /dev/null || mktemp -d -t 'tmp')
 trap cleanup INT TERM EXIT
 
-cd "$WORKSPACE"
+if [ -z "$LOCAL_COPY" ]; then
+  echo "Downloading llhttp source..."
+  curl -fsSL https://github.com/nodejs/llhttp/archive/refs/tags/v$NEW_VERSION.tar.gz | tar xz -C "$WORKSPACE"
+
+  LOCAL_COPY="$(find "$WORKSPACE" -mindepth 1 -maxdepth 1 -type d -print -quit)"
+fi
 
 echo "Replacing existing llhttp (except GYP and GN build files)"
 mv "$DEPS_DIR/llhttp/"*.gn "$DEPS_DIR/llhttp/"*.gni "$WORKSPACE/"
 
-if [ -n "$LOCAL_COPY" ]; then
-  echo "Copying llhttp release from $LOCAL_COPY ..."
-  
-  echo "Building llhttp ..."
-  cd "$BASE_DIR"
+echo "Building llhttp ..."
+(
   cd "$LOCAL_COPY"
-  npm install
+  "$NODE" "$NPM" ci --ignore-scripts
+  "$NODE" "$NPM" exec tsc
   RELEASE=$NEW_VERSION make release
+)
 
-  echo "Copying llhttp release ..."
-  rm -rf "$DEPS_DIR/llhttp"
-  cp -a release "$DEPS_DIR/llhttp"
-elif echo "$NEW_VERSION" | grep -qs "/" ; then # Download a release
-  REPO="git@github.com:$NEW_VERSION.git"
-  BRANCH=$2
-  [ -z "$BRANCH" ] && BRANCH=main
-
-  echo "Cloning llhttp source archive $REPO ..."
-  git clone "$REPO" llhttp
-  cd llhttp
-  echo "Checking out branch $BRANCH ..."
-  git checkout "$BRANCH"
-
-  echo "Building llhttp ..."
-  npm install
-  RELEASE=$NEW_VERSION make release
-
-  echo "Copying llhttp release ..."
-  rm -rf "$DEPS_DIR/llhttp"
-  cp -a release "$DEPS_DIR/llhttp"
-else
-  echo "Download llhttp release $NEW_VERSION ..."
-  LLHTTP_TARBALL="llhttp-v$NEW_VERSION.tar.gz"
-  curl -sL -o "$LLHTTP_TARBALL" "https://github.com/nodejs/llhttp/archive/refs/tags/release/v$NEW_VERSION.tar.gz"
-  gzip -dc "$LLHTTP_TARBALL" | tar xf -
-
-  echo "Copying llhttp release ..."
-  rm -rf "$DEPS_DIR/llhttp"
-  cp -a "llhttp-release-v$NEW_VERSION" "$DEPS_DIR/llhttp"
-fi
+echo "Overwriting vendored files..."
+rm -rf "$DEPS_DIR/llhttp"
+cp -a "$LOCAL_COPY/release" "$DEPS_DIR/llhttp"
 
 mv "$WORKSPACE/"*.gn "$WORKSPACE/"*.gni "$DEPS_DIR/llhttp"
 

--- a/tools/dep_updaters/update-llhttp.sh
+++ b/tools/dep_updaters/update-llhttp.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -e
+set -ex
 
 # Shell script to update llhttp in the source tree to specific version
 
@@ -51,7 +51,7 @@ trap cleanup INT TERM EXIT
 
 if [ -z "$LOCAL_COPY" ]; then
   echo "Downloading llhttp source..."
-  curl -fsSL https://github.com/nodejs/llhttp/archive/refs/tags/v$NEW_VERSION.tar.gz | tar xz -C "$WORKSPACE"
+  curl -fsSL "https://github.com/nodejs/llhttp/archive/refs/tags/v$NEW_VERSION.tar.gz" | tar xz -C "$WORKSPACE"
 
   LOCAL_COPY="$(find "$WORKSPACE" -mindepth 1 -maxdepth 1 -type d -print -quit)"
 fi


### PR DESCRIPTION
Simplifies the script by dropping the `git` commands and consolidate around a single code path whether we're dealing with an existing local clone or a fresh tarball extract. Also removed the dependency on the global `npm`, disable running scripts, and switched to `npm ci` instead of `npm install`
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
