### PR TITLE
doc: reserve NMV 149 for Electron 44

### DIFF
--- a/doc/abi_version_registry.json
+++ b/doc/abi_version_registry.json
@@ -1,5 +1,6 @@
 {
   "NODE_MODULE_VERSION": [
+    { "modules": 149,"runtime": "electron", "variant": "electron",             "versions": "44" },
     { "modules": 148,"runtime": "electron", "variant": "electron",             "versions": "43" },
     { "modules": 147,"runtime": "node",     "variant": "v8_14.6",              "versions": "26.0.0-pre" },
     { "modules": 146,"runtime": "electron", "variant": "electron",             "versions": "42" },


### PR DESCRIPTION
Reserving NODE_MODULE_VERSION 149 for Electron 44.

[Electron release task](https://github.com/orgs/electron/projects/129/views/3?pane=issue&itemId=184431814)

Thx! :)