### PR TITLE
test_runner: remove unused shuffleArrayWithSeed

### DIFF
--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -7,7 +7,6 @@ const {
   ArrayPrototypePop,
   ArrayPrototypePush,
   ArrayPrototypeReduce,
-  ArrayPrototypeSlice,
   ArrayPrototypeSome,
   JSONParse,
   MathFloor,
@@ -164,31 +163,6 @@ function createSeededGenerator(seed) {
     value ^= value + MathImul(value ^ value >>> 7, 61 | value);
     return ((value ^ value >>> 14) >>> 0) / 4_294_967_296;
   };
-}
-
-/**
- * Return a deterministically shuffled copy of an array.
- * @template T
- * @param {T[]} values
- * @param {number} seed
- * @returns {T[]}
- */
-function shuffleArrayWithSeed(values, seed) {
-  if (values.length < 2) {
-    return values;
-  }
-
-  const randomized = ArrayPrototypeSlice(values);
-  const random = createSeededGenerator(seed);
-
-  for (let i = randomized.length - 1; i > 0; i--) {
-    const j = MathFloor(random() * (i + 1));
-    const tmp = randomized[i];
-    randomized[i] = randomized[j];
-    randomized[j] = tmp;
-  }
-
-  return randomized;
 }
 
 function tryBuiltinReporter(name) {
@@ -761,7 +735,6 @@ module.exports = {
   kDefaultPattern,
   kMaxRandomSeed,
   parseCommandLine,
-  shuffleArrayWithSeed,
   reporterScope,
   shouldColorizeTestFiles,
   getCoverageReport,

--- a/test/parallel/test-runner-seeded-generator.js
+++ b/test/parallel/test-runner-seeded-generator.js
@@ -1,0 +1,33 @@
+// Flags: --expose-internals
+'use strict';
+require('../common');
+const assert = require('node:assert');
+const { createSeededGenerator, kMaxRandomSeed } = require('internal/test_runner/utils');
+
+function sequence(seed, length = 10) {
+  const random = createSeededGenerator(seed);
+  const values = [];
+  for (let i = 0; i < length; i++) {
+    values.push(random());
+  }
+  return values;
+}
+
+// The same seed must always produce the same sequence so that
+// --test-random-seed reproduces a randomized test order across runs.
+assert.deepStrictEqual(sequence(0), sequence(0));
+assert.deepStrictEqual(sequence(12345), sequence(12345));
+assert.deepStrictEqual(sequence(kMaxRandomSeed), sequence(kMaxRandomSeed));
+
+// Different seeds must produce different sequences.
+assert.notDeepStrictEqual(sequence(11111), sequence(22222));
+assert.notDeepStrictEqual(sequence(0), sequence(1));
+
+// Seeds are coerced to uint32, matching the range accepted by
+// --test-random-seed.
+assert.deepStrictEqual(sequence(1), sequence(1 + 2 ** 32));
+
+// All generated values must fall in [0, 1).
+for (const value of sequence(98765, 1000)) {
+  assert.ok(value >= 0 && value < 1, `value ${value} out of range`);
+}


### PR DESCRIPTION
shuffleArrayWithSeed was introduced along with test order randomization but was never called: the feature picks a random pending subtest at dequeue time using createSeededGenerator directly. Remove the dead helper and its export, and add direct unit coverage for createSeededGenerator's deterministic contract.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
