### PR TITLE
buffer: normalize lone "\r" in Blob native line endings

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -122,7 +122,7 @@ function getSource(source, endings) {
     source = new Uint8Array(source);
   } else if (!isArrayBufferView(source)) {
     if (endings === 'native')
-      source = RegExpPrototypeSymbolReplace(/\n|\r\n/g, source, EOL);
+      source = RegExpPrototypeSymbolReplace(/\r\n|\r|\n/g, source, EOL);
     source = enc.encode(source);
   }
 

--- a/test/parallel/test-blob.js
+++ b/test/parallel/test-blob.js
@@ -403,6 +403,24 @@ assert.throws(() => new Blob({}), {
   const b = new Blob(['hello\n'], { endings: 'native' });
   assert.strictEqual(b.size, EOL.length + 5);
 
+  // The WHATWG "convert line endings to native" algorithm normalizes every
+  // standalone "\r", "\n", and "\r\n" sequence to the native line ending.
+  // Refs: https://w3c.github.io/FileAPI/#convert-line-endings-to-native
+  (async () => {
+    const cases = [
+      ['a\rb', `a${EOL}b`],
+      ['a\nb', `a${EOL}b`],
+      ['a\r\nb', `a${EOL}b`],
+      ['a\r\rb', `a${EOL}${EOL}b`],
+      ['a\n\rb', `a${EOL}${EOL}b`],
+      ['\r\n\r', `${EOL}${EOL}`],
+    ];
+    for (const [input, expected] of cases) {
+      const blob = new Blob([input], { endings: 'native' });
+      assert.strictEqual(await blob.text(), expected);
+    }
+  })().then(common.mustCall());
+
   [1, {}, 'foo'].forEach((endings) => {
     assert.throws(() => new Blob([], { endings }), {
       code: 'ERR_INVALID_ARG_VALUE',


### PR DESCRIPTION
`new Blob(parts, { endings: 'native' })` failed to normalize a standalone carriage return. The replacement regex only matched `\n` and `\r\n`, so a lone `\r` (and runs such as `\r\r`) were left untouched instead of being converted to the platform's native line ending.

The WHATWG "convert line endings to native" algorithm requires `\r`, `\n`, and `\r\n` to all be normalized. Match `\r\n` before a lone `\r` so that CRLF collapses to a single native ending.

Refs: https://w3c.github.io/FileAPI/#convert-line-endings-to-native

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
