### PR TITLE
stream: fix Utf8Stream stall after full write of multi-byte data

### DIFF
--- a/lib/internal/streams/fast-utf8-stream.js
+++ b/lib/internal/streams/fast-utf8-stream.js
@@ -878,11 +878,15 @@ class Utf8Stream extends EventEmitter {
 function releaseWritingBuf(writingBuf, len, n) {
   if (typeof writingBuf === 'string') {
     const byteLength = Buffer.byteLength(writingBuf);
-    if (byteLength !== n) {
-      // Since fs.write returns the number of bytes written, we need to find
-      // how many complete characters fit within those n bytes.
-      // If a partial write splits a multi-byte UTF-8 character, we must back up
-      // to the start of that character to avoid data corruption.
+    // `fs.write` returns the number of bytes written, but `len` is tracked in
+    // characters and `writingBuf` is sliced by character index below, so `n`
+    // must be converted from bytes to characters in both cases.
+    if (byteLength === n) {
+      // The whole string was written: advance past every character.
+      n = writingBuf.length;
+    } else {
+      // A partial write may split a multi-byte UTF-8 character, so we must back
+      // up to the start of that character to avoid data corruption.
       const buf = Buffer.from(writingBuf);
       // Back up from position n to find a valid UTF-8 character boundary.
       // UTF-8 continuation bytes have the pattern 10xxxxxx (0x80-0xBF).

--- a/test/parallel/test-fastutf8stream-full-write-utf8.js
+++ b/test/parallel/test-fastutf8stream-full-write-utf8.js
@@ -1,0 +1,59 @@
+'use strict';
+
+// Regression test: after a multi-byte UTF-8 chunk is *fully* written, the
+// stream must keep flushing the remaining buffered chunks instead of stalling.
+//
+// `releaseWritingBuf()` tracks the buffered length in characters, but on a full
+// write it used to subtract the number of *bytes* reported by fs.write instead
+// of the number of *characters*. For multi-byte data this drove the internal
+// length to zero, so the stream emitted 'drain' and went idle while queued
+// chunks were left unwritten.
+
+const common = require('../common');
+const assert = require('node:assert');
+const { Utf8Stream } = require('node:fs');
+
+// "€" is a single JS character that encodes to three UTF-8 bytes, so the byte
+// count and character count differ - which is exactly what triggered the bug.
+const CHAR = '€';
+const COUNT = 3;
+
+const chunks = [];
+const fsOverride = {
+  // Always report a full (successful) write.
+  write: common.mustCallAtLeast((fd, data, enc, cb) => {
+    chunks.push(data);
+    process.nextTick(cb, null, Buffer.byteLength(data));
+  }, COUNT),
+  writeSync() { throw new Error('writeSync should not be used in async mode'); },
+  fsync(fd, cb) { cb(); },
+  fsyncSync() {},
+  close(fd, cb) { cb(); },
+  open(path, flags, mode, cb) { cb(null, 42); },
+  mkdir(path, opts, cb) { cb(); },
+  mkdirSync() {},
+};
+
+const stream = new Utf8Stream({
+  fd: 42,
+  sync: false,
+  minLength: 0,
+  // Force each character into its own buffered chunk so that, while the first
+  // write is in flight, the remaining characters stay queued.
+  maxWrite: 1,
+  fs: fsOverride,
+});
+
+stream.on('ready', common.mustCall(() => {
+  for (let i = 0; i < COUNT; i++) {
+    stream.write(CHAR);
+  }
+
+  // Without calling end(): the stream must flush everything on its own.
+  setTimeout(common.mustCall(() => {
+    assert.strictEqual(chunks.length, COUNT,
+                       `expected ${COUNT} writes, got ${chunks.length}`);
+    assert.strictEqual(chunks.join(''), CHAR.repeat(COUNT));
+    stream.destroy();
+  }), common.platformTimeout(100));
+}));


### PR DESCRIPTION
releaseWritingBuf() tracks the buffered length in characters but, on a full write, decremented it by the number of bytes reported by fs.write instead of the number of characters. For multi-byte UTF-8 data this drove the internal length to zero, so the stream emitted 'drain' and went idle while queued chunks were left unwritten. Convert the byte count to a character count in the full-write case as well.
<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
