### PR TITLE
loader: enforce path normalization before lookup

### DIFF
--- a/lib/internal/modules/package_map.js
+++ b/lib/internal/modules/package_map.js
@@ -140,6 +140,8 @@ class PackageMap {
    * @returns {string|null}
    */
   #getKeyForPath(filePath) {
+    filePath = pathResolve(filePath);
+
     const cached = this.#pathToKeyCache.get(filePath);
     if (cached !== undefined) { return cached; }
 

--- a/test/parallel/test-require-package-map.js
+++ b/test/parallel/test-require-package-map.js
@@ -79,7 +79,6 @@ describe('CJS: --experimental-package-map', { concurrency: !process.env.TEST_PAR
       assert.match(stdout, /dep-b using dep-a-value/);
       assert.strictEqual(status, 0, stderr);
     });
-
   });
 
   describe('resolution boundaries', () => {

--- a/test/parallel/test-require-package-map.js
+++ b/test/parallel/test-require-package-map.js
@@ -79,6 +79,7 @@ describe('CJS: --experimental-package-map', { concurrency: !process.env.TEST_PAR
       assert.match(stdout, /dep-b using dep-a-value/);
       assert.strictEqual(status, 0, stderr);
     });
+
   });
 
   describe('resolution boundaries', () => {
@@ -299,6 +300,22 @@ describe('CJS: --experimental-package-map', { concurrency: !process.env.TEST_PAR
 
   describe('longest path wins', () => {
     const longestPathMap = fixtures.path('package-map/package-map-longest-path.json');
+
+    it('resolves from createRequire() paths with mixed separators', () => {
+      const { status, stdout, stderr } = spawnSync(process.execPath, [
+        '--no-warnings',
+        '--experimental-package-map', longestPathMap,
+        '-e',
+        `const { createRequire } = require('node:module'); const req = createRequire(process.cwd() + '/node_modules/inner/index.js'); const dep = req('dep-a'); console.log(dep.default);`,
+      ], {
+        cwd: fixtures.path('package-map/root'),
+        encoding: 'utf8',
+      });
+
+      assert.strictEqual(stderr, '');
+      assert.match(stdout, /dep-a-value/);
+      assert.strictEqual(status, 0, stderr);
+    });
 
     it('resolves nested package using its own dependencies, not the parent', () => {
       // Inner lives at ./root/node_modules/inner which is inside root's


### PR DESCRIPTION
It seems that calling `createRequire(p)` doesn't normalize `p` when it's an absolute path (see [here](https://github.com/nodejs/node/blob/120c2a45586f1c7f46f299d9aa0a4d1da7fed71f/lib/internal/modules/cjs/loader.js#L2171)). This causes package maps to fail on calls such as `createRequire(process.cwd() + "/node_modules/foo/index.js")` because the forward slashes will remain and mismatch with the internal folder -> package name map (whose keys *are* normalized).

A fix would be to normalize `p` within `createRequire`, but it felt reasonable to make a smaller change to the package map lookup method, since nothing else cared about that before.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
