### PR TITLE
quic: fix broken listEndpoints export, test callbacks & nghttp3 include

### DIFF
--- a/lib/quic.js
+++ b/lib/quic.js
@@ -8,6 +8,7 @@ emitExperimentalWarning('quic');
 const {
   connect,
   listen,
+  listEndpoints,
   QuicEndpoint,
   QuicError,
   QuicSession,
@@ -34,6 +35,7 @@ const constants = {
 module.exports = {
   connect,
   listen,
+  listEndpoints,
   QuicEndpoint,
   QuicError,
   QuicSession,

--- a/src/quic/http3.cc
+++ b/src/quic/http3.cc
@@ -1,4 +1,3 @@
-#include "nghttp3/lib/nghttp3_conn.h"
 #if HAVE_OPENSSL && HAVE_QUIC
 #include "guard.h"
 #ifndef OPENSSL_NO_QUIC

--- a/test/parallel/test-quic-internal-setcallbacks.mjs
+++ b/test/parallel/test-quic-internal-setcallbacks.mjs
@@ -15,6 +15,7 @@ const callbacks = {
   onEndpointClose() {},
   onSessionNew() {},
   onSessionClose() {},
+  onSessionApplication() {},
   onSessionDatagram() {},
   onSessionDatagramStatus() {},
   onSessionHandshake() {},


### PR DESCRIPTION
The QUIC build & tests are broken on main in multiple ways:

#63860: The recent nghttp3 deps update (#63776) included internal changes which use _Generic (supported for C++ by Clang, but not by gcc). This only affects nghttp3 internals, but we had a dangling unused include which referenced them, so it broke things. We don't need these internals, and if we don't include them the problem goes away.

ListEndpoints (added in #63536) wasn't actually exported, so its tests fail on main. It clearly should be, it's included in the docs etc and used in the tests.

The new onSessionApplication callback (added in #63558) wasn't included in the setCallbacks test, which failed.

This PR drops the unused include, exports listEndpoints, and fixes the setCallbacks test.

It doesn't totally fix all QUIC build issues on main - there's one more, fixed already in https://github.com/nodejs/node/pull/63821. That's an independent ngtcp2 deps issue (mergeable right now if anybody wants to add a 2nd approve there, or in a few days if not).

Independent of fix this, I'm now going to look to set up a CI job that builds & tests with `--experimental-quic` to stop this happening again. I'll do that in another PR, watch this space.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
