### PR TITLE
test: fix watch cwd argv test flake

### DIFF
--- a/test/test-runner/test-run-watch-cwd-isolation-none-argv.mjs
+++ b/test/test-runner/test-run-watch-cwd-isolation-none-argv.mjs
@@ -2,7 +2,7 @@
 // parent process argv when spawning the watch child.
 import * as common from '../common/index.mjs';
 import assert from 'node:assert';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { run } from 'node:test';
 import tmpdir from '../common/tmpdir.js';
@@ -11,8 +11,10 @@ import { skipIfNoWatch } from '../common/watch.js';
 skipIfNoWatch();
 tmpdir.refresh();
 
+const watchedDir = join(tmpdir.path, 'watched');
 const marker = join(tmpdir.path, 'marker');
-writeFileSync(join(tmpdir.path, 'test.js'), `
+mkdirSync(watchedDir);
+writeFileSync(join(watchedDir, 'test.js'), `
 const test = require('node:test');
 const { writeFileSync } = require('node:fs');
 
@@ -23,7 +25,7 @@ test('test ran from cwd', () => {
 
 const controller = new AbortController();
 const stream = run({
-  cwd: tmpdir.path,
+  cwd: watchedDir,
   watch: true,
   signal: controller.signal,
   isolation: 'none',


### PR DESCRIPTION
This fixes a flaky watch mode test by keeping the marker file outside the
watched cwd.

The test runs `run({ watch: true, cwd, isolation: 'none' })` without explicit
files, so the runner watches the whole cwd. On Linux, writing the marker file
inside that cwd can trigger a watch restart before the test aborts the stream,
causing a second `test:pass` event.

The marker is now written in the parent tmpdir while the test file lives in a
dedicated watched subdirectory.

Refs: https://github.com/nodejs/reliability/issues?q=%22test-run-watch-cwd-isolation-none-argv%22

<details>
<summary>Example</summary>

```console
not ok 5145 test-runner/test-run-watch-cwd-isolation-none-argv
  ---
  duration_ms: 866.79500
  severity: fail
  exitcode: 1
  stack: |-
    Mismatched noop function calls. Expected exactly 1, actual 2.
        at Module.mustCall (/home/iojs/build/workspace/node-test-commit-linuxone/test/common/index.js:468:10)
        at file:///home/iojs/build/workspace/node-test-commit-linuxone/test/test-runner/test-run-watch-cwd-isolation-none-argv.mjs:39:31
        at ModuleJob.run (node:internal/modules/esm/module_job:447:25)
        at async node:internal/modules/esm/loader:646:26
        at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5)
```

</details>

---

Assisted-by: openai:gpt-5.5