### PR TITLE
http: fix drain event with cork/uncork

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -315,7 +315,7 @@ OutgoingMessage.prototype.uncork = function uncork() {
       callbacks.push(buf[n + 2]);
     }
   }
-  this._send(crlf_buf, null, callbacks.length ? (err) => {
+  const ret = this._send(crlf_buf, null, callbacks.length ? (err) => {
     for (const callback of callbacks) {
       callback(err);
     }
@@ -323,6 +323,12 @@ OutgoingMessage.prototype.uncork = function uncork() {
 
   this[kChunkedBuffer].length = 0;
   this[kChunkedLength] = 0;
+
+  // If we successfully flushed and had pending drain, emit it
+  if (ret && this[kNeedDrain]) {
+    this[kNeedDrain] = false;
+    this.emit('drain');
+  }
 };
 
 OutgoingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -315,7 +315,7 @@ OutgoingMessage.prototype.uncork = function uncork() {
       callbacks.push(buf[n + 2]);
     }
   }
-  const ret = this._send(crlf_buf, null, callbacks.length ? (err) => {
+  this._send(crlf_buf, null, callbacks.length ? (err) => {
     for (const callback of callbacks) {
       callback(err);
     }
@@ -324,8 +324,8 @@ OutgoingMessage.prototype.uncork = function uncork() {
   this[kChunkedBuffer].length = 0;
   this[kChunkedLength] = 0;
 
-  // If we successfully flushed and had pending drain, emit it
-  if (ret && this[kNeedDrain]) {
+  // If we had a pending drain and flushed all data, emit the drain event.
+  if (this[kNeedDrain] && this.writableLength === 0) {
     this[kNeedDrain] = false;
     this.emit('drain');
   }

--- a/test/parallel/test-http-response-drain-cork.js
+++ b/test/parallel/test-http-response-drain-cork.js
@@ -10,10 +10,10 @@ const server = http.createServer(common.mustCall(async (req, res) => {
   res.cork();
 
   // Write small amount - won't need drain
-  assert.strictEqual(res.write('1'.repeat(100)), true);
+  assert.strictEqual(res.write('1'.repeat(10)), true);
 
-  // Write large amount that should require drain
-  assert.strictEqual(res.write('2'.repeat(1000000)), false);
+  // Write enough to exceed highWaterMark (set in 'connection' listener)
+  assert.strictEqual(res.write('2'.repeat(1000)), false);
 
   // Verify writableNeedDrain is set
   assert.strictEqual(res.writableNeedDrain, true);
@@ -27,24 +27,22 @@ const server = http.createServer(common.mustCall(async (req, res) => {
     }));
   });
 
-  // Uncork should trigger drain if needed
+  // Uncork should trigger drain
   res.uncork();
-
   await drainPromise;
 
-  // Cork again for next write
-  res.cork();
-
-  // Write more data
-  res.write('3'.repeat(100));
-
-  // Final uncork and end
-  res.uncork();
   res.end();
 }));
 
-server.listen(0, common.mustCall(() => {
+server.on('connection', common.mustCall((socket) => {
+  // Set high water mark large enough to cover HTTP overhead + first
+  // small content batch, but not enough to cover second batch.
+  socket._writableState.highWaterMark = 1000;
+}));
+
+server.listen(0, common.localhostIPv4, common.mustCall(() => {
   http.get({
+    host: common.localhostIPv4,
     port: server.address().port,
   }, common.mustCall((res) => {
     let data = '';
@@ -56,12 +54,11 @@ server.listen(0, common.mustCall(() => {
 
     res.on('end', common.mustCall(() => {
       // Verify we got all the data
-      assert.strictEqual(data.length, 100 + 1000000 + 100);
-      assert.strictEqual(data.substring(0, 100), '1'.repeat(100));
-      assert.strictEqual(data.substring(100, 1000100), '2'.repeat(1000000));
-      assert.strictEqual(data.substring(1000100), '3'.repeat(100));
+      assert.strictEqual(data.length, 10 + 1000);
+      assert.strictEqual(data.substring(0, 10), '1'.repeat(10));
+      assert.strictEqual(data.substring(10), '2'.repeat(1000));
 
-      server.close();
+      server.close(common.mustCall());
     }));
   }));
 }));

--- a/test/parallel/test-http-response-drain-cork.js
+++ b/test/parallel/test-http-response-drain-cork.js
@@ -1,0 +1,67 @@
+'use strict';
+const common = require('../common');
+const http = require('http');
+const assert = require('assert');
+
+// Test that drain event is emitted correctly when using cork/uncork
+// with ServerResponse and the write buffer is full
+
+const server = http.createServer(common.mustCall(async (req, res) => {
+  res.cork();
+
+  // Write small amount - won't need drain
+  assert.strictEqual(res.write('1'.repeat(100)), true);
+
+  // Write large amount that should require drain
+  assert.strictEqual(res.write('2'.repeat(1000000)), false);
+
+  // Verify writableNeedDrain is set
+  assert.strictEqual(res.writableNeedDrain, true);
+
+  // Wait for drain event after uncorking
+  const drainPromise = new Promise((resolve) => {
+    res.once('drain', common.mustCall(() => {
+      // After drain, writableNeedDrain should be false
+      assert.strictEqual(res.writableNeedDrain, false);
+      resolve();
+    }));
+  });
+
+  // Uncork should trigger drain if needed
+  res.uncork();
+
+  await drainPromise;
+
+  // Cork again for next write
+  res.cork();
+
+  // Write more data
+  res.write('3'.repeat(100));
+
+  // Final uncork and end
+  res.uncork();
+  res.end();
+}));
+
+server.listen(0, common.mustCall(() => {
+  http.get({
+    port: server.address().port,
+  }, common.mustCall((res) => {
+    let data = '';
+    res.setEncoding('utf8');
+
+    res.on('data', (chunk) => {
+      data += chunk;
+    });
+
+    res.on('end', common.mustCall(() => {
+      // Verify we got all the data
+      assert.strictEqual(data.length, 100 + 1000000 + 100);
+      assert.strictEqual(data.substring(0, 100), '1'.repeat(100));
+      assert.strictEqual(data.substring(100, 1000100), '2'.repeat(1000000));
+      assert.strictEqual(data.substring(1000100), '3'.repeat(100));
+
+      server.close();
+    }));
+  }));
+}));


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/60432

This is a copy of PR #60437, so credit for the fix goes to @ThierryMT. Sadly that PR was abandoned and I [wasn't able to get a response from the author](https://github.com/nodejs/node/issues/60432#issuecomment-4542250959). I've just applied their changes to the latest main, patched up the lint errors, and applied the suggested change to the tests. I've signed the certificate of origin on the basis that the test is based on the reproduction I provided in the original bug report #60432 (hence, created in part by me), but let me know if this is too tenuous and I can write a new test from scratch instead. The fix itself is so trivial that I'm not sure there's a way to write it which isn't effectively the same code.

---

Original PR description:

When using `cork()` and `uncork()` with `ServerResponse`, the `drain` event was not reliably emitted after uncorking. This occurred because the `uncork()` method did not check if a drain was pending (`kNeedDrain` flag) after flushing the chunked buffer.

**The Problem:**
- When corked, `write()` buffers data in `kChunkedBuffer` instead of sending immediately
- If `write()` returns `false`, `kNeedDrain` is set to `true`
- When `uncork()` is called, it flushes the buffer by calling `_send()`
- After flushing, `uncork()` never checked if drain was needed or emitted the event
- This left the response waiting for a `drain` event that would never fire

**The Fix:**
This commit ensures that when `uncork()` successfully flushes buffered data and a drain was needed, the `drain` event is emitted immediately.

**Changes:**
- Modified `OutgoingMessage.prototype.uncork()` in `lib/_http_outgoing.js`
- Capture return value from final `_send()` call
- Check if drain was pending after successful flush
- Emit `drain` event when appropriate

**Testing:**
The issue could be reproduced by using `cork()` with multiple large writes and checking for `drain` events. With this fix, the `drain` event now fires correctly after `uncork()`.