### PR TITLE
build: pin envinfo versions in github actions

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -83,7 +83,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Make tarball
         run: |
           export DISTTYPE=nightly
@@ -125,7 +125,7 @@ jobs:
         with:
           version: v0.16.0
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Download tarball
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           version: v0.16.0
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Install gcovr
         run: pip install gcovr==7.2
       - name: Configure

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           version: v0.16.0
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Install gcovr
         run: pip install gcovr==7.2
       - name: Configure

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -84,7 +84,7 @@ jobs:
           rustup override set "$RUSTC_VERSION"
           rustup --version
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Build
         run: ./vcbuild.bat clang-cl v8temporal
       # TODO(bcoe): investigate tests that fail with coverage enabled

--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -44,7 +44,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
 
       # install a version and checkout
       - name: Get latest nightly

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Build lto
         run: |
           sudo apt-get update && sudo apt-get install ninja-build -y

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Build
         run: NODE=$(command -v node) make doc-only
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Lint addon docs
         run: NODE=$(command -v node) make lint-addon-docs
   lint-cpp:
@@ -49,7 +49,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Lint C/C++ files
         run: make lint-cpp
   format-cpp:
@@ -70,7 +70,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Format C/C++ files
         run: |
           make format-cpp-build
@@ -103,7 +103,7 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Lint JavaScript files
         run: |
           set +e
@@ -184,7 +184,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Lint Python
         run: |
           make lint-py-build
@@ -208,7 +208,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Lint YAML
         run: |
           make lint-yaml-build || true

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -65,7 +65,7 @@ jobs:
         with:
           version: v0.16.0
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Build
         run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test Internet

--- a/.github/workflows/test-linux-quic.yml
+++ b/.github/workflows/test-linux-quic.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           version: v0.16.0
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Build
         working-directory: node
         run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn --v8-enable-temporal-support --experimental-quic"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -81,7 +81,7 @@ jobs:
         with:
           version: v0.16.0
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       - name: Build
         working-directory: node
         run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn --v8-enable-temporal-support"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           version: v0.16.0
       - name: Environment Information
-        run: npx envinfo
+        run: npx envinfo@7.21.0
       # The `npm ci` for this step fails a lot as part of the Test step. Run it
       # now so that we don't have to wait 2 hours for the Build step to pass
       # first before that failure happens. (And if there's something about


### PR DESCRIPTION
Currently they all run `npx envinfo` without pinning the version. This can be a supply-chain risk.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
