### PR TITLE
debugger: preserve probe failure attribution

### DIFF
--- a/lib/internal/debugger/inspect_probe.js
+++ b/lib/internal/debugger/inspect_probe.js
@@ -707,7 +707,8 @@ class ProbeInspectorSession {
 
   async callCdp(method, params, probe = null) {
     if (this.finished) { throw kInspectorFailedSentinel; }
-    this.inFlight = { __proto__: null, method, probe };
+    const inFlight = { __proto__: null, method, probe };
+    this.inFlight = inFlight;
     debug('CDP -> %s%s', method, probe !== null ? `, probe=${probe.index}` : '');
     try {
       const result = await this.client.callMethod(method, params);
@@ -730,6 +731,7 @@ class ProbeInspectorSession {
           this.recordInspectorFailure({
             reason: 'Target process exited during probe evaluation',
             advice: kReviewProbeExprAdvice,
+            inFlight,
           });
         }
         throw kInspectorFailedSentinel;
@@ -741,41 +743,47 @@ class ProbeInspectorSession {
           reason: 'Probe mode failed before user code ran',
           advice: kStartupTeardownAdvice,
           cdpError: err,
+          inFlight,
         });
       } else if (method === 'Debugger.evaluateOnCallFrame') {
         this.recordInspectorFailure({
           reason: 'The inspector could not evaluate a probe expression',
           advice: `The rejection details are recorded on the probe hit. ${kReviewProbeExprAdvice}`,
           cdpError: err,
+          inFlight,
         });
       } else if (this.lastProbeIndex !== null) {
         this.recordInspectorFailure({
           reason: 'Probe session failed after a probe evaluation',
           advice: 'If the failure repeats, review the most-recently-evaluated probe expression.',
           cdpError: err,
+          inFlight,
         });
       } else {
         this.recordInspectorFailure({
           reason: 'Probe session failed during inspector activity',
           advice: 'This is likely a Node.js bug. Please file an issue.',
           cdpError: err,
+          inFlight,
         });
       }
       throw kInspectorFailedSentinel;
     } finally {
-      this.inFlight = null;
+      if (this.inFlight === inFlight) {
+        this.inFlight = null;
+      }
     }
   }
 
   // Records the first inspector-side terminal for the session, later callers are ignored.
