### PR TITLE
ffi: fix float passing in libffi for riscv64

### DIFF
--- a/deps/libffi/src/riscv/ffi.c
+++ b/deps/libffi/src/riscv/ffi.c
@@ -35,10 +35,15 @@
 
 #if __riscv_float_abi_double
 #define ABI_FLEN 64
-#define ABI_FLOAT double
+typedef union {
+    uint64_t i;
+    double d;
+} float_reg;
 #elif __riscv_float_abi_single
 #define ABI_FLEN 32
-#define ABI_FLOAT float
+typedef union {
+    float f;
+} float_reg;
 #endif
 
 #define NARGREG 8
@@ -48,7 +53,7 @@
 typedef struct call_context
 {
 #if ABI_FLEN
-    ABI_FLOAT fa[8];
+    float_reg fa[8];
 #endif
     size_t a[8];
     /* used by the assembly code to in-place construct its own stack frame */
@@ -127,6 +132,30 @@ static float_struct_info struct_passed_as_elements(call_builder *cb, ffi_type *t
 
     return ret;
 }
+
+#if ABI_FLEN >= 64
+/* Float values in wider RISC-V FP registers are NaN-boxed */
+static void marshal_float(call_builder *cb, void *data) {
+    union {
+        uint32_t i;
+        float f;
+    } value;
+
+    value.f = *(float *)data;
+    cb->aregs->fa[cb->used_float++].i =
+        UINT64_C(0xffffffff00000000) | value.i;
+}
+
+static void unmarshal_float(call_builder *cb, void *data) {
+    union {
+        uint32_t i;
+        float f;
+    } value;
+
+    value.i = (uint32_t)cb->aregs->fa[cb->used_float++].i;
+    *(float *)data = value.f;
+}
+#endif
 #endif
 
 /* allocates a single register, float register, or XLEN-sized stack slot to a datum */
@@ -146,17 +175,18 @@ static void marshal_atom(call_builder *cb, int type, void *data) {
 #endif
         case FFI_TYPE_POINTER: value = *(size_t *)data; break;
 
-        /* float values may be recoded in an implementation-defined way
-           by hardware conforming to 2.1 or earlier, so use asm to
-           reinterpret floats as doubles */
-#if ABI_FLEN >= 32
+#if ABI_FLEN >= 64
         case FFI_TYPE_FLOAT:
-            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(float *)data));
+            marshal_float(cb, data);
+            return;
+#elif ABI_FLEN >= 32
+        case FFI_TYPE_FLOAT:
+            asm("" : "=f"(cb->aregs->fa[cb->used_float++].f) : "0"(*(float *)data));
             return;
 #endif
 #if ABI_FLEN >= 64
         case FFI_TYPE_DOUBLE:
-            asm("" : "=f"(cb->aregs->fa[cb->used_float++]) : "0"(*(double *)data));
+            asm("" : "=f"(cb->aregs->fa[cb->used_float++].d) : "0"(*(double *)data));
             return;
 #endif
         default: FFI_ASSERT(0); break;
@@ -172,14 +202,18 @@ static void marshal_atom(call_builder *cb, int type, void *data) {
 static void unmarshal_atom(call_builder *cb, int type, void *data) {
     size_t value;
     switch (type) {
-#if ABI_FLEN >= 32
+#if ABI_FLEN >= 64
         case FFI_TYPE_FLOAT:
-            asm("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++]));
+            unmarshal_float(cb, data);
+            return;
+#elif ABI_FLEN >= 32
+        case FFI_TYPE_FLOAT:
+            asm("" : "=f"(*(float *)data) : "0"(cb->aregs->fa[cb->used_float++].f));
             return;
 #endif
 #if ABI_FLEN >= 64
         case FFI_TYPE_DOUBLE:
-            asm("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++]));
+            asm("" : "=f"(*(double *)data) : "0"(cb->aregs->fa[cb->used_float++].d));
             return;
 #endif
     }


### PR DESCRIPTION
libffi was incorrectly passing floats as doubles on RISC-V. This PR applies the merged upstream fix (libffi/libffi#972) for the vendored copy of libffi since libffi appears to have a very long release cycle (last release was at 2025-08-02).

This fixes the following three new test failures caught in https://github.com/riscv-forks/node-riscv/actions/runs/27544719447/job/81437248188:

```
out/Release/node --experimental-ffi --expose-gc --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /home/kxxt/node-riscv/test/ffi/test-ffi-dynamic-library.js
out/Release/node --experimental-ffi --expose-internals --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /home/kxxt/node-riscv/test/ffi/test-ffi-shared-buffer.js
out/Release/node --experimental-ffi --expose-gc --test-reporter=./test/common/test-error-reporter.js --test-reporter-destination=stdout /home/kxxt/node-riscv/test/ffi/test-ffi-calls.js
```

CC @nodejs/platform-riscv64

I am testing this PR on riscv64 at https://github.com/riscv-forks/node-riscv/actions/runs/27756747452/job/82120430409?pr=4

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
