### PR TITLE
test: fix flaky test-runner coverage threshold test

### DIFF
--- a/test/parallel/test-runner-run-coverage.mjs
+++ b/test/parallel/test-runner-run-coverage.mjs
@@ -154,10 +154,13 @@ describe('require(\'node:test\').run coverage settings', { concurrency: true }, 
       for await (const _ of stream);
     });
 
-    await it('should run with coverage and fail when below line threshold', async () => {
+    await it('should run with coverage and fail when below line threshold', async (t) => {
       const thresholdErrors = [];
       const originalExitCode = process.exitCode;
-      assert.notStrictEqual(originalExitCode, 1);
+      t.after(() => {
+        process.exitCode = originalExitCode;
+      });
+      process.exitCode = undefined;
       const stream = run({
         files,
         coverage: true,
@@ -178,7 +181,6 @@ describe('require(\'node:test\').run coverage settings', { concurrency: true }, 
       for await (const _ of stream);
       assert.deepStrictEqual(thresholdErrors.sort(), ['branch', 'function', 'line']);
       assert.strictEqual(process.exitCode, 1);
-      process.exitCode = originalExitCode;
     });
   });
 });


### PR DESCRIPTION
This fixes a flaky assertion in `parallel/test-runner-run-coverage.mjs`.

The threshold subtest was asserting that process.exitCode was not already
1 before starting its coverage run. That value is process-global, so it
can be affected by other run() coverage activity in the same process.

The test now clears process.exitCode before the threshold check and
restores the original value with a cleanup hook.

Refs: https://github.com/nodejs/reliability/issues?q=%22test-runner-run-coverage%22

<details>
<summary>Example</summary>

```console
not ok 3959 parallel/test-runner-run-coverage
  ---
  duration_ms: 710.47400
  severity: fail
  exitcode: 1
  stack: |-
    Test failure: 'should run with coverage and fail when below line threshold'
    Location: test/parallel/test-runner-run-coverage.mjs:157:11
    AssertionError [ERR_ASSERTION]: Expected "actual" to be strictly unequal to: 1
        at TestContext.<anonymous> (file:///home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-run-coverage.mjs:160:14)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Suite.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at process.processTicksAndRejections (node:internal/process/task_queues:104:5)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: 1,
      expected: 1,
      operator: 'notStrictEqual',
      diff: 'simple'
    }
```

</details>