-  recordInspectorFailure({ reason, advice, cdpError, internalError }) {
+  recordInspectorFailure({ reason, advice, cdpError, internalError, inFlight = this.inFlight }) {
     if (this.finished) { return; }
     debug('recordInspectorFailure "%s": inFlight=%j, lastProbeIndex=%s, cdpError=%j',
-          reason, this.inFlight, this.lastProbeIndex, cdpError);
+          reason, inFlight, this.lastProbeIndex, cdpError);
     const child = this.child;
     const exitedAbnormally = child !== null &&
       (child.signalCode !== null || (child.exitCode !== null && child.exitCode !== 0));
-    const inFlightProbe = this.inFlight === null ? null : this.inFlight.probe;
+    const inFlightProbe = inFlight === null ? null : inFlight.probe;
     // This normally emits `probe_failure`, but yields to `probe_target_exit` when the child
     // has already exited abnormally and there is no in-flight probe to attribute to.
     if (exitedAbnormally && inFlightProbe === null) {
@@ -783,7 +791,7 @@ class ProbeInspectorSession {
       return;
     }
 
-    const failedCdpMethod = this.inFlight === null ? null : this.inFlight.method;
+    const failedCdpMethod = inFlight === null ? null : inFlight.method;
     let protocolError = null;
     // // `ERR_DEBUGGER_ERROR` is a Node-internal code, not a CDP-level protocol code
     if (cdpError !== undefined && cdpError.code !== 'ERR_DEBUGGER_ERROR') {


### PR DESCRIPTION
`parallel/test-debugger-probe-failure-process-exit` can be flaky when a
probe expression exits the target while `Debugger.evaluateOnCallFrame` is
pending.

An older overlapping CDP request can clear the shared `inFlight` state before
the probe evaluation failure is recorded. When that happens, the failure is
reported as if the probe never ran, leaving it in `pending`, instead of
recording the expected failed probe hit.

This PR keeps the CDP in-flight context local to each `callCdp()` invocation
and passes it explicitly into failure reporting. Also it clears `this.inFlight` only if
the finishing call still owns the current in-flight state.

Refs: https://github.com/nodejs/reliability/issues?q=%22test-debugger-probe-failure-process-exit%22

<details>
<summary>Example</summary>

```
not ok 636 parallel/test-debugger-probe-failure-process-exit
  ---
  duration_ms: 628.15400
  severity: fail
  exitcode: 1
  stack: |-
    [process 631511]: --- stderr ---
    INSPECT_PROBE 631511: child stderr: "Debugger listening on ws://127.0.0.1:40237/395b9597-9abd-4a28-bb14-0a569e12a20b\nFor help, see: https://nodejs.org/learn/getting-started/debugging\n"
    INSPECT_PROBE 631511: CDP -> Runtime.enable
    INSPECT_PROBE 631511: child stderr: "Debugger attached.\n"
    INSPECT_PROBE 631511: CDP <- Runtime.enable (success)
    INSPECT_PROBE 631511: CDP -> Debugger.enable
    INSPECT_PROBE 631511: CDP <- Debugger.enable (success)
    INSPECT_PROBE 631511: CDP -> Debugger.setBreakpointByUrl
    INSPECT_PROBE 631511: CDP <- Debugger.setBreakpointByUrl (success)
    INSPECT_PROBE 631511: breakpoint set: id=2:7:0:^(.*[\/\\])?probe-exits-during-probe\.js$ urlRegex=^(.*[\/\\])?probe-exits-during-probe\.js$ locations=[]
    INSPECT_PROBE 631511: CDP -> Runtime.runIfWaitingForDebugger
    INSPECT_PROBE 631511: CDP <- Runtime.runIfWaitingForDebugger (success)
    INSPECT_PROBE 631511: scriptParsed: scriptId=88 url=file:///home/iojs/build/workspace/node-test-commit-linuxone/test/fixtures/debugger/probe-exits-during-probe.js, length=130
    INSPECT_PROBE 631511: paused: finished=0, reason=Break on start hitBreakpoints=[]
    INSPECT_PROBE 631511: CDP -> Debugger.resume
    INSPECT_PROBE 631511: paused: finished=0, reason=other hitBreakpoints=["2:7:0:^(.*[\\/\\\\])?probe-exits-during-probe\\.js$"]
    INSPECT_PROBE 631511: CDP -> Debugger.evaluateOnCallFrame, probe=0
    INSPECT_PROBE 631511: CDP <- Debugger.resume (success)
    INSPECT_PROBE 631511: child stderr: "Waiting for the debugger to disconnect...\n"
    INSPECT_PROBE 631511: disconnect sentinel detected, resetting client
    INSPECT_PROBE 631511: CDP <- Debugger.evaluateOnCallFrame error: ERR_DEBUGGER_ERROR
    INSPECT_PROBE 631511: recordInspectorFailure "Target process exited during probe evaluation": inFlight=null, lastProbeIndex=null, cdpError=undefined
    INSPECT_PROBE 631511: finish: exitCode=1, terminal=error
    
    [process 631511]: --- stdout ---
    {"v":2,"probes":[{"expr":"exitDuringProbe()","target":{"suffix":"probe-exits-during-probe.js","line":8}}],"results":[{"event":"error","pending":[0],"error":{"code":"probe_failure","message":"Target process exited during probe evaluation before probes: probe-exits-during-probe.js:8. If the failure repeats, review the probe expression.","stderr":""}}]}
    
    [process 631511]: status = 1, signal = null
    /home/iojs/build/workspace/node-test-commit-linuxone/test/common/child_process.js:112
        throw error;
        ^
    
    Error: - stdout did not match expectation, checker throws:
    AssertionError [ERR_ASSERTION]: Expected values to be strictly deep-equal:
    + actual - expected
    ... Skipped lines
    
      {
        probes: [
          {
            expr: 'exitDuringProbe()',
            target: {
    ...
            error: {
    -         message: 'Probe evaluation did not complete'
    -       },
    -       event: 'hit',
    -       hit: 1,
    -       location: {
    -         column: 1,
    -         line: 8,
    -         url: 'file:///home/iojs/build/workspace/node-test-commit-linuxone/test/fixtures/debugger/probe-exits-during-probe.js'
    -       },
    -       probe: 0
    -     },
    -     {
    -       error: {
              code: 'probe_failure',
    +         message: 'Target process exited during probe evaluation before probes: probe-exits-during-probe.js:8. If the failure repeats, review the probe expression.',
    -         details: {
    -           lastCdpMethod: 'Debugger.evaluateOnCallFrame'
    -         },
    -         message: 'Target process exited during probe evaluation. If the failure repeats, review the probe expression.',
    -         probe: 0,
              stderr: ''
            },
            event: 'error',
    +       pending: [
    +         0
    +       ]
    -       pending: []
          }
        ],
        v: 2
      }
    
        at assertProbeJson (/home/iojs/build/workspace/node-test-commit-linuxone/test/common/debugger-probe.js:65:10)
        at stdout (/home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-debugger-probe-failure-process-exit.js:25:5)
        at checkOutput (/home/iojs/build/workspace/node-test-commit-linuxone/test/common/child_process.js:52:7)
        at expectSyncExit (/home/iojs/build/workspace/node-test-commit-linuxone/test/common/child_process.js:129:32)
        at spawnSyncAndExit (/home/iojs/build/workspace/node-test-commit-linuxone/test/common/child_process.js:143:10)
        at Object.<anonymous> (/home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-debugger-probe-failure-process-exit.js:17:1)
        at Module._compile (node:internal/modules/cjs/loader:1947:14)
        at Object..js (node:internal/modules/cjs/loader:2087:10)
        at Module.load (node:internal/modules/cjs/loader:1669:32)
        at Module._load (node:internal/modules/cjs/loader:1450:12) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: [Object],
      expected: [Object],
      operator: 'deepStrictEqual',
      diff: 'simple'
    }
        at Object.<anonymous> (/home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-debugger-probe-failure-process-exit.js:17:1)
        at Module._compile (node:internal/modules/cjs/loader:1947:14)
        at Object..js (node:internal/modules/cjs/loader:2087:10)
        at Module.load (node:internal/modules/cjs/loader:1669:32)
        at Module._load (node:internal/modules/cjs/loader:1450:12)
        at wrapModuleLoad (node:internal/modules/cjs/loader:260:19)
        at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
        at node:internal/main/run_main_module:33:47 {
      options: {
        cwd: '/home/iojs/build/workspace/node-test-commit-linuxone/test/fixtures/debugger',
        env: { NODE_DEBUG: 'inspect_probe' }
      },
      command: '/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node inspect --json --probe probe-exits-during-probe.js:8 --expr exitDuringProbe() probe-exits-during-probe.js'
    }
```

</details>

---

Assisted-by: openai:gpt-5.5