### PR TITLE
stream: proxy first own method in Readable.wrap()

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -1349,7 +1349,7 @@ Readable.prototype.wrap = function(stream) {
 
   // Proxy all the other methods. Important when wrapping filters and duplexes.
   const streamKeys = ObjectKeys(stream);
-  for (let j = 1; j < streamKeys.length; j++) {
+  for (let j = 0; j < streamKeys.length; j++) {
     const i = streamKeys[j];
     if (this[i] === undefined && typeof stream[i] === 'function') {
       this[i] = stream[i].bind(stream);

--- a/test/parallel/test-stream2-readable-wrap-proxy-methods.js
+++ b/test/parallel/test-stream2-readable-wrap-proxy-methods.js
@@ -1,0 +1,40 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Readable } = require('stream');
+
+// Readable.prototype.wrap() proxies the methods of the wrapped old-style
+// stream onto the new Readable. Regression test for an off-by-one that made
+// the proxy loop start at index 1, silently skipping the first own-enumerable
+// key returned by Object.keys() — so a method happening to sit at that first
+// position was never proxied.
+
+// A minimal old-style stream whose *first* own-enumerable key is a method.
+// `Object.keys()` preserves insertion order for string keys, so `firstMethod`
+// is `streamKeys[0]` — exactly the slot the bug skipped.
+const source = {
+  firstMethod() { return `first:${this === source}`; },
+  secondMethod() { return `second:${this === source}`; },
+  on() { return this; },
+  pause() {},
+  resume() {},
+};
+
+assert.strictEqual(Object.keys(source)[0], 'firstMethod');
+
+const wrapped = new Readable().wrap(source);
+
+// The method at the first key must be proxied (was `undefined` before the fix).
+assert.strictEqual(typeof wrapped.firstMethod, 'function');
+assert.strictEqual(typeof wrapped.secondMethod, 'function');
+
+// Proxied methods stay bound to the original stream.
+assert.strictEqual(wrapped.firstMethod(), 'first:true');
+assert.strictEqual(wrapped.secondMethod(), 'second:true');
+
+// Existing Readable methods must not be clobbered by the proxying.
+assert.strictEqual(wrapped.pause, Readable.prototype.pause);
+assert.strictEqual(wrapped.resume, Readable.prototype.resume);
+
+wrapped.on('end', common.mustNotCall());
+wrapped.destroy();


### PR DESCRIPTION
The method-proxying loop in Readable.prototype.wrap() started at index 1, silently skipping streamKeys[0] and leaving a method at the first own-enumerable key unproxied.

This was introduced in ee9e2a2eb6 when ArrayPrototypeForEach( ObjectKeys(stream), ...) — which iterates from index 0 — was rewritten as a manual for loop for performance. The faithful translation starts at 0; a sibling loop converted in the same commit correctly does so. The bug stayed hidden because keys[0] is usually _events (a non-function), which the loop's typeof guard skips anyway.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
