### PR TITLE
fs: cache glob matcher functions in path.matchesGlob

### DIFF
--- a/benchmark/path/matchesGlob-posix.js
+++ b/benchmark/path/matchesGlob-posix.js
@@ -1,0 +1,28 @@
+'use strict';
+const common = require('../common.js');
+const { posix } = require('path');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  path: [
+    'src/index.ts',
+    'src/index.test.ts',
+    'src/foo/bar/biz/baz/index.test.ts',
+  ],
+  pattern: [
+    'src/**/baz/*.test.ts',
+    'src/**/baz/*.ts',
+    'test/**/*.ts',
+  ],
+  n: [1e5],
+});
+
+function main({ path, pattern, n }) {
+  bench.start();
+  let a;
+  for (let i = 0; i < n; i++) {
+    a = posix.matchesGlob(path, pattern);
+  }
+  bench.end(n);
+  assert(a + 'a');
+}

--- a/benchmark/path/matchesGlob-win32.js
+++ b/benchmark/path/matchesGlob-win32.js
@@ -1,0 +1,29 @@
+'use strict';
+const common = require('../common.js');
+const { win32 } = require('path');
+const assert = require('assert');
+
+const bench = common.createBenchmark(main, {
+  path: [
+    'src/index.ts',
+    'src\\index.ts',
+    'src/foo/bar/biz/baz/index.test.ts',
+    'src\\foo\\bar\\biz\\baz\\index.test.ts',
+  ],
+  pattern: [
+    'src/**/baz/*.test.ts',
+    'src/**/baz/*.ts',
+    'test/**/*.ts',
+  ],
+  n: [1e5],
+});
+
+function main({ path, pattern, n }) {
+  bench.start();
+  let a;
+  for (let i = 0; i < n; i++) {
+    a = win32.matchesGlob(path, pattern);
+  }
+  bench.end(n);
+  assert(a + 'a');
+}

--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -922,6 +922,9 @@ class Glob {
   }
 }
 
