### PR TITLE
test_runner: filter execArgv fallback for child tests

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -208,7 +208,7 @@ function getRunArgs(path, { forceExit,
   const nodeOptionsSet = new SafeSet(processNodeOptions);
   const unknownProcessExecArgv = ArrayPrototypeFilter(
     process.execArgv,
-    (arg) => !nodeOptionsSet.has(arg),
+    (arg, i, arr) => !nodeOptionsSet.has(arg) && filterExecArgv(arg, i, arr),
   );
   ArrayPrototypePushApply(runArgs, unknownProcessExecArgv);
 


### PR DESCRIPTION
Fixes flaky failures in `parallel/test-runner-flag-propagation`.

Apply the test runner propagation filter to `process.execArgv` entries that
are not reported by the options binding.

Some flags, such as config-file/test-runner flags, can reach the isolated
child test fallback path through `process.execArgv`. Without filtering that
path, flags like `--experimental-config-file` may leak into child tests and
re-enable options that should not propagate, including
`--experimental-test-coverage`.

This change keeps preserving V8-only flags such as `--allow-natives-syntax`,
while filtering test-runner control flags consistently across both
option-binding flags and fallback `execArgv` entries.

Refs: https://github.com/nodejs/reliability/issues?q=%22test-runner-flag-propagation%22

<details>
<summary>Example</summary>

```
not ok 3946 parallel/test-runner-flag-propagation
  ---
  duration_ms: 6171.58100
  severity: fail
  exitcode: 1
  stack: |-
    Test failure: 'should propagate --experimental-test-coverage from config file (test) to child tests'
    Location: test/parallel/test-runner-flag-propagation.js:94:7
    AssertionError [ERR_ASSERTION]: Config file propagation test failed for --experimental-test-coverage.
    
    1 !== 0
    
        at TestContext.<anonymous> (/home/iojs/build/workspace/node-test-commit-linux-containered/test/parallel/test-runner-flag-propagation.js:126:16)
        at Test.runInAsyncScope (node:async_hooks:226:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Suite.processPendingSubtests (node:internal/test_runner/test:960:18)
        at Test.postRun (node:internal/test_runner/test:1522:19)
        at Test.run (node:internal/test_runner/test:1447:12)
        at async Suite.processPendingSubtests (node:internal/test_runner/test:960:7) {
      generatedMessage: false,
      code: 'ERR_ASSERTION',
      actual: 1,
      expected: 0,
      operator: 'strictEqual',
      diff: 'simple'
    }
```

</details>

---

Assisted-by: openai:gpt-5.5