### PR TITLE
deps: add ngtcp2_fmt.c to build configuration (ngtcp2.gyp)

### DIFF
--- a/deps/ngtcp2/ngtcp2.gyp
+++ b/deps/ngtcp2/ngtcp2.gyp
@@ -18,6 +18,7 @@
       'ngtcp2/lib/ngtcp2_crypto.c',
       'ngtcp2/lib/ngtcp2_dcidtr.c',
       'ngtcp2/lib/ngtcp2_err.c',
+      'ngtcp2/lib/ngtcp2_fmt.c',
       'ngtcp2/lib/ngtcp2_frame_chain.c',
       'ngtcp2/lib/ngtcp2_gaptr.c',
       'ngtcp2/lib/ngtcp2_idtr.c',


### PR DESCRIPTION

The following compilation configuration will result in an error.

```
python configure.py --v8-enable-temporal-support --experimental-quic --experimental-dtls --enable-thin-lto --dest-cpu=x64 --clang-cl=20.1.8
```

```
lld-link : warning : ignoring unknown argument '-fno-lto' [D:\1\nodejs\node_mksnapshot.vcxproj]
lld-link : warning : ignoring unknown argument '-flto=thin' [D:\1\nodejs\node_mksnapshot.vcxproj]
lld-link : error : undefined symbol: ngtcp2_fmt_write_str [D:\1\nodejs\node_mksnapshot.vcxproj]
  >>> referenced by ngtcp2\lib\ngtcp2_conn.c
  >>>               ngtcp2.lib(ngtcp2_conn.obj)
  >>> referenced by ngtcp2\lib\ngtcp2_pv.c
  >>>               ngtcp2.lib(ngtcp2_pv.obj)
  >>> referenced by ngtcp2\lib\ngtcp2_log.c
  >>>               ngtcp2.lib(ngtcp2_log.obj)
  >>> referenced 3 more times
  
lld-link : error : undefined symbol: ngtcp2_fmt_write_uint64w [D:\1\nodejs\node_mksnapshot.vcxproj]
  >>> referenced by ngtcp2\lib\ngtcp2_conn.c
  >>>               ngtcp2.lib(ngtcp2_conn.obj)
  >>> referenced by ngtcp2\lib\ngtcp2_pv.c
  >>>               ngtcp2.lib(ngtcp2_pv.obj)
  >>> referenced by ngtcp2\lib\ngtcp2_log.c
  >>>               ngtcp2.lib(ngtcp2_log.obj)
  >>> referenced 3 more times
  
...
```

After investigation, it was found that the sources section of the ngtcp2.gyp configuration file was missing the ngtcp2_fmt.c file, which caused the linking failure. After adding it, local compilation could be done normally.