### PR TITLE
stream: reject iter consumers on abort

### DIFF
--- a/lib/internal/streams/iter/consumers.js
+++ b/lib/internal/streams/iter/consumers.js
@@ -48,6 +48,7 @@ const {
 
 const {
   concatBytes,
+  yieldAbortable,
 } = require('internal/streams/iter/utils');
 
 const {
@@ -121,7 +122,9 @@ async function collectAsync(source, signal, limit) {
   signal?.throwIfAborted();
 
   // Normalize source via from() - accepts strings, ArrayBuffers, protocols, etc.
-  const normalized = from(source);
+  const abortableSource = signal && isAsyncIterable(source) ?
+    yieldAbortable(source, signal) : source;
+  const normalized = from(abortableSource);
   const chunks = [];
 
   // Fast path: no signal and no limit
@@ -136,8 +139,9 @@ async function collectAsync(source, signal, limit) {
 
   // Slow path: with signal or limit checks
   let totalBytes = 0;
+  const iterable = signal ? yieldAbortable(normalized, signal) : normalized;
 
-  for await (const batch of normalized) {
+  for await (const batch of iterable) {
     signal?.throwIfAborted();
     for (let i = 0; i < batch.length; i++) {
       const chunk = batch[i];

--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -14,18 +14,11 @@ const {
   ArrayPrototypeSlice,
   PromisePrototypeThen,
   PromiseResolve,
-  PromiseWithResolvers,
-  SafePromisePrototypeFinally,
-  SafePromiseRace,
   SymbolAsyncIterator,
   SymbolIterator,
   TypedArrayPrototypeGetByteLength,
   Uint8Array,
 } = primordials;
-
-const {
-  markPromiseAsHandled,
-} = internalBinding('util');
 
 const {
   codes: {
@@ -60,6 +53,7 @@ const {
   parsePullArgs,
   toUint8Array,
   wrapError,
+  yieldAbortable,
 } = require('internal/streams/iter/utils');
 
 const {
@@ -688,81 +682,6 @@ async function* applyValidatedStatefulAsyncTransform(source, transform, options)
   // withFlushAsync wrapper there is no extra yield to give
   // the outer pipeline a chance to see the abort.
   options.signal?.throwIfAborted();
-}
-
-function getOnAbort(reject, signal) {
-  return () => reject(signal.reason);
-}
-
-/**
- * Read one item from an async iterator, rejecting early if the signal aborts.
- * @param {AsyncIterator} iterator - The iterator to read from.
- * @param {AbortSignal|undefined} signal - Optional abort signal.
- * @returns {Promise<IteratorResult<Uint8Array[]>>|IteratorResult<Uint8Array[]>}
- */
-function abortableNext(iterator, signal) {
-  if (signal === undefined) {
-    return iterator.next();
-  }
-
-  signal.throwIfAborted();
-
-  const next = iterator.next();
-  const { promise, reject } = PromiseWithResolvers();
-  const onAbort = getOnAbort(reject, signal);
-  signal.addEventListener('abort', onAbort, { __proto__: null, once: true });
-  if (signal.aborted) {
-    onAbort();
-  }
-
-  return SafePromisePrototypeFinally(SafePromiseRace([next, promise]), () => {
-    signal.removeEventListener('abort', onAbort);
-  });
-}
-
-/**
- * Wrap an async source so each pending read is abort-aware.
- * @param {AsyncIterable<Uint8Array[]>} source - The source to read from.
- * @param {AbortSignal|undefined} signal - Optional abort signal.
- * @returns {AsyncIterable<Uint8Array[]>}
- */
-function yieldAbortable(source, signal) {
-  if (signal === undefined) {
-    return source;
-  }
-
-  return {
-    __proto__: null,
-    async *[SymbolAsyncIterator]() {
-      const iterator = source[SymbolAsyncIterator]();
-      let completed = false;
-      let aborted = false;
-
-      try {
-        while (true) {
-          const { done, value } = await abortableNext(iterator, signal);
-          if (done) {
-            completed = true;
-            return;
-          }
-          signal.throwIfAborted();
-          yield value;
-        }
-      } catch (error) {
-        aborted = signal.aborted;
-        throw error;
-      } finally {
-        if (!completed && typeof iterator.return === 'function') {
-          const result = iterator.return();
-          if (aborted) {
-            markPromiseAsHandled(result);
-          } else {
-            await result;
-          }
-        }
-      }
-    },
-  };
 }
 
 /**

--- a/lib/internal/streams/iter/utils.js
+++ b/lib/internal/streams/iter/utils.js
@@ -8,13 +8,21 @@ const {
   MathMin,
   NumberMAX_SAFE_INTEGER,
   PromiseResolve,
+  PromiseWithResolvers,
+  SafePromisePrototypeFinally,
+  SafePromiseRace,
   String,
+  SymbolAsyncIterator,
   TypedArrayPrototypeGetBuffer,
   TypedArrayPrototypeGetByteLength,
   TypedArrayPrototypeGetByteOffset,
   TypedArrayPrototypeSet,
   Uint8Array,
 } = primordials;
+
+const {
+  markPromiseAsHandled,
+} = internalBinding('util');
 
 const { TextEncoder } = require('internal/encoding');
 const {
@@ -67,6 +75,81 @@ function onSignalAbort(signal, handler) {
   } else {
     signal.addEventListener('abort', handler, { __proto__: null, once: true });
   }
+}
+
+function getOnAbort(reject, signal) {
+  return () => reject(signal.reason);
+}
+
+/**
+ * Read one item from an async iterator, rejecting early if the signal aborts.
+ * @param {AsyncIterator} iterator - The iterator to read from.
+ * @param {AbortSignal|undefined} signal - Optional abort signal.
+ * @returns {Promise<IteratorResult<Uint8Array[]>>|IteratorResult<Uint8Array[]>}
+ */
+function abortableNext(iterator, signal) {
+  if (signal === undefined) {
+    return iterator.next();
+  }
+
+  signal.throwIfAborted();
+
+  const next = iterator.next();
+  const { promise, reject } = PromiseWithResolvers();
+  const onAbort = getOnAbort(reject, signal);
+  signal.addEventListener('abort', onAbort, { __proto__: null, once: true });
+  if (signal.aborted) {
+    onAbort();
+  }
+
+  return SafePromisePrototypeFinally(SafePromiseRace([next, promise]), () => {
+    signal.removeEventListener('abort', onAbort);
+  });
+}
+
+/**
+ * Wrap an async source so each pending read is abort-aware.
+ * @param {AsyncIterable<Uint8Array[]>} source - The source to read from.
+ * @param {AbortSignal|undefined} signal - Optional abort signal.
+ * @returns {AsyncIterable<Uint8Array[]>}
+ */
+function yieldAbortable(source, signal) {
+  if (signal === undefined) {
+    return source;
+  }
+
+  return {
+    __proto__: null,
+    async *[SymbolAsyncIterator]() {
+      const iterator = source[SymbolAsyncIterator]();
+      let completed = false;
+      let aborted = false;
+
+      try {
+        while (true) {
+          const { done, value } = await abortableNext(iterator, signal);
+          if (done) {
+            completed = true;
+            return;
+          }
+          signal.throwIfAborted();
+          yield value;
+        }
+      } catch (error) {
+        aborted = signal.aborted;
+        throw error;
+      } finally {
+        if (!completed && typeof iterator.return === 'function') {
+          const result = iterator.return();
+          if (aborted) {
+            markPromiseAsHandled(result);
+          } else {
+            await result;
+          }
+        }
+      }
+    },
+  };
 }
 
 /**
@@ -301,4 +384,5 @@ module.exports = {
   toUint8Array,
   validateBackpressure,
   wrapError,
+  yieldAbortable,
 };

--- a/test/parallel/test-stream-iter-consumers-bytes.js
+++ b/test/parallel/test-stream-iter-consumers-bytes.js
@@ -51,6 +51,30 @@ async function testBytesAsyncAbort() {
   );
 }
 
+async function testAsyncConsumersAbortPendingNext() {
+  const consumers = [
+    ['bytes', bytes],
+    ['text', text],
+    ['arrayBuffer', arrayBuffer],
+    ['array', array],
+  ];
+
+  for (const [name, consumer] of consumers) {
+    const ac = new AbortController();
+    const reason = new Error(`${name} boom`);
+
+    async function* never() {
+      await new Promise(() => {});
+      yield [];
+    }
+
+    const promise = consumer(never(), { __proto__: null, signal: ac.signal });
+    ac.abort(reason);
+
+    await assert.rejects(promise, reason);
+  }
+}
+
 async function testBytesEmpty() {
   const data = await bytes(from([]));
   assert.ok(data instanceof Uint8Array);
@@ -203,6 +227,7 @@ Promise.all([
   testBytesAsync(),
   testBytesAsyncLimit(),
   testBytesAsyncAbort(),
+  testAsyncConsumersAbortPendingNext(),
   testBytesEmpty(),
   testArrayBufferSyncBasic(),
   testArrayBufferAsync(),

--- a/test/parallel/test-stream-iter-consumers-bytes.js
+++ b/test/parallel/test-stream-iter-consumers-bytes.js
@@ -14,6 +14,7 @@ const {
   arrayBufferSync,
   array,
   arraySync,
+  toAsyncStreamable,
 } = require('stream/iter');
 
 // =============================================================================
@@ -69,6 +70,31 @@ async function testAsyncConsumersAbortPendingNext() {
     }
 
     const promise = consumer(never(), { __proto__: null, signal: ac.signal });
+    ac.abort(reason);
+
+    await assert.rejects(promise, reason);
+  }
+}
+
+async function testAsyncConsumersAbortPendingNormalization() {
+  const consumers = [
+    ['bytes', bytes],
+    ['text', text],
+    ['arrayBuffer', arrayBuffer],
+    ['array', array],
+  ];
+
+  for (const [name, consumer] of consumers) {
+    const ac = new AbortController();
+    const reason = new Error(`${name} normalization boom`);
+    const source = {
+      __proto__: null,
+      [toAsyncStreamable]() {
+        return new Promise(() => {});
+      },
+    };
+
+    const promise = consumer(source, { __proto__: null, signal: ac.signal });
     ac.abort(reason);
 
     await assert.rejects(promise, reason);
@@ -228,6 +254,7 @@ Promise.all([
   testBytesAsyncLimit(),
   testBytesAsyncAbort(),
   testAsyncConsumersAbortPendingNext(),
+  testAsyncConsumersAbortPendingNormalization(),
   testBytesEmpty(),
   testArrayBufferSyncBasic(),
   testArrayBufferAsync(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64065

This updates `node:stream/iter` async consumers to reject promptly when
their abort signal fires while an async iterator read is pending.

Previously, `bytes()`, `text()`, `arrayBuffer()`, and `array()` only checked
the signal before and after receiving a batch. If the source was stuck in a
pending `next()`, aborting the signal did not settle the consumer promise.

The change reuses the abort-aware iterator wrapper from the pull pipeline by
moving it into shared stream/iter utils, then applies it in consumers before
normalization and while consuming the normalized source.

---

Assisted-by: openai:gpt-5.5