### PR TITLE
stream: fix dropped first chunk in Utf8Stream buffer mode

### DIFF
--- a/lib/internal/streams/fast-utf8-stream.js
+++ b/lib/internal/streams/fast-utf8-stream.js
@@ -818,7 +818,7 @@ class Utf8Stream extends EventEmitter {
       bufs.length === 0 ||
       lens[lens.length - 1] + data.length > this.#maxWrite
     ) {
-      ArrayPrototypePush(bufs, []);
+      ArrayPrototypePush(bufs, [data]);
       ArrayPrototypePush(lens, data.length);
     } else {
       ArrayPrototypePush(bufs[bufs.length - 1], data);

--- a/test/parallel/test-fastutf8stream-write-buffer.js
+++ b/test/parallel/test-fastutf8stream-write-buffer.js
@@ -1,0 +1,72 @@
+'use strict';
+
+// Regression test for buffer content mode: the first buffer of every
+// batch used to be dropped, corrupting the output and eventually
+// crashing in mergeBuf(). Refs: https://github.com/nodejs/node/pull/58897
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('node:assert');
+const {
+  readFile,
+  Utf8Stream,
+} = require('node:fs');
+const { join } = require('node:path');
+
+tmpdir.refresh();
+let fileCounter = 0;
+
+function getTempFile() {
+  return join(tmpdir.path, `fastutf8stream-${process.pid}-${Date.now()}-${fileCounter++}.log`);
+}
+
+runTests(false);
+runTests(true);
+
+function runTests(sync) {
+  {
+    // A single buffer write must end up in the file.
+    const dest = getTempFile();
+    const stream = new Utf8Stream({ dest, sync, contentMode: 'buffer' });
+
+    stream.on('ready', common.mustCall(() => {
+      assert.ok(stream.write(Buffer.from('hello world\n')));
+      stream.end();
+
+      stream.on('finish', common.mustCall(() => {
+        readFile(dest, 'utf8', common.mustSucceed((data) => {
+          assert.strictEqual(data, 'hello world\n');
+        }));
+      }));
+    }));
+  }
+
+  {
+    // Writes that exceed maxWrite start a new batch; data must survive
+    // the batch boundary and be written in order.
+    const dest = getTempFile();
+    const stream = new Utf8Stream({
+      dest,
+      sync,
+      contentMode: 'buffer',
+      minLength: 60,
+      maxWrite: 64,
+    });
+
+    stream.on('ready', common.mustCall(() => {
+      stream.write(Buffer.from('a'.repeat(40)));
+      stream.write(Buffer.from('b'.repeat(40)));
+      stream.write(Buffer.from('c'.repeat(40)));
+      stream.end();
+
+      stream.on('finish', common.mustCall(() => {
+        readFile(dest, 'utf8', common.mustSucceed((data) => {
+          assert.strictEqual(
+            data,
+            'a'.repeat(40) + 'b'.repeat(40) + 'c'.repeat(40),
+          );
+        }));
+      }));
+    }));
+  }
+}


### PR DESCRIPTION
In buffer content mode, #writeBuffer pushed an empty array when starting a new batch (including the very first write), so the data buffer was never stored while its length was still recorded in lens. The first write then emitted zero bytes and the misaligned bufs/lens queues crashed in mergeBuf() with a TypeError. Push [data] instead, matching the upstream sonic-boom implementation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
