### PR TITLE
test: limit young generation in heap snapshot tests

### DIFF
--- a/test/fixtures/workload/grow-worker-and-set-near-heap-limit.js
+++ b/test/fixtures/workload/grow-worker-and-set-near-heap-limit.js
@@ -9,7 +9,10 @@ new Worker(path.join(__dirname, 'grow-and-set-near-heap-limit.js'), {
   },
   resourceLimits: {
     maxOldGenerationSizeMb:
-      parseInt(process.env.TEST_OLD_SPACE_SIZE) || 20
-  }
+      parseInt(process.env.TEST_OLD_SPACE_SIZE) || 20,
+    ...(process.env.TEST_YOUNG_SPACE_SIZE !== undefined && {
+      maxYoungGenerationSizeMb: parseInt(process.env.TEST_YOUNG_SPACE_SIZE),
+    }),
+  },
 });
 

--- a/test/fixtures/workload/grow-worker.js
+++ b/test/fixtures/workload/grow-worker.js
@@ -9,6 +9,9 @@ new Worker(path.join(__dirname, 'grow.js'), {
   ],
   resourceLimits: {
     maxOldGenerationSizeMb:
-      parseInt(process.env.TEST_OLD_SPACE_SIZE) || 20
-  }
+      parseInt(process.env.TEST_OLD_SPACE_SIZE) || 20,
+    ...(process.env.TEST_YOUNG_SPACE_SIZE !== undefined && {
+      maxYoungGenerationSizeMb: parseInt(process.env.TEST_YOUNG_SPACE_SIZE),
+    }),
+  },
 });

--- a/test/parallel/test-heapsnapshot-near-heap-limit-by-api-in-worker.js
+++ b/test/parallel/test-heapsnapshot-near-heap-limit-by-api-in-worker.js
@@ -22,6 +22,7 @@ const env = {
     env: {
       TEST_SNAPSHOTS: 1,
       TEST_OLD_SPACE_SIZE: 50,
+      TEST_YOUNG_SPACE_SIZE: 16,
       ...env
     }
   });

--- a/test/parallel/test-heapsnapshot-near-heap-limit-worker.js
+++ b/test/parallel/test-heapsnapshot-near-heap-limit-worker.js
@@ -20,6 +20,7 @@ const env = {
     env: {
       TEST_SNAPSHOTS: 1,
       TEST_OLD_SPACE_SIZE: 50,
+      TEST_YOUNG_SPACE_SIZE: 16,
       ...env
     }
   });


### PR DESCRIPTION
This updates the worker heap snapshot near-heap-limit tests to set an explicit
young generation size for the worker.

The snapshot near-heap-limit callback uses the isolate's max young generation
size as temporary overhead while writing the heap snapshot. On some platforms
that value can be large enough relative to the test's old-space limit that V8
can hit a fatal OOM path before the worker resource-limit callback reports
`ERR_WORKER_OUT_OF_MEMORY`.

By setting `TEST_YOUNG_SPACE_SIZE=16` for these tests, the temporary heap limit
increase is deterministic while keeping the old-space limit unchanged.

Refs: https://github.com/nodejs/reliability/issues?q=%22test-heapsnapshot-near-heap-limit-worker%22

<details>
<summary>Example</summary>

```
not ok 1454 parallel/test-heapsnapshot-near-heap-limit-worker
  ---
  duration_ms: 2286.98900
  severity: fail
  exitcode: 1
  stack: |-
    
    Invoked NearHeapLimitCallback, processing=false, current_limit=52428800, initial_limit=52428800
    max_young_gen_size=100663296, young_gen_size=0, old_gen_size=62999720, total_size=62999720
    Estimated available memory=5850988544, estimated overhead=100663296
    Start generating Heap.20260623.013159.1325404.1.001.heapsnapshot...
    Invoked NearHeapLimitCallback, processing=true, current_limit=52428800, initial_limit=52428800
    max_young_gen_size=100663296, young_gen_size=0, old_gen_size=62978952, total_size=62978952
    Estimated available memory=5869744128, estimated overhead=100663296
    Not generating snapshots in nested callback. new_limit=153092096
    1/1 snapshots taken.
    Removing the near heap limit callbackWrote snapshot to /home/iojs/node-tmp/.tmp.1449/Heap.20260623.013159.1325404.1.001.heapsnapshot
    
    <--- Last few GCs --->
    
    [1325404:0x3ff58001000]      779 ms: Mark-Compact (reduce) 60.1 (62.6) -> 60.1 (62.6) MB, pooled: 0.0 MB, 4.75 / 0.00 ms (average mu = 0.027, current mu = 0.001) heap profiler; GC in old space requested
    [1325404:0x3ff58001000]      783 ms: Mark-Compact (reduce) 60.1 (62.6) -> 60.1 (62.6) MB, pooled: 0.0 MB, 4.24 / 0.00 ms (average mu = 0.015, current mu = 0.001) heap profiler; GC in old space requested
    
    FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
    ----- Native stack trace -----
    
     1: 0x1423860 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
     2: 0x196de6c  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
     3: 0x1c439d0  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
     4: 0x1c4120a  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
     5: 0x1c32a5a  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
     6: 0x1c45232  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
     7: 0x1cc8ff4  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
     8: 0x16e0aac node::PerIsolatePlatformData::RunForegroundTask(std::unique_ptr<v8::Task, std::default_delete<v8::Task> >) [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
     9: 0x16defba node::PerIsolatePlatformData::FlushForegroundTasksInternal() [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
    10: 0x2a78b4c  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
    11: 0x2a8fb8c  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
    12: 0x2a7960a uv_run [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
    13: 0x14b6334 node::SpinEventLoopInternal(node::Environment*) [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
    14: 0x17c9b1c node::worker::Worker::Run() [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
    15: 0x17d01f4  [/home/iojs/build/workspace/node-test-commit-linuxone/out/Release/node]
    16: 0x3ff8a5080de  [/lib64/libpthread.so.0]
    17: 0x3ff8a328b7e  [/lib64/libc.so.6]
    18: (nil) 
    
    node:internal/assert/utils:146
      throw error;
      ^
    
    AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
    
      assert(stderr.includes('ERR_WORKER_OUT_OF_MEMORY'))
    
        at Object.<anonymous> (/home/iojs/build/workspace/node-test-commit-linuxone/test/parallel/test-heapsnapshot-near-heap-limit-worker.js:34:5)
        at Module._compile (node:internal/modules/cjs/loader:1947:14)
        at Object..js (node:internal/modules/cjs/loader:2087:10)
        at Module.load (node:internal/modules/cjs/loader:1669:32)
        at Module._load (node:internal/modules/cjs/loader:1450:12)
        at wrapModuleLoad (node:internal/modules/cjs/loader:260:19)
        at Module.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:154:5)
        at node:internal/main/run_main_module:33:47 {
      generatedMessage: true,
      code: 'ERR_ASSERTION',
      actual: false,
      expected: true,
      operator: '==',
      diff: 'simple'
    }
```

</details>

---

Assisted-by: openai:gpt-5.5