### PR TITLE
inspector: fix inspector.close() documented behavior

### DIFF
--- a/doc/api/inspector.md
+++ b/doc/api/inspector.md
@@ -415,8 +415,8 @@ changes:
     description: The API is exposed in the worker threads.
 -->
 
-Attempts to close all remaining connections, blocking the event loop until all
-are closed. Once all connections are closed, deactivates the inspector.
+Deactivates the inspector. If there are active connections, they are forcibly
+terminated. Blocks until the inspector server has fully stopped.
 
 ### `inspector.console`
 

--- a/test/parallel/test-inspector-close-terminate-connections.js
+++ b/test/parallel/test-inspector-close-terminate-connections.js
@@ -1,0 +1,35 @@
+'use strict';
+const common = require('../common');
+common.skipIfInspectorDisabled();
+
+const assert = require('assert');
+const { NodeInstance } = require('../common/inspector-helper.js');
+
+// Verify that inspector.close() forcibly terminates active WebSocket
+// connections without waiting for the client to disconnect.
+
+async function test() {
+  const script = `
+    const inspector = require('inspector');
+    inspector.close();
+    process.exit(42);
+  `;
+
+  const instance = new NodeInstance(['--inspect-brk=0'], script);
+  const session = await instance.connectInspectorSession();
+
+  // Enable Runtime domain and wait for an event to confirm the session is live.
+  await session.send({ method: 'Runtime.enable' });
+  await session.waitForNotification('Runtime.executionContextCreated');
+
+  // Resume execution so the script calls inspector.close().
+  await session.send({ method: 'Runtime.runIfWaitingForDebugger' });
+
+  // The server should forcibly disconnect us.
+  await session.waitForServerDisconnect();
+
+  const { exitCode } = await instance.expectShutdown();
+  assert.strictEqual(exitCode, 42);
+}
+
+test().then(common.mustCall());


### PR DESCRIPTION
The `inspector.close()` forcibly terminates all active connections,
allowing the process to exit cleanly, without waiting for the devtool
client to disconnect.

This does not change any behavior. This only updates the doc and added
a test verifying it.

@nodejs/inspector 