### PR TITLE
doc: fix callback example import in fs documentation

### DIFF
--- a/doc/api/fs.md
+++ b/doc/api/fs.md
@@ -8790,7 +8790,7 @@ rename('/tmp/hello', '/tmp/world', (err) => {
 ```
 
 ```cjs
-const { rename, stat } = require('node:fs/promises');
+const { rename, stat } = require('node:fs');
 
 rename('/tmp/hello', '/tmp/world', (err) => {
   if (err) throw err;


### PR DESCRIPTION
## Summary

The CommonJS example in the "Ordering of callback and promise-based operations"
section demonstrates callback-based usage but imports `rename` and `stat`
from `node:fs/promises`.

Since callback-based APIs are provided by `node:fs`, the example should
import from `node:fs` instead.

This change aligns the CommonJS example with the equivalent ESM example
and the callback API being demonstrated.