### PR TITLE
sqlite: do not leave database open after failed open

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -941,6 +941,19 @@ bool DatabaseSync::Open() {
     return false;
   }
 
+  // sqlite3_open_v2() assigns a database handle even when it fails. Such a
+  // handle is in a "sick" state and may only be used to retrieve the error
+  // and must then be released with sqlite3_close(). Close and reset the
+  // handle on any failure below so that a failed open() does not leave the
+  // database in an open state.
+  bool opened = false;
+  auto reset_connection_on_failure = OnScopeLeave([&]() {
+    if (!opened && connection_ != nullptr) {
+      sqlite3_close_v2(connection_);
+      connection_ = nullptr;
+    }
+  });
+
   // TODO(cjihrig): Support additional flags.
   int default_flags = SQLITE_OPEN_URI;
   int flags = open_config_.get_read_only()
@@ -1003,6 +1016,7 @@ bool DatabaseSync::Open() {
         env()->isolate(), this, load_extension_ret, SQLITE_OK, false);
   }
 
+  opened = true;
   return true;
 }
 

--- a/test/parallel/test-sqlite-database-sync.js
+++ b/test/parallel/test-sqlite-database-sync.js
@@ -2,7 +2,7 @@
 const { skipIfSQLiteMissing } = require('../common');
 skipIfSQLiteMissing();
 const tmpdir = require('../common/tmpdir');
-const { existsSync } = require('node:fs');
+const { existsSync, mkdirSync } = require('node:fs');
 const { join } = require('node:path');
 const { DatabaseSync, StatementSync } = require('node:sqlite');
 const { suite, test } = require('node:test');
@@ -307,6 +307,42 @@ suite('DatabaseSync.prototype.open()', () => {
       message: /database is already open/,
     });
     t.assert.strictEqual(db.isOpen, true);
+  });
+
+  test('does not leave the database open after a failed open', (t) => {
+    // Regression test for https://github.com/nodejs/node/issues/63831
+    const dbDir = join(tmpdir.path, `database-dir-${cnt++}`);
+    const dbPath = join(dbDir, 'failed-open.db');
+    using db = new DatabaseSync(dbPath, { open: false });
+
+    // The directory does not exist, so opening the database fails.
+    t.assert.throws(() => {
+      db.open();
+    }, {
+      code: 'ERR_SQLITE_ERROR',
+      message: /unable to open database file/,
+    });
+    t.assert.strictEqual(db.isOpen, false);
+
+    // The connection must not be usable after a failed open.
+    t.assert.throws(() => {
+      db.exec('SELECT 1');
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /database is not open/,
+    });
+    t.assert.throws(() => {
+      db.function('fn', () => {});
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: /database is not open/,
+    });
+
+    // The database can be opened once the underlying problem is resolved.
+    mkdirSync(dbDir);
+    t.assert.strictEqual(db.open(), undefined);
+    t.assert.strictEqual(db.isOpen, true);
+    db.exec('CREATE TABLE foo (id INTEGER PRIMARY KEY)');
   });
 });
 


### PR DESCRIPTION
When `sqlite3_open_v2()` fails, SQLite still assigns a database handle in a "sick" state. Such a handle may only be used to retrieve error information and must then be released with `sqlite3_close()`. `DatabaseSync::Open()` kept the handle in `connection_`, so after a failed `open()`:

- `database.isOpen` incorrectly reported `true`.
- Every method passed the "database is not open" check and called SQLite APIs on the sick handle, which is an API misuse.
- `database.function()` and `database.aggregate()` leaked their user data in builds with `SQLITE_ENABLE_API_ARMOR`, because SQLite rejects calls on a sick handle with `SQLITE_MISUSE` before taking ownership of the user data. This is the leak reported by LeakSanitizer in the issue.
- `open()` could not be retried because the database appeared to be open.

This change closes and resets the connection handle when `open()` fails at any point, so a failed `open()` leaves the database closed, subsequent method calls throw `ERR_INVALID_STATE`, and `open()` can be retried once the underlying problem is resolved. Error reporting is unchanged: the error message is read from the sick handle before it is closed.

Before (v24.16.0):

```console
$ node -e "
const { DatabaseSync } = require('node:sqlite');
const db = new DatabaseSync('/nonexistent-dir/x.db', { open: false, readOnly: true });
try { db.open(); } catch {}
console.log(db.isOpen);      // true
db.function('f', () => {});  // operates on the sick handle
"
```

Fixes: https://github.com/nodejs/node/issues/63831