### PR TITLE
lib: fix missing lazyDOMException import

### DIFF
--- a/lib/internal/crypto/hash.js
+++ b/lib/internal/crypto/hash.js
@@ -38,6 +38,7 @@ const {
 } = require('internal/crypto/keys');
 
 const {
+  lazyDOMException,
   normalizeEncoding,
   encodingsMap,
   getDeprecationWarningEmitter,


### PR DESCRIPTION
Fixes a missing `lazyDOMException` in `lib/internal/crypto/hash.js` relied upon when openssl < 3 or boringssl is used by #63988 that was removed just before in #63975.

I apologize for the noise.