### PR TITLE
crypto: fix unhandled error in Hash._transform

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -125,7 +125,8 @@ Hash.prototype.copy = function copy(options) {
 };
 
 Hash.prototype._transform = function _transform(chunk, encoding, callback) {
-  this[kHandle].update(chunk, encoding);
+  if (!this[kHandle].update(chunk, encoding))
+    return callback(new ERR_CRYPTO_HASH_UPDATE_FAILED());
   callback();
 };
 

--- a/test/parallel/test-crypto-hash.js
+++ b/test/parallel/test-crypto-hash.js
@@ -294,3 +294,25 @@ if (!process.features.openssl_is_boringssl) {
 {
   crypto.Hash('sha256');
 }
+
+// Regression test: Hash.prototype._transform should propagate
+// ERR_CRYPTO_HASH_UPDATE_FAILED when the native update call fails.
+// See https://github.com/nodejs/node/issues/63258
+{
+  const h = crypto.createHash('sha256');
+  const kHandle = Object.getOwnPropertySymbols(h)
+    .find((s) => s.toString() === 'Symbol(kHandle)');
+  const originalUpdate = h[kHandle].update;
+
+  // Mock the native update to simulate failure.
+  h[kHandle].update = () => false;
+
+  h.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'ERR_CRYPTO_HASH_UPDATE_FAILED');
+
+    // Restore original to avoid side effects.
+    h[kHandle].update = originalUpdate;
+  }));
+
+  h.write('data');
+}


### PR DESCRIPTION
crypto: fix silent error swallowing in Hash.write()

Problem:
crypto.createHash().update() throws ERR_CRYPTO_HASH_UPDATE_FAILED
when the native EVP_DigestUpdate call fails. However, the same
failure occurring via .write() (Transform._transform) was not
checked, so:
- write() returned true
- no 'error' event was emitted
- the write callback received null
- the resulting digest was silently incorrect

Fix:
_transform() now checks the boolean result of the native update
call and forwards an error (same error class as update()) via
callback(err) on failure, leaving the success path unchanged.

Testing:
Added a regression test in test/parallel/test-crypto-hash.js that
fault-injects a failing update and asserts an error is surfaced
via the stream/callback instead of producing a wrong digest.

Fixes: #63258