### PR TITLE
meta: update sccache version in test-linux-quic

### DIFF
--- a/.github/workflows/test-linux-quic.yml
+++ b/.github/workflows/test-linux-quic.yml
@@ -68,7 +68,7 @@ jobs:
         if: github.base_ref == 'main' || github.ref_name == 'main'
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
-          version: v0.12.0
+          version: v0.16.0
       - name: Environment Information
         run: npx envinfo
       - name: Build


### PR DESCRIPTION
The recent update PR pre-dated this workflow.

Refs: #63078