### PR TITLE
tools: validate version number in release proposal commit message lint

### DIFF
--- a/.github/workflows/lint-release-proposal.yml
+++ b/.github/workflows/lint-release-proposal.yml
@@ -28,13 +28,24 @@ jobs:
           persist-credentials: false
           fetch-depth: 2
       - name: Lint release commit title format
+        id: commit-message-parse
         run: |
-          EXPECTED_TITLE='^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}, Version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ (\(Current|'.+' \(LTS)\)$'
+          VERSION=$(${CXX:-cc} -E -dM src/node_version.h | awk '
+            $2 == "NODE_MAJOR_VERSION"  { maj = $3 }
+            $2 == "NODE_MINOR_VERSION"  { min = $3 }
+            $2 == "NODE_PATCH_VERSION"  { pat = $3 }
+            $2 == "NODE_VERSION_LTS_CODENAME" { gsub(/^"|"$/, "'"'"'",$3); lts = $3 }
+            END { if (maj) print maj "\\." min "\\." pat " " (lts != "'"''"'" ? lts " \\(LTS" : "\\(Current" ) "\\)" }
+          ')
+          MAJOR=${VERSION%%\\.*}
+          EXPECTED_TITLE='^[[:digit:]]{4}-[[:digit:]]{2}-[[:digit:]]{2}, Version '"$VERSION"'$'
           echo "Expected commit title format: $EXPECTED_TITLE"
           COMMIT_SUBJECT="$(git --no-pager log -1 --format=%s)"
-          echo "Actual: $ACTUAL"
+          echo "Actual: $COMMIT_SUBJECT"
           echo "$COMMIT_SUBJECT" | grep -q -E "$EXPECTED_TITLE"
-          echo "COMMIT_SUBJECT=$COMMIT_SUBJECT" >> "$GITHUB_ENV"
+
+          echo "COMMIT_SUBJECT=$COMMIT_SUBJECT" >> "$GITHUB_OUTPUT"
+          echo "MAJOR=$MAJOR" >> "$GITHUB_OUTPUT"
       - name: Lint release commit message trailers
         run: |
           EXPECTED_TRAILER="^$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/pull/[[:digit:]]+\$"
@@ -54,8 +65,6 @@ jobs:
           SKIP_XZ=1 make release-only
       - name: Lint release commit content
         run: |
-          MAJOR="$(awk '/^#define NODE_MAJOR_VERSION / { print $3 }' src/node_version.h)"
-
           echo "Checking for expected files in the release commit:"
           missing_expected=
           for expected in CHANGELOG.md src/node_version.h doc/changelogs/; do
@@ -81,7 +90,6 @@ jobs:
         run: |
           EXPECTED_CHANGELOG_TITLE_INTRO="## $COMMIT_SUBJECT, @"
           echo "Expected CHANGELOG section title: $EXPECTED_CHANGELOG_TITLE_INTRO"
-          MAJOR="$(awk '/^#define NODE_MAJOR_VERSION / { print $3 }' src/node_version.h)"
           CHANGELOG_PATH="doc/changelogs/CHANGELOG_V${MAJOR}.md"
           CHANGELOG_TITLE="$(grep "$EXPECTED_CHANGELOG_TITLE_INTRO" "$CHANGELOG_PATH")"
           echo "Actual: $CHANGELOG_TITLE"
@@ -106,4 +114,6 @@ jobs:
           done
         shell: bash  # See https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#exit-codes-and-error-action-preference, we want the pipefail option.
         env:
+          COMMIT_SUBJECT: ${{ steps.commit-message-parse.outputs.COMMIT_SUBJECT }}
+          MAJOR: ${{ steps.commit-message-parse.outputs.MAJOR }}
           GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
So the linter can catch things like https://github.com/nodejs/node/pull/64062#discussion_r3453112446



<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
