### PR TITLE
fs: allocate FSReqPromise stat arrays lazily

### DIFF
--- a/src/node_file-inl.h
+++ b/src/node_file-inl.h
@@ -209,13 +209,7 @@ FSReqPromise<AliasedBufferT>::FSReqPromise(BindingData* binding_data,
                                            v8::Local<v8::Object> obj,
                                            bool use_bigint)
     : FSReqBase(
-          binding_data, obj, AsyncWrap::PROVIDER_FSREQPROMISE, use_bigint),
-      stats_field_array_(
-          env()->isolate(),
-          static_cast<size_t>(FsStatsOffset::kFsStatsFieldsNumber)),
-      statfs_field_array_(
-          env()->isolate(),
-          static_cast<size_t>(FsStatFsOffset::kFsStatFsFieldsNumber)) {}
+          binding_data, obj, AsyncWrap::PROVIDER_FSREQPROMISE, use_bigint) {}
 
 template <typename AliasedBufferT>
 void FSReqPromise<AliasedBufferT>::Reject(v8::Local<v8::Value> reject) {
@@ -253,14 +247,24 @@ void FSReqPromise<AliasedBufferT>::Resolve(v8::Local<v8::Value> value) {
 
 template <typename AliasedBufferT>
 void FSReqPromise<AliasedBufferT>::ResolveStat(const uv_stat_t* stat) {
-  FillStatsArray(&stats_field_array_, stat);
-  Resolve(stats_field_array_.GetJSArray());
+  if (!stats_field_array_.has_value()) {
+    stats_field_array_.emplace(
+        env()->isolate(),
+        static_cast<size_t>(FsStatsOffset::kFsStatsFieldsNumber));
+  }
+  FillStatsArray(&stats_field_array_.value(), stat);
+  Resolve(stats_field_array_->GetJSArray());
 }
 
 template <typename AliasedBufferT>
 void FSReqPromise<AliasedBufferT>::ResolveStatFs(const uv_statfs_t* stat) {
-  FillStatFsArray(&statfs_field_array_, stat);
-  Resolve(statfs_field_array_.GetJSArray());
+  if (!statfs_field_array_.has_value()) {
+    statfs_field_array_.emplace(
+        env()->isolate(),
+        static_cast<size_t>(FsStatFsOffset::kFsStatFsFieldsNumber));
+  }
+  FillStatFsArray(&statfs_field_array_.value(), stat);
+  Resolve(statfs_field_array_->GetJSArray());
 }
 
 template <typename AliasedBufferT>
@@ -280,8 +284,12 @@ void FSReqPromise<AliasedBufferT>::SetReturnValue(
 template <typename AliasedBufferT>
 void FSReqPromise<AliasedBufferT>::MemoryInfo(MemoryTracker* tracker) const {
   FSReqBase::MemoryInfo(tracker);
-  tracker->TrackField("stats_field_array", stats_field_array_);
-  tracker->TrackField("statfs_field_array", statfs_field_array_);
+  if (stats_field_array_.has_value()) {
+    tracker->TrackField("stats_field_array", stats_field_array_.value());
+  }
+  if (statfs_field_array_.has_value()) {
+    tracker->TrackField("statfs_field_array", statfs_field_array_.value());
+  }
 }
 
 FSReqBase* GetReqWrap(const v8::FunctionCallbackInfo<v8::Value>& args,

--- a/src/node_file.h
+++ b/src/node_file.h
@@ -266,8 +266,11 @@ class FSReqPromise final : public FSReqBase {
                       bool use_bigint);
 
   bool finished_ = false;
-  AliasedBufferT stats_field_array_;
-  AliasedBufferT statfs_field_array_;
+  // Constructed lazily in ResolveStat()/ResolveStatFs(): most operations
+  // never resolve with stats, and eagerly allocating the backing stores
+  // for every request is a significant per-request cost.
+  std::optional<AliasedBufferT> stats_field_array_;
+  std::optional<AliasedBufferT> statfs_field_array_;
 };
 
 class FSReqAfterScope final {

--- a/test/pummel/test-heapdump-fs-promise.js
+++ b/test/pummel/test-heapdump-fs-promise.js
@@ -20,7 +20,7 @@ fs.stat(__filename);
   validateByRetainingPathFromNodes(nodes, 'Node / FSReqPromise', [
     { node_name: 'FSReqPromise', edge_name: 'native_to_javascript' },
   ]);
-  validateByRetainingPathFromNodes(nodes, 'Node / FSReqPromise', [
-    { node_name: 'Node / AliasedFloat64Array', edge_name: 'stats_field_array' },
-  ]);
+  // The stats field array is allocated lazily when the request resolves
+  // with stats, so it is not retained by a request that is still pending
+  // and cannot be observed in a heap snapshot.
 }


### PR DESCRIPTION
#### Description of Change

Every promise-based fs operation allocates two `AliasedBuffer`s at request construction — an 18-field stats array and an 8-field statfs array — although only stat-family resolutions ever read the first and only `statfs()` reads the second. Each one costs an `ArrayBuffer`, a `TypedArray` and a strong `v8::Global`, so a plain `fsp.writeFile()` pays for two backing stores it can never use. The callback path has no equivalent cost: `FSReqCallback` resolves stats through a shared per-process array.

Under concurrency this allocation churn is the dominant overhead of the promises path — profiling 64 in-flight 1KB reads shows ~21% of CPU ticks in the malloc family for promises vs ~5% for callbacks issuing identical syscalls.

This PR constructs the arrays lazily in `ResolveStat()`/`ResolveStatFs()`:

- Non-stat operations (open, read, write, close, unlink, …) now allocate neither array; stat-family ops allocate one; only `statfs` allocates the statfs array.
- Once created, lifetime is unchanged — the array is still owned by the request, so deferred promise continuations read from request-owned memory exactly as before. The reason the per-request copy exists (continuations, unlike callbacks, don't consume the result synchronously) is preserved.
- `MemoryInfo` reports the arrays only when they exist.

`benchmark/compare.js` shows significant improvements on the concurrent configurations — `writefile-promises` **+12.6…20.7%**, `readfile-promises` **+19.1…21.5%** (unencoded), `bench-stat-promise` **+2.2…3.5%** — with sequential large-payload configs neutral (those are threadpool-latency-bound, as expected).

<details>
<summary>Benchmark results</summary>

`benchmark/compare.js`, 10 samples per configuration, Welch t-test (`***` p&lt;0.001, `**` p&lt;0.01, `*` p&lt;0.05):

```
fs/bench-stat-promise.js statType='fstat' n=200000                          +3.51% ***
fs/bench-stat-promise.js statType='lstat' n=200000                          +2.20% *
fs/bench-stat-promise.js statType='stat' n=200000                           +2.88% ***
fs/readfile-promises.js c=1  len=1024     enc=''       +3.25% ***   enc='utf-8'  +4.21% ***
fs/readfile-promises.js c=1  len=512k     enc=''       +3.61%       enc='utf-8'  +4.38% **
fs/readfile-promises.js c=1  len=8M       enc=''       +8.34% **    enc='utf-8'  -2.35%
fs/readfile-promises.js c=1  len=16M      enc=''       +2.30%       enc='utf-8'  +1.41%
fs/readfile-promises.js c=1  len=32M      enc=''       -2.17%       enc='utf-8'  +0.43%
fs/readfile-promises.js c=10 len=1024     enc=''      +21.02% ***   enc='utf-8' +19.84% ***
fs/readfile-promises.js c=10 len=512k     enc=''       +7.07% *     enc='utf-8'  +0.94%
fs/readfile-promises.js c=10 len=4M       enc=''      +19.14% **    enc='utf-8'  +1.39% *
fs/readfile-promises.js c=10 len=8M       enc=''      +21.51% ***   enc='utf-8'  -0.25%
fs/readfile-promises.js c=10 len=16M      enc=''      +20.99% ***   enc='utf-8'  +0.99% *
fs/readfile-promises.js c=10 len=32M      enc=''       +5.16% **    enc='utf-8'  +0.76%
fs/writefile-promises.js c=1  size=2      asc +7.17%*** buf +6.00%*** utf +5.83%***
fs/writefile-promises.js c=1  size=1024   asc +5.19%*** buf +6.00%*** utf +5.06%***
fs/writefile-promises.js c=1  size=64k    asc +2.65%*** buf +4.00%*** utf +2.12%***
fs/writefile-promises.js c=1  size=1M     asc +0.88%    buf +0.93%*   utf -0.38%
fs/writefile-promises.js c=10 size=2      asc +19.80%*** buf +18.70%*** utf +20.71%***
fs/writefile-promises.js c=10 size=1024   asc +13.51%*** buf +18.77%*** utf +12.58%***
fs/writefile-promises.js c=10 size=64k    asc +4.58%***  buf +2.65%**   utf +11.02%***
fs/writefile-promises.js c=10 size=1M     asc +2.25%*    buf +0.15%     utf +0.06%
```

Additional ad-hoc microbenchmarks (tmpfs, 64 ops in flight): `fsp.writeFile` 1KB **+53%**, `fsp.stat` **+26%**, `fsp.readFile` 1KB **+22%** — with all callback variants unchanged (±3%), confirming attribution since callbacks never construct `FSReqPromise`. Scripts: https://gist.github.com/MarshallOfSound/7d22707e3e550a782e96f9da0081e9f1

</details>

#### Checklist

- [x] I have built and tested this change
- [x] `test/parallel/test-fs-*` pass (342 tests; 3 pre-existing environment failures fail identically on `main`)
- [x] Verified `fsp.stat`, `fsp.statfs` and `fsp.readFile` resolve correctly through the lazily-created-array paths
