### PR TITLE
stream: observe abort while awaiting pipeTo source

### DIFF
--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -1090,7 +1090,7 @@ async function pipeTo(source, ...args) {
     } else if (transforms.length === 0) {
       // Fast path: no transforms - iterate normalized source directly
       if (signal) {
-        for await (const batch of normalized) {
+        for await (const batch of yieldAbortable(normalized, signal)) {
           signal.throwIfAborted();
           const p = writeBatch(batch);
           if (p) await p;

--- a/test/parallel/test-stream-iter-pipeto-signal.js
+++ b/test/parallel/test-stream-iter-pipeto-signal.js
@@ -6,6 +6,7 @@
 
 const common = require('../common');
 const assert = require('assert');
+const { setTimeout } = require('timers/promises');
 const { pipeTo, from } = require('stream/iter');
 
 // pipeTo with live signal, no transforms — abort mid-stream
@@ -28,6 +29,38 @@ async function testPipeToLiveSignalNoTransforms() {
   );
   // Should have written at least the first two chunks before abort
   assert.ok(written.length >= 1);
+}
+
+// pipeTo with live signal, no transforms — abort while waiting for next chunk
+async function testPipeToLiveSignalNoTransformsPendingNext() {
+  const ac = new AbortController();
+  const reason = new Error('abort reason');
+  const writer = {
+    write: common.mustNotCall(),
+  };
+  const source = {
+    [Symbol.asyncIterator]() {
+      return {
+        next() {
+          return new Promise(() => {});
+        },
+      };
+    },
+  };
+
+  setTimeout(10)
+    .then(() => ac.abort(reason))
+    .then(common.mustCall());
+
+  const result = await Promise.race([
+    assert.rejects(
+      () => pipeTo(source, writer, { signal: ac.signal }),
+      reason,
+    ).then(() => 'aborted'),
+    setTimeout(1000, 'timed out'),
+  ]);
+
+  assert.strictEqual(result, 'aborted');
 }
 
 // pipeTo with live signal + transforms — abort mid-stream
@@ -84,6 +117,7 @@ async function testPipeToLiveSignalWithTransformsCompletes() {
 
 Promise.all([
   testPipeToLiveSignalNoTransforms(),
+  testPipeToLiveSignalNoTransformsPendingNext(),
   testPipeToLiveSignalWithTransforms(),
   testPipeToLiveSignalCompletes(),
   testPipeToLiveSignalWithTransformsCompletes(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64014

`stream/iter`'s `pipeTo()` already checks the abort signal after receiving
source batches, but the no-transform path did not observe aborts while waiting
for the next source chunk.

This updates that path to use the existing abort-aware iterator wrapper so
`pipeTo()` rejects promptly when the signal aborts, even if the source
`next()` call is still pending.

---

Assisted-by: openai:gpt-5.5