### PR TITLE
src: do not track weak `BaseObject`s as childrens of `Realm`s

### DIFF
--- a/src/base_object.cc
+++ b/src/base_object.cc
@@ -180,4 +180,6 @@ void BaseObjectList::MemoryInfo(node::MemoryTracker* tracker) const {
   }
 }
 
+const char* const MemoryTracker::kWeakEdge = "<MemoryTracker::kWeakEdge>";
+
 }  // namespace node

--- a/src/base_object.cc
+++ b/src/base_object.cc
@@ -174,9 +174,15 @@ void BaseObjectList::Cleanup() {
   }
 }
 
-void BaseObjectList::MemoryInfo(node::MemoryTracker* tracker) const {
+void BaseObjectList::MemoryInfo(MemoryTracker* tracker) const {
   for (auto bo : *this) {
-    if (bo->IsDoneInitializing()) tracker->Track(bo);
+    if (bo->IsDoneInitializing()) {
+      // TODO(addaleax): Add weak edges instead of no edges once
+      // https://github.com/v8/v8/commit/e37cadf1143a8c5bbe44c0408186b5a26cc23863
+      // is available for us
+      tracker->Track(
+          bo, bo->persistent().IsWeak() ? MemoryTracker::KWeakEdge : nullptr);
+    }
   }
 }
 

--- a/src/base_object.cc
+++ b/src/base_object.cc
@@ -181,7 +181,7 @@ void BaseObjectList::MemoryInfo(MemoryTracker* tracker) const {
       // https://github.com/v8/v8/commit/e37cadf1143a8c5bbe44c0408186b5a26cc23863
       // is available for us
       tracker->Track(
-          bo, bo->persistent().IsWeak() ? MemoryTracker::KWeakEdge : nullptr);
+          bo, bo->persistent().IsWeak() ? MemoryTracker::kWeakEdge : nullptr);
     }
   }
 }

--- a/src/cppgc_helpers.cc
+++ b/src/cppgc_helpers.cc
@@ -16,7 +16,10 @@ void CppgcWrapperList::MemoryInfo(MemoryTracker* tracker) const {
   for (auto node : *this) {
     CppgcMixin* ptr = node->persistent.Get();
     if (ptr != nullptr) {
-      tracker->Track(ptr);
+      // TODO(addaleax): Add weak edges instead of no edges once
+      // https://github.com/v8/v8/commit/e37cadf1143a8c5bbe44c0408186b5a26cc23863
+      // is available for us
+      tracker->Track(ptr, MemoryTracker::KWeakEdge);
     }
   }
 }

--- a/src/cppgc_helpers.cc
+++ b/src/cppgc_helpers.cc
@@ -19,7 +19,7 @@ void CppgcWrapperList::MemoryInfo(MemoryTracker* tracker) const {
       // TODO(addaleax): Add weak edges instead of no edges once
       // https://github.com/v8/v8/commit/e37cadf1143a8c5bbe44c0408186b5a26cc23863
       // is available for us
-      tracker->Track(ptr, MemoryTracker::KWeakEdge);
+      tracker->Track(ptr, MemoryTracker::kWeakEdge);
     }
   }
 }

