### PR TITLE
quic: Fix wake up blob

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -476,14 +476,14 @@ function createBlobReaderStream(reader) {
       // Lazily register a wakeup callback that the C++ side can invoke
       // when new data is available after a STATUS_BLOCK.
       let immediate;
-      reader.setWakeup(() => {
+      this.wakeup = () => {
         if (this.pendingPulls.length > 0) {
           immediate ??= setImmediate(() => {
             immediate = undefined;
             this.readNext(c);
           });
         }
-      });
+      };
     },
     pull(c) {
       const { promise, resolve, reject } = PromiseWithResolvers();

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -481,8 +481,7 @@ function createBlobReaderStream(reader) {
           immediate ??= setImmediate(() => {
             immediate = undefined;
             this.readNext(c);
-          })
-        }
+          });
         }
       });
     },

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -475,11 +475,17 @@ function createBlobReaderStream(reader) {
       this.pendingPulls = [];
       // Lazily register a wakeup callback that the C++ side can invoke
       // when new data is available after a STATUS_BLOCK.
-      this.wakeup = () => {
-        if (this.pendingPulls.length > 0) {
-          this.readNext(c);
+      let immediate;
+      reader.setWakeup(() => {
+        if (this.pendingPulls.length > 0 &&
+          typeof immediate === 'undefined') {
+          // Postpone the execution to the next steps of the event loop
+          immediate = setImmediate(() => {
+            immediate = undefined;
+            this.readNext(c);
+          });
         }
-      };
+      });
     },
     pull(c) {
       const { promise, resolve, reject } = PromiseWithResolvers();
@@ -577,7 +583,16 @@ const kMaxBatchChunks = 16;
 async function* createBlobReaderIterable(reader, options = kEmptyObject) {
   const { getReadError } = options;
   let wakeup = PromiseWithResolvers();
-  reader.setWakeup(wakeup.resolve);
+  let immediate;
+  reader.setWakeup(() => {
+    if (typeof immediate === 'undefined') {
+      // Postpone the execution to the next steps of the event loop
+      immediate = setImmediate(() => {
+        immediate = undefined;
+        wakeup.resolve?.();
+      });
+    }
+  });
 
   try {
     while (true) {
@@ -624,7 +639,6 @@ async function* createBlobReaderIterable(reader, options = kEmptyObject) {
       if (blocked) {
         const fin = await wakeup.promise;
         wakeup = PromiseWithResolvers();
-        reader.setWakeup(wakeup.resolve);
         // If the wakeup was triggered by FIN (EndReadable), the DataQueue
         // is capped. Continue the loop to pull again -- the next pull will
         // return EOS. Without this, a race between the data notification

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -583,13 +583,10 @@ async function* createBlobReaderIterable(reader, options = kEmptyObject) {
   let wakeup = PromiseWithResolvers();
   let immediate;
   reader.setWakeup(() => {
-    if (typeof immediate === 'undefined') {
-      // Postpone the execution to the next steps of the event loop
-      immediate = setImmediate(() => {
-        immediate = undefined;
-        wakeup.resolve?.();
-      });
-    }
+    immediate ??= setImmediate(() => {
+      immediate = undefined;
+      wakeup.resolve?.();
+    });
   });
 
   try {

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -477,13 +477,12 @@ function createBlobReaderStream(reader) {
       // when new data is available after a STATUS_BLOCK.
       let immediate;
       reader.setWakeup(() => {
-        if (this.pendingPulls.length > 0 &&
-          typeof immediate === 'undefined') {
-          // Postpone the execution to the next steps of the event loop
-          immediate = setImmediate(() => {
+        if (this.pendingPulls.length > 0) {
+          immediate ??= setImmediate(() => {
             immediate = undefined;
             this.readNext(c);
-          });
+          })
+        }
         }
       });
     },

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -582,7 +582,7 @@ async function* createBlobReaderIterable(reader, options = kEmptyObject) {
   const { getReadError } = options;
   let wakeup = PromiseWithResolvers();
   let immediate;
-  let fin = false;  
+  let fin = false;
   reader.setWakeup((setfin) => {
     fin ||= setfin;
     immediate ??= setImmediate(() => {

--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -582,7 +582,9 @@ async function* createBlobReaderIterable(reader, options = kEmptyObject) {
   const { getReadError } = options;
   let wakeup = PromiseWithResolvers();
   let immediate;
-  reader.setWakeup(() => {
+  let fin = false;  
+  reader.setWakeup((setfin) => {
+    fin ||= setfin;
     immediate ??= setImmediate(() => {
       immediate = undefined;
       wakeup.resolve?.();
@@ -632,7 +634,7 @@ async function* createBlobReaderIterable(reader, options = kEmptyObject) {
       if (error) throw error;
 
       if (blocked) {
-        const fin = await wakeup.promise;
+        await wakeup.promise;
         wakeup = PromiseWithResolvers();
         // If the wakeup was triggered by FIN (EndReadable), the DataQueue
         // is capped. Continue the loop to pull again -- the next pull will


### PR DESCRIPTION
The quic implementation calls setWakeUp of Blob with the assumption that it is only executed once per event loop cycle.
This assumption is wrong.
Only setImmediate will guarantee that the
execution is delayed to later in the event loop
and happening once in the event loop.

Fixes: https://github.com/nodejs/node/issues/64035

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
