### PR TITLE
test: make blob desiredSize assertion robust

### DIFF
--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -354,8 +354,10 @@ assert.throws(() => new Blob({}), {
   assert(!done);
   setTimeout(common.mustCall(() => {
     // The blob stream is now a byte stream hence after the first read,
-    // it should pull in the next 'hello' which is 5 bytes hence -5.
-    assert.strictEqual(stream[kState].controller.desiredSize, 0);
+    // it may have pulled in the next 'hello' which is 5 bytes hence -5.
+    // The ordering of this timer and the stream's setImmediate() pull
+    // continuation can vary across platforms.
+    assert([0, -5].includes(stream[kState].controller.desiredSize));
   }), 0);
 })().then(common.mustCall());
 


### PR DESCRIPTION
Fixes flaky `parallel/test-blob` failures where
`ReadableByteStreamController.desiredSize` could be either `0` or `-5`
after the first blob stream read.

The test checks from a `setTimeout(0)` callback, while `Blob.stream()`
continues pulling data via `setImmediate()`. Depending on event loop
ordering, the next 5-byte `"hello"` chunk may already be queued by the
time the assertion runs.

This updates the assertion to accept both valid intermediate states and
documents the scheduling dependency.

Refs: https://github.com/nodejs/reliability/issues?q=sort%3Aupdated-desc%20%22parallel%2Ftest-blob%22

<details>
<summary>Example</summary>

```
not ok 797 parallel/test-blob
  ---
  duration_ms: 252.40200
  severity: fail
  exitcode: 1
  stack: |-
    node:internal/assert/utils:146
      throw error;
      ^
    
    AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
    
    -5 !== 0
    
        at Timeout.<anonymous> (/home/iojs/build/workspace/node/test/parallel/test-blob.js:358:12)
        at Timeout._onTimeout (/home/iojs/build/workspace/node/test/common/index.js:510:15)
        at listOnTimeout (node:internal/timers:605:17)
        at process.processTimers (node:internal/timers:541:7) {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: -5,
      expected: 0,
      operator: 'strictEqual',
      diff: 'simple'
    }
```

</details>

---

Assisted-by: openai:gpt-5.5