### PR TITLE
test: fix debugger probe throwing getter flake

### DIFF
--- a/test/fixtures/debugger/probe-throwing-getter.js
+++ b/test/fixtures/debugger/probe-throwing-getter.js
@@ -13,9 +13,10 @@ function markProbesDone() {
 
 module.exports = { holder, markProbesDone };
 
-globalThis.probeLine1 = 1;
-globalThis.probeLine2 = 2;
-
 const interval = setInterval(() => {
+  // Keep these module bindings visible to probe evaluation from this callback.
+  void holder; void markProbesDone;
+  globalThis.probeLine1 = 1;
+  globalThis.probeLine2 = 2;
   if (probesDone) clearInterval(interval);
 }, 50);

--- a/test/parallel/test-debugger-probe-expression-throws.js
+++ b/test/parallel/test-debugger-probe-expression-throws.js
@@ -12,16 +12,16 @@ const { assertProbeJson } = require('../common/debugger-probe');
 const cwd = fixtures.path('debugger');
 const fixture = 'probe-throwing-getter.js';
 const probes = [
-  { expr: 'holder.throwingGetter', target: { suffix: fixture, line: 16 } },
+  { expr: 'holder.throwingGetter', target: { suffix: fixture, line: 19 } },
   // This clears the interval so the process will exit naturally.
-  { expr: 'markProbesDone()', target: { suffix: fixture, line: 17 } },
+  { expr: 'markProbesDone()', target: { suffix: fixture, line: 20 } },
 ];
 const url = fixtures.fileURL('debugger', fixture).href;
 
 spawnSyncAndExit(process.execPath, [
   'inspect', '--json',
-  '--probe', `${fixture}:16`, '--expr', probes[0].expr,
-  '--probe', `${fixture}:17`, '--expr', probes[1].expr,
+  '--probe', `${fixture}:19`, '--expr', probes[0].expr,
+  '--probe', `${fixture}:20`, '--expr', probes[1].expr,
   fixture,
 ], { cwd, env: { ...process.env, NODE_DEBUG: 'inspect_probe' } }, {
   status: 0,
@@ -34,7 +34,7 @@ spawnSyncAndExit(process.execPath, [
         probe: 0,
         event: 'hit',
         hit: 1,
-        location: { url, line: 16, column: 1 },
+        location: { url, line: 19, column: 3 },
         error: {
           message: 'Error: boom\n<stack>',
           details: {
@@ -53,7 +53,7 @@ spawnSyncAndExit(process.execPath, [
         probe: 1,
         event: 'hit',
         hit: 1,
-        location: { url, line: 17, column: 1 },
+        location: { url, line: 20, column: 3 },
         result: { type: 'undefined' },
       }, {
         event: 'completed',


### PR DESCRIPTION
Fixes a flaky debugger probe test seen in the macOS unusual-character path CI rerun.

The fixture previously placed both probe target statements at top level. If the
target script ran before those breakpoints were bound, both probes could be
missed and the fixture would stay alive until probe mode timed out.

This moves the target statements into the fixture's existing interval so they
remain available until the completion probe runs and clears the interval.

Refs: https://github.com/nodejs/node/actions/runs/27588057763/job/81562704514

<details>
<summary>Error Log</summary>

```console
=== release test-debugger-probe-expression-throws ===
Path: parallel/test-debugger-probe-expression-throws
Error: --- stderr ---
[process 60703]: --- stderr ---
INSPECT_PROBE 60703: child stderr: "Debugger listening on ws://127.0.0.1:63110/03881a62-edc2-43dd-adc8-dd61c7d6367c\nFor help, see: [https://nodejs.org/learn/getting-started/debugging\n](https://nodejs.org/learn/getting-started/debugging/n)"
INSPECT_PROBE 60703: child stderr: "Debugger attached.\n"
INSPECT_PROBE 60703: CDP -> Runtime.enable
INSPECT_PROBE 60703: CDP <- Runtime.enable (success)
INSPECT_PROBE 60703: CDP -> Debugger.enable
INSPECT_PROBE 60703: CDP <- Debugger.enable (success)
INSPECT_PROBE 60703: CDP -> Debugger.setBreakpointByUrl
INSPECT_PROBE 60703: CDP <- Debugger.setBreakpointByUrl (success)
INSPECT_PROBE 60703: breakpoint set: id=2:15:0:^(.*[\/\\])?probe-throwing-getter\.js$ urlRegex=^(.*[\/\\])?probe-throwing-getter\.js$ locations=[]
INSPECT_PROBE 60703: CDP -> Debugger.setBreakpointByUrl
INSPECT_PROBE 60703: CDP <- Debugger.setBreakpointByUrl (success)
INSPECT_PROBE 60703: breakpoint set: id=2:16:0:^(.*[\/\\])?probe-throwing-getter\.js$ urlRegex=^(.*[\/\\])?probe-throwing-getter\.js$ locations=[]
INSPECT_PROBE 60703: CDP -> Runtime.runIfWaitingForDebugger
INSPECT_PROBE 60703: CDP <- Runtime.runIfWaitingForDebugger (success)
INSPECT_PROBE 60703: timeout fired: finished=false, inFlight=null, lastProbeIndex=null
INSPECT_PROBE 60703: finish: exitCode=1, terminal=timeout

[process 60703]: --- stdout ---
{"v":2,"probes":[{"expr":"holder.throwingGetter","target":{"suffix":"probe-throwing-getter.js","line":16}},{"expr":"markProbesDone()","target":{"suffix":"probe-throwing-getter.js","line":17}}],"results":[{"event":"timeout","pending":[0,1],"error":{"code":"probe_timeout","message":"Timed out after 30000ms waiting for probes: probe-throwing-getter.js:16, probe-throwing-getter.js:17"}}]}

[process 60703]: status = 1, signal = null
/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/child_process.js:112
    throw error;
    ^

Error: - process terminated with status 1, expected 0
    at Object.<anonymous> (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/parallel/test-debugger-probe-expression-throws.js:21:1)
    at Module._compile (node:internal/modules/cjs/loader:1947:14)
    at Object..js (node:internal/modules/cjs/loader:2087:10)
    at Module.load (node:internal/modules/cjs/loader:1669:32)
    at Module._load (node:internal/modules/cjs/loader:1450:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:260:19)
    at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
    at node:internal/main/run_main_module:33:47 {
  options: {
    cwd: '/Users/runner/work/node/node/dir%20with $unusual"chars?\'åß∂ƒ©∆¬…`/test/fixtures/debugger',
    env: { NODE_DEBUG: 'inspect_probe' }
  },
  command: '/Users/runner/work/node/node/dir%20with $unusual"chars?\'åß∂ƒ©∆¬…`/out/Release/node inspect --json --probe probe-throwing-getter.js:16 --expr holder.throwingGetter --probe probe-throwing-getter.js:17 --expr markProbesDone() probe-throwing-getter.js'
}
```

</details>

---

Assisted-by: openai:gpt-5.5