### PR TITLE
deps: c-ares: cherry-pick 8ba37af8e3fb

### DIFF
--- a/deps/cares/src/lib/ares_sysconfig_win.c
+++ b/deps/cares/src/lib/ares_sysconfig_win.c
@@ -106,7 +106,7 @@ static ares_bool_t get_REG_SZ(HKEY hKey, const WCHAR *leafKeyName, char **outptr
 
   /* Get the value for real */
   res = RegQueryValueExW(hKey, leafKeyName, 0, NULL, (BYTE *)val, &size);
-  if (res != ERROR_SUCCESS || size == 1) {
+  if (res != ERROR_SUCCESS || size == sizeof(WCHAR)) {
     ares_free(val);
     return ARES_FALSE;
   }


### PR DESCRIPTION
Fixes the OS's DNS servers list being ignored on Windows since #60997. This patch landed in c-ares in February, but with no sign of an imminent release, it's probably worth cherry-picking this; the impact is fairly significant.

Fixes: #62347