### PR TITLE
doc: fix keepAliveTimeout default in http.createServer options

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -3772,7 +3772,7 @@ changes:
     needs to wait for additional incoming data, after it has finished writing
     the last response, before a socket will be destroyed.
     See [`server.keepAliveTimeout`][] for more information.
-    **Default:** `5000`.
+    **Default:** `65000`.
   * `maxHeaderSize` {number} Optionally overrides the value of
     [`--max-http-header-size`][] for requests received by this server, i.e.
     the maximum length of request headers in bytes.


### PR DESCRIPTION
PR #62782 updated the `keepAliveTimeout` default from 5 seconds to 65 seconds and correctly updated the `server.keepAliveTimeout` property section, but the `http.createServer()` options table was not updated and still shows `**Default:** \`5000\``.

This PR fixes the remaining reference.

**Before:**
```
**Default:** `5000`.
```

**After:**
```
**Default:** `65000`.
```