### PR TITLE
net: add experimental net/promises API

### DIFF
--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -452,6 +452,35 @@ changes:
 Calls [`server.close()`][] and returns a promise that fulfills when the
 server has closed.
 
+### `server[Symbol.asyncIterator]()`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+* Returns: {AsyncIterator} An async iterator that yields each incoming
+  [`net.Socket`][].
+
+Returns an async iterator over the server's incoming connections, allowing them
+to be consumed with `for await...of` as an alternative to the [`'connection'`][]
+event. Iteration ends when the server emits [`'close'`][], and rejects if the
+server emits [`'error'`][].
+
+```mjs
+import { createServer } from 'node:net';
+
+const server = createServer().listen(8124);
+for await (const socket of server) {
+  socket.end('hello world!');
+}
+```
+
+Connections are buffered while the loop body is busy; the server does not stop
+accepting them, so a consumer that is slower than the connection rate can buffer
+without bound. Use [`server.maxConnections`][] to bound concurrency.
+
 ### `server.getConnections(callback)`
 
 <!-- YAML
@@ -2297,19 +2326,26 @@ added: REPLACEME
   * `connectionListener` {Function} Automatically set as a listener for the
     [`'connection'`][] event.
   * `signal` {AbortSignal} An `AbortSignal` that may be used to abort the
-    listening server.
+    server. Aborting before the server is listening rejects the returned
+    promise with an `AbortError`; aborting at any later point closes the
+    server, matching the `signal` option of [`server.listen()`][].
 * Returns: {Promise} Fulfills with a listening [`net.Server`][].
 
 Creates a [`net.Server`][] and begins listening. The returned promise is
 fulfilled with the server once its [`'listening'`][] event fires, and is
-rejected if the server fails to bind or the `signal` is aborted. When the
-promise rejects, the server is closed.
+rejected if the server fails to bind or the `signal` is aborted before it is
+listening. When the promise rejects, the server is closed.
+
+The resolved server is async iterable, so incoming connections can be consumed
+with `for await...of` (see `server[Symbol.asyncIterator]()`).
 
 ```mjs
 import { listen } from 'node:net/promises';
 
 const server = await listen({ port: 8124 });
-console.log('server bound to', server.address().port);
+for await (const socket of server) {
+  socket.end('hello world!');
+}
 ```
 
 [IPC]: #ipc-support

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -2241,6 +2241,77 @@ net.isIPv6('::1'); // returns true
 net.isIPv6('fhqwhgads'); // returns false
 ```
 
+## `net/promises` API
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1 - Experimental
+
+The `net/promises` API provides a set of `net` functions that return `Promise`
+objects rather than relying on events. The API is accessible via
+`require('node:net').promises` or `require('node:net/promises')`.
+
+### `netPromises.connect(options)`
+
+### `netPromises.connect(path)`
+
+### `netPromises.connect(port[, host])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object} Accepts the same arguments as [`net.connect()`][]. May
+  include a `signal` {AbortSignal} that can be used to abort an in-progress
+  connection attempt.
+* Returns: {Promise} Fulfills with a connected [`net.Socket`][].
+
+A promise-based alternative to [`net.connect()`][]. The returned promise is
+fulfilled with the socket once its [`'connect'`][] event fires, and is rejected
+if the connection fails or the `signal` is aborted. When the promise rejects,
+the underlying socket is destroyed.
+
+This API is named for the action it performs and awaits — connecting — to
+parallel [`netPromises.listen()`][]. It is not named `createConnection()`,
+because that name belongs to the socket-factory taxonomy of the callback API,
+which has no counterpart here.
+
+```mjs
+import { connect } from 'node:net/promises';
+
+const socket = await connect({ port: 8124 });
+socket.write('hello world!');
+socket.end();
+```
+
+### `netPromises.listen([options])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `options` {Object} Accepts the same options as [`net.createServer()`][] and
+  [`server.listen()`][], plus:
+  * `connectionListener` {Function} Automatically set as a listener for the
+    [`'connection'`][] event.
+  * `signal` {AbortSignal} An `AbortSignal` that may be used to abort the
+    listening server.
+* Returns: {Promise} Fulfills with a listening [`net.Server`][].
+
+Creates a [`net.Server`][] and begins listening. The returned promise is
+fulfilled with the server once its [`'listening'`][] event fires, and is
+rejected if the server fails to bind or the `signal` is aborted. When the
+promise rejects, the server is closed.
+
+```mjs
+import { listen } from 'node:net/promises';
+
+const server = await listen({ port: 8124 });
+console.log('server bound to', server.address().port);
+```
+
 [IPC]: #ipc-support
 [Identifying paths for IPC connections]: #identifying-paths-for-ipc-connections
 [RFC 8305]: https://www.rfc-editor.org/rfc/rfc8305.txt
