### PR TITLE
doc: fix Fast FFI argument count in ffi.md

### DIFF
--- a/doc/api/ffi.md
+++ b/doc/api/ffi.md
@@ -125,8 +125,13 @@ raw pointer `bigint` values. For pointer-like parameters, `null`, `undefined`,
 strings, `Buffer`, typed array, `DataView`, and `ArrayBuffer` values are
 converted on the JavaScript side before calling the optimized native wrapper.
 
-Optimized Fast FFI calls support at most 8 function arguments. Functions with
-more than 7 arguments use the generic FFI call path instead.
+Optimized Fast FFI calls support at most 8 function arguments, but the exact
+limit depends on the architecture and on the argument types, because each
+argument must fit in the registers used by the platform trampoline. Integer
+and pointer arguments are limited to 7 on AArch64 and to 6 on x86-64, while
+floating-point arguments can use up to 8 on both. Functions that exceed these
+limits, including any function with more than 8 arguments, use the generic FFI
+call path instead.
 
 ## Signature objects
 


### PR DESCRIPTION
The text said functions with more than 7 arguments fall back to the generic call path, contradicting the preceding sentence that Fast FFI calls support up to 8 arguments. The implementation only falls back when there are more than 8 arguments (src/ffi/fast.cc), so correct the threshold to 8.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
