### PR TITLE
deps: v8: Make Promise resolvers not keep resolved Promises alive

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -40,7 +40,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.22',
+    'v8_embedder_string': '-node.23',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -40,7 +40,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.23',
+    'v8_embedder_string': '-node.24',
 
     ##### V8 defaults for Node.js #####
 

--- a/common.gypi
+++ b/common.gypi
@@ -40,7 +40,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.21',
+    'v8_embedder_string': '-node.22',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-promise.h
+++ b/deps/v8/include/v8-promise.h
@@ -158,8 +158,10 @@ using PromiseHook = void (*)(PromiseHookType type, Local<Promise> promise,
 enum PromiseRejectEvent {
   kPromiseRejectWithNoHandler = 0,
   kPromiseHandlerAddedAfterReject = 1,
-  kPromiseRejectAfterResolved = 2,
-  kPromiseResolveAfterResolved = 3,
+  kPromiseRejectAfterResolved V8_DEPRECATED("These events are being removed") =
+      2,
+  kPromiseResolveAfterResolved V8_DEPRECATED("These events are being removed") =
+      3,
 };
 
 class PromiseRejectMessage {

--- a/deps/v8/include/v8-promise.h
+++ b/deps/v8/include/v8-promise.h
@@ -158,10 +158,8 @@ using PromiseHook = void (*)(PromiseHookType type, Local<Promise> promise,
 enum PromiseRejectEvent {
   kPromiseRejectWithNoHandler = 0,
   kPromiseHandlerAddedAfterReject = 1,
-  kPromiseRejectAfterResolved V8_DEPRECATED("These events are being removed") =
-      2,
-  kPromiseResolveAfterResolved V8_DEPRECATED("These events are being removed") =
-      3,
+  kDeprecatedPromiseRejectAfterResolved V8_DEPRECATED("Removed event") = 2,
+  kDeprecatedPromiseResolveAfterResolved V8_DEPRECATED("Removed event") = 3,
 };
 
 class PromiseRejectMessage {

--- a/deps/v8/src/builtins/builtins-promise.h
+++ b/deps/v8/src/builtins/builtins-promise.h
@@ -13,11 +13,9 @@ namespace internal {
 class PromiseBuiltins {
  public:
   enum PromiseResolvingFunctionContextSlot {
-    // The promise which resolve/reject callbacks fulfill.
-    kPromiseSlot = Context::MIN_CONTEXT_SLOTS,
-
-    // Whether the callback was already invoked.
-    kAlreadyResolvedSlot,
+    // The promise which resolve/reject callbacks fulfill, or Undefined
+    // if already resolved.
+    kPromiseIfNotResolvedSlot = Context::MIN_CONTEXT_SLOTS,
 
     // Whether to trigger a debug event or not. Used in catch
     // prediction.

--- a/deps/v8/src/builtins/promise-abstract-operations.tq
+++ b/deps/v8/src/builtins/promise-abstract-operations.tq
@@ -12,12 +12,6 @@ extern transitioning runtime RejectPromise(
 extern transitioning runtime PromiseRevokeReject(
     implicit context: Context)(JSPromise): JSAny;
 
-extern transitioning runtime PromiseRejectAfterResolved(
-    implicit context: Context)(JSPromise, JSAny): JSAny;
-
-extern transitioning runtime PromiseResolveAfterResolved(
-    implicit context: Context)(JSPromise, JSAny): JSAny;
-
 extern transitioning runtime PromiseRejectEventFromStack(
     implicit context: Context)(JSPromise, JSAny): JSAny;
 }
@@ -406,7 +400,7 @@ transitioning javascript builtin PromiseCapabilityDefaultReject(
 
   // 4. If alreadyResolved.[[Value]] is true, return undefined.
   if (alreadyResolved == True) {
-    return runtime::PromiseRejectAfterResolved(promise, reason);
+    return Undefined;
   }
 
   // 5. Set alreadyResolved.[[Value]] to true.
@@ -434,7 +428,7 @@ transitioning javascript builtin PromiseCapabilityDefaultResolve(
 
   // 4. If alreadyResolved.[[Value]] is true, return undefined.
   if (alreadyResolved == True) {
-    return runtime::PromiseResolveAfterResolved(promise, resolution);
+    return Undefined;
   }
 
   // 5. Set alreadyResolved.[[Value]] to true.

--- a/deps/v8/src/builtins/promise-abstract-operations.tq
+++ b/deps/v8/src/builtins/promise-abstract-operations.tq
@@ -265,8 +265,8 @@ const kPromiseCapabilitySize:
 type PromiseResolvingFunctionContext extends FunctionContext;
 extern enum PromiseResolvingFunctionContextSlot extends intptr
     constexpr 'PromiseBuiltins::PromiseResolvingFunctionContextSlot' {
-  kPromiseSlot: Slot<PromiseResolvingFunctionContext, JSPromise>,
-  kAlreadyResolvedSlot: Slot<PromiseResolvingFunctionContext, Boolean>,
+  kPromiseIfNotResolvedSlot:
+      Slot<PromiseResolvingFunctionContext, JSPromise|Undefined>,
   kDebugEventSlot: Slot<PromiseResolvingFunctionContext, Boolean>,
   kPromiseContextLength
 }
@@ -390,25 +390,29 @@ transitioning builtin NewPromiseCapability(
 transitioning javascript builtin PromiseCapabilityDefaultReject(
     js-implicit context: Context, receiver: JSAny)(reason: JSAny): JSAny {
   const context = %RawDownCast<PromiseResolvingFunctionContext>(context);
-  // 2. Let promise be F.[[Promise]].
-  const promise =
-      *ContextSlot(context, PromiseResolvingFunctionContextSlot::kPromiseSlot);
+  // 2. Let promise be promiseOrEmpty.[[Value]].
+  const promiseOrEmpty =
+      *ContextSlot(
+      context, PromiseResolvingFunctionContextSlot::kPromiseIfNotResolvedSlot);
 
-  // 3. Let alreadyResolved be F.[[AlreadyResolved]].
-  const alreadyResolved = *ContextSlot(
-      context, PromiseResolvingFunctionContextSlot::kAlreadyResolvedSlot);
-
-  // 4. If alreadyResolved.[[Value]] is true, return undefined.
-  if (alreadyResolved == True) {
-    return Undefined;
+  // 1. If promiseOrEmpty.[[Value]] is ~empty~, return undefined.
+  let promise: JSPromise;
+  typeswitch (promiseOrEmpty) {
+    case (Undefined): {
+      return Undefined;
+    }
+    case (p: JSPromise): {
+      promise = p;
+    }
   }
 
-  // 5. Set alreadyResolved.[[Value]] to true.
+  // 3. Set promiseOrEmpty.[[Value]] to ~empty~.
   *ContextSlot(
-      context, PromiseResolvingFunctionContextSlot::kAlreadyResolvedSlot) =
-      True;
+      context, PromiseResolvingFunctionContextSlot::kPromiseIfNotResolvedSlot) =
+      Undefined;
 
-  // 6. Return RejectPromise(promise, reason).
+  // 4. Perform RejectPromise(promise, reason).
+  // 5. Return undefined.
   const debugEvent = *ContextSlot(
       context, PromiseResolvingFunctionContextSlot::kDebugEventSlot);
   return RejectPromise(promise, reason, debugEvent);
@@ -418,23 +422,26 @@ transitioning javascript builtin PromiseCapabilityDefaultReject(
 transitioning javascript builtin PromiseCapabilityDefaultResolve(
     js-implicit context: Context, receiver: JSAny)(resolution: JSAny): JSAny {
   const context = %RawDownCast<PromiseResolvingFunctionContext>(context);
-  // 2. Let promise be F.[[Promise]].
-  const promise: JSPromise =
-      *ContextSlot(context, PromiseResolvingFunctionContextSlot::kPromiseSlot);
+  // 2. Let promise be promiseOrEmpty.[[Value]].
+  const promiseOrEmpty =
+      *ContextSlot(
+      context, PromiseResolvingFunctionContextSlot::kPromiseIfNotResolvedSlot);
 
-  // 3. Let alreadyResolved be F.[[AlreadyResolved]].
-  const alreadyResolved: Boolean = *ContextSlot(
-      context, PromiseResolvingFunctionContextSlot::kAlreadyResolvedSlot);
-
-  // 4. If alreadyResolved.[[Value]] is true, return undefined.
-  if (alreadyResolved == True) {
-    return Undefined;
+  // 1. If promiseOrEmpty.[[Value]] is ~empty~, return undefined.
+  let promise: JSPromise;
+  typeswitch (promiseOrEmpty) {
+    case (Undefined): {
+      return Undefined;
+    }
+    case (p: JSPromise): {
+      promise = p;
+    }
   }
 
-  // 5. Set alreadyResolved.[[Value]] to true.
+  // 3. Set promiseOrEmpty.[[Value]] to ~empty~.
   *ContextSlot(
-      context, PromiseResolvingFunctionContextSlot::kAlreadyResolvedSlot) =
-      True;
+      context, PromiseResolvingFunctionContextSlot::kPromiseIfNotResolvedSlot) =
+      Undefined;
 
   // The rest of the logic (and the catch prediction) is
   // encapsulated in the dedicated ResolvePromise builtin.

--- a/deps/v8/src/builtins/promise-all.tq
+++ b/deps/v8/src/builtins/promise-all.tq
@@ -63,17 +63,14 @@ macro CreatePromiseResolvingFunctionsContext(
           nativeContext,
           PromiseResolvingFunctionContextSlot::kPromiseContextLength));
   InitContextSlot(
-      resolveContext, PromiseResolvingFunctionContextSlot::kPromiseSlot,
-      promise);
-  InitContextSlot(
-      resolveContext, PromiseResolvingFunctionContextSlot::kAlreadyResolvedSlot,
-      False);
+      resolveContext,
+      PromiseResolvingFunctionContextSlot::kPromiseIfNotResolvedSlot, promise);
   InitContextSlot(
       resolveContext, PromiseResolvingFunctionContextSlot::kDebugEventSlot,
       debugEvent);
   static_assert(
       PromiseResolvingFunctionContextSlot::kPromiseContextLength ==
-      ContextSlot::MIN_CONTEXT_SLOTS + 3);
+      ContextSlot::MIN_CONTEXT_SLOTS + 2);
   return resolveContext;
 }
 

--- a/deps/v8/src/compiler/js-call-reducer.cc
+++ b/deps/v8/src/compiler/js-call-reducer.cc
@@ -2543,10 +2543,8 @@ TNode<Object> PromiseBuiltinReducerAssembler::ReducePromiseConstructor(
   // Allocate a promise context for the closures below.
   TNode<Context> promise_context = CreateFunctionContext(
       native_context, context, PromiseBuiltins::kPromiseContextLength);
-  StoreContextNoCellSlot(promise_context, PromiseBuiltins::kPromiseSlot,
-                         promise);
-  StoreContextNoCellSlot(promise_context, PromiseBuiltins::kAlreadyResolvedSlot,
-                         FalseConstant());
+  StoreContextNoCellSlot(promise_context,
+                         PromiseBuiltins::kPromiseIfNotResolvedSlot, promise);
   StoreContextNoCellSlot(promise_context, PromiseBuiltins::kDebugEventSlot,
                          TrueConstant());
 

--- a/deps/v8/src/d8/d8.cc
+++ b/deps/v8/src/d8/d8.cc
@@ -4575,11 +4575,13 @@ static void PrintMessageCallback(Local<Message> message, Local<Value> error) {
 
 void Shell::PromiseRejectCallback(v8::PromiseRejectMessage data) {
   if (options.ignore_unhandled_promises) return;
+  START_ALLOW_USE_DEPRECATED();
   if (data.GetEvent() == v8::kPromiseRejectAfterResolved ||
       data.GetEvent() == v8::kPromiseResolveAfterResolved) {
     // Ignore reject/resolve after resolved.
     return;
   }
+  END_ALLOW_USE_DEPRECATED();
   v8::Local<v8::Promise> promise = data.GetPromise();
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   PerIsolateData* isolate_data = PerIsolateData::Get(isolate);

--- a/deps/v8/src/d8/d8.cc
+++ b/deps/v8/src/d8/d8.cc
@@ -4575,13 +4575,6 @@ static void PrintMessageCallback(Local<Message> message, Local<Value> error) {
 
 void Shell::PromiseRejectCallback(v8::PromiseRejectMessage data) {
   if (options.ignore_unhandled_promises) return;
-  START_ALLOW_USE_DEPRECATED();
-  if (data.GetEvent() == v8::kPromiseRejectAfterResolved ||
-      data.GetEvent() == v8::kPromiseResolveAfterResolved) {
-    // Ignore reject/resolve after resolved.
-    return;
-  }
-  END_ALLOW_USE_DEPRECATED();
   v8::Local<v8::Promise> promise = data.GetPromise();
   v8::Isolate* isolate = v8::Isolate::GetCurrent();
   PerIsolateData* isolate_data = PerIsolateData::Get(isolate);

--- a/deps/v8/src/execution/isolate.cc
+++ b/deps/v8/src/execution/isolate.cc
@@ -1253,9 +1253,12 @@ void CaptureAsyncStackTrace(Isolate* isolate, DirectHandle<JSPromise> promise,
       DirectHandle<JSFunction> function(
           Cast<JSFunction>(reaction->fulfill_handler()), isolate);
       DirectHandle<Context> context(function->context(), isolate);
-      promise = direct_handle(
-          Cast<JSPromise>(context->GetNoCell(PromiseBuiltins::kPromiseSlot)),
-          isolate);
+      Tagged<Object> promise_or_undefined =
+          context->GetNoCell(PromiseBuiltins::kPromiseIfNotResolvedSlot);
+      if (!TryCast(direct_handle(promise_or_undefined, isolate), &promise)) {
+        DCHECK(IsUndefined(promise_or_undefined));
+        return;
+      }
     } else {
       // We have some generic promise chain here, so try to
       // continue with the chained promise on the reaction

--- a/deps/v8/src/runtime/runtime-promise.cc
+++ b/deps/v8/src/runtime/runtime-promise.cc
@@ -34,8 +34,10 @@ RUNTIME_FUNCTION(Runtime_PromiseRejectAfterResolved) {
   HandleScope scope(isolate);
   DirectHandle<JSPromise> promise = args.at<JSPromise>(0);
   DirectHandle<Object> reason = args.at(1);
+  START_ALLOW_USE_DEPRECATED();
   isolate->ReportPromiseReject(promise, reason,
                                v8::kPromiseRejectAfterResolved);
+  END_ALLOW_USE_DEPRECATED();
   return ReadOnlyRoots(isolate).undefined_value();
 }
 
@@ -44,8 +46,10 @@ RUNTIME_FUNCTION(Runtime_PromiseResolveAfterResolved) {
   HandleScope scope(isolate);
   DirectHandle<JSPromise> promise = args.at<JSPromise>(0);
   DirectHandle<Object> resolution = args.at(1);
+  START_ALLOW_USE_DEPRECATED();
   isolate->ReportPromiseReject(promise, resolution,
                                v8::kPromiseResolveAfterResolved);
+  END_ALLOW_USE_DEPRECATED();
   return ReadOnlyRoots(isolate).undefined_value();
 }
 

--- a/deps/v8/src/runtime/runtime-promise.cc
+++ b/deps/v8/src/runtime/runtime-promise.cc
@@ -29,30 +29,6 @@ RUNTIME_FUNCTION(Runtime_PromiseRejectEventFromStack) {
   return ReadOnlyRoots(isolate).undefined_value();
 }
 
-RUNTIME_FUNCTION(Runtime_PromiseRejectAfterResolved) {
-  DCHECK_EQ(2, args.length());
-  HandleScope scope(isolate);
-  DirectHandle<JSPromise> promise = args.at<JSPromise>(0);
-  DirectHandle<Object> reason = args.at(1);
-  START_ALLOW_USE_DEPRECATED();
-  isolate->ReportPromiseReject(promise, reason,
-                               v8::kPromiseRejectAfterResolved);
-  END_ALLOW_USE_DEPRECATED();
-  return ReadOnlyRoots(isolate).undefined_value();
-}
-
-RUNTIME_FUNCTION(Runtime_PromiseResolveAfterResolved) {
-  DCHECK_EQ(2, args.length());
-  HandleScope scope(isolate);
-  DirectHandle<JSPromise> promise = args.at<JSPromise>(0);
-  DirectHandle<Object> resolution = args.at(1);
-  START_ALLOW_USE_DEPRECATED();
-  isolate->ReportPromiseReject(promise, resolution,
-                               v8::kPromiseResolveAfterResolved);
-  END_ALLOW_USE_DEPRECATED();
-  return ReadOnlyRoots(isolate).undefined_value();
-}
-
 RUNTIME_FUNCTION(Runtime_PromiseRevokeReject) {
   DCHECK_EQ(1, args.length());
   HandleScope scope(isolate);

--- a/deps/v8/src/runtime/runtime.h
+++ b/deps/v8/src/runtime/runtime.h
@@ -441,8 +441,6 @@ constexpr bool CanTriggerGC(T... properties) {
   F(PromiseRevokeReject, 1, 1)           \
   F(RejectPromise, 3, 1)                 \
   F(ResolvePromise, 2, 1)                \
-  F(PromiseRejectAfterResolved, 2, 1)    \
-  F(PromiseResolveAfterResolved, 2, 1)   \
   F(ConstructSuppressedError, 3, 1)      \
   F(ConstructAggregateErrorHelper, 4, 1) \
   F(ConstructInternalAggregateErrorHelper, -1 /* <= 5*/, 1)

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -16381,8 +16381,6 @@ TEST(ErrorLevelWarning) {
 v8::PromiseRejectEvent reject_event = v8::kPromiseRejectWithNoHandler;
 int promise_reject_counter = 0;
 int promise_revoke_counter = 0;
-int promise_reject_after_resolved_counter = 0;
-int promise_resolve_after_resolved_counter = 0;
 int promise_reject_msg_line_number = -1;
 int promise_reject_msg_column_number = -1;
 int promise_reject_line_number = -1;
@@ -16439,12 +16437,12 @@ void PromiseRejectCallback(v8::PromiseRejectMessage reject_message) {
       break;
     }
       START_ALLOW_USE_DEPRECATED();
-    case v8::kPromiseRejectAfterResolved: {
-      promise_reject_after_resolved_counter++;
+    case v8::kDeprecatedPromiseRejectAfterResolved: {
+      // Unreachable
       break;
     }
-    case v8::kPromiseResolveAfterResolved: {
-      promise_resolve_after_resolved_counter++;
+    case v8::kDeprecatedPromiseResolveAfterResolved: {
+      // Unreachable
       break;
     }
       END_ALLOW_USE_DEPRECATED();
@@ -16470,8 +16468,6 @@ v8::Local<v8::Value> RejectValue() {
 void ResetPromiseStates() {
   promise_reject_counter = 0;
   promise_revoke_counter = 0;
-  promise_reject_after_resolved_counter = 0;
-  promise_resolve_after_resolved_counter = 0;
   promise_reject_msg_line_number = -1;
   promise_reject_msg_column_number = -1;
   promise_reject_line_number = -1;
@@ -16710,8 +16706,6 @@ TEST(PromiseRejectCallback) {
   CHECK(!GetPromise("v0")->HasHandler());
   CHECK_EQ(0, promise_reject_counter);
   CHECK_EQ(0, promise_revoke_counter);
-  CHECK_EQ(1, promise_reject_after_resolved_counter);
-  CHECK_EQ(0, promise_resolve_after_resolved_counter);
 
   ResetPromiseStates();
 
@@ -16728,8 +16722,6 @@ TEST(PromiseRejectCallback) {
   CHECK(!GetPromise("y0")->HasHandler());
   CHECK_EQ(1, promise_reject_counter);
   CHECK_EQ(0, promise_revoke_counter);
-  CHECK_EQ(0, promise_reject_after_resolved_counter);
-  CHECK_EQ(1, promise_resolve_after_resolved_counter);
 
   // Test stack frames.
   env.isolate()->SetCaptureStackTraceForUncaughtExceptions(true);

--- a/deps/v8/test/cctest/test-api.cc
+++ b/deps/v8/test/cctest/test-api.cc
@@ -16438,6 +16438,7 @@ void PromiseRejectCallback(v8::PromiseRejectMessage reject_message) {
       CHECK(reject_message.GetValue().IsEmpty());
       break;
     }
+      START_ALLOW_USE_DEPRECATED();
     case v8::kPromiseRejectAfterResolved: {
       promise_reject_after_resolved_counter++;
       break;
@@ -16446,6 +16447,7 @@ void PromiseRejectCallback(v8::PromiseRejectMessage reject_message) {
       promise_resolve_after_resolved_counter++;
       break;
     }
+      END_ALLOW_USE_DEPRECATED();
   }
 }
 

--- a/deps/v8/test/cctest/test-code-stub-assembler.cc
+++ b/deps/v8/test/cctest/test-code-stub-assembler.cc
@@ -3037,7 +3037,8 @@ TEST(CreatePromiseResolvingFunctionsContext) {
   DirectHandle<Context> context_js = Cast<Context>(result);
   CHECK_EQ(isolate->root(RootIndex::kEmptyScopeInfo), context_js->scope_info());
   CHECK_EQ(*isolate->native_context(), context_js->native_context());
-  CHECK(IsJSPromise(context_js->GetNoCell(PromiseBuiltins::kPromiseSlot)));
+  CHECK(IsJSPromise(
+      context_js->GetNoCell(PromiseBuiltins::kPromiseIfNotResolvedSlot)));
   CHECK_EQ(ReadOnlyRoots(isolate).false_value(),
            context_js->GetNoCell(PromiseBuiltins::kDebugEventSlot));
 }
@@ -3246,7 +3247,8 @@ TEST(NewPromiseCapability) {
       CHECK_EQ(*isolate->native_context(), callback_context->native_context());
       CHECK_EQ(PromiseBuiltins::kPromiseContextLength,
                callback_context->length());
-      CHECK_EQ(callback_context->GetNoCell(PromiseBuiltins::kPromiseSlot),
+      CHECK_EQ(callback_context->GetNoCell(
+                   PromiseBuiltins::kPromiseIfNotResolvedSlot),
                result->promise());
     }
   }

--- a/deps/v8/test/inspector/isolate-data.cc
+++ b/deps/v8/test/inspector/isolate-data.cc
@@ -402,14 +402,6 @@ void InspectorIsolateData::PromiseRejectHandler(v8::PromiseRejectMessage data) {
                                  strlen(reason_str)));
     return;
 
-  } else {
-    START_ALLOW_USE_DEPRECATED();
-    if (data.GetEvent() == v8::kPromiseRejectAfterResolved ||
-        data.GetEvent() == v8::kPromiseResolveAfterResolved) {
-      // Ignore reject/resolve after resolved, like the blink handler.
-      return;
-    }
-    END_ALLOW_USE_DEPRECATED();
   }
 
   v8::Local<v8::Value> exception = data.GetValue();

--- a/deps/v8/test/inspector/isolate-data.cc
+++ b/deps/v8/test/inspector/isolate-data.cc
@@ -401,10 +401,15 @@ void InspectorIsolateData::PromiseRejectHandler(v8::PromiseRejectMessage data) {
         v8_inspector::StringView(reinterpret_cast<const uint8_t*>(reason_str),
                                  strlen(reason_str)));
     return;
-  } else if (data.GetEvent() == v8::kPromiseRejectAfterResolved ||
-             data.GetEvent() == v8::kPromiseResolveAfterResolved) {
-    // Ignore reject/resolve after resolved, like the blink handler.
-    return;
+
+  } else {
+    START_ALLOW_USE_DEPRECATED();
+    if (data.GetEvent() == v8::kPromiseRejectAfterResolved ||
+        data.GetEvent() == v8::kPromiseResolveAfterResolved) {
+      // Ignore reject/resolve after resolved, like the blink handler.
+      return;
+    }
+    END_ALLOW_USE_DEPRECATED();
   }
 
   v8::Local<v8::Value> exception = data.GetValue();

--- a/deps/v8/test/mjsunit/regress/regress-crbug-42213031.js
+++ b/deps/v8/test/mjsunit/regress/regress-crbug-42213031.js
@@ -1,0 +1,26 @@
+// Copyright 2026 the V8 project authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+// Flags: --expose-gc
+
+const pending = new Promise(() => {});
+
+(async function () {
+  let wr;
+
+  await (async function () {
+    const payload = { };
+    wr = new WeakRef(payload);
+    const resolved = Promise.resolve(payload);
+    // The pending Promise should not prevent GC of the race Promise once the race settles.
+    await Promise.race([pending, resolved]);
+  })();
+
+  await gc({ type: 'major', execution: 'async' });
+
+  assertEquals(undefined, wr.deref());
+})().catch((e) => {
+  console.error(e);
+  quit(1);
+});


### PR DESCRIPTION
Cherry-pick of [7774767](https://chromium-review.googlesource.com/c/v8/v8/+/7774767), [7897881](https://chromium-review.googlesource.com/c/v8/v8/+/7897881), and [7646250](https://chromium-review.googlesource.com/c/v8/v8/+/7646250), the last of which just landed a few hours ago but I don't anticipate problems with it. It wasn't _quite_ trivial because upstream v8 introduced a new use of the `kPromiseSlot` which node's copy doesn't have yet, so there is a single upstream hunk which is left out here. Otherwise this is just the result of `git node v8 backport 1a391f98cc7a9196369f2d6cab7df35ffbe92c08 0cc9eb22c0b0d132344b83b906f8a0e5aaa7b61e da20a197a7f9c2045b1ee501a472072944a86332`.

This fixes (or at least seriously mitigates) https://github.com/nodejs/node/issues/17469 - not quite a complete fix because there's still two resolvers created and held per call to `Promise.race`, but the result Promise itself is not held, so you aren't holding on to arbitrarily large objects [like this](https://github.com/nodejs/node/issues/17469#issuecomment-685216777).

Node used to depend on the APIs removed herein, but they were deprecated ages ago and EOL'd in https://github.com/nodejs/node/pull/58707, with the last traces removed in https://github.com/nodejs/node/pull/62336.