### PR TITLE
util: make MIMEParams accessors case-insensitive

### DIFF
--- a/lib/internal/mime.js
+++ b/lib/internal/mime.js
@@ -148,12 +148,13 @@ class MIMEParams {
    */
   delete(name) {
     this.#parse();
-    this.#data.delete(name);
+    this.#data.delete(toASCIILower(`${name}`));
   }
 
   get(name) {
     this.#parse();
     const data = this.#data;
+    name = toASCIILower(`${name}`);
     if (data.has(name)) {
       return data.get(name);
     }
@@ -162,13 +163,13 @@ class MIMEParams {
 
   has(name) {
     this.#parse();
-    return this.#data.has(name);
+    return this.#data.has(toASCIILower(`${name}`));
   }
 
   set(name, value) {
     this.#parse();
     const data = this.#data;
-    name = `${name}`;
+    name = toASCIILower(`${name}`);
     value = `${value}`;
     const invalidNameIndex = SafeStringPrototypeSearch(name, NOT_HTTP_TOKEN_CODE_POINT);
     if (name.length === 0 || invalidNameIndex !== -1) {

--- a/test/parallel/test-mime-api.js
+++ b/test/parallel/test-mime-api.js
@@ -158,3 +158,30 @@ assert.throws(() => params.set(`x${NOT_HTTP_TOKEN_CODE_POINT}`, 'x'), /parameter
 assert.throws(() => params.set('x', `${NOT_HTTP_QUOTED_STRING_CODE_POINT};`), /parameter value/i);
 assert.throws(() => params.set('x', `${NOT_HTTP_QUOTED_STRING_CODE_POINT}x`), /parameter value/i);
 assert.throws(() => params.set('x', `x${NOT_HTTP_QUOTED_STRING_CODE_POINT}`), /parameter value/i);
+
+// MIME parameter names are case-insensitive. The parser lower-cases them, so
+// the MIMEParams accessors must lower-case their argument too; otherwise a
+// parsed parameter is unreachable by the casing the caller actually used and
+// `set()` can create case-colliding duplicate parameters.
+// Refs: https://mimesniff.spec.whatwg.org/ (parameter names are ASCII-lowercased)
+{
+  const mime = new MIMEType('text/plain;Charset=value');
+  assert.strictEqual(mime.params.get('Charset'), 'value');
+  assert.strictEqual(mime.params.get('charset'), 'value');
+  assert.strictEqual(mime.params.get('CHARSET'), 'value');
+  assert.strictEqual(mime.params.has('Charset'), true);
+  assert.strictEqual(`${mime.params}`, 'charset=value');
+
+  // `set()` with a mixed-case name overwrites the same parameter rather than
+  // adding a second, case-colliding one.
+  const params = new MIMEType('text/plain').params;
+  params.set('Foo', 'a');
+  params.set('foo', 'b');
+  assert.deepStrictEqual([...params], [['foo', 'b']]);
+  assert.strictEqual(`${params}`, 'foo=b');
+
+  // `delete()` is case-insensitive as well.
+  params.delete('FOO');
+  assert.strictEqual(params.has('foo'), false);
+  assert.deepStrictEqual([...params], []);
+}


### PR DESCRIPTION
MIME parameter names are case-insensitive and the parser already ASCII-lowercases them, but MIMEParams.get(), has(), delete() and set() compared against the raw argument. As a result a parsed parameter was unreachable by the casing the caller used (e.g. params.get('Charset') returned null for "Charset=utf-8"), and set() could create duplicate, case-colliding parameters.

Lowercase the name in the accessors to match the parser, consistent with the whatwg-mimetype reference implementation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