--- a/src/memory_tracker-inl.h
+++ b/src/memory_tracker-inl.h
@@ -131,7 +131,7 @@ void MemoryTracker::TrackField(const char* edge_name,
   if (value == nullptr) return;
   auto it = seen_.find(value);
   if (it != seen_.end()) {
-    graph_->AddEdge(CurrentNode(), it->second, edge_name);
+    AddEdge(CurrentNode(), it->second, edge_name);
   } else {
     Track(value, edge_name);
   }
@@ -253,9 +253,9 @@ void MemoryTracker::TrackField(const char* edge_name,
                                const v8::Local<T>& value,
                                const char* node_name) {
   if (!value.IsEmpty())
-    graph_->AddEdge(CurrentNode(),
-                    graph_->V8Node(value.template As<v8::Value>()),
-                    edge_name);
+    AddEdge(CurrentNode(),
+            graph_->V8Node(value.template As<v8::Value>()),
+            edge_name);
 }
 
 template <typename T>
@@ -300,7 +300,7 @@ void MemoryTracker::Track(const CppgcMixin* retainer, const char* edge_name) {
   auto it = seen_.find(retainer);
   if (it != seen_.end()) {
     if (CurrentNode() != nullptr) {
-      graph_->AddEdge(CurrentNode(), it->second, edge_name);
+      AddEdge(CurrentNode(), it->second, edge_name);
     }
     return;  // It has already been tracked, no need to call MemoryInfo again
   }
@@ -317,7 +317,7 @@ void MemoryTracker::Track(const MemoryRetainer* retainer,
   auto it = seen_.find(retainer);
   if (it != seen_.end()) {
     if (CurrentNode() != nullptr) {
-      graph_->AddEdge(CurrentNode(), it->second, edge_name);
+      AddEdge(CurrentNode(), it->second, edge_name);
     }
     return;  // It has already been tracked, no need to call MemoryInfo again
   }
@@ -376,7 +376,7 @@ MemoryRetainerNode* MemoryTracker::AddNode(const CppgcMixin* retainer,
   MemoryRetainerNode* n = new MemoryRetainerNode(this, retainer);
   seen_[retainer] = n;
   if (CurrentNode() != nullptr) {
-    graph_->AddEdge(CurrentNode(), n->JSWrapperNode(), edge_name);
+    AddEdge(CurrentNode(), n->JSWrapperNode(), edge_name);
   }
 
   return n;
@@ -392,11 +392,11 @@ MemoryRetainerNode* MemoryTracker::AddNode(const MemoryRetainer* retainer,
   MemoryRetainerNode* n = new MemoryRetainerNode(this, retainer);
   graph_->AddNode(std::unique_ptr<v8::EmbedderGraph::Node>(n));
   seen_[retainer] = n;
-  if (CurrentNode() != nullptr) graph_->AddEdge(CurrentNode(), n, edge_name);
+  if (CurrentNode() != nullptr) AddEdge(CurrentNode(), n, edge_name);
 
   if (n->JSWrapperNode() != nullptr) {
-    graph_->AddEdge(n, n->JSWrapperNode(), "native_to_javascript");
-    graph_->AddEdge(n->JSWrapperNode(), n, "javascript_to_native");
+    AddEdge(n, n->JSWrapperNode(), "native_to_javascript");
+    AddEdge(n->JSWrapperNode(), n, "javascript_to_native");
   }
 
   return n;
@@ -408,7 +408,7 @@ MemoryRetainerNode* MemoryTracker::AddNode(const char* node_name,
   MemoryRetainerNode* n = new MemoryRetainerNode(this, node_name, size);
   graph_->AddNode(std::unique_ptr<v8::EmbedderGraph::Node>(n));
 
-  if (CurrentNode() != nullptr) graph_->AddEdge(CurrentNode(), n, edge_name);
+  if (CurrentNode() != nullptr) AddEdge(CurrentNode(), n, edge_name);
 
   return n;
 }
@@ -433,6 +433,13 @@ MemoryRetainerNode* MemoryTracker::PushNode(const char* node_name,
   MemoryRetainerNode* n = AddNode(node_name, size, edge_name);
   node_stack_.push(n);
   return n;
+}
+
+void MemoryTracker::AddEdge(v8::EmbedderGraph::Node* from,
+                            v8::EmbedderGraph::Node* to,
+                            const char* edge_name) {
+  if (edge_name == kWeakEdge) return;
+  graph_->AddEdge(from, to, edge_name);
 }
 
 void MemoryTracker::PopNode() {

--- a/src/memory_tracker.h
+++ b/src/memory_tracker.h
@@ -300,6 +300,13 @@ class MemoryTracker {
                                 v8::EmbedderGraph* graph)
     : isolate_(isolate), graph_(graph) {}
 
+  // Can be passed to Track() if it is not desirable
+  // to create a strong edge between nodes, i.e. when
+  // the node should be added to the graph and the
+  // parent node is "tracking" the target node but
+  // not directly keeping it alive.
+  static const char* const kWeakEdge;
+
  private:
   typedef std::unordered_map<const MemoryRetainer*, MemoryRetainerNode*>
       NodeMap;
@@ -321,6 +328,9 @@ class MemoryTracker {
                                       size_t size,
                                       const char* edge_name = nullptr);
   inline void PopNode();
+  inline void AddEdge(v8::EmbedderGraph::Node* from,
+                      v8::EmbedderGraph::Node* to,
+                      const char* edge_name = nullptr);
 
   v8::Isolate* isolate_;
   v8::EmbedderGraph* graph_;

--- a/test/common/heap.js
+++ b/test/common/heap.js
@@ -336,6 +336,19 @@ function validateByRetainingPath(...args) {
   return validateByRetainingPathFromNodes(nodes, ...args);
 }
 
+function getRetainingNodes(startingNode, filter) {
+  const seen = new Set();
+  function listNodes(node) {
+    if (!filter(node) || seen.has(node)) return;
+    seen.add(node);
+    for (const edge of node.incomingEdges) {
+      listNodes(edge.from);
+    }
+  }
+  listNodes(startingNode);
+  return [...seen];
+}
+
 module.exports = {
   recordState,
   validateSnapshotNodes,
@@ -343,4 +356,5 @@ module.exports = {
   validateByRetainingPathFromNodes,
   getHeapSnapshotOptionTests,
   createJSHeapSnapshot,
+  getRetainingNodes,
 };

--- a/test/pummel/test-heapdump-zlib.js
+++ b/test/pummel/test-heapdump-zlib.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { validateByRetainingPath, validateByRetainingPathFromNodes } = require('../common/heap');
+const { validateByRetainingPath, validateByRetainingPathFromNodes, getRetainingNodes } = require('../common/heap');
 const zlib = require('zlib');
 
 // Before zlib stream is created, no ZlibStream should be created.
@@ -25,6 +25,18 @@ const gzip = zlib.createGzip();
     { node_name: 'Node / zlib_memory', edge_name: 'zlib_memory' },
   ], true);
   assert.strictEqual(withMemory.length, 0);
+}
+
+{
+  // Assert that the `ZlibStream` has no unexpected connections
+  // to other `Node / ...` nodes.
+  const contexts = validateByRetainingPath('Node / ZlibContext', []);
+  assert.deepStrictEqual(
+    getRetainingNodes(contexts[0], (node) => node.name?.startsWith('Node /'))
+      .map((node) => node.name).sort(), [
+      'Node / ZlibContext',
+      'Node / ZlibStream',
+    ]);
 }
 
 // After zlib stream is written, zlib_memory should be created.


### PR DESCRIPTION
##### src: allow tracking children in `MemoryTracker` with weak edges

Allowing the addition of child nodes with a weak edge
between them enables expressing a relationship of the
"node A keeps track of node B and no other node does,
but node A does not keep node B alive" kind, which is
the relationship between `Realm`s and weak `BaseObject` instances.
This is a prerequisite for the following commit.

Note that the relevant V8 feature is not available
in Node.js yet. It's still worth doing this, both
because it allows us to prepare for that upstream
change, and because the current representation of
these edges in heap dumps is factually incorrect
and hinders debugging in existing Node.js versions.

Refs: https://github.com/v8/v8/commit/e37cadf1143a8c5bbe44c0408186b5a26cc23863

##### src: do not track weak `BaseObject`s as childrens of `Realm`s

Heap dumps are used for analyzing the relationship between
objects that keep each other alive, so that retainers of
memory can be detected and memory leaks fixed.

6e60ab744e6a13 broke this for a wide range of `BaseObject`
instances. Marking all `BaseObject`s, including weak ones,
as children of `Realm` and `Environment` instances gives
the incorrect impression that they are held alive by those
objects, effectively hiding the "real" set of strong roots
that keep other objects alive through GC.

An upcoming change in V8 will allow us to represent this
relationship between `Realm` and `Environment` and its
`BaseObject` and `CppgcMixin` instances properly.

Refs: https://github.com/v8/v8/commit/e37cadf1143a8c5bbe44c0408186b5a26cc23863
Refs: https://github.com/nodejs/node/pull/57417
