### PR TITLE
repl: add experimental TypeScript support

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1393,9 +1393,8 @@ added: REPLACEME
 
 > Stability: 1.0 - Early development
 
-Enable experimental support for TypeScript stripping in the REPL. Input that is
-valid JavaScript is evaluated as JavaScript before falling back to TypeScript
-type stripping.
+Enable experimental support for TypeScript stripping in the REPL. When enabled, REPL
+input must be valid TypeScript to be executed.
 
 ### `--experimental-sea-config`
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3856,8 +3856,8 @@ one is included in the list below.
 * `--experimental-package-map`
 * `--experimental-print-required-tla`
 * `--experimental-quic`
-* `--experimental-require-module`
 * `--experimental-repl-typescript`
+* `--experimental-require-module`
 * `--experimental-shadow-realm`
 * `--experimental-specifier-resolution`
 * `--experimental-stream-iter`

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1385,6 +1385,18 @@ added:
 
 Enable experimental support for the QUIC protocol.
 
+### `--experimental-repl-typescript`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+> Stability: 1.0 - Early development
+
+Enable experimental support for TypeScript stripping in the REPL. Input that is
+valid JavaScript is evaluated as JavaScript before falling back to TypeScript
+type stripping.
+
 ### `--experimental-sea-config`
 
 <!-- YAML

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -3857,6 +3857,7 @@ one is included in the list below.
 * `--experimental-print-required-tla`
 * `--experimental-quic`
 * `--experimental-require-module`
+* `--experimental-repl-typescript`
 * `--experimental-shadow-realm`
 * `--experimental-specifier-resolution`
 * `--experimental-stream-iter`

--- a/doc/node.1
+++ b/doc/node.1
@@ -778,6 +778,11 @@ this flag allows Node.js to locate and print their locations.
 .It Fl -experimental-quic
 Enable experimental support for the QUIC protocol.
 .
+.It Fl -experimental-repl-typescript
+Enable experimental support for TypeScript stripping in the REPL. Input that is
+valid JavaScript is evaluated as JavaScript before falling back to TypeScript
+type stripping.
+.
 .It Fl -experimental-sea-config
 Use this flag to generate a blob that can be injected into the Node.js
 binary to produce a single executable application. See the documentation

--- a/doc/node.1
+++ b/doc/node.1
@@ -1989,6 +1989,8 @@ one is included in the list below.
 .It
 \fB--experimental-quic\fR
 .It
+\fB--experimental-repl-typescript\fR
+.It
 \fB--experimental-require-module\fR
 .It
 \fB--experimental-shadow-realm\fR

--- a/lib/internal/repl/eval.js
+++ b/lib/internal/repl/eval.js
@@ -27,12 +27,15 @@ const {
   transformModuleSyntax,
 } = require('internal/repl/transform');
 const { getReplInspector, prepareContext } = require('internal/repl/inspector');
+const { getOptionValue } = require('internal/options');
 
 let debug = require('internal/util/debuglog').debuglog('repl', (fn) => {
   debug = fn;
 });
 
 const blankRegExp = /^\s*$/;
+const experimentalREPLTypeScript =
+  getOptionValue('--experimental-repl-typescript');
 
 // Matches the first stack frame that belongs to the REPL
 const internalFrameRegExp =
