### PR TITLE
crypto: throw on uninitialized DH computeSecret

### DIFF
--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -1710,6 +1710,13 @@ DataPointer DHPointer::getPrivateKey() const {
   return BignumPointer::Encode(pvt_key);
 }
 
+bool DHPointer::hasPrivateKey() const {
+  if (!dh_) return false;
+  const BIGNUM* pvt_key = nullptr;
+  DH_get0_key(dh_.get(), nullptr, &pvt_key);
+  return pvt_key != nullptr;
+}
+
 DataPointer DHPointer::generateKeys() const {
   ClearErrorOnReturn clearErrorOnReturn;
   if (!dh_) return {};

--- a/deps/ncrypto/ncrypto.h
+++ b/deps/ncrypto/ncrypto.h
@@ -1116,6 +1116,7 @@ class DHPointer final {
   DataPointer getGenerator() const;
   DataPointer getPublicKey() const;
   DataPointer getPrivateKey() const;
+  bool hasPrivateKey() const;
   DataPointer generateKeys() const;
   DataPointer computeSecret(const BignumPointer& peer) const;
 

--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -324,6 +324,11 @@ void ComputeSecret(const FunctionCallbackInfo<Value>& args) {
       break;
   }
 
+  if (!dh.hasPrivateKey()) {
+    return THROW_ERR_CRYPTO_INVALID_STATE(
+        env, "Cannot compute shared secret without a private key");
+  }
+
   auto dp = dh.computeSecret(key);
 
   Local<Value> buffer;

--- a/test/parallel/test-crypto-dh-errors.js
+++ b/test/parallel/test-crypto-dh-errors.js
@@ -100,6 +100,28 @@ assert.throws(
   'failed to throw the expected error.'
 );
 
+{
+  const group = crypto.getDiffieHellman('modp14');
+  const alice = crypto.createDiffieHellman(
+    group.getPrime(), group.getGenerator());
+  const bob = crypto.createDiffieHellman(
+    group.getPrime(), group.getGenerator());
+  bob.generateKeys();
+
+  assert.throws(
+    () => alice.computeSecret(bob.getPublicKey()),
+    {
+      name: 'Error',
+      code: 'ERR_CRYPTO_INVALID_STATE',
+      message: 'Cannot compute shared secret without a private key'
+    });
+
+  alice.generateKeys();
+  assert.deepStrictEqual(
+    alice.computeSecret(bob.getPublicKey()),
+    bob.computeSecret(alice.getPublicKey()));
+}
+
 assert.throws(
   () => crypto.createDiffieHellman('', true),
   {


### PR DESCRIPTION
Reject DiffieHellman computeSecret() when the instance does not have private key material instead of returning an empty buffer.

Fixes: https://github.com/nodejs/node/issues/63674

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
