### PR TITLE
src: guard OpenSSL compression header include

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -12,7 +12,9 @@
 #include "util.h"
 #include "v8.h"
 
+#ifdef NODE_OPENSSL_HAS_CERT_COMP
 #include <openssl/comp.h>
+#endif
 #include <openssl/pkcs12.h>
 #include <openssl/rand.h>
 #include <openssl/x509.h>


### PR DESCRIPTION
Follow up to https://github.com/nodejs/node/pull/62217 which for some reason didn't run test-shared.yml which is now failing on main and PRs.

Refs (main): https://github.com/nodejs/node/actions/runs/27836231188/job/82385093927
Refs (PR): https://github.com/nodejs/node/actions/runs/27838253550/job/82391504086