### PR TITLE
util: fix OOM in inspect color stack formatting

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -1876,9 +1876,15 @@ function markNodeModules(ctx, line) {
     tempLine += StringPrototypeSlice(line, lastPos, moduleStart);
 
     let moduleEnd = StringPrototypeIndexOf(line, separator, moduleStart);
-    if (line[moduleStart] === '@') {
+    if (moduleEnd === -1) {
+      // No trailing separator: the module name runs to the end of the line.
+      moduleEnd = line.length;
+    } else if (line[moduleStart] === '@') {
       // Namespaced modules have an extra slash: @namespace/package
       moduleEnd = StringPrototypeIndexOf(line, separator, moduleEnd + 1);
+      if (moduleEnd === -1) {
+        moduleEnd = line.length;
+      }
     }
 
     const nodeModule = StringPrototypeSlice(line, moduleStart, moduleEnd);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -3419,6 +3419,21 @@ assert.strictEqual(
 }
 
 {
+  // A node_modules segment that is the last path component (no trailing
+  // separator after the module name) must not send markNodeModules into an
+  // infinite loop that exhausts the heap.
+  // https://github.com/nodejs/node/issues/64011
+  const err = new Error('boom');
+  err.stack = 'Error: boom\n    at /app/node_modules/foo.js:1:1';
+  const out = util.inspect(err, { colors: true });
+  assert.strictEqual(
+    out,
+    'Error: boom\n' +
+      '    at /app/node_modules/\x1B[4mfoo.js:1:1\x1B[24m',
+  );
+}
+
+{
   // Cross platform checks.
   const err = new Error('foo');
   util.inspect(err, { colors: true }).split('\n').forEach(common.mustCallAtLeast((line, i) => {


### PR DESCRIPTION
Fixes the heap out-of-memory crash in `util.inspect(err, { colors: true })` reported in #64011. When `err.stack` contained a frame whose `node_modules` path segment was the final path component with no trailing separator (for example `at /app/node_modules/foo.js:1:1`), `markNodeModules` entered an infinite loop so the `StringPrototypeIndexOf` search for the next separator returned `-1` `moduleEnd` and `searchFrom` were set to `-1` and the next `StringPrototypeIndexOf(line, 'node_modules', -1)` restarted the scan from index `0` which rematched the same segment and growing `tempLine` without bound until the heap was exhausted.

The fix clamps `moduleEnd` to `line.length` when no trailing separator is found so `searchFrom` advances past the match and the loop terminates. It also guards the namespaced (`@scope`) branch against running on a `-1` indexd which closed a second path into the same loop.

Adds a regression test in `test/parallel/test-util-inspect.js` which asserrts that inspecting an error with such a stack frame returns the expected colorized output instead of hanging

Fixes https://github.com/nodejs/node/issues/64011