### PR TITLE
stream: respect iter consumer abort signals

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -127,7 +127,7 @@ class BroadcastImpl {
     // own internal AbortController that follows the external signal.
     // When no transforms, return rawConsumer directly (controller elided
     // per PULL-02 optimization -- no transforms means no signal recipient).
-    if (transforms.length > 0) {
+    if (transforms.length > 0 || options?.signal) {
       const pullArgs = [...transforms];
       if (options?.signal) {
         ArrayPrototypePush(pullArgs,

--- a/lib/internal/streams/iter/share.js
+++ b/lib/internal/streams/iter/share.js
@@ -97,7 +97,7 @@ class ShareImpl {
     const { transforms, options } = parsePullArgs(args);
     const rawConsumer = this.#createRawConsumer();
 
-    if (transforms.length > 0) {
+    if (transforms.length > 0 || options?.signal) {
       if (options) {
         return pullWithTransforms(rawConsumer, ...transforms, options);
       }

--- a/test/parallel/test-stream-iter-broadcast-basic.js
+++ b/test/parallel/test-stream-iter-broadcast-basic.js
@@ -173,6 +173,19 @@ async function testPendingNextSettlesAfterReturn() {
   assert.strictEqual(result.value, undefined);
 }
 
+async function testPushAbortSignalRejectsPendingNext() {
+  const ac = new AbortController();
+  const reason = new Error('push aborted');
+  const { broadcast: bc } = broadcast();
+  const iter = bc.push({ signal: ac.signal })[Symbol.asyncIterator]();
+
+  const pendingNext = iter.next();
+  const rejected = assert.rejects(pendingNext, (error) => error === reason);
+  ac.abort(reason);
+
+  await rejected;
+}
+
 // =============================================================================
 // Writer fail detaches consumers
 // =============================================================================
@@ -267,6 +280,7 @@ Promise.all([
   testCancelWithReason(),
   testCancelWithFalsyReason(),
   testPendingNextSettlesAfterReturn(),
+  testPushAbortSignalRejectsPendingNext(),
   testFailDetachesConsumers(),
   testWriterFailIdempotent(),
   testLateJoinerSeesBufferedData(),

--- a/test/parallel/test-stream-iter-share-async.js
+++ b/test/parallel/test-stream-iter-share-async.js
@@ -196,6 +196,25 @@ async function testShareAbortSignalWhileSourcePullPending() {
   await Promise.all([rejected1, rejected2]);
 }
 
+async function testSharePullAbortSignalRejectsPendingNext() {
+  const ac = new AbortController();
+  const reason = new Error('pull aborted');
+  const shared = share(
+    // eslint-disable-next-line require-yield
+    (async function* never() {
+      await new Promise(() => {});
+    })(),
+  );
+  const iter = shared.pull({ signal: ac.signal })[Symbol.asyncIterator]();
+
+  const pendingNext = iter.next();
+  const rejected = assert.rejects(pendingNext, (error) => error === reason);
+  ac.abort(reason);
+
+  await rejected;
+  shared.cancel();
+}
+
 async function testShareAlreadyAborted() {
   const shared = share(from('data'), { signal: AbortSignal.abort() });
   const consumer = shared.pull();
@@ -340,6 +359,7 @@ Promise.all([
   testShareCancelWithReason(),
   testShareAbortSignal(),
   testShareAbortSignalWhileSourcePullPending(),
+  testSharePullAbortSignalRejectsPendingNext(),
   testShareAlreadyAborted(),
   testShareSourceError(),
   testShareLateJoiningConsumer(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63302

`broadcast.push({ signal })` and `share.pull({ signal })` ignored the
per-consumer `AbortSignal` on the raw fast path when no transforms were
provided. This left pending `next()` calls unresolved after the signal aborted.

This updates both paths to delegate to the existing `pull()` pipeline when a
per-consumer signal is present, preserving the raw fast path for calls without
signals.

---

Assisted-by: openai:gpt-5.5