@@ -119,11 +122,28 @@ function createReplEval(repl) {
     installDynamicImport(context);
     prepareContext(context);
 
+    let code = rawCode;
+    const valid = isValidSyntax(code);
+
+    if (!valid && experimentalREPLTypeScript) {
+      try {
+        const { stripTypeScriptModuleTypes } =
+          require('internal/modules/typescript');
+        code = stripTypeScriptModuleTypes(code, file);
+      } catch (err) {
+        if (err.code !== 'ERR_INVALID_TYPESCRIPT_SYNTAX' &&
+            err.code !== 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX') {
+          throw err;
+        }
+        // Let the evaluator report the original JavaScript syntax error. It
+        // also determines whether incomplete input is recoverable.
+      }
+    }
+
     // Wrap bare object literals so `{ a: 1 }` is evaluated as an expression
     // rather than a block statement.
-    let code = rawCode;
-    if (isObjectLiteral(code) && isValidSyntax(code)) {
-      code = `(${StringPrototypeTrim(rawCode)})\n`;
+    if (valid && isObjectLiteral(code)) {
+      code = `(${StringPrototypeTrim(code)})\n`;
     }
 
     // Rewrite ES module syntax into runnable script form.

--- a/lib/internal/repl/eval.js
+++ b/lib/internal/repl/eval.js
@@ -123,9 +123,8 @@ function createReplEval(repl) {
     prepareContext(context);
 
     let code = rawCode;
-    const valid = isValidSyntax(code);
 
-    if (!valid && experimentalREPLTypeScript) {
+    if (experimentalREPLTypeScript) {
       try {
         const { stripTypeScriptModuleTypes } =
           require('internal/modules/typescript');
@@ -142,7 +141,7 @@ function createReplEval(repl) {
 
     // Wrap bare object literals so `{ a: 1 }` is evaluated as an expression
     // rather than a block statement.
-    if (valid && isObjectLiteral(code)) {
+    if (isObjectLiteral(code) && isValidSyntax(code)) {
       code = `(${StringPrototypeTrim(code)})\n`;
     }
 

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -730,6 +730,10 @@ EnvironmentOptionsParser::EnvironmentOptionsParser() {
             kAllowedInEnvvar,
             false,
             OptionNamespaces::kPermissionNamespace);
+  AddOption("--experimental-repl-typescript",
+            "experimental TypeScript support in the REPL",
+            &EnvironmentOptions::experimental_repl_typescript,
+            kAllowedInEnvvar);
   AddOption("--experimental-vm-modules",
             "experimental ES Module support in vm module",
             &EnvironmentOptions::experimental_vm_modules,

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -154,6 +154,7 @@ class EnvironmentOptions : public Options {
   bool allow_wasi = false;
   bool allow_ffi = false;
   bool allow_worker_threads = false;
+  bool experimental_repl_typescript = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_vm_modules = EXPERIMENTALS_DEFAULT_VALUE;
   bool async_context_frame = true;
   bool expose_internals = false;

--- a/test/parallel/test-repl-typescript.mjs
+++ b/test/parallel/test-repl-typescript.mjs
@@ -1,0 +1,25 @@
+// Flags: --experimental-repl-typescript
+
+import * as common from '../common/index.mjs';
+import assert from 'node:assert';
+import { startNewREPLServer } from '../common/repl.js';
+
+common.skipIfInspectorDisabled();
+
+const { run, output } = startNewREPLServer({
+  terminal: false,
+  prompt: '> ',
+});
+
+await run('let x: number = 3\n');
+assert.match(output.accumulator, /undefined\n> /);
+output.accumulator = '';
+
+await run('x\n');
+assert.match(output.accumulator, /3\n> /);
+output.accumulator = '';
+
+// Syntax which is valid in both languages must retain its JavaScript
+// semantics instead of being type-stripped.
+await run("const foo = () => 'hello world'; foo<Object>(0);\n");
+assert.match(output.accumulator, /false\n> /);

--- a/test/parallel/test-repl-typescript.mjs
+++ b/test/parallel/test-repl-typescript.mjs
@@ -22,4 +22,4 @@ output.accumulator = '';
 // Syntax which is valid in both languages must retain its JavaScript
 // semantics instead of being type-stripped.
 await run("const foo = () => 'hello world'; foo<Object>(0);\n");
-assert.match(output.accumulator, /false\n> /);
+assert.match(output.accumulator, /true\n> /);

--- a/test/parallel/test-repl-typescript.mjs
+++ b/test/parallel/test-repl-typescript.mjs
@@ -18,8 +18,3 @@ output.accumulator = '';
 await run('x\n');
 assert.match(output.accumulator, /3\n> /);
 output.accumulator = '';
-
-// Syntax which is valid in both languages must retain its JavaScript
-// semantics instead of being type-stripped.
-await run("const foo = () => 'hello world'; foo<Object>(0);\n");
-assert.match(output.accumulator, /true\n> /);


### PR DESCRIPTION
Adds experimental TypeScript support to the REPL, opt-in-able via the `--experimental-repl-typescript` flag.