### PR TITLE
debugger: lazily wait for initial break output

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -25,6 +25,7 @@ const {
   Promise,
   PromisePrototypeThen,
   PromiseResolve,
+  PromiseWithResolvers,
   ReflectGetOwnPropertyDescriptor,
   ReflectOwnKeys,
   RegExpPrototypeExec,
@@ -380,6 +381,8 @@ function createRepl(inspector) {
   let selectedFrame;
   let exitDebugRepl;
   let contextLineNumber = 2;
+  let initialBreakRender;
+  let waitForInitialBreakRender = false;
 
   function resetOnStart() {
     knownScripts = {};
@@ -890,6 +893,13 @@ function createRepl(inspector) {
       });
   }
 
+  function createInitialBreakRenderPromise(pauseRender) {
+    const { promise, resolve, reject } = PromiseWithResolvers();
+    initialBreakRender = promise;
+    PromisePrototypeThen(pauseRender, resolve, reject);
+    return promise;
+  }
+
   Debugger.on('paused', ({ callFrames, reason /* , hitBreakpoints */ }) => {
     if (process.env.NODE_INSPECT_RESUME_ON_START === '1' &&
         reason === 'Break on start') {
@@ -910,7 +920,7 @@ function createRepl(inspector) {
 
     const header = `${breakType} in ${scriptUrl}:${lineNumber + 1}`;
 
-    inspector.suspendReplWhile(() =>
+    const pauseRender = inspector.suspendReplWhile(() =>
       PromisePrototypeThen(
         SafePromiseAllReturnArrayLike([formatWatchers(true), selectedFrame.list(contextLineNumber)]),
         ({ 0: watcherList, 1: context }) => {
@@ -919,6 +929,10 @@ function createRepl(inspector) {
             inspect(context);
           print(`${header}\n${breakContext}`);
         }));
+
+    if (waitForInitialBreakRender && !initialBreakRender) {
+      createInitialBreakRenderPromise(pauseRender);
+    }
   });
 
   function handleResumed() {
@@ -1186,6 +1200,9 @@ function createRepl(inspector) {
   }
 
   async function initAfterStart() {
+    waitForInitialBreakRender =
+      !!inspector.options?.script &&
+      process.env.NODE_INSPECT_RESUME_ON_START !== '1';
     await Runtime.enable();
     await Profiler.enable();
     await Profiler.setSamplingInterval({ interval: 100 });
@@ -1194,7 +1211,12 @@ function createRepl(inspector) {
     await Debugger.setBlackboxPatterns({ patterns: [] });
     await Debugger.setPauseOnExceptions({ state: pauseOnExceptionState });
     await restoreBreakpoints();
-    return Runtime.runIfWaitingForDebugger();
+    await Runtime.runIfWaitingForDebugger();
+    await PromiseResolve();
+    waitForInitialBreakRender = false;
+    const initialBreakRenderPromise = initialBreakRender;
+    initialBreakRender = null;
+    await initialBreakRenderPromise;
   }
 
   return async function startRepl() {


### PR DESCRIPTION
Fix a flaky `test-debugger-run-after-quit-restart` failure where the debugger
REPL could display `debug>` before the initial break output had been rendered.

The startup path now waits for the first local `--inspect-brk` pause render to
finish before completing REPL startup, but only when that pause render is
observed during startup initialization. This preserves the prompt ordering fix
without hanging when the debug target exits or disconnects before producing an
initial pause event.

Refs:
* https://github.com/nodejs/node/actions/runs/27582782593/job/81546582775
* https://github.com/nodejs/node/actions/runs/27608332546/job/81625923848
* https://github.com/nodejs/node/actions/runs/27702868250/job/81943652942
* https://github.com/nodejs/node/actions/runs/27582782593/job/81546582775

<details>
<summary>Error Log</summary>

```
=== release test-debugger-run-after-quit-restart ===
Path: parallel/test-debugger-run-after-quit-restart
Error: --- stderr ---
/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:92
        const timeoutErr = new Error(`Timeout (${TIMEOUT}) while waiting for ${pattern}`);
                           ^

Error: Timeout (15000) while waiting for /break (?:on start )?in/i
    at /Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:92:28
    at new Promise (<anonymous>)
    at Object.waitFor (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:67:14)
    at Object.waitForInitialBreak (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/common/debugger.js:116:18)
    at Object.<anonymous> (/Users/runner/work/node/node/dir%20with $unusual"chars?'åß∂ƒ©∆¬…`/test/parallel/test-debugger-run-after-quit-restart.js:18:7)
    at Module._compile (node:internal/modules/cjs/loader:1947:14)
    at Object..js (node:internal/modules/cjs/loader:2087:10)
    at Module.load (node:internal/modules/cjs/loader:1669:32)
    at Module._load (node:internal/modules/cjs/loader:1450:12)
    at wrapModuleLoad (node:internal/modules/cjs/loader:260:19) {
  output: '< Debugger listening on ws://127.0.0.1:62970/019e6944-4d82-44b5-956b-e4505af5b290\n' +
    '< For help, see: https://nodejs.org/learn/getting-started/debugging\n' +
    '< \n' +
    '\n' +
    '\n' +
    'connecting to 127.0.0.1:62970 ...\n' +
    '< Debugger attached.\n' +
    '< \n' +
    '\n' +
    ' ok\n' +
    '\n' +
    'debug> '
}
```

</details>

---

Assisted-by: openai:gpt-5.5