### PR TITLE
buffer: validate copyArrayBuffer offsets against buffer length

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1569,6 +1569,10 @@ void CopyArrayBuffer(const FunctionCallbackInfo<Value>& args) {
   uint32_t source_offset = args[3].As<Uint32>()->Value();
   size_t bytes_to_copy = args[4].As<Uint32>()->Value();
 
+  // Assert the offsets are within bounds before the subtractions below, which
+  // would otherwise underflow and defeat the bytes_to_copy bounds checks.
+  CHECK_LE(destination_offset, destination_byte_length);
+  CHECK_LE(source_offset, source_byte_length);
   CHECK_GE(destination_byte_length - destination_offset, bytes_to_copy);
   CHECK_GE(source_byte_length - source_offset, bytes_to_copy);
 


### PR DESCRIPTION
`CopyArrayBuffer()` computed `byteLength - offset` in unsigned arithmetic before its `CHECK_GE` bounds check. An offset greater than the buffer length wrapped the subtraction to a near-`SIZE_MAX` value, so the check passed and `memcpy()` copied out of bounds.

The only in-tree caller is the Web Streams BYOB reader, which validates the offsets in JS via `canCopyArrayBuffer()` before calling. The binding is also reachable directly through `process.binding('buffer').copyArrayBuffer(...)`, which bypasses that guard, so the offsets reach C++ unchecked. Only in-process (trusted) code can reach it, so this is a robustness fix, not a vulnerability.

Validate the destination and source ranges in C++ and throw `ERR_OUT_OF_RANGE`, as the other range checks in `node_buffer.cc` already do.

Reproduction before the change (in-process JS, no flags):

```js
const b = process.binding('buffer');
b.copyArrayBuffer(new ArrayBuffer(1024), 1025, new ArrayBuffer(8), 0, 8);
// writes 8 bytes past the destination, corrupting the adjacent heap chunk
```

After the change the call throws `ERR_OUT_OF_RANGE`.
