### PR TITLE
http: add 'sendingHeaders' event for response header manipulation

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2096,6 +2096,63 @@ emitted when the last segment of the response headers and body have been
 handed off to the operating system for transmission over the network. It
 does not imply that the client has received anything yet.
 
+### Event: `'sendingHeaders'`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Emitted synchronously, exactly once, immediately before the status line and
+response headers are serialized and sent to the client. The listener is called
+with `this` bound to the response.
+
+This is the moment at which the response is about to become committed: when the
+event fires, [`response.headersSent`][] is still `false`, so a listener may make
+final changes to the outgoing message. From inside the listener it is valid to:
+
+* read headers with [`response.getHeader()`][] / [`response.getHeaders()`][];
+* add, replace, or remove headers with [`response.setHeader()`][],
+  [`outgoingMessage.appendHeader()`][], and [`response.removeHeader()`][];
+* change [`response.statusCode`][] and [`response.statusMessage`][].
+
+The event is emitted regardless of how the headers are flushed: an explicit call
+to [`response.writeHead()`][], implicit headers triggered by the first
+[`response.write()`][] or [`response.end()`][], or [`response.flushHeaders()`][].
+Because it is a single emission point, multiple independent listeners (for
+example logging, session, and content-negotiation middleware) can each register
+without coordinating with one another. Listeners run in registration order.
+
+The listener runs synchronously and must not be an `async` function: work
+deferred past an `await` runs after the headers are already sent, so only
+changes made synchronously take effect.
+
+```js
+const server = http.createServer((req, res) => {
+  const startTime = Date.now();
+
+  res.on('sendingHeaders', function() {
+    // Set a header at the last possible moment, based on final state.
+    this.setHeader('X-Response-Time', `${Date.now() - startTime}ms`);
+    if (!this.getHeader('Content-Type')) {
+      this.setHeader('Content-Type', 'text/plain');
+    }
+  });
+
+  res.end('hello');
+});
+```
+
+A header passed inline to `response.writeHead()` is visible to the listener and
+can be modified there, including the array form:
+
+```js
+res.on('sendingHeaders', function() {
+  // 'X-Inline' was passed to writeHead() below; it can still be removed here.
+  this.removeHeader('X-Inline');
+});
+res.writeHead(200, ['X-Inline', 'value', 'Content-Type', 'text/plain']);
+```
+
 ### `response.addTrailers(headers)`
 
 <!-- YAML
@@ -4781,6 +4838,7 @@ const agent2 = new http.Agent({ proxyEnv: process.env });
 [`net.Socket`]: net.md#class-netsocket
 [`net.createConnection()`]: net.md#netcreateconnectionoptions-connectlistener
 [`new URL()`]: url.md#new-urlinput-base
+[`outgoingMessage.appendHeader()`]: #outgoingmessageappendheadername-value
 [`outgoingMessage.setHeader(name, value)`]: #outgoingmessagesetheadername-value
 [`outgoingMessage.setHeaders()`]: #outgoingmessagesetheadersheaders
 [`outgoingMessage.socket`]: #outgoingmessagesocket
@@ -4798,9 +4856,15 @@ const agent2 = new http.Agent({ proxyEnv: process.env });
 [`request.writableFinished`]: #requestwritablefinished
 [`request.write(data, encoding)`]: #requestwritechunk-encoding-callback
 [`response.end()`]: #responseenddata-encoding-callback
+[`response.flushHeaders()`]: #responseflushheaders
 [`response.getHeader()`]: #responsegetheadername
+[`response.getHeaders()`]: #responsegetheaders
+[`response.headersSent`]: #responseheaderssent
+[`response.removeHeader()`]: #responseremoveheadername
 [`response.setHeader()`]: #responsesetheadername-value
 [`response.socket`]: #responsesocket
+[`response.statusCode`]: #responsestatuscode
+[`response.statusMessage`]: #responsestatusmessage
 [`response.strictContentLength`]: #responsestrictcontentlength
 [`response.writableEnded`]: #responsewritableended
 [`response.writableFinished`]: #responsewritablefinished

--- a/doc/api/http2.md
+++ b/doc/api/http2.md
@@ -4403,6 +4403,29 @@ does not imply that the client has received anything yet.
 
 After this event, no more events will be emitted on the response object.
 
