### PR TITLE
test_runner: add timestamp to JUnit reporter testsuites

### DIFF
--- a/lib/internal/test_runner/reporter/junit.js
+++ b/lib/internal/test_runner/reporter/junit.js
@@ -5,6 +5,9 @@ const {
   ArrayPrototypeMap,
   ArrayPrototypePush,
   ArrayPrototypeSome,
+  Date,
+  DateNow,
+  DatePrototypeToISOString,
   NumberPrototypeToFixed,
   ObjectEntries,
   RegExpPrototypeSymbolReplace,
@@ -112,6 +115,11 @@ module.exports = async function* junitReporter(source) {
           currentTest.attrs.tests = nonCommentChildren.length;
           currentTest.attrs.failures = ArrayPrototypeFilter(currentTest.children, isFailure).length;
           currentTest.attrs.skipped = ArrayPrototypeFilter(currentTest.children, isSkipped).length;
+          // A suite's `test:start` is emitted lazily (when its first subtest
+          // reports), so derive the start time from the end minus the measured
+          // duration rather than stamping the (late) test:start moment.
+          currentTest.attrs.timestamp =
+            DatePrototypeToISOString(new Date(DateNow() - event.data.details.duration_ms));
           currentTest.attrs.hostname = HOSTNAME;
         } else {
           currentTest.tag = 'testcase';

--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -226,6 +226,7 @@ function replaceJunitDuration(str) {
     .replaceAll(/time="[0-9.]+"/g, 'time="*"')
     .replaceAll(/duration_ms [0-9.]+/g, 'duration_ms *')
     .replaceAll(`hostname="${hostname()}"`, 'hostname="HOSTNAME"')
+    .replaceAll(/timestamp="[^"]*"/g, 'timestamp="*"')
     .replaceAll(/file="[^"]*"/g, 'file="*"');
 }
 

--- a/test/fixtures/test-runner/output/junit_reporter.snapshot
+++ b/test/fixtures/test-runner/output/junit_reporter.snapshot
@@ -128,7 +128,7 @@ true !== false
 	<testcase name="immediate throw - passes but warns" time="*" classname="test" file="*"/>
 	<testcase name="immediate reject - passes but warns" time="*" classname="test" file="*"/>
 	<testcase name="immediate resolve pass" time="*" classname="test" file="*"/>
-	<testsuite name="subtest sync throw fail" time="*" disabled="0" errors="0" tests="1" failures="1" skipped="0" hostname="HOSTNAME">
+	<testsuite name="subtest sync throw fail" time="*" disabled="0" errors="0" tests="1" failures="1" skipped="0" timestamp="*" hostname="HOSTNAME">
 		<testcase name="+sync throw fail" time="*" classname="test" file="*" failure="thrown from subtest sync throw fail">
 			<failure type="testCodeFailure" message="thrown from subtest sync throw fail">
 Error [ERR_TEST_FAILURE]: thrown from subtest sync throw fail
@@ -151,15 +151,15 @@ Error [ERR_TEST_FAILURE]: thrown from subtest sync throw fail
 [Error [ERR_TEST_FAILURE]: Symbol(thrown symbol from sync throw non-error fail)] { code: 'ERR_TEST_FAILURE', failureType: 'testCodeFailure', cause: Symbol(thrown symbol from sync throw non-error fail) }
 		</failure>
 	</testcase>
-	<testsuite name="level 0a" time="*" disabled="0" errors="0" tests="4" failures="0" skipped="0" hostname="HOSTNAME">
+	<testsuite name="level 0a" time="*" disabled="0" errors="0" tests="4" failures="0" skipped="0" timestamp="*" hostname="HOSTNAME">
 		<testcase name="level 1a" time="*" classname="test" file="*"/>
 		<testcase name="level 1b" time="*" classname="test" file="*"/>
 		<testcase name="level 1c" time="*" classname="test" file="*"/>
 		<testcase name="level 1d" time="*" classname="test" file="*"/>
 	</testsuite>
-	<testsuite name="top level" time="*" disabled="0" errors="0" tests="2" failures="0" skipped="0" hostname="HOSTNAME">
+	<testsuite name="top level" time="*" disabled="0" errors="0" tests="2" failures="0" skipped="0" timestamp="*" hostname="HOSTNAME">
 		<testcase name="+long running" time="*" classname="test" file="*"/>
-		<testsuite name="+short running" time="*" disabled="0" errors="0" tests="1" failures="0" skipped="0" hostname="HOSTNAME">
+		<testsuite name="+short running" time="*" disabled="0" errors="0" tests="1" failures="0" skipped="0" timestamp="*" hostname="HOSTNAME">
 			<testcase name="++short running" time="*" classname="test" file="*"/>
 		</testsuite>
 	</testsuite>
@@ -266,7 +266,7 @@ Error [ERR_TEST_FAILURE]: thrown from callback async throw
 		</failure>
 	</testcase>
 	<testcase name="callback async throw after done" time="*" classname="test" file="*"/>
-	<testsuite name="only is set on subtests but not in only mode" time="*" disabled="0" errors="0" tests="3" failures="0" skipped="0" hostname="HOSTNAME">
+	<testsuite name="only is set on subtests but not in only mode" time="*" disabled="0" errors="0" tests="3" failures="0" skipped="0" timestamp="*" hostname="HOSTNAME">
 		<testcase name="running subtest 1" time="*" classname="test" file="*"/>
 		<testcase name="running subtest 3" time="*" classname="test" file="*"/>
 		<testcase name="running subtest 4" time="*" classname="test" file="*"/>
@@ -288,7 +288,7 @@ Error [ERR_TEST_FAILURE]: thrown from callback async throw
 }
 		</failure>
 	</testcase>
-	<testsuite name="subtest sync throw fails" time="*" disabled="0" errors="0" tests="2" failures="2" skipped="0" hostname="HOSTNAME">
+	<testsuite name="subtest sync throw fails" time="*" disabled="0" errors="0" tests="2" failures="2" skipped="0" timestamp="*" hostname="HOSTNAME">
 		<testcase name="sync throw fails at first" time="*" classname="test" file="*" failure="thrown from subtest sync throw fails at first">
 			<failure type="testCodeFailure" message="thrown from subtest sync throw fails at first">
 Error [ERR_TEST_FAILURE]: thrown from subtest sync throw fails at first

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -200,6 +200,12 @@ describe('node:test reporters', { concurrency: true }, () => {
     assert.strictEqual(child.stdout.toString(), '');
     const fileContents = fs.readFileSync(file, 'utf8');
     assert.match(fileContents, /<testsuite .*name="nested".*tests="2".*failures="1".*skipped="0".*>/);
+    // The exact timestamp format is intentionally not pinned here (still under
+    // discussion); assert only that the value is present and a real date.
+    const { 1: timestamp } = fileContents.match(/<testsuite [^>]*timestamp="([^"]+)"/) ?? [];
+    assert.ok(timestamp, 'testsuite should have a timestamp attribute');
+    assert.match(timestamp, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+    assert.ok(!Number.isNaN(Date.parse(timestamp)), `expected a valid date, got ${timestamp}`);
     assert.match(fileContents, /<testcase .*name="failing".*>\s*<failure .*type="testCodeFailure".*message="error".*>/);
     assert.match(fileContents, /<testcase .*name="ok".*classname="test".*\/>/);
     assert.match(fileContents, /<testcase .*name="top level".*classname="test".*\/>/);


### PR DESCRIPTION
Adds the standard JUnit `timestamp` attribute (ISO 8601) to `<testsuite>` elements, which the reporter was omitting. Major CI tools (Jenkins / GitLab / Azure DevOps) use it to order suites from parallel runs and to build test-trend history, and other producers (pytest, jest-junit, mocha-junit-reporter, Maven Surefire) all emit it.

The suite start time is derived as end-minus-duration, because the runner reports a suite's `test:start` lazily (when its first subtest reports) — stamping at that moment would otherwise record a time close to the suite's end.

The exact value format (full ISO-8601 with `Z` vs the legacy no-timezone Ant form) is an open question — see #64028. This currently emits `Date.prototype.toISOString()` (UTC, `Z`).

Fixes: https://github.com/nodejs/node/issues/64028
