### PR TITLE
quic: fix reader backpressure deadlock on idle connections

### DIFF
--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1512,7 +1512,6 @@ void Stream::EndWriting() {
 void Stream::EntryRead(size_t amount) {
   // Called when the JS consumer reads data from the inbound DataQueue.
   // Extend the flow control window so the sender can transmit more.
-  //
   if (session().is_destroyed()) return;
   Session::SendPendingDataScope send_scope(&session());
   session().ExtendStreamOffset(id(), amount);

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1512,6 +1512,9 @@ void Stream::EndWriting() {
 void Stream::EntryRead(size_t amount) {
   // Called when the JS consumer reads data from the inbound DataQueue.
   // Extend the flow control window so the sender can transmit more.
+  //
+  if (session().is_destroyed()) return;
+  Session::SendPendingDataScope send_scope(&session());
   session().ExtendStreamOffset(id(), amount);
   session().ExtendOffset(amount);
 }

--- a/test/parallel/test-quic-stream-read-after-blocked.mjs
+++ b/test/parallel/test-quic-stream-read-after-blocked.mjs
@@ -1,0 +1,63 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// Test: a sender blocked on flow control is resumed once the consumer
+// starts reading. This confirms that we do flush MAX_STREAM_DATA
+// frames as expected when the consumer reads.
+
+import { hasQuic, skip, mustCall, mustCallAtLeast } from '../common/index.mjs';
+import { setTimeout as delay } from 'node:timers/promises';
+import assert from 'node:assert';
+
+const { strictEqual, deepStrictEqual } = assert;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+const { bytes } = await import('stream/iter');
+
+// Larger than the default 256 KB stream flow-control window:
+const size = 1024 * 1024;
+const expected = new Uint8Array(size);
+for (let i = 0; i < size; i++) expected[i] = i & 0xff;
+
+const senderBlocked = Promise.withResolvers();
+const done = Promise.withResolvers();
+
+const serverEndpoint = await listen(mustCall((serverSession) => {
+  serverSession.onstream = mustCall(async (stream) => {
+    stream.onblocked = mustCallAtLeast(() => senderBlocked.resolve(stream), 1);
+    stream.setBody(expected);
+    await stream.closed;
+  });
+}));
+
+const clientSession = await connect(serverEndpoint.address);
+await clientSession.opened;
+
+// Write a byte to open the stream:
+const stream = await clientSession.createBidirectionalStream();
+await stream.writer.write(new Uint8Array([1]));
+
+// Wait until the sender has filled the window and blocked.
+const serverStream = await senderBlocked.promise;
+
+// Poll until everything has been acked, so the stream is fully idle:
+while (serverStream.stats.maxOffsetAcknowledged !== serverStream.stats.bytesSent) {
+  await delay(1);
+}
+
+// Try to read:
+const received = await bytes(stream);
+strictEqual(received.byteLength, expected.byteLength);
+deepStrictEqual(received, expected);
+
+stream.writer.endSync();
+await stream.closed;
+clientSession.close();
+done.resolve();
+
+await done.promise;
+await clientSession.closed;
+await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-read-after-blocked.mjs
+++ b/test/parallel/test-quic-stream-read-after-blocked.mjs
@@ -58,6 +58,5 @@ await stream.closed;
 clientSession.close();
 done.resolve();
 
-await done.promise;
-await clientSession.closed;
+await Promise.all([done.promise, clientSession.closed]);
 await serverEndpoint.close();


### PR DESCRIPTION
When we're not reading from a QUIC stream, inbound data will build up until it hits the stream flow control window, and then the remote peer will stop sending until we're ready to continue.

When we're ready, we call `session().ExtendStreamOffset` (which calls `ngtcp2_conn_extend_max_stream_offset`) to send a `MAX_STREAM_DATA` frame to the peer expanding the window,  telling them they can send us more.

Right now this doesn't always work: we call `ExtendStreamOffset` but that only queues the frame, it doesn't actually send it. This is masked in most cases by other activity on most sessions that ends up sending the frame with it implicitly (most commonly acks).

If you ever have an idle session though, and then you read a stream that's been blocked like this, the frame will never be sent, which deadlocks: you're waiting for more data, and the remote peer is waiting to be told it's allowed to send some.

This PR fixes that, by ensuring we always flush a send after we update the stream window.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
