### PR TITLE
test: use one-off agent in http consumed timeout test

### DIFF
--- a/test/parallel/test-http-server-consumed-timeout.js
+++ b/test/parallel/test-http-server-consumed-timeout.js
@@ -58,7 +58,8 @@ function runTest(timeoutDuration) {
   server.listen(0, common.mustCall(() => {
     const req = http.request({
       port: server.address().port,
-      method: 'POST'
+      method: 'POST',
+      agent: false,
     }, () => {
       let lastIntervalTimestamp = Date.now();
       const interval = setInterval(() => {


### PR DESCRIPTION
Fixes a flaky hang in `parallel/test-http-server-consumed-timeout`.

The test can retry with a larger timeout when timer intervals are delayed.
That retry is started from the `server.close()` callback, but the client
request could leave an idle keep-alive socket open. With the current default
server keep-alive timeout, `server.close()` can wait long enough for repeated
attempts to hit the test runner timeout.

This changes the client request to use `agent: false`, so the connection is
not pooled and `server.close()` can complete promptly.

Refs: https://github.com/nodejs/reliability/issues?q=%22test-http-server-consumed-timeout%22

<details>
<summary>Example</summary>

```console
not ok 2091 parallel/test-http-server-consumed-timeout
  ---
  duration_ms: 120051.76500
  severity: fail
  exitcode: -15
  stack: |-
    timeout
    Time between intervals: 234
    Trying w/ timeout of 468
```

</details>