### PR TITLE
cli: fix env vars missing from `node --help`

### DIFF
--- a/lib/internal/main/print_help.js
+++ b/lib/internal/main/print_help.js
@@ -72,17 +72,17 @@ const envVars = new SafeMap(ArrayPrototypeConcat([
     'libuv\'s threadpool' }],
 ], hasIntl ? [
   ['NODE_ICU_DATA', { helpText: 'data path for ICU (Intl object) data' +
-    hasSmallICU ? '' : ' (will extend linked-in data)' }],
-] : []), (hasNodeOptions ? [
+    (hasSmallICU ? '' : ' (will extend linked-in data)') }],
+] : [], hasNodeOptions ? [
   ['NODE_OPTIONS', { helpText: 'set CLI options in the environment via a ' +
     'space-separated list' }],
-] : []), hasCrypto ? [
+] : [], hasCrypto ? [
   ['OPENSSL_CONF', { helpText: 'load OpenSSL configuration from file' }],
   ['SSL_CERT_DIR', { helpText: 'sets OpenSSL\'s directory of trusted ' +
     'certificates when used in conjunction with --use-openssl-ca' }],
   ['SSL_CERT_FILE', { helpText: 'sets OpenSSL\'s trusted certificate file ' +
     'when used in conjunction with --use-openssl-ca' }],
-] : []);
+] : []));
 
 
 function indent(text, depth) {

--- a/test/parallel/test-cli-node-print-help.js
+++ b/test/parallel/test-cli-node-print-help.js
@@ -36,6 +36,47 @@ function validateNodePrintHelp() {
   ];
 
   cliHelpOptions.forEach(testForSubstring);
+
+  validateEnvVarSection();
+}
+
+// Verify that the "Environment variables:" section lists the expected
+// entries. Each entry is printed at the start of its own line, so matching
+// against the start of a line avoids false positives from names that also
+// appear inside an option's description (e.g. `--icu-data-dir` mentions
+// "overrides NODE_ICU_DATA" and `--openssl-config` mentions
+// "overrides OPENSSL_CONF"). These checks guard against malformed
+// construction of the environment-variable list that would silently drop
+// entries from the help output.
+function validateEnvVarSection() {
+  const { internalBinding } = require('internal/test/binding');
+  const { hasNodeOptions } = internalBinding('config');
+
+  const start = stdOut.indexOf('Environment variables:');
+  assert.ok(start !== -1, 'Missing "Environment variables:" section');
+  const end = stdOut.indexOf('Documentation can be found', start);
+  const envSection = stdOut.slice(start, end === -1 ? undefined : end);
+
+  const expectedEnvVars = [
+    { name: 'FORCE_COLOR', present: true },
+    { name: 'NODE_PATH', present: true },
+    { name: 'NODE_ICU_DATA', present: common.hasIntl },
+    { name: 'NODE_OPTIONS', present: hasNodeOptions },
+    { name: 'OPENSSL_CONF', present: common.hasCrypto },
+    { name: 'SSL_CERT_DIR', present: common.hasCrypto },
+    { name: 'SSL_CERT_FILE', present: common.hasCrypto },
+  ];
+
+  for (const { name, present } of expectedEnvVars) {
+    const re = new RegExp(`^${name}\\b`, 'm');
+    if (present) {
+      assert.match(envSection, re,
+                   `Missing environment variable ${name} in:\n${envSection}`);
+    } else {
+      assert.doesNotMatch(envSection, re,
+                          `Unexpected environment variable ${name} in:\n${envSection}`);
+    }
+  }
 }
 
 function testForSubstring(options) {


### PR DESCRIPTION
The `envVars` table in print_help.js was built with a malformed expression that silently dropped entries from the help output:

1. The closing parenthesis of `ArrayPrototypeConcat()` was placed after the `hasIntl` argument, so the `hasNodeOptions` and `hasCrypto` lists were passed as extra arguments to `new SafeMap()`, which ignores everything after the first. As a result NODE_OPTIONS, OPENSSL_CONF, SSL_CERT_DIR and SSL_CERT_FILE never appeared.

2. The NODE_ICU_DATA helpText used `'...' + hasSmallICU ? '' : '...'`, which parses as `('...' + hasSmallICU) ? '' : '...'` and is always the empty string. Since format() skips entries with falsy helpText, the NODE_ICU_DATA entry was dropped as well.

The existing test only checked for the bare `NODE_ICU_DATA` and `OPENSSL_CONF` substrings, which also occur in the `--icu-data-dir` and `--openssl-config` descriptions, so the missing entries went unnoticed. The added test parses the "Environment variables:" section and asserts each entry appears at the start of a line.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
