### PR TITLE
build: add manually-dispatched stress-test workflow

### DIFF
--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -1,0 +1,113 @@
+name: Stress Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      test_path:
+        description: Test path or glob (e.g. test/parallel/test-debugger-break.js or "test/parallel/test-debugger-*")
+        required: true
+        type: string
+      os:
+        description: Runner to use
+        required: true
+        default: macos-15
+        type: choice
+        options:
+          - macos-15
+          - ubuntu-24.04
+          - ubuntu-24.04-arm
+      repeat:
+        description: Number of times to repeat each test (--repeat)
+        required: true
+        default: '1000'
+        type: string
+      test_jobs:
+        description: Number of jobs to run in parallel (-j).
+        required: true
+        default: '1'
+        type: string
+      test_args:
+        description: Extra args for tools/test.py, space-separated (e.g. "-t 10 --worker")
+        required: false
+        default: ''
+        type: string
+
+env:
+  PYTHON_VERSION: '3.14'
+  XCODE_VERSION: '16.4'
+  CLANG_VERSION: '19'
+  RUSTC_VERSION: '1.82'
+
+permissions:
+  contents: read
+
+jobs:
+  stress-test:
+    runs-on: ${{ inputs.os }}
+    env:
+      # Linux builds with clang (matching test-linux.yml), macOS with gcc/g++.
+      CC: ${{ startsWith(inputs.os, 'ubuntu') && 'sccache clang-19' || 'sccache gcc' }}
+      CXX: ${{ startsWith(inputs.os, 'ubuntu') && 'sccache clang++-19' || 'sccache g++' }}
+      SCCACHE_GHA_ENABLED: ${{ github.base_ref == 'main' || github.ref_name == 'main' }}
+      SCCACHE_IDLE_TIMEOUT: '0'
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+          path: node
+      - name: Install Clang ${{ env.CLANG_VERSION }}
+        if: runner.os == 'Linux'
+        uses: ./node/.github/actions/install-clang
+        with:
+          clang-version: ${{ env.CLANG_VERSION }}
+      - name: Set up Xcode ${{ env.XCODE_VERSION }}
+        if: runner.os == 'macOS'
+        run: sudo xcode-select -s /Applications/Xcode_${{ env.XCODE_VERSION }}.app
+      - name: Set up Python ${{ env.PYTHON_VERSION }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          allow-prereleases: true
+      - name: Install Rust ${{ env.RUSTC_VERSION }}
+        run: |
+          rustup override set "$RUSTC_VERSION"
+          rustup --version
+      - name: Set up sccache
+        uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
+        with:
+          version: v0.16.0
+      - name: Environment Information
+        run: npx envinfo@7.21.0
+      # This is needed due to https://github.com/nodejs/build/issues/3878
+      - name: Cleanup
+        if: runner.os == 'macOS'
+        run: |
+          echo "::group::Free space before cleanup"
+          df -h
+          echo "::endgroup::"
+          echo "::group::Cleaned Files"
+
+          sudo rm -rf /Users/runner/Library/Android/sdk
+
+          echo "::endgroup::"
+          echo "::group::Free space after cleanup"
+          df -h
+          echo "::endgroup::"
+      - name: Build
+        run: make -C node build-ci -j"$(getconf _NPROCESSORS_ONLN)" V=1 CONFIG_FLAGS="--error-on-warn --v8-enable-temporal-support"
+      - name: Stress run ${{ inputs.test_path }} x${{ inputs.repeat }}
+        shell: bash
+        env:
+          REPEAT: ${{ inputs.repeat }}
+          JOBS: ${{ inputs.test_jobs }}
+          TEST_ARGS: ${{ inputs.test_args }}
+          TEST_PATH: ${{ inputs.test_path }}
+        run: |
+          cd node
+          read -ra EXTRA_ARGS <<< "$TEST_ARGS"
+          python3 tools/test.py \
+            --repeat "$REPEAT" \
+            -j "$JOBS" \
+            -p actions \
+            "${EXTRA_ARGS[@]}" \
+            "$TEST_PATH"

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -1,4 +1,4 @@
-name: Stress Test
+name: Stress Test (rebase tested branch on main for cache reuse)
 
 on:
   workflow_dispatch:
@@ -48,7 +48,10 @@ jobs:
       # Linux builds with clang (matching test-linux.yml), macOS with gcc/g++.
       CC: ${{ startsWith(inputs.os, 'ubuntu') && 'sccache clang-19' || 'sccache gcc' }}
       CXX: ${{ startsWith(inputs.os, 'ubuntu') && 'sccache clang++-19' || 'sccache g++' }}
-      SCCACHE_GHA_ENABLED: ${{ github.base_ref == 'main' || github.ref_name == 'main' }}
+      # Enable sccache - this is okay for a manually-dispatched workflow that is typically used to
+      # test lib-only or test-only deflaking changes. This should be able to pick up cache from
+      # test-linux.yml and test-macos.yml running on the main branch.
+      SCCACHE_GHA_ENABLED: 'true'
       SCCACHE_IDLE_TIMEOUT: '0'
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3


### PR DESCRIPTION
Add a GitHub action workflow that can be manually dispatched to stress-run tests on a PR/branch to verify flakiness.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
