### PR TITLE
test: keep finalization close fixture ref alive

### DIFF
--- a/test/fixtures/process/close.mjs
+++ b/test/fixtures/process/close.mjs
@@ -1,7 +1,9 @@
 import { strictEqual } from 'assert'
 
+let obj
+
 function setup() {
-  const obj = { foo: 'bar' }
+  obj = { foo: 'bar' }
   process.finalization.register(obj, shutdown)
 }
 
@@ -14,5 +16,6 @@ function shutdown(obj) {
 setup()
 
 process.on('exit', function () {
+  strictEqual(obj.foo, 'bar')
   strictEqual(shutdownCalled, true)
 })


### PR DESCRIPTION
Follow-up to https://github.com/nodejs/node/pull/63209

Fixes a flaky `parallel/test-process-finalization` failure on win11-arm64.

The `close.mjs` fixture registered an object created inside `setup()` and then
expected the finalization callback to run during `exit`. Since
`process.finalization.register()` keeps only a weak reference, V8 can collect
that object after `setup()` returns. When that happens, the callback is not run
and the fixture fails with `shutdownCalled === false`.

Keep a strong reference to the object until the `exit` assertion so the test
covers the intended behavior deterministically.

Refs: https://github.com/nodejs/reliability/issues?q=%22test-process-finalization%22

<details>
<summary>Example</summary>

```
not ok 825 parallel/test-process-finalization
  ---
  duration_ms: 2270.99300
  severity: fail
  exitcode: 1
  stack: |-
    Test failure: 'should exit file close.mjs with code=0'
    Location: test\parallel\test-process-finalization.mjs:18:3
    Error: - process terminated with status 1, expected 0
        at TestContext.<anonymous> (file:///d:/workspace/node-test-binary-windows-js-suites/node/test/parallel/test-process-finalization.mjs:19:5)
        at Test.runInAsyncScope (node:async_hooks:227:14)
        at Test.run (node:internal/test_runner/test:1382:25)
        at Test.start (node:internal/test_runner/test:1242:17)
        at startSubtestAfterBootstrap (node:internal/test_runner/harness:387:17) {
      options: {
        cwd: 'd:\\workspace\\node-test-binary-windows-js-suites\\node\\test\\fixtures\\process'
      },
      command: 'd:\\workspace\\node-test-binary-windows-js-suites\\node\\Release\\node.exe --expose-gc close.mjs'
    }
    
    [process 4800]: --- stderr ---
    (node:4800) ExperimentalWarning: process.finalization.register is an experimental feature and might change at any time
    (Use `node --trace-warnings ...` to show where the warning was created)
    node:internal/assert/utils:146
      throw error;
      ^
    
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    
    false !== true
    
        at process.<anonymous> (file:///d:/workspace/node-test-binary-windows-js-suites/node/test/fixtures/process/close.mjs:17:3)
        at process.emit (node:events:509:20) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: 'strictEqual',
      diff: 'simple'
    }
    
    Node.js v27.0.0-pre
    
    [process 4800]: --- stdout ---
    
    [process 4800]: status = 1, signal = null
    (node:296) ExperimentalWarning: process.finalization.register is an experimental feature and might change at any time
    (Use `node --trace-warnings ...` to show where the warning was created)
    (node:296) ExperimentalWarning: process.finalization.registerBeforeExit is an experimental feature and might change at any time
```

</details>

---

Assisted-by: openai:gpt-5.5