### PR TITLE
doc: add fetch implementation differences

### DIFF
--- a/doc/api/globals.md
+++ b/doc/api/globals.md
@@ -567,6 +567,18 @@ The implementation is based upon [undici](https://undici.nodejs.org), an HTTP/1.
 written from scratch for Node.js. You can figure out which version of `undici` is bundled
 in your Node.js process reading the `process.versions.undici` property.
 
+### Differences from browser `fetch()`
+
+The Node.js implementation of `fetch()` is browser-compatible but is
+implemented by undici. Some browser-specific behaviors do not apply in Node.js.
+
+Known differences include:
+
+* Browser-specific forbidden header restrictions are not applied, although
+  lower-level HTTP constraints still apply.
+* Cookies are not automatically stored or sent between requests.
+* `AsyncIterable` instances can be used as `Request` or `Response` bodies.
+
 ### Custom dispatcher
 
 You can use a custom dispatcher to dispatch requests passing it in fetch's options object.


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/52163

This documents a few known differences between Node.js `fetch()` and browser `fetch()` implementations, including browser-specific header restrictions, cookie storage, and `AsyncIterable` bodies.

Validation:
- `git diff --check` passes.
- `node tools\lint-md\lint-md.mjs doc/api/globals.md` could not be run locally because markdown lint dependencies are not installed (`ERR_MODULE_NOT_FOUND: Cannot find package 'unified'`).