### PR TITLE
include missing header malloc.h

### DIFF
--- a/deps/LIEF/third-party/spdlog/include/spdlog/fmt/bundled/format.h
+++ b/deps/LIEF/third-party/spdlog/include/spdlog/fmt/bundled/format.h
@@ -39,6 +39,7 @@
 #endif
 
 #include "base.h"
+#include "malloc.h"
 
 #ifndef FMT_MODULE
 #  include <cmath>    // std::signbit


### PR DESCRIPTION
building using musl fails due to missing header:
```
../../deps/LIEF/third-party/spdlog/include/spdlog/fmt/bundled/format.h:747:28: error: use of undeclared identifier 'malloc'
  747 |     T* p = static_cast<T*>(malloc(n * sizeof(T)));
      |                            ^~~~~~
../../deps/LIEF/third-party/spdlog/include/spdlog/fmt/bundled/format.h:752:35: error: call to function 'free' that is neither visible in the template definition nor found by argument-dependent lookup
  752 |   void deallocate(T* p, size_t) { free(p); }
      |                                   ^
```

see-also: https://bugs.gentoo.org/977458
fix: #63920

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