+#### Event: `'sendingHeaders'`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+Emitted synchronously, exactly once, immediately before the response headers are
+serialized and the `HEADERS` frame is sent. The listener is called with `this`
+bound to the response, while `response.headersSent` is still `false`, so it may
+make final changes to the outgoing message: read or modify headers with
+[`response.setHeader()`][], `response.appendHeader()`, and
+`response.removeHeader()`, or change `response.statusCode`.
+
+The event is reached by every header-flushing path
+([`response.writeHead()`][], implicit headers from the first
+[`response.write()`][] or [`response.end()`][], and `response.flushHeaders()`),
+so independent middleware can each register a listener without coordinating.
+Listeners run in registration order and must be synchronous; changes deferred
+past an `await` run after the headers are already sent and have no effect.
+
+This is the HTTP/2 counterpart of the HTTP/1
+[`'sendingHeaders'`](http.md#event-sendingheaders) event.
+
 #### `response.addTrailers(headers)`
 
 <!-- YAML

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -111,6 +111,7 @@ const onResponseFinishChannel = dc.channel('http.server.response.finish');
 const kServerResponse = Symbol('ServerResponse');
 const kServerResponseStatistics = Symbol('ServerResponseStatistics');
 const kUpgradeStream = Symbol('UpgradeStream');
+const kSendingHeadersEmitted = Symbol('SendingHeadersEmitted');
 
 const kOptimizeEmptyRequests = Symbol('OptimizeEmptyRequestsOption');
 
@@ -210,6 +211,8 @@ function ServerResponse(req, options) {
   this.sendDate = true;
   this._sent100 = false;
   this._expect_continue = false;
+  // Guards the one-shot 'sendingHeaders' emit against re-entrancy.
+  this[kSendingHeadersEmitted] = false;
 
   if (req.httpVersionMajor < 1 || req.httpVersionMinor < 1) {
     this.useChunkedEncodingByDefault = chunkExpression.test(req.headers.te);
@@ -419,18 +422,22 @@ function writeHead(statusCode, reason, obj) {
   }
 
 
-  if (typeof reason === 'string') {
+  const hasExplicitReason = typeof reason === 'string';
+  if (hasExplicitReason) {
     // writeHead(statusCode, reasonPhrase[, headers])
     this.statusMessage = reason;
   } else {
     // writeHead(statusCode[, headers])
-    this.statusMessage ||= STATUS_CODES[statusCode] || 'unknown';
     obj ??= reason;
   }
   this.statusCode = statusCode;
 
+  // With a 'sendingHeaders' listener, always materialize kOutHeaders (including
+  // inline writeHead() headers) so the listener sees one mutable header view.
+  const hasHeadersListeners = this.listenerCount('sendingHeaders') > 0;
+
   let headers;
-  if (this[kOutHeaders]) {
+  if (this[kOutHeaders] || hasHeadersListeners) {
     // Slow-case: when progressive API and header fields are passed.
     let k;
     if (ArrayIsArray(obj)) {
@@ -465,6 +472,34 @@ function writeHead(statusCode, reason, obj) {
   } else {
     // Only writeHead() called
     headers = obj;
+  }
+
+  // Pre-serialization hook, reached by every path (writeHead(), implicit
+  // headers, flushHeaders()): listeners run synchronously right before the
+  // status line and headers are serialized and may still mutate them.
+  if (hasHeadersListeners && !this[kSendingHeadersEmitted]) {
+    this[kSendingHeadersEmitted] = true;
+    this.emit('sendingHeaders');
+
+    // A listener that flushed the headers itself re-entered writeHead(); the
+    // guard stops a re-emit, but serializing again would double the header
+    // block, so fail like a second writeHead() call.
+    if (this._header) {
+      throw new ERR_HTTP_HEADERS_SENT('write');
+    }
+
+    // Re-read state; `res.statusCode` isn't validated on assignment.
+    headers = this[kOutHeaders];
+    statusCode = this.statusCode | 0;
+    if (statusCode < 100 || statusCode > 999) {
+      throw new ERR_HTTP_INVALID_STATUS_CODE(statusCode);
+    }
+  }
+
+  // Default the reason phrase from the final status code when none was set;
+  // runs on every path so a listener changing the code is reflected.
+  if (!hasExplicitReason && !this.statusMessage) {
+    this.statusMessage = STATUS_CODES[statusCode] || 'unknown';
   }
 
   if (checkInvalidHeaderChar(this.statusMessage))

--- a/lib/internal/http2/compat.js
+++ b/lib/internal/http2/compat.js
@@ -487,6 +487,7 @@ class Http2ServerResponse extends Stream {
       headRequest: false,
       sendDate: true,
       statusCode: HTTP_STATUS_OK,
+      sendingHeadersEmitted: false,
     };
     this[kHeaders] = { __proto__: null };
     this[kTrailers] = { __proto__: null };
@@ -795,6 +796,20 @@ class Http2ServerResponse extends Stream {
     }
 
     state.statusCode = statusCode;
+
+    // Pre-serialization hook mirroring the HTTP/1 'sendingHeaders' event:
+    // listeners run synchronously right before the HEADERS frame is sent.
+    if (this.listenerCount('sendingHeaders') > 0 &&
+        !state.sendingHeadersEmitted) {
+      state.sendingHeadersEmitted = true;
+      this.emit('sendingHeaders');
+
+      // A listener that flushed the headers itself re-entered writeHead(); the
+      // guard stops a re-emit, but sending the HEADERS frame again is invalid.
+      if (this[kStream].headersSent)
+        throw new ERR_HTTP2_HEADERS_SENT();
+    }
+
     this[kBeginSend]();
 
     return this;

--- a/test/parallel/test-http-sending-headers.js
+++ b/test/parallel/test-http-sending-headers.js
@@ -1,0 +1,261 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+// 1) Fires once, before serialization, for an implicit-header response (end()).
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    let fired = 0;
+    res.on('sendingHeaders', common.mustCall(function() {
+      fired++;
+      // Headers not yet sent, still mutable.
+      assert.strictEqual(this.headersSent, false);
+      this.setHeader('X-Added-In-Hook', 'yes');
+    }));
+    res.end('body');
+    // Synchronous: hook has already run by the time end() returns.
+    assert.strictEqual(fired, 1);
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers['x-added-in-hook'], 'yes');
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 2) Listener may change the status code, and it is reflected on the wire.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.statusCode = 503;
+      this.statusMessage = 'Service Unavailable';
+    }));
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.statusCode, 503);
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 3) Listener sees and can remove headers passed INLINE to writeHead(),
+//    including the array form.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      assert.strictEqual(this.getHeader('X-Inline'), 'a');
+      this.removeHeader('X-Inline');
+      this.setHeader('X-From-Hook', 'b');
+    }));
+    res.writeHead(200, ['X-Inline', 'a', 'Content-Type', 'text/plain']);
+    res.end('ok');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers['x-inline'], undefined);
+      assert.strictEqual(res.headers['x-from-hook'], 'b');
+      assert.strictEqual(res.headers['content-type'], 'text/plain');
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 4) Multiple listeners all run (FIFO, EventEmitter semantics).
+{
+  const order = [];
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(() => order.push(1)));
+    res.on('sendingHeaders', common.mustCall(() => order.push(2)));
+    res.end();
+    assert.deepStrictEqual(order, [1, 2]);
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 5) flushHeaders() also triggers the hook exactly once.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.setHeader('X-Flushed', '1');
+    }));
+    res.flushHeaders();
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.headers['x-flushed'], '1');
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 6) The hook is synchronous: only changes made before an `await` take effect.
+//    Work deferred past `await` runs after the headers are sent, so a later
+//    setHeader() throws and a statusCode change is not reflected on the wire.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(async function() {
+      this.setHeader('X-Sync', 'before');
+      await null;
+      assert.strictEqual(this.headersSent, true);
+      this.statusCode = 503; // No effect: headers already sent.
+      assert.throws(() => this.setHeader('X-Async', 'after'), {
+        code: 'ERR_HTTP_HEADERS_SENT',
+      });
+      server.close();
+    }));
+    res.end('hello');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.headers['x-sync'], 'before');
+      assert.strictEqual(res.headers['x-async'], undefined);
+      res.resume();
+    }));
+  }));
+}
+
+// 7) A listener that flushes the headers itself re-enters writeHead(). The emit
+//    is guarded so the event still fires exactly once (common.mustCall below),
+//    and the illegal self-flush surfaces as ERR_HTTP_HEADERS_SENT rather than a
+//    stack overflow.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.flushHeaders();
+    }));
+    assert.throws(() => res.end('hello'), { code: 'ERR_HTTP_HEADERS_SENT' });
+    res.destroy();
+    server.close();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const req = http.get({ port: server.address().port });
+    req.on('response', (res) => res.resume());
+    req.on('error', () => {}); // The reset from destroy() is expected
+  }));
+}
+
+// 8) A listener that changes only the status code gets the reason phrase that
+//    matches the final code (not the one defaulted from the original code).
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.statusCode = 503; // statusMessage intentionally left unset
+    }));
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.statusCode, 503);
+      assert.strictEqual(res.statusMessage, 'Service Unavailable');
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 9) An explicit empty reason phrase is preserved (the deferred status-line
+//    default must not overwrite it), and the listener sees the empty phrase.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      assert.strictEqual(this.statusMessage, '');
+    }));
+    res.writeHead(200, '');
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.statusCode, 200);
+      assert.strictEqual(res.statusMessage, '');
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 10) A listener may set a reason phrase that happens to equal a status-code
+//     default while changing the code; the explicit choice is kept (the derived
+//     phrase is only applied when none was set, detected via `=== undefined`).
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.statusCode = 503;
+      this.statusMessage = 'OK'; // Explicit, equals the 200 default
+    }));
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.statusCode, 503);
+      assert.strictEqual(res.statusMessage, 'OK');
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 11) A listener that sets its own reason phrase keeps it, even when it also
+//     changes the status code (the refresh only touches the auto-derived one).
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.statusCode = 503;
+      this.statusMessage = 'Custom Reason';
+    }));
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    http.get({ port: server.address().port }, common.mustCall((res) => {
+      assert.strictEqual(res.statusCode, 503);
+      assert.strictEqual(res.statusMessage, 'Custom Reason');
+      res.resume().on('end', common.mustCall(() => server.close()));
+    }));
+  }));
+}
+
+// 12) A listener that changes the status code and flushes the headers itself
+//     re-enters writeHead(); the reason phrase is derived on that path too, so
+//     it matches the final code (not a stale one). The illegal self-flush still
+//     throws ERR_HTTP_HEADERS_SENT.
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.statusCode = 503;
+      this.flushHeaders();
+    }));
+    assert.throws(() => res.end('x'), { code: 'ERR_HTTP_HEADERS_SENT' });
+    // The re-entrant writeHead() derived the reason phrase for the final code.
+    assert.strictEqual(res.statusMessage, 'Service Unavailable');
+    res.destroy();
+    server.close();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const req = http.get({ port: server.address().port });
+    req.on('response', (res) => res.resume());
+    req.on('error', () => {}); // The reset from destroy() is expected
+  }));
+}

