### PR TITLE
src: omit unconvertible names in cjs_lexer::Parse

### DIFF
--- a/src/node_cjs_lexer.cc
+++ b/src/node_cjs_lexer.cc
@@ -67,25 +67,25 @@ void Parse(const FunctionCallbackInfo<Value>& args) {
 
   const auto& analysis = result.value();
 
-  // Convert exports to JS Set
+  // Convert exports to JS Set, omitting any name that cannot be turned into a
+  // V8 string (e.g. on string allocation failure) instead of aborting.
   Local<Set> exports_set = Set::New(isolate);
   for (const auto& exp : analysis.exports) {
     Local<String> exp_str;
-    if (!CreateString(isolate, exp).ToLocal(&exp_str) ||
-        exports_set->Add(context, exp_str).IsEmpty()) {
-      return;
+    if (CreateString(isolate, exp).ToLocal(&exp_str)) {
+      USE(exports_set->Add(context, exp_str));
     }
   }
 
-  // Convert reexports to JS array using batch creation
+  // Convert reexports to JS array, omitting any name that cannot be turned into
+  // a V8 string.
   LocalVector<Value> reexports_vec(isolate);
   reexports_vec.reserve(analysis.re_exports.size());
   for (const auto& reexp : analysis.re_exports) {
     Local<String> reexp_str;
-    if (!CreateString(isolate, reexp).ToLocal(&reexp_str)) {
-      return;
+    if (CreateString(isolate, reexp).ToLocal(&reexp_str)) {
+      reexports_vec.push_back(reexp_str);
     }
-    reexports_vec.push_back(reexp_str);
   }
 
   // Create result array [exports (Set), reexports (Array)]

--- a/src/node_cjs_lexer.cc
+++ b/src/node_cjs_lexer.cc
@@ -72,8 +72,9 @@ void Parse(const FunctionCallbackInfo<Value>& args) {
   Local<Set> exports_set = Set::New(isolate);
   for (const auto& exp : analysis.exports) {
     Local<String> exp_str;
-    if (CreateString(isolate, exp).ToLocal(&exp_str)) {
-      USE(exports_set->Add(context, exp_str));
+    if (CreateString(isolate, exp).ToLocal(&exp_str) &&
+        exports_set->Add(context, exp_str).IsEmpty()) {
+      return;
     }
   }
 


### PR DESCRIPTION
Follow-up to [#63885](https://github.com/nodejs/node/pull/63885) ([`aa25a0a30c3`](https://github.com/nodejs/node/commit/aa25a0a30c3c1008522b29f8a4467ee912d65e5e)).

That change made `CreateString()` return a `MaybeLocal<String>` and bailed out of `Parse()` (early `return`) when an export / re-export name could not be converted to a V8 string or when `Set::Add()` failed. Because the binding then returns `undefined`, the JS caller (`cjsPreparseModuleExports` in `lib/internal/modules/esm/translators.js`, which does `const { 0: exportNames, 1: reexports } = cjsParse(source)`) fails the entire exports preparse for that module.

This makes the conversion best-effort instead: omit any individual export / re-export name that cannot be turned into a V8 string and continue, so the remaining names are still returned and a single pathological name no longer fails the whole preparse. `Set::Add()` is a `V8_WARN_UNUSED_RESULT`, so its result is explicitly discarded with `USE()`.

```cpp
for (const auto& exp : analysis.exports) {
  Local<String> exp_str;
  if (CreateString(isolate, exp).ToLocal(&exp_str)) {
    USE(exports_set->Add(context, exp_str));
  }
}
```

Verified locally: `node_cjs_lexer.cc` builds clean, `cpplint` passes, the `cjs_lexer` binding returns the expected export/re-export names (ASCII + non-ASCII) and handles `null`/empty input, and `test/es-module` CJS-exports tests pass.

Refs: https://github.com/nodejs/node/pull/63885
Refs: https://github.com/nodejs/node/issues/63323