### PR TITLE
stream: handle setEncoding after buffered data

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -604,6 +604,8 @@ Readable.prototype.setEncoding = function(enc) {
   for (const data of state.buffer.slice(state.bufferIndex)) {
     content += decoder.write(data);
   }
+  if ((state[kState] & kEnded) !== 0)
+    content += decoder.end();
   state.buffer.length = 0;
   state.bufferIndex = 0;
 

--- a/test/parallel/test-stream-readable-setEncoding-existing-buffers.js
+++ b/test/parallel/test-stream-readable-setEncoding-existing-buffers.js
@@ -58,3 +58,48 @@ const assert = require('assert');
     assert.deepStrictEqual(chunks, ['🎉']);
   });
 }
+
+{
+  // Call .setEncoding() before the stream starts flowing, after _read()
+  // has buffered the first chunk of a split character.
+  const chunks = [
+    Buffer.from([0xf0, 0x9f]),
+    Buffer.from([0x8e, 0x89]),
+    null,
+  ];
+  const r = new Readable({
+    read() {
+      this.push(chunks.shift());
+    },
+  });
+
+  r.read(0);
+  assert.strictEqual(r.readableFlowing, null);
+  assert.strictEqual(r.readableLength, 2);
+
+  r.setEncoding('utf8');
+  const received = [];
+  r.on('data', (chunk) => received.push(chunk));
+
+  process.nextTick(() => {
+    assert.deepStrictEqual(received, ['🎉']);
+  });
+}
+
+{
+  // Call .setEncoding() after EOF while the buffer contains an
+  // incomplete character.
+  const r = new Readable({ read() {} });
+
+  r.push(Buffer.from([0xf0]));
+  r.push(Buffer.from([0x9f]));
+  r.push(null);
+
+  r.setEncoding('utf8');
+  const chunks = [];
+  r.on('data', (chunk) => chunks.push(chunk));
+
+  process.nextTick(() => {
+    assert.deepStrictEqual(chunks, ['�']);
+  });
+}


### PR DESCRIPTION
Fixes `Readable.prototype.setEncoding()` when it is called after byte data has already been buffered but before that data is consumed.

This addresses the Node.js core stream behavior behind nodejs/undici#5002: if `setEncoding('utf8')` is applied after bytes are buffered, split multibyte UTF-8 sequences must be handed to a single `StringDecoder` so consumers do not see `U+FFFD` corruption at chunk boundaries.

When the buffered data ends with an incomplete multibyte sequence and the stream has ended, the new decoder needs to be finalized so it can emit the replacement character instead of dropping the bytes.

Tests cover:
- calling `setEncoding()` after split multibyte data is buffered
- calling it before the stream starts flowing after `_read()` buffered the first chunk
- calling it after EOF with an incomplete buffered UTF-8 sequence

Refs: https://github.com/nodejs/node/issues/63570
Refs: https://github.com/nodejs/undici/issues/5002
