### PR TITLE
quic: fix get_reader bug that lost data from open streams on FIN

### DIFF
--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1408,7 +1408,13 @@ bool Stream::is_readable() const {
 }
 
 BaseObjectPtr<Blob::Reader> Stream::get_reader() {
-  if (!is_readable() || state()->has_reader) return {};
+  if (state()->has_reader || !inbound_) return {};
+  // Local unidirectional streams are never readable.
+  if (!is_pending() && direction() == Direction::UNIDIRECTIONAL &&
+      ngtcp2_conn_is_local_stream(session(), id())) {
+    return {};
+  }
+
   state()->has_reader = 1;
   auto reader = Blob::Reader::Create(env(), Blob::Create(env(), inbound_));
   reader_ = reader;

--- a/test/parallel/test-quic-stream-read-after-fin.mjs
+++ b/test/parallel/test-quic-stream-read-after-fin.mjs
@@ -1,0 +1,57 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// Test: reading a stream after its read side has received FIN, although
+// the stream is still alive.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import { setTimeout as delay } from 'node:timers/promises';
+import assert from 'node:assert';
+
+const { deepStrictEqual } = assert;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+const { bytes } = await import('stream/iter');
+
+const expected = new TextEncoder().encode('data sent before any reader');
+const serverSent = Promise.withResolvers();
+const done = Promise.withResolvers();
+
+const serverEndpoint = await listen(mustCall((serverSession) => {
+  serverSession.onstream = mustCall(async (stream) => {
+    // Reply with the full body plus FIN:
+    stream.setBody(expected);
+    serverSent.resolve();
+    await stream.closed;
+  });
+}));
+
+const clientSession = await connect(serverEndpoint.address);
+await clientSession.opened;
+
+const stream = await clientSession.createBidirectionalStream();
+
+// Write a byte to open the stream:
+const writer = stream.writer;
+await writer.write(new Uint8Array([1]));
+
+// Wait until the server has sent its response, with a buffer for the local
+// delivery time itself. We can't actually read to check without undermining
+// the test itself unfortunately.
+await serverSent.promise;
+await delay(10);
+
+const received = await bytes(stream);
+deepStrictEqual(received, expected);
+
+writer.endSync();
+await stream.closed;
+clientSession.close();
+done.resolve();
+
+await done.promise;
+await clientSession.closed;
+await serverEndpoint.close();


### PR DESCRIPTION
Currently if you receive a stream, but you don't start reading the body immediately, you can lose the stream body entirely even while the stream is still open.

This happens because `get_reader` returned an empty reader if `is_readable()` was false, which happens when the stream's data is finished, even though it may be happily received and ready to read. This happens even if the writable side of the stream is open and the stream is otherwise active as normal.

This is reasonably common I think. For an HTTP/3 server where you receive a request and you do anything async before you start reading the body, if the client finishes the body before you start reading it (a small body delivered within the flow control window) you'd just get empty data. Nice easy standalone fix & test.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
