### PR TITLE
crypto: reject resizable backing stores in Web Crypto buffer parameters

### DIFF
--- a/lib/internal/crypto/webidl.js
+++ b/lib/internal/crypto/webidl.js
@@ -11,7 +11,6 @@ const {
 
 const {
   lazyDOMException,
-  kEmptyObject,
 } = require('internal/util');
 const { CryptoKey } = require('internal/crypto/webcrypto');
 const {
@@ -133,30 +132,7 @@ const dictAlgorithm = [
 converters.Algorithm = createDictionaryConverter(
   'Algorithm', dictAlgorithm);
 
-// TODO(panva): Reject resizable backing stores in a semver-major with:
-// converters.BigInteger = webidl.Uint8Array;
-converters.BigInteger = (V, opts = kEmptyObject) => {
-  return webidl.Uint8Array(V, {
-    prefix: opts.prefix,
-    context: opts.context,
-    code: opts.code,
-    allowResizable: true,
-    allowShared: false,
-  });
-};
-
-// TODO(panva): Reject resizable backing stores in a semver-major by
-// removing this altogether.
-converters.BufferSource = (V, opts = kEmptyObject) => {
-  return webidl.BufferSource(V, {
-    prefix: opts.prefix,
-    context: opts.context,
-    code: opts.code,
-    allowResizable: opts.allowResizable === undefined ?
-      true : opts.allowResizable,
-    allowShared: opts.allowShared,
-  });
-};
+converters.BigInteger = webidl.Uint8Array;
 
 const dictRsaKeyGenParams = [
   {

--- a/test/parallel/test-webcrypto-webidl.js
+++ b/test/parallel/test-webcrypto-webidl.js
@@ -178,8 +178,13 @@ function assertJsonWebKey(actual, expected) {
     const resizable = new ArrayBuffer(8, { maxByteLength: 16 });
     const view = new Uint8Array(resizable);
 
-    // TODO(panva): Reject resizable backing stores in a semver-major
-    assert.deepStrictEqual(converters.BigInteger(view), view);
+    const resizableError = {
+      name: 'TypeError',
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: `${prefix}: ${context} is backed by a resizable ` +
+        'ArrayBuffer, which is not allowed.',
+    };
+    assert.throws(() => converters.BigInteger(view, opts), resizableError);
   }
 }
 
@@ -223,32 +228,21 @@ function assertJsonWebKey(actual, expected) {
     const view = new Uint8Array(resizable);
     const dataView = new DataView(resizable);
 
-    // TODO(panva): Reject resizable backing stores in a semver-major by
-    // removing the crypto/webidl BufferSource override.
-    assert.deepStrictEqual(converters.BufferSource(resizable), resizable);
-    assert.deepStrictEqual(converters.BufferSource(view), view);
-    assert.deepStrictEqual(converters.BufferSource(dataView), dataView);
     const resizableError = {
       name: 'TypeError',
       code: 'ERR_INVALID_ARG_TYPE',
       message: `${prefix}: ${context} is backed by a resizable ` +
         'ArrayBuffer, which is not allowed.',
     };
-    assert.throws(() => converters.BufferSource(resizable, {
-      __proto__: null,
-      ...opts,
-      allowResizable: false,
-    }), resizableError);
-    assert.throws(() => converters.BufferSource(view, {
-      __proto__: null,
-      ...opts,
-      allowResizable: false,
-    }), resizableError);
-    assert.throws(() => converters.BufferSource(dataView, {
-      __proto__: null,
-      ...opts,
-      allowResizable: false,
-    }), resizableError);
+    assert.throws(
+      () => converters.BufferSource(resizable, opts),
+      resizableError);
+    assert.throws(
+      () => converters.BufferSource(view, opts),
+      resizableError);
+    assert.throws(
+      () => converters.BufferSource(dataView, opts),
+      resizableError);
   }
 }
 


### PR DESCRIPTION
Aligns the BigInteger and BufferSource Web IDL converters with the default backing-store validation, rejecting views over resizable ArrayBuffers instead of silently allowing them.