### PR TITLE
build: add QUIC CI job for PRs matching QUIC related paths

### DIFF
--- a/.github/workflows/test-linux-quic.yml
+++ b/.github/workflows/test-linux-quic.yml
@@ -1,0 +1,82 @@
+name: Test Linux (with QUIC)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/test-linux-quic.yml
+      - configure.py
+      - node.gyp
+      - node.gypi
+      - deps/ngtcp2/**
+      - deps/nghttp3/**
+      - deps/openssl/**
+      - src/quic/**
+      - src/node_bob*
+      - lib/quic.js
+      - lib/http3.js
+      - lib/internal/quic/**
+      - lib/stream/iter.js
+      - lib/internal/streams/iter/**
+      - test/cctest/test_quic_*
+      - test/common/quic*
+      - test/common/quic/**
+      - test/parallel/*quic*
+      - test/parallel/test-stream-iter-*
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: '3.14'
+  FLAKY_TESTS: keep_retrying
+  CLANG_VERSION: '19'
+  CC: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'sccache' || '' }} clang-19
+  CXX: ${{ (github.base_ref == 'main' || github.ref_name == 'main') && 'sccache' || '' }} clang++-19
+  SCCACHE_GHA_ENABLED: ${{ github.base_ref == 'main' || github.ref_name == 'main' }}
+  SCCACHE_IDLE_TIMEOUT: '0'
+  RUSTC_VERSION: '1.82'
+
+permissions:
+  contents: read
+
+jobs:
+  test-quic:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+          path: node
+      - name: Install Clang ${{ env.CLANG_VERSION }}
+        uses: ./node/.github/actions/install-clang
+        with:
+          clang-version: ${{ env.CLANG_VERSION }}
+      - name: Install Rust ${{ env.RUSTC_VERSION }}
+        run: |
+          rustup override set "$RUSTC_VERSION"
+          rustup --version
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          allow-prereleases: true
+      - name: Set up sccache
+        if: github.base_ref == 'main' || github.ref_name == 'main'
+        uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+        with:
+          version: v0.12.0
+      - name: Environment Information
+        run: npx envinfo
+      - name: Build
+        working-directory: node
+        run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn --v8-enable-temporal-support --experimental-quic"
+      - name: Test
+        working-directory: node
+        run: make test-ci -j1 V=1 TEST_CI_ARGS="-p actions --measure-flakiness 9"
+      - name: Ensure running tests did not cause any change in the tree
+        working-directory: node
+        run: git add -A && git diff --name-only --exit-code --staged


### PR DESCRIPTION
Matching paths notably includes stream/iter (since they're closely related and rapidly evolving together) and ngtcp2, nghttp3 & openssl deps.

The config here is based primarily on test-linux.yml, the diffs are simplifications: PRs only to limit the disruption (don't run on branches & releases etc for now), filtered to specific paths, just one build (ARM only, like test-internet/test-shared), no unusual characters test.

~~This will fail until https://github.com/nodejs/node/pull/63874 & https://github.com/nodejs/node/pull/63821 are merged - that's expected, QUIC builds are currently broken on main.~~ PRs now merged, this has been rebased and it's all passing :partying_face: 

I'm hoping all the tiny fixes there will go in pretty fast though, happy to discuss the CI job here separately and check the best setup approach for this while QUIC is still experimental. This is my first time touching any of Node CI so let me know if this isn't quite right somewhere.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
