### PR TITLE
docs(access): document 2fa alias for mfa settings

### DIFF
--- a/deps/npm/docs/content/commands/npm-access.md
+++ b/deps/npm/docs/content/commands/npm-access.md
@@ -12,6 +12,7 @@ npm access list collaborators [<package> [<user>]]
 npm access get status [<package>]
 npm access set status=public|private [<package>]
 npm access set mfa=none|publish|automation [<package>]
+npm access set 2fa=none|publish|automation [<package>]
 npm access grant <read-only|read-write> <scope:team> [<package>]
 npm access revoke <scope:team> [<package>]
 ```
@@ -30,6 +31,8 @@ For all of the subcommands, `npm access` will perform actions on the packages in
 ### Details
 
 `npm access` always operates directly on the current registry, configurable from the command line using `--registry=<registry url>`.
+
+The `2fa` setting is supported as an alias for `mfa`.
 
 Unscoped packages are *always public*.
 


### PR DESCRIPTION
## Summary

Document support for the `2fa` alias in `npm access set`.

The implementation currently supports:

* `2fa=none`
* `2fa=publish`
* `2fa=automation`

via the same code path as the corresponding `mfa` options, but the command documentation only lists the `mfa` variants.

This change updates the command synopsis and adds a short note clarifying that `2fa` is an alias for `mfa`.
