### PR TITLE
test: improve lcov reporter snapshot diagnostics

### DIFF
--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -238,9 +238,25 @@ function pickTestFileFromLcov(str) {
   const firstLineOfTestFile = lines.findIndex(
     (line) => line.startsWith('SF:') && line.trim().endsWith('output.js'),
   );
+
+  if (firstLineOfTestFile === -1) {
+    assert.fail(
+      'Could not find coverage for test/fixtures/test-runner/output/output.js ' +
+      `in LCOV output:\n${str || '<empty>'}`,
+    );
+  }
+
   const lastLineOfTestFile = lines.findIndex(
     (line, index) => index > firstLineOfTestFile && line.trim() === 'end_of_record',
   );
+
+  if (lastLineOfTestFile === -1) {
+    assert.fail(
+      'Could not find end_of_record for test/fixtures/test-runner/output/output.js ' +
+      `in LCOV output:\n${str}`,
+    );
+  }
+
   return (
     lines[0] + '\n' + lines.slice(firstLineOfTestFile, lastLineOfTestFile + 1).join('\n') + '\n'
   );

--- a/test/common/assertSnapshot.js
+++ b/test/common/assertSnapshot.js
@@ -234,14 +234,15 @@ function replaceJunitDuration(str) {
 // This transform picks only the first line and then the lines from the test
 // file.
 function pickTestFileFromLcov(str) {
+  const expectedFile = 'output.js';
   const lines = str.split(/\n/);
   const firstLineOfTestFile = lines.findIndex(
-    (line) => line.startsWith('SF:') && line.trim().endsWith('output.js'),
+    (line) => line.startsWith('SF:') && line.trim().endsWith(expectedFile),
   );
 
   if (firstLineOfTestFile === -1) {
     assert.fail(
-      'Could not find coverage for test/fixtures/test-runner/output/output.js ' +
+      `Could not find LCOV source record ending with ${expectedFile} ` +
       `in LCOV output:\n${str || '<empty>'}`,
     );
   }
@@ -252,7 +253,7 @@ function pickTestFileFromLcov(str) {
 
   if (lastLineOfTestFile === -1) {
     assert.fail(
-      'Could not find end_of_record for test/fixtures/test-runner/output/output.js ' +
+      `Could not find end_of_record for LCOV source record ending with ${expectedFile} ` +
       `in LCOV output:\n${str}`,
     );
   }

--- a/test/fixtures/test-runner/output/lcov_reporter.js
+++ b/test/fixtures/test-runner/output/lcov_reporter.js
@@ -3,7 +3,7 @@ require('../../../common');
 const fixtures = require('../../../common/fixtures');
 const spawn = require('node:child_process').spawn;
 
-spawn(
+const child = spawn(
   process.execPath,
   [
     '--no-warnings',
@@ -14,3 +14,16 @@ spawn(
   ],
   { stdio: 'inherit' },
 );
+
+child.on('error', (err) => {
+  throw err;
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+
+  process.exitCode = code ?? 1;
+});


### PR DESCRIPTION
Improve diagnostics for flaky `test-output-lcov-reporter` failures.

The LCOV snapshot transform previously returned `\n\n` when the expected
`output.js` coverage record was missing, which made the failure look like a
snapshot mismatch instead of showing that no usable LCOV record was found.

This change:
- propagates exit errors from the nested LCOV reporter fixture process
- reports a targeted assertion when the expected LCOV record or
  `end_of_record` is missing

This should make future failures point at the actual coverage/output issue.

Refs: https://github.com/nodejs/reliability/issues?q=%22test-output-lcov-reporter%22

<details>
<summary>Error log</summary>

```console
not ok 637 test-runner/test-output-lcov-reporter
  ---
  duration_ms: 1241.98400
  severity: fail
  exitcode: 1
  stack: |-
    node:internal/modules/run_main:107
        triggerUncaughtException(
        ^
    
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    + actual - expected
    
    + '\n\n'
    - 'TN:\n' +
    -   'SF:test/fixtures/test-runner/output/output.js\n' +
    -   'FN:8,anonymous_0\n' +
    -   'FN:12,anonymous_1\n' +
    -   'FN:16,anonymous_2\n' +
    -   'FN:20,anonymous_3\n' +
    -   'FN:24,anonymous_4\n' +
    -   'FN:28,anonymous_5\n' +
    -   'FN:32,anonymous_6\n' +
    -   'FN:36,anonymous_7\n' +
    -   'FN:40,anonymous_8\n' +
    -   'FN:45,anonymous_9\n' +
    -   'FN:50,anonymous_10\n' +
    -   'FN:54,anonymous_11\n' +
    -   'FN:58,anonymous_12\n' +
    -   'FN:62,anonymous_13\n' +
    -   'FN:66,anonymous_14\n' +
    -   'FN:70,anonymous_15\n' +
    -   'FN:74,anonymous_16\n' +
    -   'FN:78,anonymous_17\n' +
    -   'FN:83,anonymous_18\n' +
    -   'FN:88,anonymous_19\n' +
    -   'FN:92,anonymous_20\n' +
    -   'FN:96,anonymous_21\n' +
    -   'FN:100,anonymous_22\n' +
    -   'FN:104,anonymous_23\n' +
    -   'FN:105,anonymous_24\n' +
    -   'FN:110,anonymous_25\n' +
    -   'FN:111,anonymous_26\n' +
    -   'FN:116,anonymous_27\n' +
    -   'FN:117,anonymous_28\n' +
    -   'FN:118,anonymous_29\n' +
    -   'FN:124,anonymous_30\n' +
    -   'FN:125,anonymous_31\n' +
    -   'FN:131,anonymous_32\n' +
    -   'FN:135,anonymous_33\n' +
    -   'FN:136,anonymous_34\n' +
    -   'FN:137,anonymous_35\n' +
    -   'FN:138,anonymous_36\n' +
    -   'FN:146,anonymous_37\n' +
    -   'FN:147,anonymous_38\n' +
    -   'FN:154,anonymous_39\n' +
    -   'FN:155,anonymous_40\n' +
    -   'FN:156,anonymous_41\n' +
    -   'FN:164,anonymous_42\n' +
    -   'FN:165,anonymous_43\n' +
    -   'FN:166,anonymous_44\n' +
    -   'FN:174,anonymous_45\n' +
    -   'FN:175,anonymous_46\n' +
    -   'FN:183,anonymous_47\n' +
    -   'FN:184,anonymous_48\n' +
    -   'FN:185,anonymous_49\n' +
    -   'FN:190,anonymous_50\n' +
    -   'FN:191,anonymous_51\n' +
    -   'FN:195,anonymous_52\n' +
    -   'FN:196,anonymous_53\n' +
    -   'FN:197,anonymous_54\n' +
    -   'FN:203,anonymous_55\n' +
    -   'FN:207,anonymous_56\n' +
    -   'FN:211,anonymous_57\n' +
    -   'FN:219,functionOnly\n' +
    -   'FN:222,anonymous_59\n' +
    -   'FN:237,functionAndOptions\n' +
    -   'FN:239,anonymous_61\n' +
    -   'FN:243,anonymous_62\n' +
    -   'FN:244,anonymous_63\n' +
    -   'FN:249,anonymous_64\n' +
    -   'FN:253,anonymous_65\n' +
    -   'FN:257,anonymous_66\n' +
    -   'FN:262,anonymous_67\n' +
    -   'FN:266,anonymous_68\n' +
    -   'FN:270,anonymous_69\n' +
    -   'FN:275,anonymous_70\n' +
    -   'FN:280,anonymous_71\n' +
    -   'FN:281,anonymous_72\n' +
    -   'FN:287,anonymous_73\n' +
    -   'FN:288,anonymous_74\n' +
    -   'FN:293,anonymous_75\n' +
    -   'FN:294,anonymous_76\n' +
    -   'FN:301,anonymous_77\n' +
    -   'FN:311,anonymous_78\n' +
    -   'FN:313,obj\n' +
    -   'FN:322,anonymous_80\n' +
    -   'FN:324,obj\n' +
    -   'FN:333,anonymous_82\n' +
    -   'FN:334,anonymous_83\n' +
    -   'FN:337,anonymous_84\n' +
    -   'FN:342,anonymous_85\n' +
    -   'FN:343,anonymous_86\n' +
    -   'FN:344,anonymous_87\n' +
    -   'FN:351,anonymous_88\n' +
    -   'FN:352,anonymous_89\n' +
    -   'FN:359,anonymous_90\n' +
    -   'FN:360,anonymous_91\n' +
    -   'FN:365,anonymous_92\n' +
    -   'FN:369,anonymous_93\n' +
    -   'FN:372,get then\n' +
    -   'FN:375,anonymous_95\n' +
    -   'FN:380,anonymous_96\n' +
    -   'FN:383,get then\n' +
    -   'FN:386,anonymous_98\n' +
    -   'FN:391,anonymous_99\n' +
    -   'FN:392,anonymous_100\n' +
    -   'FN:393,anonymous_101\n' +
    -   'FN:397,anonymous_102\n' +
    -   'FN:398,anonymous_103\n' +
    -   'FN:399,anonymous_104\n' +
    -   'FN:405,anonymous_105\n' +
    -   'FN:409,anonymous_106\n' +
    -   'FNDA:1,anonymous_0\n' +
    -   'FNDA:1,anonymous_1\n' +
    -   'FNDA:1,anonymous_2\n' +
    -   'FNDA:1,anonymous_3\n' +
    -   'FNDA:1,anonymous_4\n' +
    -   'FNDA:0,anonymous_5\n' +
    -   'FNDA:1,anonymous_6\n' +
    -   'FNDA:1,anonymous_7\n' +
    -   'FNDA:1,anonymous_8\n' +
    -   'FNDA:1,anonymous_9\n' +
    -   'FNDA:1,anonymous_10\n' +
    -   'FNDA:1,anonymous_11\n' +
    -   'FNDA:1,anonymous_12\n' +
    -   'FNDA:1,anonymous_13\n' +
    -   'FNDA:1,anonymous_14\n' +
    -   'FNDA:1,anonymous_15\n' +
    -   'FNDA:1,anonymous_16\n' +
    -   'FNDA:1,anonymous_17\n' +
    -   'FNDA:1,anonymous_18\n' +
    -   'FNDA:1,anonymous_19\n' +
    -   'FNDA:1,anonymous_20\n' +
    -   'FNDA:1,anonymous_21\n' +
    -   'FNDA:1,anonymous_22\n' +
    -   'FNDA:1,anonymous_23\n' +
    -   'FNDA:1,anonymous_24\n' +
    -   'FNDA:1,anonymous_25\n' +
    -   'FNDA:1,anonymous_26\n' +
    -   'FNDA:1,anonymous_27\n' +
    -   'FNDA:1,anonymous_28\n' +
    -   'FNDA:1,anonymous_29\n' +
    -   'FNDA:1,anonymous_30\n' +
    -   'FNDA:1,anonymous_31\n' +
    -   'FNDA:1,anonymous_32\n' +
    -   'FNDA:1,anonymous_33\n' +
    -   'FNDA:1,anonymous_34\n' +
    -   'FNDA:1,anonymous_35\n' +
    -   'FNDA:1,anonymous_36\n' +
    -   'FNDA:1,anonymous_37\n' +
    -   'FNDA:1,anonymous_38\n' +
    -   'FNDA:1,anonymous_39\n' +
    -   'FNDA:1,anonymous_40\n' +
    -   'FNDA:1,anonymous_41\n' +
    -   'FNDA:1,anonymous_42\n' +
    -   'FNDA:1,anonymous_43\n' +
    -   'FNDA:1,anonymous_44\n' +
    -   'FNDA:1,anonymous_45\n' +
    -   'FNDA:1,anonymous_46\n' +
    -   'FNDA:1,anonymous_47\n' +
    -   'FNDA:1,anonymous_48\n' +
    -   'FNDA:1,anonymous_49\n' +
    -   'FNDA:1,anonymous_50\n' +
    -   'FNDA:1,anonymous_51\n' +
    -   'FNDA:1,anonymous_52\n' +
    -   'FNDA:1,anonymous_53\n' +
    -   'FNDA:1,anonymous_54\n' +
    -   'FNDA:0,anonymous_55\n' +
    -   'FNDA:0,anonymous_56\n' +
    -   'FNDA:1,anonymous_57\n' +
    -   'FNDA:1,functionOnly\n' +
    -   'FNDA:1,anonymous_59\n' +
    -   'FNDA:0,functionAndOptions\n' +
    -   'FNDA:1,anonymous_61\n' +
    -   'FNDA:1,anonymous_62\n' +
    -   'FNDA:1,anonymous_63\n' +
    -   'FNDA:1,anonymous_64\n' +
    -   'FNDA:1,anonymous_65\n' +
    -   'FNDA:1,anonymous_66\n' +
    -   'FNDA:1,anonymous_67\n' +
    -   'FNDA:1,anonymous_68\n' +
    -   'FNDA:1,anonymous_69\n' +
    -   'FNDA:1,anonymous_70\n' +
    -   'FNDA:1,anonymous_71\n' +
    -   'FNDA:1,anonymous_72\n' +
    -   'FNDA:1,anonymous_73\n' +
    -   'FNDA:1,anonymous_74\n' +
    -   'FNDA:1,anonymous_75\n' +
    -   'FNDA:1,anonymous_76\n' +
    -   'FNDA:1,anonymous_77\n' +
    -   'FNDA:1,anonymous_78\n' +
    -   'FNDA:1,obj\n' +
    -   'FNDA:1,anonymous_80\n' +
    -   'FNDA:1,obj\n' +
    -   'FNDA:1,anonymous_82\n' +
    -   'FNDA:1,anonymous_83\n' +
    -   'FNDA:1,anonymous_84\n' +
    -   'FNDA:1,anonymous_85\n' +
    -   'FNDA:1,anonymous_86\n' +
    -   'FNDA:1,anonymous_87\n' +
    -   'FNDA:1,anonymous_88\n' +
    -   'FNDA:1,anonymous_89\n' +
    -   'FNDA:1,anonymous_90\n' +
    -   'FNDA:1,anonymous_91\n' +
    -   'FNDA:1,anonymous_92\n' +
    -   'FNDA:1,anonymous_93\n' +
    -   'FNDA:1,get then\n' +
    -   'FNDA:1,anonymous_95\n' +
    -   'FNDA:1,anonymous_96\n' +
    -   'FNDA:1,get then\n' +
    -   'FNDA:1,anonymous_98\n' +
    -   'FNDA:1,anonymous_99\n' +
    -   'FNDA:1,anonymous_100\n' +
    -   'FNDA:1,anonymous_101\n' +
    -   'FNDA:1,anonymous_102\n' +
    -   'FNDA:1,anonymous_103\n' +
    -   'FNDA:1,anonymous_104\n' +
    -   'FNDA:1,anonymous_105\n' +
    -   'FNDA:1,anonymous_106\n' +
    -   'FNF:107\n' +
    -   'FNH:103\n' +
    -   'BRDA:1,0,0,1\n' +
    -   'BRDA:8,1,0,1\n' +
    -   'BRDA:12,2,0,1\n' +
    -   'BRDA:16,3,0,1\n' +
    -   'BRDA:20,4,0,1\n' +
    -   'BRDA:24,5,0,1\n' +
    -   'BRDA:32,6,0,1\n' +
    -   'BRDA:36,7,0,1\n' +
    -   'BRDA:40,8,0,1\n' +
    -   'BRDA:45,9,0,1\n' +
    -   'BRDA:50,10,0,1\n' +
    -   'BRDA:54,11,0,1\n' +
    -   'BRDA:58,12,0,1\n' +
    -   'BRDA:62,13,0,1\n' +
    -   'BRDA:66,14,0,1\n' +
    -   'BRDA:70,15,0,1\n' +
    -   'BRDA:74,16,0,1\n' +
    -   'BRDA:78,17,0,1\n' +
    -   'BRDA:83,18,0,1\n' +
    -   'BRDA:88,19,0,1\n' +
    -   'BRDA:92,20,0,1\n' +
    -   'BRDA:96,21,0,1\n' +
    -   'BRDA:100,22,0,1\n' +
    -   'BRDA:104,23,0,1\n' +
    -   'BRDA:105,24,0,1\n' +
    -   'BRDA:110,25,0,1\n' +
    -   'BRDA:111,26,0,1\n' +
    -   'BRDA:116,27,0,1\n' +
    -   'BRDA:117,28,0,1\n' +
    -   'BRDA:118,29,0,1\n' +
    -   'BRDA:124,30,0,1\n' +
    -   'BRDA:125,31,0,1\n' +
    -   'BRDA:131,32,0,1\n' +
    -   'BRDA:135,33,0,1\n' +
    -   'BRDA:136,34,0,1\n' +
    -   'BRDA:137,35,0,1\n' +
    -   'BRDA:138,36,0,1\n' +
    -   'BRDA:146,37,0,1\n' +
    -   'BRDA:147,38,0,1\n' +
    -   'BRDA:154,39,0,1\n' +
    -   'BRDA:155,40,0,1\n' +
    -   'BRDA:156,41,0,1\n' +
    -   'BRDA:164,42,0,1\n' +
    -   'BRDA:165,43,0,1\n' +
    -   'BRDA:166,44,0,1\n' +
    -   'BRDA:174,45,0,1\n' +
    -   'BRDA:175,46,0,1\n' +
    -   'BRDA:183,47,0,1\n' +
    -   'BRDA:184,48,0,1\n' +
    -   'BRDA:185,49,0,1\n' +
    -   'BRDA:190,50,0,1\n' +
    -   'BRDA:191,51,0,1\n' +
    -   'BRDA:195,52,0,1\n' +
    -   'BRDA:196,53,0,1\n' +
    -   'BRDA:197,54,0,1\n' +
    -   'BRDA:211,55,0,1\n' +
    -   'BRDA:219,56,0,1\n' +
    -   'BRDA:222,57,0,1\n' +
    -   'BRDA:239,58,0,1\n' +
    -   'BRDA:243,59,0,1\n' +
    -   'BRDA:244,60,0,1\n' +
    -   'BRDA:249,61,0,1\n' +
    -   'BRDA:253,62,0,1\n' +
    -   'BRDA:257,63,0,1\n' +
    -   'BRDA:262,64,0,1\n' +
    -   'BRDA:266,65,0,1\n' +
    -   'BRDA:270,66,0,1\n' +
    -   'BRDA:275,67,0,1\n' +
    -   'BRDA:280,68,0,1\n' +
    -   'BRDA:281,69,0,1\n' +
    -   'BRDA:287,70,0,1\n' +
    -   'BRDA:288,71,0,1\n' +
    -   'BRDA:293,72,0,1\n' +
    -   'BRDA:294,73,0,1\n' +
    -   'BRDA:301,74,0,1\n' +
    -   'BRDA:311,75,0,1\n' +
    -   'BRDA:313,76,0,1\n' +
    -   'BRDA:322,77,0,1\n' +
    -   'BRDA:324,78,0,1\n' +
    -   'BRDA:333,79,0,1\n' +
    -   'BRDA:334,80,0,1\n' +
    -   'BRDA:337,81,0,1\n' +
    -   'BRDA:342,82,0,1\n' +
    -   'BRDA:343,83,0,1\n' +
    -   'BRDA:344,84,0,1\n' +
    -   'BRDA:351,85,0,1\n' +
    -   'BRDA:352,86,0,1\n' +
    -   'BRDA:359,87,0,1\n' +
    -   'BRDA:360,88,0,1\n' +
    -   'BRDA:365,89,0,1\n' +
    -   'BRDA:369,90,0,1\n' +
    -   'BRDA:372,91,0,1\n' +
    -   'BRDA:373,92,0,0\n' +
    -   'BRDA:375,93,0,1\n' +
    -   'BRDA:380,94,0,1\n' +
    -   'BRDA:383,95,0,1\n' +
    -   'BRDA:384,96,0,0\n' +
    -   'BRDA:386,97,0,1\n' +
    -   'BRDA:391,98,0,1\n' +
    -   'BRDA:394,99,0,0\n' +
    -   'BRDA:392,100,0,1\n' +
    -   'BRDA:393,101,0,1\n' +
    -   'BRDA:397,102,0,1\n' +
    -   'BRDA:400,103,0,0\n' +
    -   'BRDA:398,104,0,1\n' +
    -   'BRDA:399,105,0,1\n' +
    -   'BRDA:405,106,0,1\n' +
    -   'BRDA:409,107,0,1\n' +
    -   'BRF:108\n' +
    -   'BRH:104\n' +
    -   'DA:1,1\n' +
    -   'DA:2,1\n' +
    -   'DA:3,1\n' +
    -   'DA:4,1\n' +
    -   'DA:5,1\n' +
    -   'DA:6,1\n' +
    -   'DA:7,1\n' +
    -   'DA:8,1\n' +
    -   'DA:9,1\n' +
    -   'DA:10,1\n' +
    -   'DA:11,1\n' +
    -   'DA:12,1\n' +
    -   'DA:13,1\n' +
    -   'DA:14,1\n' +
    -   'DA:15,1\n' +
    -   'DA:16,1\n' +
    -   'DA:17,1\n' +
    -   'DA:18,1\n' +
    -   'DA:19,1\n' +
    -   'DA:20,1\n' +
    -   'DA:21,1\n' +
    -   'DA:22,1\n' +
    -   'DA:23,1\n' +
    -   'DA:24,1\n' +
    -   'DA:25,1\n' +
    -   'DA:26,1\n' +
    -   'DA:27,1\n' +
    -   'DA:28,1\n' +
    -   'DA:29,0\n' +
    -   'DA:30,1\n' +
    -   'DA:31,1\n' +
    -   'DA:32,1\n' +
    -   'DA:33,1\n' +
    -   'DA:34,1\n' +
    -   'DA:35,1\n' +
    -   'DA:36,1\n' +
    -   'DA:37,1\n' +
    -   'DA:38,1\n' +
    -   'DA:39,1\n' +
    -   'DA:40,1\n' +
    -   'DA:41,1\n' +
    -   'DA:42,1\n' +
    -   'DA:43,1\n' +
    -   'DA:44,1\n' +
    -   'DA:45,1\n' +
    -   'DA:46,1\n' +
    -   'DA:47,1\n' +
    -   'DA:48,1\n' +
    -   'DA:49,1\n' +
    -   'DA:50,1\n' +
    -   'DA:51,1\n' +
    -   'DA:52,1\n' +
    -   'DA:53,1\n' +
    -   'DA:54,1\n' +
    -   'DA:55,1\n' +
    -   'DA:56,1\n' +
    -   'DA:57,1\n' +
    -   'DA:58,1\n' +
    -   'DA:59,1\n' +
    -   'DA:60,1\n' +
    -   'DA:61,1\n' +
    -   'DA:62,1\n' +
    -   'DA:63,1\n' +
    -   'DA:64,1\n' +
    -   'DA:65,1\n' +
    -   'DA:66,1\n' +
    -   'DA:67,1\n' +
    -   'DA:68,1\n' +
    -   'DA:69,1\n' +
    -   'DA:70,1\n' +
    -   'DA:71,1\n' +
    -   'DA:72,1\n' +
    -   'DA:73,1\n' +
    -   'DA:74,1\n' +
    -   'DA:75,1\n' +
    -   'DA:76,1\n' +
    -   'DA:77,1\n' +
    -   'DA:78,1\n' +
    -   'DA:79,1\n' +
    -   'DA:80,1\n' +
    -   'DA:81,1\n' +
    -   'DA:82,1\n' +
    -   'DA:83,1\n' +
    -   'DA:84,1\n' +
    -   'DA:85,1\n' +
    -   'DA:86,1\n' +
    -   'DA:87,1\n' +
    -   'DA:88,1\n' +
    -   'DA:89,1\n' +
    -   'DA:90,1\n' +
    -   'DA:91,1\n' +
    -   'DA:92,1\n' +
    -   'DA:93,1\n' +
    -   'DA:94,1\n' +
    -   'DA:95,1\n' +
    -   'DA:96,1\n' +
    -   'DA:97,1\n' +
    -   'DA:98,1\n' +
    -   'DA:99,1\n' +
    -   'DA:100,1\n' +
    -   'DA:101,1\n' +
    -   'DA:102,1\n' +
    -   'DA:103,1\n' +
    -   'DA:104,1\n' +
    -   'DA:105,1\n' +
    -   'DA:106,1\n' +
    -   'DA:107,1\n' +
    -   'DA:108,1\n' +
    -   'DA:109,1\n' +
    -   'DA:110,1\n' +
    -   'DA:111,1\n' +
    -   'DA:112,1\n' +
    -   'DA:113,1\n' +
    -   'DA:114,1\n' +
    -   'DA:115,1\n' +
    -   'DA:116,1\n' +
    -   'DA:117,1\n' +
    -   'DA:118,1\n' +
    -   'DA:119,1\n' +
    -   'DA:120,1\n' +
    -   'DA:121,1\n' +
    -   'DA:122,1\n' +
    -   'DA:123,1\n' +
    -   'DA:124,1\n' +
    -   'DA:125,1\n' +
    -   'DA:126,1\n' +
    -   'DA:127,1\n' +
    -   'DA:128,1\n' +
    -   'DA:129,1\n' +
    -   'DA:130,1\n' +
    -   'DA:131,1\n' +
    -   'DA:132,1\n' +
    -   'DA:133,1\n' +
    -   'DA:134,1\n' +
    -   'DA:135,1\n' +
    -   'DA:136,1\n' +
    -   'DA:137,1\n' +
    -   'DA:138,1\n' +
    -   'DA:139,1\n' +
    -   'DA:140,1\n' +
    -   'DA:141,1\n' +
    -   'DA:142,1\n' +
    -   'DA:143,1\n' +
    -   'DA:144,1\n' +
    -   'DA:145,1\n' +
    -   'DA:146,1\n' +
    -   'DA:147,1\n' +
    -   'DA:148,1\n' +
    -   'DA:149,1\n' +
    -   'DA:150,1\n' +
    -   'DA:151,1\n' +
    -   'DA:152,1\n' +
    -   'DA:153,1\n' +
    -   'DA:154,1\n' +
    -   'DA:155,1\n' +
    -   'DA:156,1\n' +
    -   'DA:157,1\n' +
    -   'DA:158,1\n' +
    -   'DA:159,1\n' +
    -   'DA:160,1\n' +
    -   'DA:161,1\n' +
    -   'DA:162,1\n' +
    -   'DA:163,1\n' +
    -   'DA:164,1\n' +
    -   'DA:165,1\n' +
    -   'DA:166,1\n' +
    -   'DA:167,1\n' +
    -   'DA:168,1\n' +
    -   'DA:169,1\n' +
    -   'DA:170,1\n' +
    -   'DA:171,1\n' +
    -   'DA:172,1\n' +
    -   'DA:173,1\n' +
    -   'DA:174,1\n' +
    -   'DA:175,1\n' +
    -   'DA:176,1\n' +
    -   'DA:177,1\n' +
    -   'DA:178,1\n' +
    -   'DA:179,1\n' +
    -   'DA:180,1\n' +
    -   'DA:181,1\n' +
    -   'DA:182,1\n' +
    -   'DA:183,1\n' +
    -   'DA:184,1\n' +
    -   'DA:185,1\n' +
    -   'DA:186,1\n' +
    -   'DA:187,1\n' +
    -   'DA:188,1\n' +
    -   'DA:189,1\n' +
    -   'DA:190,1\n' +
    -   'DA:191,1\n' +
    -   'DA:192,1\n' +
    -   'DA:193,1\n' +
    -   'DA:194,1\n' +
    -   'DA:195,1\n' +
    -   'DA:196,1\n' +
    -   'DA:197,1\n' +
    -   'DA:198,1\n' +
    -   'DA:199,1\n' +
    -   'DA:200,1\n' +
    -   'DA:201,1\n' +
    -   'DA:202,1\n' +
    -   'DA:203,1\n' +
    -   'DA:204,0\n' +
    -   'DA:205,1\n' +
    -   'DA:206,1\n' +
    -   'DA:207,1\n' +
    -   'DA:208,0\n' +
    -   'DA:209,1\n' +
    -   'DA:210,1\n' +
    -   'DA:211,1\n' +
    -   'DA:212,1\n' +
    -   'DA:213,1\n' +
    -   'DA:214,1\n' +
    -   'DA:215,1\n' +
    -   'DA:216,1\n' +
    -   'DA:217,1\n' +
    -   'DA:218,1\n' +
    -   'DA:219,1\n' +
    -   'DA:220,1\n' +
    -   'DA:221,1\n' +
    -   'DA:222,1\n' +
    -   'DA:223,1\n' +
    -   'DA:224,1\n' +
    -   'DA:225,1\n' +
    -   'DA:226,1\n' +
    -   'DA:227,1\n' +
    -   'DA:228,1\n' +
    -   'DA:229,1\n' +
    -   'DA:230,1\n' +
    -   'DA:231,1\n' +
    -   'DA:232,1\n' +
    -   'DA:233,1\n' +
    -   'DA:234,1\n' +
    -   'DA:235,1\n' +
    -   'DA:236,1\n' +
    -   'DA:237,1\n' +
    -   'DA:238,1\n' +
    -   'DA:239,1\n' +
    -   'DA:240,1\n' +
    -   'DA:241,1\n' +
    -   'DA:242,1\n' +
    -   'DA:243,1\n' +
    -   'DA:244,1\n' +
    -   'DA:245,1\n' +
    -   'DA:246,1\n' +
    -   'DA:247,1\n' +
    -   'DA:248,1\n' +
    -   'DA:249,1\n' +
    -   'DA:250,1\n' +
    -   'DA:251,1\n' +
    -   'DA:252,1\n' +
    -   'DA:253,1\n' +
    -   'DA:254,1\n' +
    -   'DA:255,1\n' +
    -   'DA:256,1\n' +
    -   'DA:257,1\n' +
    -   'DA:258,1\n' +
    -   'DA:259,1\n' +
    -   'DA:260,1\n' +
    -   'DA:261,1\n' +
    -   'DA:262,1\n' +
    -   'DA:263,1\n' +
    -   'DA:264,1\n' +
    -   'DA:265,1\n' +
    -   'DA:266,1\n' +
    -   'DA:267,1\n' +
    -   'DA:268,1\n' +
    -   'DA:269,1\n' +
    -   'DA:270,1\n' +
    -   'DA:271,1\n' +
    -   'DA:272,1\n' +
    -   'DA:273,1\n' +
    -   'DA:274,1\n' +
    -   'DA:275,1\n' +
    -   'DA:276,1\n' +
    -   'DA:277,1\n' +
    -   'DA:278,1\n' +
    -   'DA:279,1\n' +
    -   'DA:280,1\n' +
    -   'DA:281,1\n' +
    -   'DA:282,1\n' +
    -   'DA:283,1\n' +
    -   'DA:284,1\n' +
    -   'DA:285,1\n' +
    -   'DA:286,1\n' +
    -   'DA:287,1\n' +
    -   'DA:288,1\n' +
    -   'DA:289,1\n' +
    -   'DA:290,1\n' +
    -   'DA:291,1\n' +
    -   'DA:292,1\n' +
    -   'DA:293,1\n' +
    -   'DA:294,1\n' +
    -   'DA:295,1\n' +
    -   'DA:296,1\n' +
    -   'DA:297,1\n' +
    -   'DA:298,1\n' +
    -   'DA:299,1\n' +
    -   'DA:300,1\n' +
    -   'DA:301,1\n' +
    -   'DA:302,1\n' +
    -   'DA:303,1\n' +
    -   'DA:304,1\n' +
    -   'DA:305,1\n' +
    -   'DA:306,1\n' +
    -   'DA:307,1\n' +
    -   'DA:308,1\n' +
    -   'DA:309,1\n' +
    -   'DA:310,1\n' +
    -   'DA:311,1\n' +
    -   'DA:312,1\n' +
    -   'DA:313,1\n' +
    -   'DA:314,1\n' +
    -   'DA:315,1\n' +
    -   'DA:316,1\n' +
    -   'DA:317,1\n' +
    -   'DA:318,1\n' +
    -   'DA:319,1\n' +
    -   'DA:320,1\n' +
    -   'DA:321,1\n' +
    -   'DA:322,1\n' +
    -   'DA:323,1\n' +
    -   'DA:324,1\n' +
    -   'DA:325,1\n' +
    -   'DA:326,1\n' +
    -   'DA:327,1\n' +
    -   'DA:328,1\n' +
    -   'DA:329,1\n' +
    -   'DA:330,1\n' +
    -   'DA:331,1\n' +
    -   'DA:332,1\n' +
    -   'DA:333,1\n' +
    -   'DA:334,1\n' +
    -   'DA:335,1\n' +
    -   'DA:336,1\n' +
    -   'DA:337,1\n' +
    -   'DA:338,1\n' +
    -   'DA:339,1\n' +
    -   'DA:340,1\n' +
    -   'DA:341,1\n' +
    -   'DA:342,1\n' +
    -   'DA:343,1\n' +
    -   'DA:344,1\n' +
    -   'DA:345,1\n' +
    -   'DA:346,1\n' +
    -   'DA:347,1\n' +
    -   'DA:348,1\n' +
    -   'DA:349,1\n' +
    -   'DA:350,1\n' +
    -   'DA:351,1\n' +
    -   'DA:352,1\n' +
    -   'DA:353,1\n' +
    -   'DA:354,1\n' +
    -   'DA:355,1\n' +
    -   'DA:356,1\n' +
    -   'DA:357,1\n' +
    -   'DA:358,1\n' +
    -   'DA:359,1\n' +
    -   'DA:360,1\n' +
    -   'DA:361,1\n' +
    -   'DA:362,1\n' +
    -   'DA:363,1\n' +
    -   'DA:364,1\n' +
    -   'DA:365,1\n' +
    -   'DA:366,1\n' +
    -   'DA:367,1\n' +
    -   'DA:368,1\n' +
    -   'DA:369,1\n' +
    -   'DA:370,1\n' +
    -   'DA:371,1\n' +
    -   'DA:372,1\n' +
    -   'DA:373,1\n' +
    -   'DA:374,1\n' +
    -   'DA:375,1\n' +
    -   'DA:376,1\n' +
    -   'DA:377,1\n' +
    -   'DA:378,1\n' +
    -   'DA:379,1\n' +
    -   'DA:380,1\n' +
    -   'DA:381,1\n' +
    -   'DA:382,1\n' +
    -   'DA:383,1\n' +
    -   'DA:384,1\n' +
    -   'DA:385,1\n' +
    -   'DA:386,1\n' +
    -   'DA:387,1\n' +
    -   'DA:388,1\n' +
    -   'DA:389,1\n' +
    -   'DA:390,1\n' +
    -   'DA:391,1\n' +
    -   'DA:392,1\n' +
    -   'DA:393,1\n' +
    -   'DA:394,1\n' +
    -   'DA:395,1\n' +
    -   'DA:396,1\n' +
    -   'DA:397,1\n' +
    -   'DA:398,1\n' +
    -   'DA:399,1\n' +
    -   'DA:400,1\n' +
    -   'DA:401,1\n' +
    -   'DA:402,1\n' +
    -   'DA:403,1\n' +
    -   'DA:404,1\n' +
    -   'DA:405,1\n' +
    -   'DA:406,1\n' +
    -   'DA:407,1\n' +
    -   'DA:408,1\n' +
    -   'DA:409,1\n' +
    -   'DA:410,1\n' +
    -   'DA:411,1\n' +
    -   'DA:412,1\n' +
    -   'DA:413,1\n' +
    -   'DA:414,1\n' +
    -   'DA:415,1\n' +
    -   'DA:416,1\n' +
    -   'DA:417,1\n' +
    -   'DA:418,1\n' +
    -   'DA:419,1\n' +
    -   'DA:420,1\n' +
    -   'DA:421,1\n' +
    -   'DA:422,1\n' +
    -   'DA:423,1\n' +
    -   'DA:424,1\n' +
    -   'DA:425,1\n' +
    -   'DA:426,1\n' +
    -   'DA:427,1\n' +
    -   'DA:428,1\n' +
    -   'DA:429,1\n' +
    -   'DA:430,1\n' +
    -   'LH:427\n' +
    -   'LF:430\n' +
    -   'end_of_record\n'
    
        at assertSnapshot (/home/iojs/build/workspace/node-test-commit-linux-containered/test/common/assertSnapshot.js:173:12)
        at async spawnAndAssert (/home/iojs/build/workspace/node-test-commit-linux-containered/test/common/assertSnapshot.js:208:3)
        at async file:///home/iojs/build/workspace/node-test-commit-linux-containered/test/test-runner/test-output-lcov-reporter.mjs:11:1 {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: '\n\n',
      expected: 'TN:\n' +
        'SF:test/fixtures/test-runner/output/output.js\n' +
        'FN:8,anonymous_0\n' +
        'FN:12,anonymous_1\n' +
        'FN:16,anonymous_2\n' +
        'FN:20,anonymous_3\n' +
        'FN:24,anonymous_4\n' +
        'FN:28,anonymous_5\n' +
        'FN:32,anonymous_6\n' +
        'FN:36,anonymous_7\n' +
        'FN:40,anonymous_8\n' +
        'FN:45,anonymous_9\n' +
        'FN:50,anonymous_10\n' +
        'FN:54,anonymous_11\n' +
        'FN:58,anonymous_12\n' +
        'FN:62,anonymous_13\n' +
        'FN:66,anonymous_14\n' +
        'FN:70,anonymous_15\n' +
        'FN:74,anonymous_16\n' +
        'FN:78,anonymous_17\n' +
        'FN:83,anonymous_18\n' +
        'FN:88,anonymous_19\n' +
        'FN:92,anonymous_20\n' +
        'FN:96,anonymous_21\n' +
        'FN:100,anonymous_22\n' +
        'FN:104,anonymous_23\n' +
        'FN:105,anonymous_24\n' +
        'FN:110,anonymous_25\n' +
        'FN:111,anonymous_26\n' +
        'FN:116,anonymous_27\n' +
        'FN:117,anonymous_28\n' +
        'FN:118,anonymous_29\n' +
        'FN:124,anonymous_30\n' +
        'FN:125,anonymous_31\n' +
        'FN:131,anonymous_32\n' +
        'FN:135,anonymous_33\n' +
        'FN:136,anonymous_34\n' +
        'FN:137,anonymous_35\n' +
        'FN:138,anonymous_36\n' +
        'FN:146,anonymous_37\n' +
        'FN:147,anonymous_38\n' +
        'FN:154,anonymous_39\n' +
        'FN:155,anonymous_40\n' +
        'FN:156,anonymous_41\n' +
        'FN:164,anonymous_42\n' +
        'FN:165,anonymous_43\n' +
        'FN:166,anonymous_44\n' +
        'FN:174,anonymous_45\n' +
        'FN:175,anonymous_46\n' +
        'FN:183,anonymous_47\n' +
        'FN:184,anonymous_48\n' +
        'FN:185,anonymous_49\n' +
        'FN:190,anonymous_50\n' +
        'FN:191,anonymous_51\n' +
        'FN:195,anonymous_52\n' +
        'FN:196,anonymous_53\n' +
        'FN:197,anonymous_54\n' +
        'FN:203,anonymous_55\n' +
        'FN:207,anonymous_56\n' +
        'FN:211,anonymous_57\n' +
        'FN:219,functionOnly\n' +
        'FN:222,anonymous_59\n' +
        'FN:237,functionAndOptions\n' +
        'FN:239,anonymous_61\n' +
        'FN:243,anonymous_62\n' +
        'FN:244,anonymous_63\n' +
        'FN:249,anonymous_64\n' +
        'FN:253,anonymous_65\n' +
        'FN:257,anonymous_66\n' +
        'FN:262,anonymous_67\n' +
        'FN:266,anonymous_68\n' +
        'FN:270,anonymous_69\n' +
        'FN:275,anonymous_70\n' +
        'FN:280,anonymous_71\n' +
        'FN:281,anonymous_72\n' +
        'FN:287,anonymous_73\n' +
        'FN:288,anonymous_74\n' +
        'FN:293,anonymous_75\n' +
        'FN:294,anonymous_76\n' +
        'FN:301,anonymous_77\n' +
        'FN:311,anonymous_78\n' +
        'FN:313,obj\n' +
        'FN:322,anonymous_80\n' +
        'FN:324,obj\n' +
        'FN:333,anonymous_82\n' +
        'FN:334,anonymous_83\n' +
        'FN:337,anonymous_84\n' +
        'FN:342,anonymous_85\n' +
        'FN:343,anonymous_86\n' +
        'FN:344,anonymous_87\n' +
        'FN:351,anonymous_88\n' +
        'FN:352,anonymous_89\n' +
        'FN:359,anonymous_90\n' +
        'FN:360,anonymous_91\n' +
        'FN:365,anonymous_92\n' +
        'FN:369,anonymous_93\n' +
        'FN:372,get then\n' +
        'FN:375,anonymous_95\n' +
        'FN:380,anonymous_96\n' +
        'FN:383,get then\n' +
        'FN:386,anonymous_98\n' +
        'FN:391,anonymous_99\n' +
        'FN:392,anonymous_100\n' +
        'FN:393,anonymous_101\n' +
        'FN:397,anonymous_102\n' +
        'FN:398,anonymous_103\n' +
        'FN:399,anonymous_104\n' +
        'FN:405,anonymous_105\n' +
        'FN:409,anonymous_106\n' +
        'FNDA:1,anonymous_0\n' +
        'FNDA:1,anonymous_1\n' +
        'FNDA:1,anonymous_2\n' +
        'FNDA:1,anonymous_3\n' +
        'FNDA:1,anonymous_4\n' +
        'FNDA:0,anonymous_5\n' +
        'FNDA:1,anonymous_6\n' +
        'FNDA:1,anonymous_7\n' +
        'FNDA:1,anonymous_8\n' +
        'FNDA:1,anonymous_9\n' +
        'FNDA:1,anonymous_10\n' +
        'FNDA:1,anonymous_11\n' +
        'FNDA:1,anonymous_12\n' +
        'FNDA:1,anonymous_13\n' +
        'FNDA:1,anonymous_14\n' +
        'FNDA:1,anonymous_15\n' +
        'FNDA:1,anonymous_16\n' +
        'FNDA:1,anonymous_17\n' +
        'FNDA:1,anonymous_18\n' +
        'FNDA:1,anonymous_19\n' +
        'FNDA:1,anonymous_20\n' +
        'FNDA:1,anonymous_21\n' +
        'FNDA:1,anonymous_22\n' +
        'FNDA:1,anonymous_23\n' +
        'FNDA:1,anonymous_24\n' +
        'FNDA:1,anonymous_25\n' +
        'FNDA:1,anonymous_26\n' +
        'FNDA:1,anonymous_27\n' +
        'FNDA:1,anonymous_28\n' +
        'FNDA:1,anonymous_29\n' +
        'FNDA:1,anonymous_30\n' +
        'FNDA:1,anonymous_31\n' +
        'FNDA:1,anonymous_32\n' +
        'FNDA:1,anonymous_33\n' +
        'FNDA:1,anonymous_34\n' +
        'FNDA:1,anonymous_35\n' +
        'FNDA:1,anonymous_36\n' +
        'FNDA:1,anonymous_37\n' +
        'FNDA:1,anonymous_38\n' +
        'FNDA:1,anonymous_39\n' +
        'FNDA:1,anonymous_40\n' +
        'FNDA:1,anonymous_41\n' +
        'FNDA:1,anonymous_42\n' +
        'FNDA:1,anonymous_43\n' +
        'FNDA:1,anonymous_44\n' +
        'FNDA:1,anonymous_45\n' +
        'FNDA:1,anonymous_46\n' +
        'FNDA:1,anonymous_47\n' +
        'FNDA:1,anonymous_48\n' +
        'FNDA:1,anonymous_49\n' +
        'FNDA:1,anonymous_50\n' +
        'FNDA:1,anonymous_51\n' +
        'FNDA:1,anonymous_52\n' +
        'FNDA:1,anonymous_53\n' +
        'FNDA:1,anonymous_54\n' +
        'FNDA:0,anonymous_55\n' +
        'FNDA:0,anonymous_56\n' +
        'FNDA:1,anonymous_57\n' +
        'FNDA:1,functionOnly\n' +
        'FNDA:1,anonymous_59\n' +
        'FNDA:0,functionAndOptions\n' +
        'FNDA:1,anonymous_61\n' +
        'FNDA:1,anonymous_62\n' +
        'FNDA:1,anonymous_63\n' +
        'FNDA:1,anonymous_64\n' +
        'FNDA:1,anonymous_65\n' +
        'FNDA:1,anonymous_66\n' +
        'FNDA:1,anonymous_67\n' +
        'FNDA:1,anonymous_68\n' +
        'FNDA:1,anonymous_69\n' +
        'FNDA:1,anonymous_70\n' +
        'FNDA:1,anonymous_71\n' +
        'FNDA:1,anonymous_72\n' +
        'FNDA:1,anonymous_73\n' +
        'FNDA:1,anonymous_74\n' +
        'FNDA:1,anonymous_75\n' +
        'FNDA:1,anonymous_76\n' +
        'FNDA:1,anonymous_77\n' +
        'FNDA:1,anonymous_78\n' +
        'FNDA:1,obj\n' +
        'FNDA:1,anonymous_80\n' +
        'FNDA:1,obj\n' +
        'FNDA:1,anonymous_82\n' +
        'FNDA:1,anonymous_83\n' +
        'FNDA:1,anonymous_84\n' +
        'FNDA:1,anonymous_85\n' +
        'FNDA:1,anonymous_86\n' +
        'FNDA:1,anonymous_87\n' +
        'FNDA:1,anonymous_88\n' +
        'FNDA:1,anonymous_89\n' +
        'FNDA:1,anonymous_90\n' +
        'FNDA:1,anonymous_91\n' +
        'FNDA:1,anonymous_92\n' +
        'FNDA:1,anonymous_93\n' +
        'FNDA:1,get then\n' +
        'FNDA:1,anonymous_95\n' +
        'FNDA:1,anonymous_96\n' +
        'FNDA:1,get then\n' +
        'FNDA:1,anonymous_98\n' +
        'FNDA:1,anonymous_99\n' +
        'FNDA:1,anonymous_100\n' +
        'FNDA:1,anonymous_101\n' +
        'FNDA:1,anonymous_102\n' +
        'FNDA:1,anonymous_103\n' +
        'FNDA:1,anonymous_104\n' +
        'FNDA:1,anonymous_105\n' +
        'FNDA:1,anonymous_106\n' +
        'FNF:107\n' +
        'FNH:103\n' +
        'BRDA:1,0,0,1\n' +
        'BRDA:8,1,0,1\n' +
        'BRDA:12,2,0,1\n' +
        'BRDA:16,3,0,1\n' +
        'BRDA:20,4,0,1\n' +
        'BRDA:24,5,0,1\n' +
        'BRDA:32,6,0,1\n' +
        'BRDA:36,7,0,1\n' +
        'BRDA:40,8,0,1\n' +
        'BRDA:45,9,0,1\n' +
        'BRDA:50,10,0,1\n' +
        'BRDA:54,11,0,1\n' +
        'BRDA:58,12,0,1\n' +
        'BRDA:62,13,0,1\n' +
        'BRDA:66,14,0,1\n' +
        'BRDA:70,15,0,1\n' +
        'BRDA:74,16,0,1\n' +
        'BRDA:78,17,0,1\n' +
        'BRDA:83,18,0,1\n' +
        'BRDA:88,19,0,1\n' +
        'BRDA:92,20,0,1\n' +
        'BRDA:96,21,0,1\n' +
        'BRDA:100,22,0,1\n' +
        'BRDA:104,23,0,1\n' +
        'BRDA:105,24,0,1\n' +
        'BRDA:110,25,0,1\n' +
        'BRDA:111,26,0,1\n' +
        'BRDA:116,27,0,1\n' +
        'BRDA:117,28,0,1\n' +
        'BRDA:118,29,0,1\n' +
        'BRDA:124,30,0,1\n' +
        'BRDA:125,31,0,1\n' +
        'BRDA:131,32,0,1\n' +
        'BRDA:135,33,0,1\n' +
        'BRDA:136,34,0,1\n' +
        'BRDA:137,35,0,1\n' +
        'BRDA:138,36,0,1\n' +
        'BRDA:146,37,0,1\n' +
        'BRDA:147,38,0,1\n' +
        'BRDA:154,39,0,1\n' +
        'BRDA:155,40,0,1\n' +
        'BRDA:156,41,0,1\n' +
        'BRDA:164,42,0,1\n' +
        'BRDA:165,43,0,1\n' +
        'BRDA:166,44,0,1\n' +
        'BRDA:174,45,0,1\n' +
        'BRDA:175,46,0,1\n' +
        'BRDA:183,47,0,1\n' +
        'BRDA:184,48,0,1\n' +
        'BRDA:185,49,0,1\n' +
        'BRDA:190,50,0,1\n' +
        'BRDA:191,51,0,1\n' +
        'BRDA:195,52,0,1\n' +
        'BRDA:196,53,0,1\n' +
        'BRDA:197,54,0,1\n' +
        'BRDA:211,55,0,1\n' +
        'BRDA:219,56,0,1\n' +
        'BRDA:222,57,0,1\n' +
        'BRDA:239,58,0,1\n' +
        'BRDA:243,59,0,1\n' +
        'BRDA:244,60,0,1\n' +
        'BRDA:249,61,0,1\n' +
        'BRDA:253,62,0,1\n' +
        'BRDA:257,63,0,1\n' +
        'BRDA:262,64,0,1\n' +
        'BRDA:266,65,0,1\n' +
        'BRDA:270,66,0,1\n' +
        'BRDA:275,67,0,1\n' +
        'BRDA:280,68,0,1\n' +
        'BRDA:281,69,0,1\n' +
        'BRDA:287,70,0,1\n' +
        'BRDA:288,71,0,1\n' +
        'BRDA:293,72,0,1\n' +
        'BRDA:294,73,0,1\n' +
        'BRDA:301,74,0,1\n' +
        'BRDA:311,75,0,1\n' +
        'BRDA:313,76,0,1\n' +
        'BRDA:322,77,0,1\n' +
        'BRDA:324,78,0,1\n' +
        'BRDA:333,79,0,1\n' +
        'BRDA:334,80,0,1\n' +
        'BRDA:337,81,0,1\n' +
        'BRDA:342,82,0,1\n' +
        'BRDA:343,83,0,1\n' +
        'BRDA:344,84,0,1\n' +
        'BRDA:351,85,0,1\n' +
        'BRDA:352,86,0,1\n' +
        'BRDA:359,87,0,1\n' +
        'BRDA:360,88,0,1\n' +
        'BRDA:365,89,0,1\n' +
        'BRDA:369,90,0,1\n' +
        'BRDA:372,91,0,1\n' +
        'BRDA:373,92,0,0\n' +
        'BRDA:375,93,0,1\n' +
        'BRDA:380,94,0,1\n' +
        'BRDA:383,95,0,1\n' +
        'BRDA:384,96,0,0\n' +
        'BRDA:386,97,0,1\n' +
        'BRDA:391,98,0,1\n' +
        'BRDA:394,99,0,0\n' +
        'BRDA:392,100,0,1\n' +
        'BRDA:393,101,0,1\n' +
        'BRDA:397,102,0,1\n' +
        'BRDA:400,103,0,0\n' +
        'BRDA:398,104,0,1\n' +
        'BRDA:399,105,0,1\n' +
        'BRDA:405,106,0,1\n' +
        'BRDA:409,107,0,1\n' +
        'BRF:108\n' +
        'BRH:104\n' +
        'DA:1,1\n' +
        'DA:2,1\n' +
        'DA:3,1\n' +
        'DA:4,1\n' +
        'DA:5,1\n' +
        'DA:6,1\n' +
        'DA:7,1\n' +
        'DA:8,1\n' +
        'DA:9,1\n' +
        'DA:10,1\n' +
        'DA:11,1\n' +
        'DA:12,1\n' +
        'DA:13,1\n' +
        'DA:14,1\n' +
        'DA:15,1\n' +
        'DA:16,1\n' +
        'DA:17,1\n' +
        'DA:18,1\n' +
        'DA:19,1\n' +
        'DA:20,1\n' +
        'DA:21,1\n' +
        'DA:22,1\n' +
        'DA:23,1\n' +
        'DA:24,1\n' +
        'DA:25,1\n' +
        'DA:26,1\n' +
        'DA:27,1\n' +
        'DA:28,1\n' +
        'DA:29,0\n' +
        'DA:30,1\n' +
        'DA:31,1\n' +
        'DA:32,1\n' +
        'DA:33,1\n' +
        'DA:34,1\n' +
        'DA:35,1\n' +
        'DA:36,1\n' +
        'DA:37,1\n' +
        'DA:38,1\n' +
        'DA:39,1\n' +
        'DA:40,1\n' +
        'DA:41,1\n' +
        'DA:42,1\n' +
        'DA:43,1\n' +
        'DA:44,1\n' +
        'DA:45,1\n' +
        'DA:46,1\n' +
        'DA:47,1\n' +
        'DA:48,1\n' +
        'DA:49,1\n' +
        'DA:50,1\n' +
        'DA:51,1\n' +
        'DA:52,1\n' +
        'DA:53,1\n' +
        'DA:54,1\n' +
        'DA:55,1\n' +
        'DA:56,1\n' +
        'DA:57,1\n' +
        'DA:58,1\n' +
        'DA:59,1\n' +
        'DA:60,1\n' +
        'DA:61,1\n' +
        'DA:62,1\n' +
        'DA:63,1\n' +
        'DA:64,1\n' +
        'DA:65,1\n' +
        'DA:66,1\n' +
        'DA:67,1\n' +
        'DA:68,1\n' +
        'DA:69,1\n' +
        'DA:70,1\n' +
        'DA:71,1\n' +
        'DA:72,1\n' +
        'DA:73,1\n' +
        'DA:74,1\n' +
        'DA:75,1\n' +
        'DA:76,1\n' +
        'DA:77,1\n' +
        'DA:78,1\n' +
        'DA:79,1\n' +
        'DA:80,1\n' +
        'DA:81,1\n' +
        'DA:82,1\n' +
        'DA:83,1\n' +
        'DA:84,1\n' +
        'DA:85,1\n' +
        'DA:86,1\n' +
        'DA:87,1\n' +
        'DA:88,1\n' +
        'DA:89,1\n' +
        'DA:90,1\n' +
        'DA:91,1\n' +
        'DA:92,1\n' +
        'DA:93,1\n' +
        'DA:94,1\n' +
        'DA:95,1\n' +
        'DA:96,1\n' +
        'DA:97,1\n' +
        'DA:98,1\n' +
        'DA:99,1\n' +
        'DA:100,1\n' +
        'DA:101,1\n' +
        'DA:102,1\n' +
        'DA:103,1\n' +
        'DA:104,1\n' +
        'DA:105,1\n' +
        'DA:106,1\n' +
        'DA:107,1\n' +
        'DA:108,1\n' +
        'DA:109,1\n' +
        'DA:110,1\n' +
        'DA:111,1\n' +
        'DA:112,1\n' +
        'DA:113,1\n' +
        'DA:114,1\n' +
        'DA:115,1\n' +
        'DA:116,1\n' +
        'DA:117,1\n' +
        'DA:118,1\n' +
        'DA:119,1\n' +
        'DA:120,1\n' +
        'DA:121,1\n' +
        'DA:122,1\n' +
        'DA:123,1\n' +
        'DA:124,1\n' +
        'DA:125,1\n' +
        'DA:126,1\n' +
        'DA:127,1\n' +
        'DA:128,1\n' +
        'DA:129,1\n' +
        'DA:130,1\n' +
        'DA:131,1\n' +
        'DA:132,1\n' +
        'DA:133,1\n' +
        'DA:134,1\n' +
        'DA:135,1\n' +
        'DA:136,1\n' +
        'DA:137,1\n' +
        'DA:138,1\n' +
        'DA:139,1\n' +
        'DA:140,1\n' +
        'DA:141,1\n' +
        'DA:142,1\n' +
        'DA:143,1\n' +
        'DA:144,1\n' +
        'DA:145,1\n' +
        'DA:146,1\n' +
        'DA:147,1\n' +
        'DA:148,1\n' +
        'DA:149,1\n' +
        'DA:150,1\n' +
        'DA:151,1\n' +
        'DA:152,1\n' +
        'DA:153,1\n' +
        'DA:154,1\n' +
        'DA:155,1\n' +
        'DA:156,1\n' +
        'DA:157,1\n' +
        'DA:158,1\n' +
        'DA:159,1\n' +
        'DA:160,1\n' +
        'DA:161,1\n' +
        'DA:162,1\n' +
        'DA:163,1\n' +
        'DA:164,1\n' +
        'DA:165,1\n' +
        'DA:166,1\n' +
        'DA:167,1\n' +
        'DA:168,1\n' +
        'DA:169,1\n' +
        'DA:170,1\n' +
        'DA:171,1\n' +
        'DA:172,1\n' +
        'DA:173,1\n' +
        'DA:174,1\n' +
        'DA:175,1\n' +
        'DA:176,1\n' +
        'DA:177,1\n' +
        'DA:178,1\n' +
        'DA:179,1\n' +
        'DA:180,1\n' +
        'DA:181,1\n' +
        'DA:182,1\n' +
        'DA:183,1\n' +
        'DA:184,1\n' +
        'DA:185,1\n' +
        'DA:186,1\n' +
        'DA:187,1\n' +
        'DA:188,1\n' +
        'DA:189,1\n' +
        'DA:190,1\n' +
        'DA:191,1\n' +
        'DA:192,1\n' +
        'DA:193,1\n' +
        'DA:194,1\n' +
        'DA:195,1\n' +
        'DA:196,1\n' +
        'DA:197,1\n' +
        'DA:198,1\n' +
        'DA:199,1\n' +
        'DA:200,1\n' +
        'DA:201,1\n' +
        'DA:202,1\n' +
        'DA:203,1\n' +
        'DA:204,0\n' +
        'DA:205,1\n' +
        'DA:206,1\n' +
        'DA:207,1\n' +
        'DA:208,0\n' +
        'DA:209,1\n' +
        'DA:210,1\n' +
        'DA:211,1\n' +
        'DA:212,1\n' +
        'DA:213,1\n' +
        'DA:214,1\n' +
        'DA:215,1\n' +
        'DA:216,1\n' +
        'DA:217,1\n' +
        'DA:218,1\n' +
        'DA:219,1\n' +
        'DA:220,1\n' +
        'DA:221,1\n' +
        'DA:222,1\n' +
        'DA:223,1\n' +
        'DA:224,1\n' +
        'DA:225,1\n' +
        'DA:226,1\n' +
        'DA:227,1\n' +
        'DA:228,1\n' +
        'DA:229,1\n' +
        'DA:230,1\n' +
        'DA:231,1\n' +
        'DA:232,1\n' +
        'DA:233,1\n' +
        'DA:234,1\n' +
        'DA:235,1\n' +
        'DA:236,1\n' +
        'DA:237,1\n' +
        'DA:238,1\n' +
        'DA:239,1\n' +
        'DA:240,1\n' +
        'DA:241,1\n' +
        'DA:242,1\n' +
        'DA:243,1\n' +
        'DA:244,1\n' +
        'DA:245,1\n' +
        'DA:246,1\n' +
        'DA:247,1\n' +
        'DA:248,1\n' +
        'DA:249,1\n' +
        'DA:250,1\n' +
        'DA:251,1\n' +
        'DA:252,1\n' +
        'DA:253,1\n' +
        'DA:254,1\n' +
        'DA:255,1\n' +
        'DA:256,1\n' +
        'DA:257,1\n' +
        'DA:258,1\n' +
        'DA:259,1\n' +
        'DA:260,1\n' +
        'DA:261,1\n' +
        'DA:262,1\n' +
        'DA:263,1\n' +
        'DA:264,1\n' +
        'DA:265,1\n' +
        'DA:266,1\n' +
        'DA:267,1\n' +
        'DA:268,1\n' +
        'DA:269,1\n' +
        'DA:270,1\n' +
        'DA:271,1\n' +
        'DA:272,1\n' +
        'DA:273,1\n' +
        'DA:274,1\n' +
        'DA:275,1\n' +
        'DA:276,1\n' +
        'DA:277,1\n' +
        'DA:278,1\n' +
        'DA:279,1\n' +
        'DA:280,1\n' +
        'DA:281,1\n' +
        'DA:282,1\n' +
        'DA:283,1\n' +
        'DA:284,1\n' +
        'DA:285,1\n' +
        'DA:286,1\n' +
        'DA:287,1\n' +
        'DA:288,1\n' +
        'DA:289,1\n' +
        'DA:290,1\n' +
        'DA:291,1\n' +
        'DA:292,1\n' +
        'DA:293,1\n' +
        'DA:294,1\n' +
        'DA:295,1\n' +
        'DA:296,1\n' +
        'DA:297,1\n' +
        'DA:298,1\n' +
        'DA:299,1\n' +
        'DA:300,1\n' +
        'DA:301,1\n' +
        'DA:302,1\n' +
        'DA:303,1\n' +
        'DA:304,1\n' +
        'DA:305,1\n' +
        'DA:306,1\n' +
        'DA:307,1\n' +
        'DA:308,1\n' +
        'DA:309,1\n' +
        'DA:310,1\n' +
        'DA:311,1\n' +
        'DA:312,1\n' +
        'DA:313,1\n' +
        'DA:314,1\n' +
        'DA:315,1\n' +
        'DA:316,1\n' +
        'DA:317,1\n' +
        'DA:318,1\n' +
        'DA:319,1\n' +
        'DA:320,1\n' +
        'DA:321,1\n' +
        'DA:322,1\n' +
        'DA:323,1\n' +
        'DA:324,1\n' +
        'DA:325,1\n' +
        'DA:326,1\n' +
        'DA:327,1\n' +
        'DA:328,1\n' +
        'DA:329,1\n' +
        'DA:330,1\n' +
        'DA:331,1\n' +
        'DA:332,1\n' +
        'DA:333,1\n' +
        'DA:334,1\n' +
        'DA:335,1\n' +
        'DA:336,1\n' +
        'DA:337,1\n' +
        'DA:338,1\n' +
        'DA:339,1\n' +
        'DA:340,1\n' +
        'DA:341,1\n' +
        'DA:342,1\n' +
        'DA:343,1\n' +
        'DA:344,1\n' +
        'DA:345,1\n' +
        'DA:346,1\n' +
        'DA:347,1\n' +
        'DA:348,1\n' +
        'DA:349,1\n' +
        'DA:350,1\n' +
        'DA:351,1\n' +
        'DA:352,1\n' +
        'DA:353,1\n' +
        'DA:354,1\n' +
        'DA:355,1\n' +
        'DA:356,1\n' +
        'DA:357,1\n' +
        'DA:358,1\n' +
        'DA:359,1\n' +
        'DA:360,1\n' +
        'DA:361,1\n' +
        'DA:362,1\n' +
        'DA:363,1\n' +
        'DA:364,1\n' +
        'DA:365,1\n' +
        'DA:366,1\n' +
        'DA:367,1\n' +
        'DA:368,1\n' +
        'DA:369,1\n' +
        'DA:370,1\n' +
        'DA:371,1\n' +
        'DA:372,1\n' +
        'DA:373,1\n' +
        'DA:374,1\n' +
        'DA:375,1\n' +
        'DA:376,1\n' +
        'DA:377,1\n' +
        'DA:378,1\n' +
        'DA:379,1\n' +
        'DA:380,1\n' +
        'DA:381,1\n' +
        'DA:382,1\n' +
        'DA:383,1\n' +
        'DA:384,1\n' +
        'DA:385,1\n' +
        'DA:386,1\n' +
        'DA:387,1\n' +
        'DA:388,1\n' +
        'DA:389,1\n' +
        'DA:390,1\n' +
        'DA:391,1\n' +
        'DA:392,1\n' +
        'DA:393,1\n' +
        'DA:394,1\n' +
        'DA:395,1\n' +
        'DA:396,1\n' +
        'DA:397,1\n' +
        'DA:398,1\n' +
        'DA:399,1\n' +
        'DA:400,1\n' +
        'DA:401,1\n' +
        'DA:402,1\n' +
        'DA:403,1\n' +
        'DA:404,1\n' +
        'DA:405,1\n' +
        'DA:406,1\n' +
        'DA:407,1\n' +
        'DA:408,1\n' +
        'DA:409,1\n' +
        'DA:410,1\n' +
        'DA:411,1\n' +
        'DA:412,1\n' +
        'DA:413,1\n' +
        'DA:414,1\n' +
        'DA:415,1\n' +
        'DA:416,1\n' +
        'DA:417,1\n' +
        'DA:418,1\n' +
        'DA:419,1\n' +
        'DA:420,1\n' +
        'DA:421,1\n' +
        'DA:422,1\n' +
        'DA:423,1\n' +
        'DA:424,1\n' +
        'DA:425,1\n' +
        'DA:426,1\n' +
        'DA:427,1\n' +
        'DA:428,1\n' +
        'DA:429,1\n' +
        'DA:430,1\n' +
        'LH:427\n' +
        'LF:430\n' +
        'end_of_record\n',
      operator: 'strictEqual',
      diff: 'simple'
    }
```

</details>

---

Assisted-by: openai:gpt-5.5