@@ -2274,6 +2345,7 @@ net.isIPv6('fhqwhgads'); // returns false
 [`net.createServer()`]: #netcreateserveroptions-connectionlistener
 [`net.getDefaultAutoSelectFamily()`]: #netgetdefaultautoselectfamily
 [`net.getDefaultAutoSelectFamilyAttemptTimeout()`]: #netgetdefaultautoselectfamilyattempttimeout
+[`netPromises.listen()`]: #netpromiseslistenoptions
 [`new net.Socket(options)`]: #new-netsocketoptions
 [`readable.setEncoding()`]: stream.md#readablesetencodingencoding
 [`server.address()`]: #serveraddress

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -468,18 +468,31 @@ to be consumed with `for await...of` as an alternative to the [`'connection'`][]
 event. Iteration ends when the server emits [`'close'`][], and rejects if the
 server emits [`'error'`][].
 
+The loop only advances to the next connection once the current iteration's body
+has finished awaiting, so connection handling should be dispatched to a separate
+async task rather than awaited inline. Otherwise connections are serialized:
+each one waits for the previous to be fully handled.
+
 ```mjs
 import { createServer } from 'node:net';
 
 const server = createServer().listen(8124);
-for await (const socket of server) {
+
+async function handleConnection(socket) {
+  // ...handle the connection, awaiting as needed.
   socket.end('hello world!');
+}
+
+for await (const socket of server) {
+  // Dispatch handling to a separate task so the loop keeps accepting
+  // connections instead of serializing them.
+  handleConnection(socket);
 }
 ```
 
-Connections are buffered while the loop body is busy; the server does not stop
-accepting them, so a consumer that is slower than the connection rate can buffer
-without bound. Use [`server.maxConnections`][] to bound concurrency.
+The server does not stop accepting connections while the loop body runs, so a
+consumer slower than the connection rate can buffer them without bound. Use
+[`server.maxConnections`][] to bound concurrency.
 
 ### `server.getConnections(callback)`
 
@@ -2343,9 +2356,7 @@ with `for await...of` (see `server[Symbol.asyncIterator]()`).
 import { listen } from 'node:net/promises';
 
 const server = await listen({ port: 8124 });
