### PR TITLE
test: mark test-debugger-run-after-quit-restart as flaky on macOS

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -52,6 +52,8 @@ test-http-server-headers-timeout-keepalive: PASS,FLAKY
 test-http-server-request-timeout-keepalive: PASS,FLAKY
 # https://github.com/nodejs/node/issues/60050
 test-cluster-dgram-1: SKIP
+# https://github.com/nodejs/node/issues/64005
+test-debugger-run-after-quit-restart: PASS,FLAKY
 
 [$arch==arm || $arch==arm64]
 # https://github.com/nodejs/node/pull/31178


### PR DESCRIPTION
This test has been observed to be flaky on macOS CI due to slow inspector round-trips, causing a 15s timeout when waiting for the initial break after restart.

Refs: https://github.com/nodejs/node/issues/64005