### PR TITLE
test_runner: improve coverage failure diagnostics

### DIFF
--- a/lib/internal/test_runner/coverage.js
+++ b/lib/internal/test_runner/coverage.js
@@ -33,6 +33,7 @@ const { fileURLToPath, URL } = require('internal/url');
 const { kMappings, SourceMap } = require('internal/source_map/source_map');
 const {
   codes: {
+    ERR_OPERATION_FAILED,
     ERR_SOURCE_MAP_CORRUPT,
     ERR_SOURCE_MAP_MISSING_SOURCE,
   },
@@ -402,7 +403,7 @@ class TestCoverage {
         }
 
         const coverageFile = join(this.coverageDirectory, entry.name);
-        const coverage = JSONParse(readFileSync(coverageFile, 'utf8'));
+        const coverage = readCoverageFile(coverageFile);
         this.mergeCoverage(result, this.mapCoverageWithSourceMap(coverage));
       }
 
@@ -584,6 +585,24 @@ class TestCoverage {
 
     // This check filters out the node_modules/ directory, unless it is explicitly included.
     return StringPrototypeIncludes(url, '/node_modules/');
+  }
+}
+
+function readCoverageFile(coverageFile) {
+  const rawCoverage = readFileSync(coverageFile, 'utf8');
+
+  if (rawCoverage.length === 0) {
+    throw new ERR_OPERATION_FAILED(`coverage file is empty: ${coverageFile}`);
+  }
+
+  try {
+    return JSONParse(rawCoverage);
+  } catch (err) {
+    const error = new ERR_OPERATION_FAILED(
+      `failed to parse coverage file ${coverageFile}: ${err.message}`,
+    );
+    error.cause = err;
+    throw error;
   }
 }
 

--- a/test/parallel/test-runner-coverage.js
+++ b/test/parallel/test-runner-coverage.js
@@ -77,6 +77,22 @@ function getSpecCoverageFixtureReport() {
   return report;
 }
 
