### PR TITLE
vfs: read RealFSProvider files from open fd

### DIFF
--- a/lib/internal/vfs/providers/real.js
+++ b/lib/internal/vfs/providers/real.js
@@ -5,6 +5,7 @@ const {
   StringPrototypeStartsWith,
 } = primordials;
 
+const { Buffer } = require('buffer');
 const fs = require('fs');
 const path = require('path');
 const { VirtualProvider } = require('internal/vfs/provider');
@@ -32,6 +33,19 @@ class RealFileHandle extends VirtualFileHandle {
     if (this.closed) {
       throw createEBADF(syscall);
     }
+  }
+
+  #readFileBuffer(size) {
+    return Buffer.allocUnsafe(size || 8192);
+  }
+
+  #readFileResult(buffer, bytesRead, options) {
+    buffer = buffer.subarray(0, bytesRead);
+    const encoding = typeof options === 'string' ? options : options?.encoding;
+    if (encoding && encoding !== 'buffer') {
+      buffer = buffer.toString(encoding);
+    }
+    return buffer;
   }
 
   /**
@@ -79,12 +93,41 @@ class RealFileHandle extends VirtualFileHandle {
 
   readFileSync(options) {
     this.#checkClosed('read');
-    return fs.readFileSync(this.#realPath, options);
+    const size = fs.fstatSync(this.#fd).size;
+    const buffer = this.#readFileBuffer(size);
+    let bytesRead = 0;
+    while (bytesRead < buffer.byteLength) {
+      const read = fs.readSync(
+        this.#fd,
+        buffer,
+        bytesRead,
+        buffer.byteLength - bytesRead,
+        bytesRead,
+      );
+      if (read === 0) break;
+      bytesRead += read;
+    }
+
+    return this.#readFileResult(buffer, bytesRead, options);
   }
 
   async readFile(options) {
     this.#checkClosed('read');
-    return fs.promises.readFile(this.#realPath, options);
+    const size = (await this.stat()).size;
+    const buffer = this.#readFileBuffer(size);
+    let bytesRead = 0;
+    while (bytesRead < buffer.byteLength) {
+      const { bytesRead: read } = await this.read(
+        buffer,
+        bytesRead,
+        buffer.byteLength - bytesRead,
+        bytesRead,
+      );
+      if (read === 0) break;
+      bytesRead += read;
+    }
+
+    return this.#readFileResult(buffer, bytesRead, options);
   }
 
   writeFileSync(data, options) {

--- a/lib/internal/vfs/providers/real.js
+++ b/lib/internal/vfs/providers/real.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const {
+  ArrayPrototypePush,
   Promise,
   StringPrototypeStartsWith,
 } = primordials;
@@ -17,6 +18,8 @@ const {
   createEBADF,
   createENOENT,
 } = require('internal/vfs/errors');
+
+const kReadFileUnknownBufferLength = 8192;
 
 /**
  * A file handle that wraps a real file descriptor.
@@ -35,10 +38,6 @@ class RealFileHandle extends VirtualFileHandle {
     }
   }
 
-  #readFileBuffer(size) {
-    return Buffer.allocUnsafe(size || 8192);
-  }
-
   #readFileResult(buffer, bytesRead, options) {
     buffer = buffer.subarray(0, bytesRead);
     const encoding = typeof options === 'string' ? options : options?.encoding;
@@ -46,6 +45,11 @@ class RealFileHandle extends VirtualFileHandle {
       buffer = buffer.toString(encoding);
     }
     return buffer;
+  }
+
+  #readFileUnknownSizeResult(buffers, totalRead, options) {
+    return this.#readFileResult(
+      Buffer.concat(buffers, totalRead), totalRead, options);
   }
 
   /**
@@ -94,7 +98,23 @@ class RealFileHandle extends VirtualFileHandle {
   readFileSync(options) {
     this.#checkClosed('read');
     const size = fs.fstatSync(this.#fd).size;
-    const buffer = this.#readFileBuffer(size);
+    if (size === 0) {
+      const buffers = [];
+      let totalRead = 0;
+
+      while (true) {
+        const buffer = Buffer.allocUnsafe(kReadFileUnknownBufferLength);
+        const read = fs.readSync(
+          this.#fd, buffer, 0, buffer.byteLength, totalRead);
+        if (read === 0) break;
+        ArrayPrototypePush(buffers, buffer.subarray(0, read));
+        totalRead += read;
+      }
+
+      return this.#readFileUnknownSizeResult(buffers, totalRead, options);
+    }
+
+    const buffer = Buffer.allocUnsafe(size);
     let bytesRead = 0;
     while (bytesRead < buffer.byteLength) {
       const read = fs.readSync(
@@ -114,7 +134,27 @@ class RealFileHandle extends VirtualFileHandle {
   async readFile(options) {
     this.#checkClosed('read');
     const size = (await this.stat()).size;
-    const buffer = this.#readFileBuffer(size);
+    if (size === 0) {
+      const buffers = [];
+      let totalRead = 0;
+
+      while (true) {
+        const buffer = Buffer.allocUnsafe(kReadFileUnknownBufferLength);
+        const { bytesRead: read } = await this.read(
+          buffer,
+          0,
+          buffer.byteLength,
+          totalRead,
+        );
+        if (read === 0) break;
+        ArrayPrototypePush(buffers, buffer.subarray(0, read));
+        totalRead += read;
+      }
+
+      return this.#readFileUnknownSizeResult(buffers, totalRead, options);
+    }
+
+    const buffer = Buffer.allocUnsafe(size);
     let bytesRead = 0;
     while (bytesRead < buffer.byteLength) {
       const { bytesRead: read } = await this.read(

--- a/test/parallel/test-vfs-fs-readFileSync.js
+++ b/test/parallel/test-vfs-fs-readFileSync.js
@@ -43,3 +43,32 @@ assert.strictEqual(
 }
 
 myVfs.unmount();
+
+// readFileSync via a RealFSProvider fd remains usable after the backing path
+// is renamed.
+{
+  const root = path.join('/tmp', 'vfs-real-readFileSync-' + process.pid);
+  const realMountPoint = path.join('/tmp', 'vfs-real-readFileSync-mount-' + process.pid);
+  fs.rmSync(root, { recursive: true, force: true });
+  fs.rmSync(realMountPoint, { recursive: true, force: true });
+  fs.mkdirSync(root, { recursive: true });
+  fs.mkdirSync(realMountPoint, { recursive: true });
+
+  const realVfs = vfs
+    .create(new vfs.RealFSProvider(root), { emitExperimentalWarning: false })
+    .mount(realMountPoint);
+  try {
+    fs.writeFileSync(path.join(root, 'a.txt'), 'still readable');
+    const fd = fs.openSync(path.join(realMountPoint, 'a.txt'), 'r');
+    try {
+      fs.renameSync(path.join(root, 'a.txt'), path.join(root, 'b.txt'));
+      assert.strictEqual(fs.readFileSync(fd, 'utf8'), 'still readable');
+    } finally {
+      fs.closeSync(fd);
+    }
+  } finally {
+    realVfs.unmount();
+    fs.rmSync(root, { recursive: true, force: true });
+    fs.rmSync(realMountPoint, { recursive: true, force: true });
+  }
+}

--- a/test/parallel/test-vfs-real-provider-handle.js
+++ b/test/parallel/test-vfs-real-provider-handle.js
@@ -92,6 +92,38 @@ const myVfs = vfs.create(new vfs.RealFSProvider(root));
     }
   }
 
+  // ===== readFile reads past the fallback chunk when fstat reports size 0 =====
+  {
+    const content = 'a'.repeat(8192) + 'trailing data';
+    fs.writeFileSync(path.join(root, 'zero-stat.txt'), content);
+    const syncHandle = await myVfs.provider.open('/zero-stat.txt', 'r');
+    const asyncHandle = await myVfs.provider.open('/zero-stat.txt', 'r');
+    const originalFstatSync = fs.fstatSync;
+    const originalFstat = fs.fstat;
+
+    fs.fstatSync = common.mustCall(function fstatSync(...args) {
+      const stats = originalFstatSync.apply(this, args);
+      stats.size = 0;
+      return stats;
+    });
+    fs.fstat = common.mustCall(function fstat(fd, options, callback) {
+      return originalFstat.call(this, fd, options, (err, stats) => {
+        if (stats) stats.size = 0;
+        callback(err, stats);
+      });
+    });
+
+    try {
+      assert.strictEqual(syncHandle.readFileSync('utf8'), content);
+      assert.strictEqual(await asyncHandle.readFile('utf8'), content);
+    } finally {
+      fs.fstatSync = originalFstatSync;
+      fs.fstat = originalFstat;
+      await syncHandle.close();
+      await asyncHandle.close();
+    }
+  }
+
   // ===== EBADF after close =====
   {
     await myVfs.promises.writeFile('/h.txt', 'hello');

--- a/test/parallel/test-vfs-real-provider-handle.js
+++ b/test/parallel/test-vfs-real-provider-handle.js
@@ -75,6 +75,23 @@ const myVfs = vfs.create(new vfs.RealFSProvider(root));
     await handle.close();
   }
 
+  // ===== readFile through an open real fd survives backing path rename =====
+  {
+    fs.writeFileSync(path.join(root, 'rename-read.txt'), 'still readable');
+    const syncHandle = await myVfs.provider.open('/rename-read.txt', 'r');
+    const asyncHandle = await myVfs.provider.open('/rename-read.txt', 'r');
+    fs.renameSync(path.join(root, 'rename-read.txt'),
+                  path.join(root, 'rename-read-renamed.txt'));
+    try {
+      assert.strictEqual(syncHandle.readFileSync('utf8'), 'still readable');
+      assert.strictEqual(await asyncHandle.readFile('utf8'), 'still readable');
+    } finally {
+      await syncHandle.close();
+      await asyncHandle.close();
+      fs.unlinkSync(path.join(root, 'rename-read-renamed.txt'));
+    }
+  }
+
   // ===== EBADF after close =====
   {
     await myVfs.promises.writeFile('/h.txt', 'hello');


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64103

`RealFileHandle.readFileSync()` and `readFile()` previously reopened the
original real path. If the backing file was renamed after the VFS fd was opened,
`fs.readFileSync(fd, ...)` failed with `ENOENT`.

This changes `RealFileHandle` to read through the already-open real fd using
positioned reads. That matches native filesystem behavior for renamed open files
and preserves the handle's current offset.

The async `readFile()` path continues to use async `stat()` and `read()`
operations.

---

Assisted-by: openai:gpt-5.5