### PR TITLE
build: suppress compiler warnings for histogram

### DIFF
--- a/deps/histogram/histogram.gyp
+++ b/deps/histogram/histogram.gyp
@@ -14,12 +14,26 @@
         'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
       },
       'conditions': [
-        [ 'clang==1 or OS!="win"', {
-          'cflags': [
-            '-Wno-atomic-alignment',
-            '-Wno-incompatible-pointer-types',
-            '-Wno-unused-function'
-          ]
+        [ 'clang==1', {
+          'conditions': [
+            [ 'OS=="win"', {
+              'msvs_settings': {
+                'VCCLCompilerTool': {
+                  'AdditionalOptions': [
+                    '-Wno-atomic-alignment',
+                    '-Wno-incompatible-pointer-types',
+                    '-Wno-unused-function'
+                  ],
+                },
+              },
+            }, {
+              'cflags': [
+                '-Wno-atomic-alignment',
+                '-Wno-incompatible-pointer-types',
+                '-Wno-unused-function'
+              ],
+            }],
+          ],
         }],
       ],
       'include_dirs': ['src', 'include'],

--- a/deps/histogram/histogram.gyp
+++ b/deps/histogram/histogram.gyp
@@ -13,6 +13,15 @@
       'xcode_settings': {
         'GCC_SYMBOLS_PRIVATE_EXTERN': 'YES',  # -fvisibility=hidden
       },
+      'conditions': [
+        [ 'clang==1 or OS!="win"', {
+          'cflags': [
+            '-Wno-atomic-alignment',
+            '-Wno-incompatible-pointer-types',
+            '-Wno-unused-function'
+          ]
+        }],
+      ],
       'include_dirs': ['src', 'include'],
       'direct_dependent_settings': {
         'include_dirs': [ 'src', 'include' ]


### PR DESCRIPTION
Synchronize compiler flags in the gyp build and [unofficial gn](https://github.com/nodejs/node/blob/f6156ce0046ae78e6c10a8e1d72a420f1d65e16e/deps/histogram/unofficial.gni#L21-L27) build of `deps/histogram`.

Fixes: https://github.com/nodejs/node/issues/63979

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
