### PR TITLE
doc,crypto: mark argon2 and encap/decap as stable

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -3308,8 +3308,6 @@ Does not perform any other validation checks on the certificate.
 added: v24.7.0
 -->
 
-> Stability: 1.2 - Release candidate
-
 * `algorithm` {string} Variant of Argon2, one of `"argon2d"`, `"argon2i"` or `"argon2id"`.
 * `parameters` {Object}
   * `message` {string|ArrayBuffer|Buffer|TypedArray|DataView} REQUIRED, this is the password for password
@@ -3393,8 +3391,6 @@ argon2('argon2id', parameters, (err, derivedKey) => {
 <!-- YAML
 added: v24.7.0
 -->
-
-> Stability: 1.2 - Release candidate
 
 * `algorithm` {string} Variant of Argon2, one of `"argon2d"`, `"argon2i"` or `"argon2id"`.
 * `parameters` {Object}
@@ -4119,8 +4115,6 @@ algorithm names.
 added: v24.7.0
 -->
 
-> Stability: 1.2 - Release candidate
-
 * `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject} Private Key
 * `ciphertext` {ArrayBuffer|Buffer|TypedArray|DataView}
 * `callback` {Function}
@@ -4187,8 +4181,6 @@ If the `callback` function is provided this function uses libuv's threadpool.
 <!-- YAML
 added: v24.7.0
 -->
-
-> Stability: 1.2 - Release candidate
 
 * `key` {Object|string|ArrayBuffer|Buffer|TypedArray|DataView|KeyObject} Public Key
 * `callback` {Function}


### PR DESCRIPTION
Remove the Release candidate stability index, thus marking these 4 methods as stable. They do not emit `ExperimentalWarning`.

- [`crypto.argon2()`](https://nodejs.org/api/crypto.html#cryptoargon2algorithm-parameters-callback)
- [`crypto.argon2Sync()`](https://nodejs.org/api/crypto.html#cryptoargon2syncalgorithm-parameters)
- [`crypto.decapsulate()`](https://nodejs.org/api/crypto.html#cryptodecapsulatekey-ciphertext-callback)
- [`crypto.encapsulate()`](https://nodejs.org/api/crypto.html#cryptoencapsulatekey-callback)