-for await (const socket of server) {
-  socket.end('hello world!');
-}
+console.log('listening on', server.address().port);
 ```
 
 [IPC]: #ipc-support

--- a/lib/internal/net/promises.js
+++ b/lib/internal/net/promises.js
@@ -53,10 +53,17 @@ async function listen(options = kEmptyObject) {
   const server = lazy.createServer(options, connectionListener);
 
   try {
-    // Pass `signal` through to listen() so net installs its own
+    // Default to an ephemeral port when no listen target is supplied, matching
+    // `server.listen()` with no arguments; passing a target-less options object
+    // (the `{}` default, or e.g. `{ signal }`) straight to listen() would throw
+    // ERR_INVALID_ARG_VALUE. `signal` is passed through so net installs its own
     // close-on-abort handler: the signal aborts the server for its entire
     // lifetime, not just the pending listen.
-    server.listen(options);
+    const hasListenTarget = options.port !== undefined ||
+                            options.path !== undefined ||
+                            options.fd !== undefined ||
+                            options.handle !== undefined;
+    server.listen(hasListenTarget ? options : { ...options, port: 0 });
     await once(server, 'listening', signal !== undefined ? { signal } : kEmptyObject);
   } catch (err) {
     // On abort, net's signal handler already closes the server, so closing

--- a/lib/internal/net/promises.js
+++ b/lib/internal/net/promises.js
@@ -1,0 +1,81 @@
+'use strict';
+
+const { once } = require('events');
+const {
+  validateAbortSignal,
+  validateObject,
+} = require('internal/validators');
+const { AbortError } = require('internal/errors');
+const { kEmptyObject } = require('internal/util');
+
+// Lazily loaded to avoid a require cycle with the `net` module, which exposes
+// this namespace through its `promises` getter.
+let net;
+function lazyNet() {
+  net ??= require('net');
+  return net;
+}
+
+// Resolves with a connected `net.Socket` once the `'connect'` event fires, and
+// rejects if the connection fails or the optional `signal` is aborted.
+async function connect(...args) {
+  const lazy = lazyNet();
+  const options = lazy._normalizeArgs(args)[0];
+  const { signal } = options;
+  if (signal !== undefined) {
+    validateAbortSignal(signal, 'options.signal');
+    if (signal.aborted) {
+      throw new AbortError(undefined, { cause: signal.reason });
+    }
+  }
+
+  // Strip the signal so the socket does not also install its own abort
+  // handling; rejecting and destroying below fully tears the socket down.
+  const socket = lazy.connect({ ...options, signal: undefined });
+
+  try {
+    await once(socket, 'connect', signal !== undefined ? { signal } : kEmptyObject);
+  } catch (err) {
+    socket.destroy();
+    throw err;
+  }
+  return socket;
+}
+
+// Creates a server and resolves with it once it is listening, rejecting if it
+// fails to bind or the optional `signal` is aborted.
+async function listen(options = kEmptyObject) {
+  validateObject(options, 'options');
+  const { signal, connectionListener } = options;
+  if (signal !== undefined) {
+    validateAbortSignal(signal, 'options.signal');
+    if (signal.aborted) {
+      throw new AbortError(undefined, { cause: signal.reason });
+    }
+  }
+
+  const lazy = lazyNet();
+  // Strip the signal so listen() does not install its own close-on-abort
+  // handler; rejecting and closing below tears the server down.
+  const serverOptions = { ...options, signal: undefined };
+  const server = lazy.createServer(serverOptions, connectionListener);
+
+  try {
+    server.listen(serverOptions);
+    await once(server, 'listening', signal !== undefined ? { signal } : kEmptyObject);
+  } catch (err) {
+    server.close();
+    throw err;
+  }
+  return server;
+}
+
+module.exports = {
+  connect,
+  listen,
+  get isIP() { return lazyNet().isIP; },
+  get isIPv4() { return lazyNet().isIPv4; },
+  get isIPv6() { return lazyNet().isIPv6; },
+  get BlockList() { return lazyNet().BlockList; },
+  get SocketAddress() { return lazyNet().SocketAddress; },
+};

--- a/lib/internal/net/promises.js
+++ b/lib/internal/net/promises.js
@@ -55,16 +55,21 @@ async function listen(options = kEmptyObject) {
   }
 
   const lazy = lazyNet();
-  // Strip the signal so listen() does not install its own close-on-abort
-  // handler; rejecting and closing below tears the server down.
-  const serverOptions = { ...options, signal: undefined };
-  const server = lazy.createServer(serverOptions, connectionListener);
+  const server = lazy.createServer(options, connectionListener);
 
   try {
-    server.listen(serverOptions);
+    // Pass `signal` through to listen() so net installs its own
+    // close-on-abort handler: the signal aborts the server for its entire
+    // lifetime, not just the pending listen.
+    server.listen(options);
     await once(server, 'listening', signal !== undefined ? { signal } : kEmptyObject);
   } catch (err) {
-    server.close();
+    // On abort, net's signal handler already closes the server, so closing
+    // again would be redundant; on other failures (e.g. a bind error) there
+    // is no such handler, so close it here.
+    if (!signal?.aborted) {
+      server.close();
+    }
     throw err;
   }
   return server;

--- a/lib/internal/net/promises.js
+++ b/lib/internal/net/promises.js
@@ -5,7 +5,6 @@ const {
   validateAbortSignal,
   validateObject,
 } = require('internal/validators');
-const { AbortError } = require('internal/errors');
 const { kEmptyObject } = require('internal/util');
 
 // Lazily loaded to avoid a require cycle with the `net` module, which exposes
@@ -24,9 +23,7 @@ async function connect(...args) {
   const { signal } = options;
   if (signal !== undefined) {
     validateAbortSignal(signal, 'options.signal');
-    if (signal.aborted) {
-      throw new AbortError(undefined, { cause: signal.reason });
-    }
+    signal.throwIfAborted();
   }
 
   // Strip the signal so the socket does not also install its own abort
@@ -49,9 +46,7 @@ async function listen(options = kEmptyObject) {
   const { signal, connectionListener } = options;
   if (signal !== undefined) {
     validateAbortSignal(signal, 'options.signal');
-    if (signal.aborted) {
-      throw new AbortError(undefined, { cause: signal.reason });
-    }
+    signal.throwIfAborted();
   }
 
   const lazy = lazyNet();

--- a/lib/net.js
+++ b/lib/net.js
@@ -37,6 +37,7 @@ const {
   ObjectSetPrototypeOf,
   Symbol,
   SymbolAsyncDispose,
+  SymbolAsyncIterator,
   SymbolDispose,
 } = primordials;
 
@@ -158,6 +159,7 @@ let dns;
 let BlockList;
 let SocketAddress;
 let netPromises;
+let kFirstEventParam;
 let autoSelectFamilyDefault = getOptionValue('--network-family-autoselection');
 let autoSelectFamilyAttemptTimeoutDefault = getOptionValue('--network-family-autoselection-attempt-timeout');
 
@@ -2761,6 +2763,14 @@ Server.prototype[SymbolAsyncDispose] = async function() {
     return;
   }
   await FunctionPrototypeCall(promisify(this.close), this);
+};
+
+Server.prototype[SymbolAsyncIterator] = function() {
+  kFirstEventParam ??= require('internal/events/symbols').kFirstEventParam;
+  return EventEmitter.on(this, 'connection', {
+    close: ['close'],
+    [kFirstEventParam]: true,
+  });
 };
 
 Server.prototype._emitCloseIfDrained = function() {

--- a/lib/net.js
+++ b/lib/net.js
@@ -157,6 +157,7 @@ let cluster;
 let dns;
 let BlockList;
 let SocketAddress;
+let netPromises;
 let autoSelectFamilyDefault = getOptionValue('--network-family-autoselection');
 let autoSelectFamilyAttemptTimeoutDefault = getOptionValue('--network-family-autoselection-attempt-timeout');
 
@@ -2853,6 +2854,10 @@ module.exports = {
   connect,
   createConnection: connect,
   createServer,
+  get promises() {
+    netPromises ??= require('internal/net/promises');
+    return netPromises;
+  },
   isIP: isIP,
   isIPv4: isIPv4,
   isIPv6: isIPv6,

--- a/lib/net/promises.js
+++ b/lib/net/promises.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('internal/net/promises');

--- a/test/parallel/test-net-promises-connect.js
+++ b/test/parallel/test-net-promises-connect.js
@@ -1,0 +1,62 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const { once } = require('events');
+const { connect } = require('net/promises');
+
+(async () => {
+  // Resolves with a connected socket and round-trips data.
+  {
+    const server = net.createServer((socket) => {
+      socket.end('hello');
+    }).listen(0);
+    await once(server, 'listening');
+    const socket = await connect({ port: server.address().port });
+    assert.strictEqual(socket.connecting, false);
+    const chunks = [];
+    for await (const chunk of socket) {
+      chunks.push(chunk);
+    }
+    assert.strictEqual(Buffer.concat(chunks).toString(), 'hello');
+    server.close();
+  }
+
+  // net.promises is the same object as require('net/promises').
+  assert.strictEqual(net.promises, require('net/promises'));
+
+  // Rejects when the connection is refused.
+  {
+    const server = net.createServer().listen(0);
+    await once(server, 'listening');
+    const { port } = server.address();
+    server.close();
+    await once(server, 'close');
+    await assert.rejects(connect({ port }), { code: 'ECONNREFUSED' });
+  }
+
+  // A pre-aborted signal rejects with an AbortError.
+  {
+    await assert.rejects(
+      connect({ port: 0, signal: AbortSignal.abort() }),
+      { name: 'AbortError' });
+  }
+
+  // Aborting while connecting rejects with an AbortError.
+  {
+    const server = net.createServer().listen(0);
+    await once(server, 'listening');
+    const controller = new AbortController();
+    const promise = connect({ port: server.address().port, signal: controller.signal });
+    controller.abort();
+    await assert.rejects(promise, { name: 'AbortError' });
+    server.close();
+  }
+
+  // An invalid signal throws.
+  {
+    await assert.rejects(
+      connect({ port: 0, signal: 'INVALID_SIGNAL' }),
+      { code: 'ERR_INVALID_ARG_TYPE' });
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-net-promises-listen.js
+++ b/test/parallel/test-net-promises-listen.js
@@ -14,6 +14,25 @@ const { listen } = require('net/promises');
     server.close();
   }
 
+  // With no listen target, defaults to an ephemeral port (like
+  // `server.listen()` with no arguments) rather than throwing.
+  {
+    const server = await listen();
+    assert.strictEqual(server.listening, true);
+    assert.strictEqual(typeof server.address().port, 'number');
+    server.close();
+  }
+
+  // A target-less options bag still defaults to an ephemeral port while
+  // honoring other options such as `host`.
+  {
+    const server = await listen({ host: '127.0.0.1' });
+    assert.strictEqual(server.listening, true);
+    assert.strictEqual(server.address().address, '127.0.0.1');
+    assert.strictEqual(typeof server.address().port, 'number');
+    server.close();
+  }
+
   // The signal aborts the server for its entire lifetime, not just the
   // pending listen: aborting after it is listening closes the server.
   {

--- a/test/parallel/test-net-promises-listen.js
+++ b/test/parallel/test-net-promises-listen.js
@@ -1,0 +1,58 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const { listen } = require('net/promises');
+
+(async () => {
+  // Resolves with a listening server.
+  {
+    const server = await listen({ port: 0 });
+    assert.strictEqual(server.listening, true);
+    assert.strictEqual(typeof server.address().port, 'number');
+    server.close();
+  }
+
+  // The connectionListener option receives incoming connections.
+  {
+    const server = await listen({
+      port: 0,
+      connectionListener: common.mustCall((socket) => {
+        socket.end();
+        server.close();
+      }),
+    });
+    const client = net.connect(server.address().port);
+    client.resume();
+  }
+
+  // A pre-aborted signal rejects with an AbortError.
+  {
+    await assert.rejects(
+      listen({ port: 0, signal: AbortSignal.abort() }),
+      { name: 'AbortError' });
+  }
+
+  // Aborting while binding rejects with an AbortError and closes the server.
+  {
+    const controller = new AbortController();
+    const promise = listen({ port: 0, signal: controller.signal });
+    controller.abort();
+    await assert.rejects(promise, { name: 'AbortError' });
+  }
+
+  // An invalid signal throws.
+  {
+    await assert.rejects(
+      listen({ port: 0, signal: 'INVALID_SIGNAL' }),
+      { code: 'ERR_INVALID_ARG_TYPE' });
+  }
+
+  // Rejects when the address is already in use.
+  {
+    const first = await listen({ port: 0 });
+    const { port } = first.address();
+    await assert.rejects(listen({ port }), { code: 'EADDRINUSE' });
+    first.close();
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-net-promises-listen.js
+++ b/test/parallel/test-net-promises-listen.js
@@ -2,6 +2,7 @@
 const common = require('../common');
 const assert = require('assert');
 const net = require('net');
+const { once } = require('events');
 const { listen } = require('net/promises');
 
 (async () => {
@@ -11,6 +12,18 @@ const { listen } = require('net/promises');
     assert.strictEqual(server.listening, true);
     assert.strictEqual(typeof server.address().port, 'number');
     server.close();
+  }
+
+  // The signal aborts the server for its entire lifetime, not just the
+  // pending listen: aborting after it is listening closes the server.
+  {
+    const controller = new AbortController();
+    const server = await listen({ port: 0, signal: controller.signal });
+    assert.strictEqual(server.listening, true);
+    const closed = once(server, 'close');
+    controller.abort();
+    await closed;
+    assert.strictEqual(server.listening, false);
   }
 
   // The connectionListener option receives incoming connections.

--- a/test/parallel/test-net-server-async-iterator.js
+++ b/test/parallel/test-net-server-async-iterator.js
@@ -1,0 +1,50 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const net = require('net');
+const { once } = require('events');
+
+(async () => {
+  // `for await...of` yields each incoming connection as a net.Socket.
+  {
+    const server = net.createServer().listen(0);
+    await once(server, 'listening');
+    const { port } = server.address();
+
+    const total = 3;
+    const clients = [];
+    for (let i = 0; i < total; i++) {
+      clients.push(net.connect(port));
+    }
+
+    let count = 0;
+    for await (const socket of server) {
+      assert.ok(socket instanceof net.Socket);
+      socket.end();
+      if (++count === total) break;
+    }
+    assert.strictEqual(count, total);
+
+    // Breaking out of the loop stops iterating but does not close the server.
+    assert.strictEqual(server.listening, true);
+
+    server.close();
+    for (const client of clients) {
+      client.destroy();
+    }
+  }
+
+  // Iteration ends cleanly when the server closes.
+  {
+    const server = net.createServer().listen(0);
+    await once(server, 'listening');
+    process.nextTick(() => server.close());
+
+    let count = 0;
+    for await (const socket of server) {
+      count++;
+      socket.end();
+    }
+    assert.strictEqual(count, 0);
+  }
+})().then(common.mustCall());

--- a/test/parallel/test-repl-tab-complete-import.js
+++ b/test/parallel/test-repl-tab-complete-import.js
@@ -52,11 +52,12 @@ replServer.complete("import\t( 'n", common.mustSucceed((data) => {
     assert.notStrictEqual(lastIndex, -1);
   });
   assert.strictEqual(completions[lastIndex + 1], '');
-  // There is only one Node.js module that starts with n:
+  // The Node.js modules that start with n:
   assert.strictEqual(completions[lastIndex + 2], 'net');
-  assert.strictEqual(completions[lastIndex + 3], '');
+  assert.strictEqual(completions[lastIndex + 3], 'net/promises');
+  assert.strictEqual(completions[lastIndex + 4], '');
   // It's possible to pick up non-core modules too
-  for (const completion of completions.slice(lastIndex + 4)) {
+  for (const completion of completions.slice(lastIndex + 5)) {
     assert.match(completion, /^n/);
   }
 }));

--- a/test/parallel/test-repl-tab-complete-require.js
+++ b/test/parallel/test-repl-tab-complete-require.js
@@ -67,11 +67,12 @@ const { startNewREPLServer } = require('../common/repl');
         assert.notStrictEqual(lastIndex, -1);
       }
       assert.strictEqual(data[0][lastIndex + 1], '');
-      // There is only one Node.js module that starts with n:
+      // The Node.js modules that start with n:
       assert.strictEqual(data[0][lastIndex + 2], 'net');
-      assert.strictEqual(data[0][lastIndex + 3], '');
+      assert.strictEqual(data[0][lastIndex + 3], 'net/promises');
+      assert.strictEqual(data[0][lastIndex + 4], '');
       // It's possible to pick up non-core modules too
-      for (const completion of data[0].slice(lastIndex + 4)) {
+      for (const completion of data[0].slice(lastIndex + 5)) {
         assert.match(completion, /^n/);
       }
     })


### PR DESCRIPTION
Adds an experimental `net/promises` namespace that provides promise-based variants of `net`'s connection and listening operations, mirroring the existing `fs/promises` and `dns/promises` modules. It is accessible via `require('node:net/promises')` or `require('node:net').promises`.

### Motivation

`net` has no promise-based API. To await a connected socket or a listening server today you have to hand-wire the `'connect'`/`'listening'` and `'error'` events into a `new Promise`, or reach for `events.once`. There is long-standing demand for a first-class promise API for these one-shot lifecycle moments (Refs: https://github.com/nodejs/node/issues/21482).

`net` is stream- and event-oriented, so only its one-shot async moments map cleanly to promises (establishing a connection and binding a server). The rest of the api remains the same.

### What's added

- `netPromises.connect(options)` / `connect(path)` / `connect(port[, host])` —
  resolves with a connected `net.Socket` once its `'connect'` event fires;
  rejects on connection failure or abort, destroying the socket.
- `netPromises.listen([options])` — creates a server, begins listening, and
  resolves with the listening `net.Server` once its `'listening'` event fires;
  rejects if it fails to bind or is aborted before listening, closing the
  server. Accepts a `connectionListener` option and the usual
  `net.createServer` / `server.listen` options. The `signal` aborts the server
  for its entire lifetime (aborting after it is listening closes it), matching
  `net.Server`'s own `signal` behavior.
- `net.Server` is now **async iterable**: `for await (const socket of server)`
  yields each incoming connection, as an alternative to the `'connection'`
  event (mirrors `readline.Interface`). Connections buffer if the consumer is
  slow; `server.maxConnections` bounds concurrency.
- The synchronous helpers (`isIP`, `isIPv4`, `isIPv6`, `BlockList`,
  `SocketAddress`) are re-exported for convenience.

Both functions accept an optional `AbortSignal` and reject with an `AbortError` when it is aborted, consistent with `timers/promises` and `readline/promises`.

#### Example:

```mjs
import { connect, listen } from 'node:net/promises';

