### PR TITLE
test: tolerate duplicate watch change events

### DIFF
--- a/test/parallel/test-watch-file-shared-dependency.mjs
+++ b/test/parallel/test-watch-file-shared-dependency.mjs
@@ -34,15 +34,22 @@ describe('watch file with shared dependency', () => {
     const controller = new AbortController();
     const watcher = new FilesWatcher({ signal: controller.signal });
 
-    watcher.on('changed', common.mustCall(({ owners }) => {
-      if (owners.size !== 2) return;
-
-      // If this code is never reached the test times out.
+    const onExpectedOwners = common.mustCall(({ owners }) => {
       assert.ok(owners.has(fixturePaths['test.js']));
       assert.ok(owners.has(fixturePaths['test-2.js']));
       controller.abort();
       done();
-    }));
+    });
+
+    function onChanged({ owners }) {
+      if (owners.size !== 2) return;
+
+      // If this code is never reached the test times out.
+      watcher.removeListener('changed', onChanged);
+      onExpectedOwners({ owners });
+    }
+
+    watcher.on('changed', onChanged);
     watcher.filterFile(fixturePaths['test.js']);
     watcher.filterFile(fixturePaths['test-2.js']);
     watcher.filterFile(fixturePaths['dependency.js'], fixturePaths['test.js']);


### PR DESCRIPTION
This deflakes `test-watch-file-shared-dependency` by allowing the watcher
listener to ignore extra or partial `changed` events.

`fs.watch()` can emit more than one event for a single write. The test only
needs to verify that the dependency change eventually reports both owners, but
wrapping the whole listener in `common.mustCall()` made any additional watcher
event fail the test.

Refs: https://github.com/nodejs/node/actions/runs/27462359210/job/81178399610

<details>
<summary>Error Log</summary>

```console
=== release test-watch-file-shared-dependency ===
Path: parallel/test-watch-file-shared-dependency
Error: --- stdout ---
Mismatched <anonymous> function calls. Expected exactly 1, actual 2.
    at Module.mustCall (/Users/runner/work/node/node/node/test/common/index.js:468:10)
    at TestContext.<anonymous> (file:///Users/runner/work/node/node/node/test/parallel/test-watch-file-shared-dependency.mjs:37:34)
    at Test.runInAsyncScope (node:async_hooks:226:14)
    at Test.run (node:internal/test_runner/test:1369:21)
    at Test.start (node:internal/test_runner/test:1242:17)
    at node:internal/test_runner/test:1867:71
    at node:internal/per_context/primordials:466:82
    at new Promise (<anonymous>)
    at new SafePromise (node:internal/per_context/primordials:435:3)
Command: out/Release/node --expose-internals --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /Users/runner/work/node/node/node/test/parallel/test-watch-file-shared-dependency.mjs
```

</details>

---

Assisted-by: openai:gpt-5.5