### PR TITLE
benchmark: add test-only and mock timers cases

### DIFF
--- a/benchmark/test_runner/mock-timers.js
+++ b/benchmark/test_runner/mock-timers.js
@@ -6,7 +6,7 @@ const { test } = require('node:test');
 const nodeTimersPromises = require('node:timers/promises');
 
 const bench = common.createBenchmark(main, {
-  n: [1, 10, 100, 1000],
+  n: [1000],
   mode: [
     'enable-empty-apis',
     'enable-setTimeout',

--- a/benchmark/test_runner/mock-timers.js
+++ b/benchmark/test_runner/mock-timers.js
@@ -1,0 +1,262 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('node:assert');
+const { test } = require('node:test');
+const nodeTimersPromises = require('node:timers/promises');
+
+const bench = common.createBenchmark(main, {
+  n: [1, 10, 100, 1000],
+  mode: [
+    'enable-empty-apis',
+    'enable-setTimeout',
+    'enable-setInterval',
+    'enable-setImmediate',
+    'enable-Date',
+    'enable-scheduler.wait',
+    'enable-AbortSignal.timeout',
+    'enable-all',
+    'enable-default',
+    'setTimeout',
+    'setInterval',
+    'setImmediate',
+    'scheduler.wait',
+    'AbortSignal.timeout',
+    'Date',
+    'setTime',
+    'runAll',
+  ],
+}, {
+  // We don't want to test the reporter here.
+  flags: ['--test-reporter=./benchmark/fixtures/empty-test-reporter.js'],
+});
+
+function benchmarkEnable(n, mode) {
+  const enableMode = mode.replace('enable-', '');
+  let enableOptions = { apis: [enableMode] };
+
+  if (enableMode === 'all') {
+    enableOptions.apis = ['setTimeout', 'setInterval', 'setImmediate', 'Date', 'scheduler.wait', 'AbortSignal.timeout'];
+  }
+
+  if (enableMode === 'empty-apis') {
+    enableOptions.apis = [];
+  }
+
+  if (enableMode === 'default') {
+    enableOptions = undefined;
+  }
+
+  test((t) => {
+    bench.start();
+
+    for (let i = 0; i < n; i++) {
+      t.mock.timers.enable(enableOptions);
+      t.mock.timers.reset();
+    }
+
+    bench.end(n);
+  });
+}
+
+function benchmarkSetTimeout(n) {
+  test((t) => {
+    let noDead;
+
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    bench.start();
+
+    for (let i = 0; i < n; i++) {
+      setTimeout(() => {
+        noDead = i;
+      }, i + 1);
+    }
+
+    t.mock.timers.tick(n + 1);
+    bench.end(n);
+
+    assert.strictEqual(noDead, n - 1);
+  });
+}
+
+function benchmarkSetInterval(n) {
+  test((t) => {
+    let noDead = 0;
+
+    t.mock.timers.enable({ apis: ['setInterval'] });
+
+    setInterval(() => {
+      noDead++;
+    }, 1);
+
+    bench.start();
+
+    t.mock.timers.tick(n);
+
+    bench.end(n);
+
+    assert.strictEqual(noDead, n);
+  });
+}
+
+function benchmarkSetImmediate(n) {
+  test((t) => {
+    let noDead;
+
+    t.mock.timers.enable({ apis: ['setImmediate'] });
+
+    bench.start();
+
+    for (let i = 0; i < n; i++) {
+      setImmediate(() => {
+        noDead = i;
+      });
+    }
+
+    t.mock.timers.tick(0);
+    bench.end(n);
+
+    assert.strictEqual(noDead, n - 1);
+  });
+}
+
+function benchmarkSchedulerWait(n) {
+  test(async (t) => {
+    const promises = [];
+    let noDead;
+
+    t.mock.timers.enable({ apis: ['scheduler.wait'] });
+
+    bench.start();
+
+    for (let i = 0; i < n; i++) {
+      promises.push(nodeTimersPromises.scheduler.wait(i + 1).then(() => {
+        noDead = i;
+      }));
+    }
+
+    t.mock.timers.tick(n + 1);
+    await Promise.all(promises);
+    bench.end(n);
+
+    assert.strictEqual(noDead, n - 1);
+  });
+}
+
+function benchmarkAbortSignalTimeout(n) {
+  test((t) => {
+    let noDead;
+
+    t.mock.timers.enable({ apis: ['AbortSignal.timeout'] });
+
+    bench.start();
+
+    for (let i = 0; i < n; i++) {
+      noDead = AbortSignal.timeout(i + 1);
+    }
+
+    t.mock.timers.tick(n + 1);
+    bench.end(n);
+
+    assert.strictEqual(noDead.aborted, true);
+  });
+}
+
+function benchmarkDate(n) {
+  test((t) => {
+    let noDead;
+
+    t.mock.timers.enable({ apis: ['Date'] });
+
+    bench.start();
+
+    for (let i = 0; i < n; i++) {
+      noDead = Date.now();
+    }
+
+    bench.end(n);
+
+    assert.strictEqual(noDead, 0);
+  });
+}
+
+function benchmarkSetTime(n) {
+  test((t) => {
+    let noDead;
+
+    t.mock.timers.enable({ apis: ['Date'] });
+
+    bench.start();
+
+    for (let i = 0; i < n; i++) {
+      t.mock.timers.setTime(i);
+      noDead = Date.now();
+    }
+
+    bench.end(n);
+
+    assert.strictEqual(noDead, n - 1);
+  });
+}
+
+function benchmarkRunAll(n) {
+  test((t) => {
+    let noDead = 0;
+
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+
+    for (let i = 0; i < n; i++) {
+      setTimeout(() => {
+        noDead++;
+      }, i + 1);
+    }
+
+    bench.start();
+
+    t.mock.timers.runAll();
+
+    bench.end(n);
+
+    assert.strictEqual(noDead, n);
+  });
+}
+
+function main({ n, mode }) {
+  switch (mode) {
+    case 'enable-empty-apis':
+    case 'enable-setTimeout':
+    case 'enable-setInterval':
+    case 'enable-setImmediate':
+    case 'enable-Date':
+    case 'enable-scheduler.wait':
+    case 'enable-AbortSignal.timeout':
+    case 'enable-all':
+    case 'enable-default':
+      benchmarkEnable(n, mode);
+      break;
+    case 'setTimeout':
+      benchmarkSetTimeout(n);
+      break;
+    case 'setInterval':
+      benchmarkSetInterval(n);
+      break;
+    case 'setImmediate':
+      benchmarkSetImmediate(n);
+      break;
+    case 'scheduler.wait':
+      benchmarkSchedulerWait(n);
+      break;
+    case 'AbortSignal.timeout':
+      benchmarkAbortSignalTimeout(n);
+      break;
+    case 'Date':
+      benchmarkDate(n);
+      break;
+    case 'setTime':
+      benchmarkSetTime(n);
+      break;
+    case 'runAll':
+      benchmarkRunAll(n);
+      break;
+  }
+}

--- a/benchmark/test_runner/test-only.js
+++ b/benchmark/test_runner/test-only.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const common = require('../common');
+const { finished } = require('node:stream/promises');
+const reporter = require('../fixtures/empty-test-reporter');
+const { test } = require('node:test');
+
+const bench = common.createBenchmark(main, {
+  n: [1, 10, 100, 1000],
+  selected: [1],
+}, {
+  // We don't want to test the reporter here.
+  flags: [
+    '--test-reporter=./benchmark/fixtures/empty-test-reporter.js',
+    '--test-only',
+  ],
+});
+
+async function run({ n, selected }) {
+  // eslint-disable-next-line no-unused-vars
+  let avoidV8Optimization;
+
+  for (let i = 0; i < selected; i++) {
+    test(`selected-${i}`, { only: true }, () => {
+      avoidV8Optimization = i;
+    });
+  }
+
+  for (let i = 0; i < n; i++) {
+    test(`not-selected-${i}`, () => {
+      throw new Error(`This test ${i} should not run.`);
+    });
+  }
+
+  return finished(reporter);
+}
+
+function main(params) {
+  bench.start();
+
+  run(params).then(() => {
+    bench.end(params.n);
+  });
+}

--- a/benchmark/test_runner/test-only.js
+++ b/benchmark/test_runner/test-only.js
@@ -6,7 +6,7 @@ const reporter = require('../fixtures/empty-test-reporter');
 const { test } = require('node:test');
 
 const bench = common.createBenchmark(main, {
-  n: [1, 10, 100, 1000],
+  n: [10000],
   selected: [1],
 }, {
   // We don't want to test the reporter here.

--- a/benchmark/test_runner/test-only.js
+++ b/benchmark/test_runner/test-only.js
@@ -17,13 +17,8 @@ const bench = common.createBenchmark(main, {
 });
 
 async function run({ n, selected }) {
-  // eslint-disable-next-line no-unused-vars
-  let avoidV8Optimization;
-
   for (let i = 0; i < selected; i++) {
-    test(`selected-${i}`, { only: true }, () => {
-      avoidV8Optimization = i;
-    });
+    test(`selected-${i}`, { only: true }, () => {});
   }
 
   for (let i = 0; i < n; i++) {


### PR DESCRIPTION
Adds another small set of `node:test` benchmarks for areas listed in https://github.com/nodejs/node/issues/55723.
A continuation of the work I started in #63754 
This is a different PR because it brings a different set of attention points, and to keep both PR easy to review.

This PR covers:

* `only` mode with `--test-only`
* `mock.timers.enable()`
* mocked `setTimeout`
* mocked `setInterval`
* mocked `setImmediate`
* mocked `scheduler.wait`
* mocked `AbortSignal.timeout`
* mocked `Date.now()`
* `mock.timers.setTime()`
* `mock.timers.runAll()`

## Notes
1. enable-* test the `enable()` + `reset()` instead of just enable. This happens because an error is thrown if enable is called multiple times without reset.
2. The `scheduler.wait` mode includes the final `Promise.all()` inside the measured section. My evaluation was that it was more appropriate to do so than not, since the scheduled waits are promise-based, but I am happy to adjust the structure if reviewers prefer a narrower measure.

## Issue found while writing this
TLDR: I found an issue (that doesn't affect this PR) with using `setImmediate` and `runAll` together while writing the benchmark; guidance welcome;

While writing the benchmark, I found that `setImmediate` doesn't work with `runAll()`. The mocked setImmediate is scheduled with a special `-1` time so it runs before zero-delay timers. `runAll()` computes `longestTimer.runAt - this.#now` in `mock_timers.js:816`, which becomes `-1`, and `tick()` rejects negative time in mock_timers.js:556. 

I would love to open a new PR to fix this issue, but this is beyond my context of how the team working on this operates and what they think would be an appropriate fix. If the person reviewing the PR could provide some guidance on the best way to handle this issue, it would be much appreciated. 

This issue doesn't impact this PR, all benchmarks still work with the current code (With tick(0) instead of runAll() for setImmediate).