### PR TITLE
crypto: guard openssl/comp.h include for BoringSSL

### DIFF
--- a/src/crypto/crypto_context.cc
+++ b/src/crypto/crypto_context.cc
@@ -12,7 +12,9 @@
 #include "util.h"
 #include "v8.h"
 
+#ifdef NODE_OPENSSL_HAS_CERT_COMP
 #include <openssl/comp.h>
+#endif  // NODE_OPENSSL_HAS_CERT_COMP
 #include <openssl/pkcs12.h>
 #include <openssl/rand.h>
 #include <openssl/x509.h>


### PR DESCRIPTION
The include was unconditional while all cert-compression usage is guarded by `NODE_OPENSSL_HAS_CERT_COMP`. BoringSSL does not ship `openssl/comp.h`, which breaks shared-BoringSSL builds on main.

Refs: https://github.com/nodejs/node/pull/62217