### PR TITLE
src: handle empty MaybeLocal in cjs_lexer::Parse

### DIFF
--- a/src/node_cjs_lexer.cc
+++ b/src/node_cjs_lexer.cc
@@ -15,6 +15,7 @@ using v8::FunctionCallbackInfo;
 using v8::Isolate;
 using v8::Local;
 using v8::LocalVector;
+using v8::MaybeLocal;
 using v8::NewStringType;
 using v8::Object;
 using v8::Set;
@@ -23,22 +24,20 @@ using v8::Value;
 
 // Create a V8 string from an export_string variant, using fast path for ASCII
 template <typename T>
-inline Local<String> CreateString(Isolate* isolate, const T& str) {
+inline MaybeLocal<String> CreateString(Isolate* isolate, const T& str) {
   std::string_view sv = lexer::get_string_view(str);
 
   if (simdutf::validate_ascii(sv.data(), sv.size())) {
     return String::NewFromOneByte(isolate,
                                   reinterpret_cast<const uint8_t*>(sv.data()),
                                   NewStringType::kInternalized,
-                                  static_cast<int>(sv.size()))
-        .ToLocalChecked();
+                                  static_cast<int>(sv.size()));
   }
 
   return String::NewFromUtf8(isolate,
                              sv.data(),
                              NewStringType::kInternalized,
-                             static_cast<int>(sv.size()))
-      .ToLocalChecked();
+                             static_cast<int>(sv.size()));
 }
 
 void Parse(const FunctionCallbackInfo<Value>& args) {
@@ -71,14 +70,22 @@ void Parse(const FunctionCallbackInfo<Value>& args) {
   // Convert exports to JS Set
   Local<Set> exports_set = Set::New(isolate);
   for (const auto& exp : analysis.exports) {
-    exports_set->Add(context, CreateString(isolate, exp)).ToLocalChecked();
+    Local<String> exp_str;
+    if (!CreateString(isolate, exp).ToLocal(&exp_str) ||
+        exports_set->Add(context, exp_str).IsEmpty()) {
+      return;
+    }
   }
 
   // Convert reexports to JS array using batch creation
   LocalVector<Value> reexports_vec(isolate);
   reexports_vec.reserve(analysis.re_exports.size());
   for (const auto& reexp : analysis.re_exports) {
-    reexports_vec.push_back(CreateString(isolate, reexp));
+    Local<String> reexp_str;
+    if (!CreateString(isolate, reexp).ToLocal(&reexp_str)) {
+      return;
+    }
+    reexports_vec.push_back(reexp_str);
   }
 
   // Create result array [exports (Set), reexports (Array)]


### PR DESCRIPTION
`CreateString()` and `Parse()` in `src/node_cjs_lexer.cc` unconditionally called `ToLocalChecked()` on the results of `String::NewFromOneByte()`, `String::NewFromUtf8()` and `Set::Add()`. If string or handle allocation fails or an exception is pending on the isolate, these return an empty `MaybeLocal` and `ToLocalChecked()` aborts the whole process:

```
FATAL ERROR: v8::ToLocalChecked Empty MaybeLocal
 1: node::OnFatalError(char const*, char const*)
 3: node::cjs_lexer::Parse(v8::FunctionCallbackInfo<v8::Value> const&)
```

`Parse()` is on the hot path of every ESM import of a CJS module (`cjsPreparseModuleExports` in `lib/internal/modules/esm/translators.js`), which sits on a normal JS frame and can handle a thrown exception. This change makes `CreateString()` return `MaybeLocal<String>` and propagates failure from `Parse()` as a regular pending JavaScript exception, so an allocation failure surfaces as a recoverable module load error instead of a fatal abort. This matches the failure behavior of the previous WASM-based `cjs-module-lexer` and the `MaybeLocal` handling conventions used elsewhere in `src/` (e.g. `AsArray` in `src/util-inl.h`).

No regression test: the failure requires V8 string/handle allocation to fail inside the binding (export names are bounded by source length, and `Set::Add` on a fresh `Set` runs no user code), which cannot be triggered deterministically from JS. Verified locally that `test/es-module` passes and that the stress reproducer from the issue runs clean.

Fixes: https://github.com/nodejs/node/issues/63323
Refs: https://github.com/nodejs/node/pull/61456