### PR TITLE
doc: setRawMode needs write permission on Windows

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -86,6 +86,11 @@ characters. <kbd>Ctrl</kbd>+<kbd>C</kbd> will no longer cause a `SIGINT` when
 in this mode. This mode does not affect terminal output processing, such as
 newline translation on Unix terminals.
 
+On Windows, `setRawMode()` requires write permission to the console input
+buffer. When opening `"\\\\.\\CONIN$"` with the [`fs.open()`][] family of APIs
+(for passing into `new tty.ReadStream()`), be sure to use a read/write flag
+such as `'r+'`.
+
 ## Class: `tty.WriteStream`
 
 <!-- YAML
@@ -342,6 +347,7 @@ The `tty.isatty()` method returns `true` if the given `fd` is associated with
 a TTY and `false` if it is not, including whenever `fd` is not a non-negative
 integer.
 
+[`fs.open()`]: fs.md#fsopenpath-flags-mode-callback
 [`net.Socket` constructor]: net.md#new-netsocketoptions
 [`process.stderr`]: process.md#processstderr
 [`process.stdin`]: process.md#processstdin


### PR DESCRIPTION
Fixes #63852. After reporting that issue, I realized that this is probably how Windows is supposed to work, and I just needed to open the console with better permissions. This PR documents this solution so that others can figure this out more easily.

## Summary of changes

Document that `tty.ReadStream#setRawMode()` on Windows requires write access to the console input buffer.

When opening `"\\\\.\\CONIN$"` with the `fs.open()` family of APIs, a read-only flag such as `'r'` allows creating a readable TTY stream, but `setRawMode()` fails because Windows needs write permission to update the console mode. Recommend using a read/write flag such as `'r+'`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
