### PR TITLE
[v24.x] deps: V8: backport d259a9e2ead7

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -38,7 +38,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.48',
+    'v8_embedder_string': '-node.49',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/maglev/maglev-code-gen-state.h
+++ b/deps/v8/src/maglev/maglev-code-gen-state.h
@@ -9,6 +9,7 @@
 #include "src/codegen/label.h"
 #include "src/codegen/machine-type.h"
 #include "src/codegen/maglev-safepoint-table.h"
+#include "src/codegen/source-position-table.h"
 #include "src/common/globals.h"
 #include "src/compiler/backend/instruction.h"
 #include "src/compiler/js-heap-broker.h"
@@ -34,9 +35,11 @@ class MaglevCodeGenState {
  public:
   MaglevCodeGenState(MaglevCompilationInfo* compilation_info,
                      MaglevSafepointTableBuilder* safepoint_table_builder,
+                     SourcePositionTableBuilder* source_position_table_builder,
                      uint32_t max_block_id)
       : compilation_info_(compilation_info),
         safepoint_table_builder_(safepoint_table_builder),
+        source_position_table_builder_(source_position_table_builder),
         real_jump_target_(max_block_id) {}
 
   void set_tagged_slots(int slots) { tagged_slots_ = slots; }
@@ -80,6 +83,9 @@ class MaglevCodeGenState {
   MaglevSafepointTableBuilder* safepoint_table_builder() const {
     return safepoint_table_builder_;
   }
+  SourcePositionTableBuilder* source_position_table_builder() const {
+    return source_position_table_builder_;
+  }
   MaglevCompilationInfo* compilation_info() const { return compilation_info_; }
 
   Label* entry_label() { return &entry_label_; }
@@ -121,6 +127,7 @@ class MaglevCodeGenState {
  private:
   MaglevCompilationInfo* const compilation_info_;
   MaglevSafepointTableBuilder* const safepoint_table_builder_;
+  SourcePositionTableBuilder* const source_position_table_builder_;
 
   std::vector<DeferredCodeInfo*> deferred_code_;
   std::vector<EagerDeoptInfo*> eager_deopts_;

--- a/deps/v8/src/maglev/maglev-code-generator.cc
+++ b/deps/v8/src/maglev/maglev-code-generator.cc
@@ -707,7 +707,14 @@ class ExceptionHandlerTrampolineBuilder {
 class MaglevCodeGeneratingNodeProcessor {
  public:
   MaglevCodeGeneratingNodeProcessor(MaglevAssembler* masm, Zone* zone)
-      : masm_(masm), zone_(zone) {}
+      : masm_(masm),
+        zone_(zone),
+        // Cache for faster check.
+        collect_source_positions_(masm->code_gen_state()
+                                      ->compilation_info()
+                                      ->collect_source_positions()) {
+    DCHECK_IMPLIES(collect_source_positions_, graph_labeller() != nullptr);
+  }
 
   void PreProcessGraph(Graph* graph) {
     // TODO(victorgomes): I wonder if we want to create a struct that shares
@@ -799,6 +806,15 @@ class MaglevCodeGeneratingNodeProcessor {
       ss << "--   " << graph_labeller()->NodeId(node) << ": "
          << PrintNode(graph_labeller(), node);
       __ RecordComment(ss.str());
+    }
+    if (collect_source_positions_) {
+      // TODO(leszeks): Consider collecting source position in a more memory
+      // friendly way, if we don't need the whole graph labeller.
+      const auto& provenance = graph_labeller()->GetNodeProvenance(node);
+      if (provenance.position.IsKnown()) {
+        code_gen_state()->source_position_table_builder()->AddPosition(
+            masm_->pc_offset(), provenance.position, false);
+      }
     }
 
     if (v8_flags.maglev_assert_stack_size) {
@@ -1105,6 +1121,7 @@ class MaglevCodeGeneratingNodeProcessor {
   }
   MaglevAssembler* const masm_;
   Zone* zone_;
+  bool collect_source_positions_;
 };
 
 class SafepointingNodeProcessor {
@@ -1695,8 +1712,9 @@ MaglevCodeGenerator::MaglevCodeGenerator(
       safepoint_table_builder_(compilation_info->zone(),
                                graph->tagged_stack_slots()),
       frame_translation_builder_(compilation_info->zone()),
+      source_position_table_builder_(compilation_info->zone()),
       code_gen_state_(compilation_info, &safepoint_table_builder_,
-                      graph->max_block_id()),
+                      &source_position_table_builder_, graph->max_block_id()),
       masm_(isolate->GetMainThreadIsolateUnsafe(), compilation_info->zone(),
             &code_gen_state_),
       graph_(graph),
@@ -1919,6 +1937,10 @@ MaybeHandle<Code> MaglevCodeGenerator::BuildCodeObject(
     LocalIsolate* local_isolate) {
   if (!code_gen_succeeded_) return {};
 
+  // Allocate the source position table.
+  Handle<TrustedByteArray> source_positions =
+      source_position_table_builder_.ToSourcePositionTable(local_isolate);
+
   Handle<DeoptimizationData> deopt_data =
       (v8_flags.maglev_deopt_data_on_background &&
        !v8_flags.maglev_build_code_on_background)
@@ -1934,7 +1956,7 @@ MaybeHandle<Code> MaglevCodeGenerator::BuildCodeObject(
           .set_stack_slots(stack_slot_count_with_fixed_frame())
           .set_parameter_count(parameter_count())
           .set_deoptimization_data(deopt_data)
-          .set_empty_source_position_table()
+          .set_source_position_table(source_positions)
           .set_inlined_bytecode_size(graph_->total_inlined_bytecode_size())
           .set_osr_offset(
               code_gen_state_.compilation_info()->toplevel_osr_offset());

--- a/deps/v8/src/maglev/maglev-code-generator.h
+++ b/deps/v8/src/maglev/maglev-code-generator.h
@@ -6,6 +6,7 @@
 #define V8_MAGLEV_MAGLEV_CODE_GENERATOR_H_
 
 #include "src/codegen/maglev-safepoint-table.h"
+#include "src/codegen/source-position-table.h"
 #include "src/common/globals.h"
 #include "src/deoptimizer/frame-translation-builder.h"
 #include "src/maglev/maglev-assembler.h"
@@ -54,6 +55,7 @@ class MaglevCodeGenerator final {
   LocalIsolate* local_isolate_;
   MaglevSafepointTableBuilder safepoint_table_builder_;
   FrameTranslationBuilder frame_translation_builder_;
+  SourcePositionTableBuilder source_position_table_builder_;
   MaglevCodeGenState code_gen_state_;
   MaglevAssembler masm_;
   Graph* const graph_;

--- a/deps/v8/src/maglev/maglev-compiler.cc
+++ b/deps/v8/src/maglev/maglev-compiler.cc
@@ -82,6 +82,18 @@ bool MaglevCompiler::Compile(LocalIsolate* local_isolate,
       compilation_info->set_graph_labeller(new MaglevGraphLabeller());
     }
 
+    // When collecting source positions for profiling, create a graph labeller
+    // so per-node provenance (including inlined positions) is recorded during
+    // graph building and a real source position table can be attached to the
+    // Code object.
+    // Upstream V8 folds this into the single graph-labeller condition; node's
+    // V8 creates the labeller in a differently-shaped block, so the condition
+    // is added separately here.
+    if (compilation_info->collect_source_positions() &&
+        !compilation_info->has_graph_labeller()) {
+      compilation_info->set_graph_labeller(new MaglevGraphLabeller());
+    }
+
     if (is_tracing_enabled &&
         (v8_flags.print_maglev_code || v8_flags.print_maglev_graph ||
          v8_flags.print_maglev_graphs || v8_flags.trace_maglev_graph_building ||

--- a/deps/v8/test/unittests/maglev/maglev-assembler-unittest.cc
+++ b/deps/v8/test/unittests/maglev/maglev-assembler-unittest.cc
@@ -18,7 +18,7 @@ class MaglevAssemblerTest : public MaglevTest {
  public:
   MaglevAssemblerTest()
       : MaglevTest(),
-        codegen_state(nullptr, nullptr, 0),
+        codegen_state(nullptr, nullptr, nullptr, 0),
         as(isolate(), zone(), &codegen_state) {}
 
   void FinalizeAndRun(Label* pass, Label* fail) {


### PR DESCRIPTION
Backports https://github.com/v8/v8/commit/d259a9e2ead784181aac206a40674eb0c173d71e to the V8 13.6 tree.

Changes only impact when running with profiling enabled.

Fixes: https://github.com/nodejs/node/issues/63816

### Adaptation

One deviation from a straight cherry-pick: upstream adds `collect_source_positions()` to a single graph-labeller condition in `MaglevCompiler::Compile`. The 13.6 tree builds the labeller in a differently shaped block, so the condition is added separately. Noted inline.

### Profiling with samply

```sh
samply record -- ./node \
  --perf-prof --interpreted-frames-native-stack \
  --detailed-line-info --no-enable-lazy-source-positions \
  your-script.js
```

Before this change, Maglev (`+`) frames resolve to a function name with no line detail. After, samples inside Maglev code map to their source lines and the inlined functions they came from.

## Example
[loop.js](https://github.com/user-attachments/files/28868281/loop.js)

When running this script, here's the before and after flamegraphs recorded with samply for convenience, but similar results can be achieved with perf + folding scripts.

### Before
<img width="1676" height="401" alt="image" src="https://github.com/user-attachments/assets/19a78975-8ba0-4193-8f27-d6b740aa0569" />

### After
<img width="1670" height="520" alt="image" src="https://github.com/user-attachments/assets/53ff709a-9380-4ef3-8807-2c74b2f3708f" />
