### PR TITLE
doc: fix import.meta example for vm.SourceTextModule

### DIFF
--- a/doc/api/vm.md
+++ b/doc/api/vm.md
@@ -919,6 +919,7 @@ const contextifiedObject = vm.createContext({ secret: 42 });
 const module = new vm.SourceTextModule(
   'Object.getPrototypeOf(import.meta.prop).secret = secret;',
   {
+    context: contextifiedObject,
     initializeImportMeta(meta) {
       // Note: this object is created in the top context. As such,
       // Object.getPrototypeOf(import.meta.prop) points to the
@@ -937,7 +938,7 @@ await module.evaluate();
 // To fix this problem, replace
 //     meta.prop = {};
 // above with
-//     meta.prop = vm.runInContext('{}', contextifiedObject);
+//     meta.prop = vm.runInContext('({})', contextifiedObject);
 ```
 
 ```cjs
@@ -947,6 +948,7 @@ const contextifiedObject = vm.createContext({ secret: 42 });
   const module = new vm.SourceTextModule(
     'Object.getPrototypeOf(import.meta.prop).secret = secret;',
     {
+      context: contextifiedObject,
       initializeImportMeta(meta) {
         // Note: this object is created in the top context. As such,
         // Object.getPrototypeOf(import.meta.prop) points to the
@@ -964,7 +966,7 @@ const contextifiedObject = vm.createContext({ secret: 42 });
   // To fix this problem, replace
   //     meta.prop = {};
   // above with
-  //     meta.prop = vm.runInContext('{}', contextifiedObject);
+  //     meta.prop = vm.runInContext('({})', contextifiedObject);
 })();
 ```
 


### PR DESCRIPTION
The `import.meta` example for `new vm.SourceTextModule()` in `vm.md` does not run as written. It fails in two separate ways:

- The constructor is missing the `context: contextifiedObject` option, so the module evaluates in the top context where `secret` is not defined. Running the snippet throws `ReferenceError: secret is not defined`. The text right above the example already describes the module as belonging to the contextified object, so the option just needs to be present.
- The trailing note suggests replacing `meta.prop = {}` with `vm.runInContext('{}', contextifiedObject)`, but `'{}'` is parsed as an empty block statement and evaluates to `undefined`. That makes the following `Object.getPrototypeOf(import.meta.prop)` throw `TypeError: Cannot convert undefined or null to object`. Wrapping it as `'({})'` returns an object, which is what the note intends.

This adds the `context` option and corrects the suggested replacement to `'({})'` in both the mjs and cjs variants, so the example and its note both behave as documented.

Fixes: https://github.com/nodejs/node/issues/64076
