### PR TITLE
fs: treat `std::errc::permission_denied` as `EPERM` error

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1785,6 +1785,9 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
             error == std::errc::too_many_files_open ||
             error == std::errc::too_many_files_open_in_system ||
             error == std::errc::directory_not_empty ||
+  #ifdef _WIN32
+            error == std::errc::permission_denied ||
+  #endif
             error == std::errc::operation_not_permitted);
   };
 
@@ -1805,7 +1808,7 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
 
     if (retryDelay > 0) {
 #ifdef _WIN32
-      Sleep(i * retryDelay / 1000);
+      Sleep(i * retryDelay);
 #else
       sleep(i * retryDelay / 1000);
 #endif


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/64016

In the thrown exception, `std::errc::permission_denied` is already treated as an `EPERM` error, but it is not included in one of the omittable errors when retrying the `RmSync` operation. This commit includes it.

This also fixes the `retryDelay` calculation on Windows where the `retryDelay` is divided by `1000` but the win32's `Sleep` function takes the argument as an `ms` unit, dividing the supplied `ms` unit further to a much smaller delay.

I tried writing a test for this fix but node doesn't do file lock when opening a file, even if it's ran as another process, and running python as a child process in the test file yields race conditions (i.e., python does create the folder and the file to be locked but the `js` test fails because it can't do a `rmSync` because the file and the folder does not exist)

But I validated the reproducible steps mentioned in the issue with this fix, the `rmSync` now delays the retries and is around `15000ms`, the same as the asynchronous `fs.rm`