+const kGlobPatternCacheLimit = 250;
+const patternFnCache = new SafeMap();
+
 /**
  * Check if a path matches a glob pattern
  * @param {string} path the path to check
@@ -932,16 +935,23 @@ class Glob {
 function matchGlobPattern(path, pattern, windows = isWindows) {
   validateString(path, 'path');
   validateString(pattern, 'pattern');
-  return lazyMinimatch().minimatch(path, pattern, {
-    kEmptyObject,
-    nocase: isMacOS || isWindows,
-    windowsPathsNoEscape: true,
-    nonegate: true,
-    nocomment: true,
-    optimizationLevel: 2,
-    platform: windows ? 'win32' : 'posix',
-    nocaseMagicOnly: true,
-  });
+
+  let matcher;
+  if (patternFnCache.has(pattern)) {
+    matcher = patternFnCache.get(pattern);
+  } else {
+    matcher = createMatcher(pattern, {
+      kEmptyObject,
+      platform: windows ? 'win32' : 'posix',
+    });
+    patternFnCache.set(pattern, matcher);
+
+    if (patternFnCache.size >= kGlobPatternCacheLimit) {
+      patternFnCache.delete(patternFnCache.keys().next().value);
+    }
+  }
+
+  return matcher.match(path);
 }
 
 module.exports = {


### PR DESCRIPTION
this PR adds benchmarks for `path.matchesGlob()` as well as a simple cache for pattern matching functions.

### rationale

most glob matching libraries in the ecosystem (including `minimatch`) provide an API to let users re-use matchers instead of re-creating them every call.

node doesn't provide such an API, and does not re-use matchers when possible, leading to it being much slower (10-15x) than just using `new Minimatch()` directly when matching a pattern more than once.

### implementation details

i decided to "hide" away the cache inside the function rather than add a new API as most users will expect the function to not be a potential footgun, and the pattern [has been used before](https://github.com/fabiospampinato/zeptomatch/blob/beb90cdbc0601b4bb61638312635258a68b15356/src/index.ts#L23-L29) in [zeptomatch](https://npmx.dev/zeptomatch)

since `matchGlobPattern()` doesn't accept any options other than pattern and path we can safely cache it by the pattern string. if this changes in the future the cache would need to accomodate the new options in the cache keys.

i went with the simplest `Map` cache implementation i could come up with as i couldn't find any LRU implementations anywhere in the codebase, if you have any suggestions for improvements please let me know!

### testing

i'm not sure how to test this properly, e.g. if i should export the cache instance and check its size, etc

some guidance here is very appreciated :)

---

<details>
<summary>benchmark results</summary>

ran on my windows 11 machine with an AMD Ryzen 9800X3D

note: these benchmarks do not test the case where we evict keys from the cache

```
                                                                                                                confidence improvement accuracy (*)    (**)   (***)
path\matchesGlob-posix.js n=100000 pattern='src/**/baz/*.test.ts' path='src/foo/bar/biz/baz/index.test.ts'             ***   1013.11 %      ±23.55% ±31.74% ±42.14%
path\matchesGlob-posix.js n=100000 pattern='src/**/baz/*.test.ts' path='src/index.test.ts'                             ***   2005.02 %      ±48.08% ±64.80% ±86.02%
path\matchesGlob-posix.js n=100000 pattern='src/**/baz/*.test.ts' path='src/index.ts'                                  ***   2073.47 %      ±27.53% ±37.10% ±49.24%
path\matchesGlob-posix.js n=100000 pattern='src/**/baz/*.ts' path='src/foo/bar/biz/baz/index.test.ts'                  ***    869.89 %      ±18.72% ±25.22% ±33.48%
path\matchesGlob-posix.js n=100000 pattern='src/**/baz/*.ts' path='src/index.test.ts'                                  ***   1726.85 %      ±29.66% ±39.97% ±53.07%
path\matchesGlob-posix.js n=100000 pattern='src/**/baz/*.ts' path='src/index.ts'                                       ***   1777.43 %      ±25.94% ±34.95% ±46.40%
path\matchesGlob-posix.js n=100000 pattern='test/**/*.ts' path='src/foo/bar/biz/baz/index.test.ts'                     ***   1074.40 %      ±22.04% ±29.70% ±39.43%
path\matchesGlob-posix.js n=100000 pattern='test/**/*.ts' path='src/index.test.ts'                                     ***   1424.64 %      ±28.72% ±38.70% ±51.38%
path\matchesGlob-posix.js n=100000 pattern='test/**/*.ts' path='src/index.ts'                                          ***   1460.18 %      ±17.52% ±23.60% ±31.33%
path\matchesGlob-win32.js n=100000 pattern='src/**/baz/*.test.ts' path='src/foo/bar/biz/baz/index.test.ts'             ***    659.77 %       ±7.00%  ±9.43% ±12.52%
path\matchesGlob-win32.js n=100000 pattern='src/**/baz/*.test.ts' path='src/index.ts'                                  ***   1056.32 %      ±12.77% ±17.21% ±22.84%
path\matchesGlob-win32.js n=100000 pattern='src/**/baz/*.test.ts' path='src\\foo\\bar\\biz\\baz\\index.test.ts'        ***    492.15 %       ±4.26%  ±5.73%  ±7.60%
path\matchesGlob-win32.js n=100000 pattern='src/**/baz/*.test.ts' path='src\\index.ts'                                 ***    858.27 %       ±6.41%  ±8.64% ±11.46%
path\matchesGlob-win32.js n=100000 pattern='src/**/baz/*.ts' path='src/foo/bar/biz/baz/index.test.ts'                  ***    565.03 %       ±5.60%  ±7.54% ±10.01%
path\matchesGlob-win32.js n=100000 pattern='src/**/baz/*.ts' path='src/index.ts'                                       ***    915.51 %       ±9.18% ±12.38% ±16.42%
path\matchesGlob-win32.js n=100000 pattern='src/**/baz/*.ts' path='src\\foo\\bar\\biz\\baz\\index.test.ts'             ***    431.51 %       ±3.11%  ±4.18%  ±5.51%
path\matchesGlob-win32.js n=100000 pattern='src/**/baz/*.ts' path='src\\index.ts'                                      ***    746.71 %       ±6.50%  ±8.75% ±11.62%
path\matchesGlob-win32.js n=100000 pattern='test/**/*.ts' path='src/foo/bar/biz/baz/index.test.ts'                     ***    597.13 %      ±12.85% ±17.31% ±22.97%
path\matchesGlob-win32.js n=100000 pattern='test/**/*.ts' path='src/index.ts'                                          ***    745.44 %      ±12.25% ±16.50% ±21.90%
path\matchesGlob-win32.js n=100000 pattern='test/**/*.ts' path='src\\foo\\bar\\biz\\baz\\index.test.ts'                ***    421.16 %       ±3.44%  ±4.61%  ±6.08%
path\matchesGlob-win32.js n=100000 pattern='test/**/*.ts' path='src\\index.ts'                                         ***    594.88 %      ±10.85% ±14.62% ±19.41%
```

i also have [a personal benchmarking repo](https://github.com/beeequeue/node-benches/blob/main/benches/match/bench.ts) where i found this issue, where the results now look like this:

<details>
<summary>screenshot</summary>

<img width="616" height="625" alt="image" src="https://github.com/user-attachments/assets/c9f5e9e5-ac52-47b8-8b6c-d01fcd94901c" />

</details>

</details>