+function formatSpawnSyncResult(result) {
+  return [
+    `status: ${result.status}`,
+    `signal: ${result.signal}`,
+    `stdout:\n${result.stdout}`,
+    `stderr:\n${result.stderr}`,
+  ].join('\n');
+}
+
+function assertIncludesReport(result, report) {
+  assert(
+    result.stdout.toString().includes(report),
+    formatSpawnSyncResult(result),
+  );
+}
+
 test('test coverage report', async (t) => {
   await t.test('handles the inspector not being available', (t) => {
     if (process.features.inspector) {
@@ -111,7 +127,7 @@ test('test tap coverage reporter', skipIfNoInspector, async (t) => {
     const options = { env: { ...process.env, NODE_V8_COVERAGE: tmpdir.path } };
     const result = spawnSync(process.execPath, args, options);
     const report = getTapCoverageFixtureReport();
-    assert(result.stdout.toString().includes(report));
+    assertIncludesReport(result, report);
     assert.strictEqual(result.stderr.toString(), '');
     assert.strictEqual(result.status, 0);
     assert(findCoverageFileForPid(result.pid));
@@ -129,7 +145,7 @@ test('test tap coverage reporter', skipIfNoInspector, async (t) => {
     const result = spawnSync(process.execPath, args);
     const report = getTapCoverageFixtureReport();
 
-    assert(result.stdout.toString().includes(report));
+    assertIncludesReport(result, report);
     assert.strictEqual(result.stderr.toString(), '');
     assert.strictEqual(result.status, 0);
     assert(!findCoverageFileForPid(result.pid));
@@ -149,7 +165,7 @@ test('test spec coverage reporter', skipIfNoInspector, async (t) => {
     const result = spawnSync(process.execPath, args, options);
     const report = getSpecCoverageFixtureReport();
 
-    assert(result.stdout.toString().includes(report));
+    assertIncludesReport(result, report);
     assert.strictEqual(result.stderr.toString(), '');
     assert.strictEqual(result.status, 0);
     assert(findCoverageFileForPid(result.pid));
@@ -166,7 +182,7 @@ test('test spec coverage reporter', skipIfNoInspector, async (t) => {
     const result = spawnSync(process.execPath, args);
     const report = getSpecCoverageFixtureReport();
 
-    assert(result.stdout.toString().includes(report));
+    assertIncludesReport(result, report);
     assert.strictEqual(result.stderr.toString(), '');
     assert.strictEqual(result.status, 0);
     assert(!findCoverageFileForPid(result.pid));
@@ -187,7 +203,7 @@ test('single process coverage is the same with --test', skipIfNoInspector, () =>
   const report = getTapCoverageFixtureReport();
 
   assert.strictEqual(result.stderr.toString(), '');
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
   assert(!findCoverageFileForPid(result.pid));
 });
@@ -226,7 +242,7 @@ test('coverage is combined for multiple processes', skipIfNoInspector, () => {
   });
 
   assert.strictEqual(result.stderr.toString(), '');
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
 });
 
@@ -268,7 +284,7 @@ test.skip('coverage works with isolation=none', skipIfNoInspector, common.mustCa
   });
 
   assert.strictEqual(result.stderr.toString(), '');
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
 }, 0));
 
@@ -285,6 +301,7 @@ test('coverage reports on lines, functions, and branches', skipIfNoInspector, as
                           ]);
   assert.strictEqual(child.stderr.toString(), '');
   const stdout = child.stdout.toString();
+  assert.notStrictEqual(stdout, '', formatSpawnSyncResult(child));
   const coverage = JSON.parse(stdout);
 
   await t.test('does not include node_modules', () => {
@@ -366,7 +383,7 @@ test('coverage with ESM hook - source irrelevant', skipIfNoInspector, () => {
   const result = spawnSync(process.execPath, args, { cwd: fixture });
 
   assert.strictEqual(result.stderr.toString(), '');
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
 });
 
@@ -401,7 +418,7 @@ test('coverage with ESM hook - source transpiled', skipIfNoInspector, () => {
   const result = spawnSync(process.execPath, args, { cwd: fixture });
 
   assert.strictEqual(result.stderr.toString(), '');
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
 });
 
@@ -435,7 +452,7 @@ test('coverage with excluded files', skipIfNoInspector, () => {
     return report.replaceAll('/', '\\');
   }
 
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
   assert(!findCoverageFileForPid(result.pid));
 });
@@ -472,7 +489,7 @@ test('coverage with included files', skipIfNoInspector, () => {
     return report.replaceAll('/', '\\');
   }
 
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
   assert(!findCoverageFileForPid(result.pid));
 });
@@ -506,7 +523,7 @@ test('coverage with included and excluded files', skipIfNoInspector, () => {
     return report.replaceAll('/', '\\');
   }
 
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
   assert(!findCoverageFileForPid(result.pid));
 });
@@ -547,7 +564,7 @@ test('correctly prints the coverage report of files contained in parent director
   });
 
   assert.strictEqual(result.stderr.toString(), '');
-  assert(result.stdout.toString().includes(report));
+  assertIncludesReport(result, report);
   assert.strictEqual(result.status, 0);
 });
 
@@ -564,5 +581,5 @@ test('coverage with directory and file named "file"', skipIfNoInspector, () => {
 
   assert.strictEqual(result.stderr.toString(), '');
   assert.strictEqual(result.status, 0);
-  assert(result.stdout.toString().includes('start of coverage report'));
+  assertIncludesReport(result, 'start of coverage report');
 });


### PR DESCRIPTION
Improve diagnostics for flaky `parallel/test-runner-coverage` failures.

This changes coverage file parsing to include the specific V8 coverage file path
when JSON parsing fails, including a clearer message for empty coverage files.

It also updates `test/parallel/test-runner-coverage.js` so missing coverage
report assertions include the spawned child process status, signal, stdout, and
stderr. This should make future CI failures actionable instead of only showing
that `stdout.includes(report)` was false.

Refs: https://github.com/nodejs/reliability/issues?q=%22parallel%2Ftest-runner-coverage%22

<details>
<summary>Example</summary>

```
not ok 3920 parallel/test-runner-coverage
  ---
  duration_ms: 2735.17800
  severity: fail
  exitcode: 1
  stack: |-
    Test failure: 'coverage is reported and dumped to NODE_V8_COVERAGE if present'
    Location: test/parallel/test-runner-coverage.js:102:11
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:114:5)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.start (node:internal/test_runner/test:1242:17)
        at TestContext.test (node:internal/test_runner/test:394:20)
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:102:11)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage is reported without NODE_V8_COVERAGE present'
    Location: test/parallel/test-runner-coverage.js:120:11
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:132:5)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.start (node:internal/test_runner/test:1242:17)
        at TestContext.test (node:internal/test_runner/test:394:20)
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:120:11)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage is reported and dumped to NODE_V8_COVERAGE if present'
    Location: test/parallel/test-runner-coverage.js:140:11
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:152:5)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.start (node:internal/test_runner/test:1242:17)
        at TestContext.test (node:internal/test_runner/test:394:20)
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:140:11)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage is reported without NODE_V8_COVERAGE present'
    Location: test/parallel/test-runner-coverage.js:158:11
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:169:5)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.start (node:internal/test_runner/test:1242:17)
        at TestContext.test (node:internal/test_runner/test:394:20)
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:158:11)
        at async Test.run (node:internal/test_runner/test:1389:7)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'single process coverage is the same with --test'
    Location: test/parallel/test-runner-coverage.js:176:1
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:190:3)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage is combined for multiple processes'
    Location: test/parallel/test-runner-coverage.js:195:1
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:229:3)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage reports on lines, functions, and branches'
    Location: test/parallel/test-runner-coverage.js:275:1
    SyntaxError: Unexpected end of JSON input
        at JSON.parse (<anonymous>)
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:288:25)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7)
    
    Test failure: 'coverage with ESM hook - source irrelevant'
    Location: test/parallel/test-runner-coverage.js:336:1
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:369:3)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage with ESM hook - source transpiled'
    Location: test/parallel/test-runner-coverage.js:373:1
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:404:3)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage with excluded files'
    Location: test/parallel/test-runner-coverage.js:408:1
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:438:3)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage with included files'
    Location: test/parallel/test-runner-coverage.js:443:1
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:475:3)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage with included and excluded files'
    Location: test/parallel/test-runner-coverage.js:480:1
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:509:3)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'correctly prints the coverage report of files contained in parent directories'
    Location: test/parallel/test-runner-coverage.js:514:1
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(result.stdout.toString().includes(report))
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:550:3)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
    
    Test failure: 'coverage with directory and file named "file"'
    Location: test/parallel/test-runner-coverage.js:555:1
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    
    1 !== 0
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-coverage.js:566:10)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Test.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: 1,
      expected: 0,
      operator: 'strictEqual',
      diff: 'simple'
    }
```

</details>

---

Assisted-by: openai:gpt-5.5