const server = await listen({ port: 0 });
const socket = await connect({ port: server.address().port });

// Consume incoming connections as an async iterator:
for await (const conn of server) {
  conn.end('hello world!');
}
```

### A note on naming (`connect`/`listen`, not `createConnection`/`createServer`)

The naming here is intentional. This API promisifies *actions* that complete: `connect()` resolves once the connection is established, and `listen()` resolves once the server is listening. The function name is the action being awaited, and the two form a parallel pair.

That is deliberately not the factory taxonomy of the callback API. There, `createConnection()` is the canonical name because it both creates a socket and initiates connecting. Creation and the action are fused, so the factory name also implies the action. `createServer()`, by contrast, is a pure factory: it does not listen; listening is the separate `server.listen()` step. So a `createConnection`/`createServer` pairing would be inconsistent in a promise API. `createServer` has no completion to await. Naming the functions for their actions (`connect`/`listen`) keeps the pair coherent, and there is no factory counterpart to alias, so `createConnection` is intentionally omitted.

### Notes

- New experimental API (Stability: 1). semver-minor.
- Implemented on top of `events.once(emitter, name, { signal })`, so error and abort handling match the rest of core.
- Documentation and tests included.

Refs: https://github.com/nodejs/node/issues/21482
Assisted-by: Claude Opus 4.8 <noreply@anthropic.com>