### PR TITLE
module: implement Symbol.dispose in ModuleHooks

### DIFF
--- a/doc/api/module.md
+++ b/doc/api/module.md
@@ -245,6 +245,7 @@ changes:
   * `deregister()` {Function} Remove the registered hooks so that they are no
     longer called. Hooks are otherwise retained for the lifetime of the running
     process.
+  * `[Symbol.dispose]` {Function} The same as `deregister`.
 
 Register [hooks][] that customize Node.js module resolution and loading behavior.
 See [Customization hooks][]. The returned object can be used to

--- a/lib/internal/modules/customization_hooks.js
+++ b/lib/internal/modules/customization_hooks.js
@@ -99,14 +99,9 @@ class ModuleHooks {
       ArrayPrototypeSplice(loadHooks, index, 1);
     }
   }
-
-  /**
-   * Deregister the hook instance.
-   */
-  [SymbolDispose]() {
-    this.deregister();
-  }
 };
+
+ModuleHooks.prototype[SymbolDispose] = ModuleHooks.prototype.deregister;
 
 /**
  * TODO(joyeecheung): taken an optional description?

--- a/lib/internal/modules/customization_hooks.js
+++ b/lib/internal/modules/customization_hooks.js
@@ -9,6 +9,7 @@ const {
   StringPrototypeSlice,
   StringPrototypeStartsWith,
   Symbol,
+  SymbolDispose,
 } = primordials;
 const {
   isAnyArrayBuffer,
@@ -83,10 +84,7 @@ class ModuleHooks {
 
     ObjectFreeze(this);
   }
-  // TODO(joyeecheung): we may want methods that allow disabling/enabling temporarily
-  // which just sets the item in the array to undefined temporarily.
-  // TODO(joyeecheung): this can be the [Symbol.dispose] implementation to pair with
-  // `using` when the explicit resource management proposal is shipped by V8.
+
   /**
    * Deregister the hook instance.
    */
@@ -100,6 +98,13 @@ class ModuleHooks {
     if (index !== -1) {
       ArrayPrototypeSplice(loadHooks, index, 1);
     }
+  }
+
+  /**
+   * Deregister the hook instance.
+   */
+  [SymbolDispose]() {
+    this.deregister();
   }
 };
 

--- a/test/module-hooks/test-module-hooks-dispose.js
+++ b/test/module-hooks/test-module-hooks-dispose.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { registerHooks } = require('module');
+
+// Test that using syntax works.
+{
+  // eslint-disable-next-line no-unused-vars
+  using hook = registerHooks({
+    load: common.mustCall((url, context, nextLoad) => {
+      const result = nextLoad(url, context);
+      assert.strictEqual(result.source, '');
+      return {
+        source: 'export const hello = "world"',
+      };
+    }),
+  });
+
+  const mod = require('../fixtures/empty.js');
+  assert.strictEqual(mod.hello, 'world');
+}
+
+delete require.cache[require.resolve('../fixtures/empty.js')];
+const mod = require('../fixtures/empty.js');
+assert.deepStrictEqual(mod, {});


### PR DESCRIPTION
This change implements the `Symbol.dispose` key in the `ModuleHooks` class as an alias for deregister. This makes `registerHooks` work with the `using` keyword.

Fixes: https://github.com/nodejs/node/issues/63846

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