--- a/test/parallel/test-http-status-message.js
+++ b/test/parallel/test-http-status-message.js
@@ -56,3 +56,23 @@ function test() {
     s.close();
   }));
 }
+
+for (const falsy of [null, 0, false, '']) {
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.statusMessage = falsy;
+    res.end('');
+  }));
+
+  server.listen(0, common.mustCall(function() {
+    const client = net.connect(this.address().port, () => {
+      client.write('GET / HTTP/1.1\r\nHost: x\r\nConnection: close\r\n\r\n');
+    });
+    const bufs = [];
+    client.on('data', (chunk) => bufs.push(chunk));
+    client.on('end', common.mustCall(() => {
+      const head = Buffer.concat(bufs).toString('latin1').split('\r\n')[0];
+      assert.strictEqual(head, 'HTTP/1.1 200 OK');
+      server.close();
+    }));
+  }));
+}

--- a/test/parallel/test-http2-compat-serverresponse-sending-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-sending-headers.js
@@ -1,0 +1,199 @@
+'use strict';
+
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+const assert = require('assert');
+const http2 = require('http2');
+
+// The 'sendingHeaders' event on the HTTP/2 compatibility ServerResponse mirrors
+// the one on the HTTP/1 ServerResponse: it is emitted synchronously, exactly
+// once, immediately before the HEADERS frame is sent, and a listener may still
+// mutate headers and the status code.
+
+// 1) Fires once, before serialization, for an implicit-header response (end()).
+{
+  const server = http2.createServer(common.mustCall((req, res) => {
+    let fired = 0;
+    res.on('sendingHeaders', common.mustCall(function() {
+      fired++;
+      // Headers not yet sent, still mutable.
+      assert.strictEqual(this.headersSent, false);
+      this.setHeader('X-Added-In-Hook', 'yes');
+    }));
+    res.end('body');
+    // Synchronous: hook has already run by the time end() returns.
+    assert.strictEqual(fired, 1);
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers['x-added-in-hook'], 'yes');
+    }));
+    req.resume();
+    req.on('end', common.mustCall(() => {
+      client.close();
+      server.close();
+    }));
+    req.end();
+  }));
+}
+
+// 2) Listener may change the status code, and it is reflected on the wire.
+{
+  const server = http2.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.statusCode = 503;
+    }));
+    res.writeHead(200);
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[':status'], 503);
+    }));
+    req.resume();
+    req.on('end', common.mustCall(() => {
+      client.close();
+      server.close();
+    }));
+    req.end();
+  }));
+}
+
+// 3) Listener sees and can remove headers passed INLINE to writeHead(),
+//    including the array form.
+{
+  const server = http2.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      assert.strictEqual(this.getHeader('X-Inline'), 'a');
+      this.removeHeader('X-Inline');
+      this.setHeader('X-From-Hook', 'b');
+    }));
+    res.writeHead(200, ['X-Inline', 'a', 'Content-Type', 'text/plain']);
+    res.end('ok');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers['x-inline'], undefined);
+      assert.strictEqual(headers['x-from-hook'], 'b');
+      assert.strictEqual(headers['content-type'], 'text/plain');
+    }));
+    req.resume();
+    req.on('end', common.mustCall(() => {
+      client.close();
+      server.close();
+    }));
+    req.end();
+  }));
+}
+
+// 4) Multiple listeners all run (FIFO, EventEmitter semantics).
+{
+  const order = [];
+  const server = http2.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(() => order.push(1)));
+    res.on('sendingHeaders', common.mustCall(() => order.push(2)));
+    res.end();
+    assert.deepStrictEqual(order, [1, 2]);
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.resume();
+    req.on('end', common.mustCall(() => {
+      client.close();
+      server.close();
+    }));
+    req.end();
+  }));
+}
+
+// 5) flushHeaders() also triggers the hook exactly once.
+{
+  const server = http2.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.setHeader('X-Flushed', '1');
+    }));
+    res.flushHeaders();
+    res.end();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers['x-flushed'], '1');
+    }));
+    req.resume();
+    req.on('end', common.mustCall(() => {
+      client.close();
+      server.close();
+    }));
+    req.end();
+  }));
+}
+
+// 6) The hook is synchronous: only changes made before an `await` take effect.
+//    Work deferred past `await` runs after the headers are sent, so a later
+//    setHeader() throws and a statusCode change is not reflected on the wire.
+{
+  const server = http2.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(async function() {
+      this.setHeader('X-Sync', 'before');
+      await null;
+      assert.strictEqual(this.headersSent, true);
+      this.statusCode = 503; // No effect: headers already sent.
+      assert.throws(() => this.setHeader('X-Async', 'after'), {
+        code: 'ERR_HTTP2_HEADERS_SENT',
+      });
+      server.close();
+    }));
+    res.end('hello');
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.on('response', common.mustCall((headers) => {
+      assert.strictEqual(headers[':status'], 200);
+      assert.strictEqual(headers['x-sync'], 'before');
+      assert.strictEqual(headers['x-async'], undefined);
+    }));
+    req.resume();
+    req.on('end', common.mustCall(() => client.close()));
+    req.end();
+  }));
+}
+
+// Re-entrancy: a listener that flushes the headers itself re-enters writeHead().
+// The emit is guarded so the event fires exactly once (common.mustCall), and the
+// illegal self-flush surfaces as ERR_HTTP2_HEADERS_SENT rather than recursing.
+{
+  const server = http2.createServer(common.mustCall((req, res) => {
+    res.on('sendingHeaders', common.mustCall(function() {
+      this.flushHeaders();
+    }));
+    assert.throws(() => res.end('hello'), { code: 'ERR_HTTP2_HEADERS_SENT' });
+    res.destroy();
+    server.close();
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const client = http2.connect(`http://localhost:${server.address().port}`);
+    const req = client.request();
+    req.resume();
+    req.on('error', () => {}); // the stream reset from destroy() is expected
+    req.on('close', () => client.close());
+    req.end();
+  }));
+}

--- a/test/parallel/test-http2-compat-serverresponse-sending-headers.js
+++ b/test/parallel/test-http2-compat-serverresponse-sending-headers.js
@@ -192,7 +192,7 @@ const http2 = require('http2');
     const client = http2.connect(`http://localhost:${server.address().port}`);
     const req = client.request();
     req.resume();
-    req.on('error', () => {}); // the stream reset from destroy() is expected
+    req.on('error', () => {}); // The stream reset from destroy() is expected
     req.on('close', () => client.close());
     req.end();
   }));


### PR DESCRIPTION
Okay, after so much time I can finally find time for this. Meanwhile, I’m still testing locally because building Node is quite heavy.

In summary, this serves as a replacement for on-headers, which is a package that does monkey-patching. The idea is to have an event so that middlewares like compression or express-session can use it to modify headers, and for now also, in the case of compression, to transform it into a gzip stream and send the data. However, we will still need two more events to fully remove the monkey-patching of res.write and res.end used in compression, express-session, and many other middlewares

cc: @blakeembrey 