### PR TITLE
docs: recommend node/default conditions

### DIFF
--- a/doc/api/packages.md
+++ b/doc/api/packages.md
@@ -720,6 +720,8 @@ least specific in object order_.
 
 Using the `"import"` and `"require"` conditions can lead to some hazards,
 which are further explained in [the dual CommonJS/ES module packages section][].
+When the goal is to avoid the dual package hazard, `"node"` and `"default"`
+conditions are usually a better fit.
 
 The `"node-addons"` condition can be used to provide an entry point which
 uses native C++ addons. However, this condition can be disabled via the
@@ -945,7 +947,21 @@ $ node other.js
 
 ## Dual CommonJS/ES module packages
 
-See [the package examples repository][] for details.
+When a package needs a Node.js-specific entry point and a fallback for other
+runtimes, prefer `"node"` and `"default"` conditions over separate
+`"require"` and `"import"` branches. For example:
+
+```json
+// package.json
+{
+  "exports": {
+    "node": "./foo.cjs",
+    "default": "./foo.mjs"
+  }
+}
+```
+
+See [the package examples repository][] for more details.
 
 ## Package maps
 


### PR DESCRIPTION
## Summary
Clarify the conditional exports docs by recommending `node`/`default` for packages that need a Node-specific entry point plus a fallback for other runtimes.

## Context
The current docs explain the hazards around `"import"` and `"require"`, but the dual-package section only pointed at the examples repo. This adds a concrete `node`/`default` example directly in the docs.

Fixes #52174

## Changes
- Add a short recommendation near the conditional exports section.
- Expand the dual CommonJS/ES module packages section with a `node`/`default` example.

## Testing
Ran:

```bash
make lint-md
```

Result: failed in this sandbox because npm could not reach `registry.npmjs.org` (`ENOTFOUND`).

Ran:

```bash
git diff --check
```

Result: passed.
