### PR TITLE
[v24.x] Revert "stream: noop pause/resume on destroyed streams"

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1233,9 +1233,6 @@ function nReadingNextTick(self) {
 // If the user uses them, then switch into old mode.
 Readable.prototype.resume = function() {
   const state = this._readableState;
-  if ((state[kState] & kDestroyed) !== 0) {
-    return this;
-  }
   if ((state[kState] & kFlowing) === 0) {
     debug('resume');
     // We flow only if there is no one listening
@@ -1276,9 +1273,6 @@ function resume_(stream, state) {
 
 Readable.prototype.pause = function() {
   const state = this._readableState;
-  if ((state[kState] & kDestroyed) !== 0) {
-    return this;
-  }
   debug('call pause');
   if ((state[kState] & (kHasFlowing | kFlowing)) !== kHasFlowing) {
     debug('pause');

--- a/test/parallel/test-stream-destroy.js
+++ b/test/parallel/test-stream-destroy.js
@@ -118,13 +118,3 @@ const http = require('http');
     req.end('asd');
   }));
 }
-
-{
-  // resume() and pause() should be no-ops on destroyed streams.
-  const r = new Readable({ read() {} });
-  r.destroy();
-  r.on('resume', common.mustNotCall());
-  r.on('pause', common.mustNotCall());
-  r.resume();
-  r.pause();
-}


### PR DESCRIPTION
This reverts commit 29b196694c78fa5f2fd7a9cd5083278deb69241d from https://github.com/nodejs/node/pull/62557

Should fix https://github.com/nodejs/node/issues/63487 based on a `git bisect` run

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
