### PR TITLE
quic: fix potential crash from unobserved closed

### DIFF
--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -3586,7 +3586,9 @@ class QuicSession {
 
     if (error) {
       // If the session is still waiting to be closed, and error
-      // is specified, reject the closed promise.
+      // is specified, reject the closed promise. Mark it handled first
+      // (as with opened) to silence errors if it's not actually awaited.
+      markPromiseAsHandled(inner.pendingClose.promise);
       inner.pendingClose.reject?.(error);
     } else {
       inner.pendingClose.resolve?.();

--- a/test/parallel/test-quic-session-unobserved-error-close.mjs
+++ b/test/parallel/test-quic-session-unobserved-error-close.mjs
@@ -1,0 +1,47 @@
+// Flags: --experimental-quic --no-warnings
+
+// Regression test: destroying a session with an error while its `closed`
+// promise is not being observed must NOT surface as an unhandled rejection.
+
+import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
+import { subscribe, unsubscribe } from 'node:diagnostics_channel';
+import { setImmediate as tick } from 'node:timers/promises';
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { listen, connect } = await import('../common/quic.mjs');
+
+// Any unhandled rejection - e.g. an unobserved `closed` rejecting - fails.
+process.on('unhandledRejection', mustNotCall('unexpected unhandled rejection'));
+
+// We use the diagnostics channel to observe the error close without actually
+// observing session.closed (not listening is the whole point of the test):
+const serverErrored = Promise.withResolvers();
+function onSessionError() {
+  unsubscribe('quic.session.error', onSessionError);
+  serverErrored.resolve();
+}
+subscribe('quic.session.error', onSessionError);
+
+// The server session callback is left deliberately empty, so no response
+// is sent and closed remains unobserved:
+const serverEndpoint = await listen(mustCall());
+
+const clientSession = await connect(serverEndpoint.address);
+await clientSession.opened;
+
+// Finish handshake before close:
+await tick();
+
+// Cleanly close from the client with an error code, so the server
+// receives a peer error close:
+await clientSession.close({ code: 1 });
+
+// Wait until the server has processed the error close, plus another tick
+// to ensure unobserved promise rejection doesn't fire anywhere:
+await serverErrored.promise;
+await tick();
+
+await serverEndpoint.close();


### PR DESCRIPTION
(This is independent of the other "split up the h3-split PR" PRs I've just opened - not related to that stream, just something else I ran into)

This fixes a potential crash in QUIC generally. Currently if you don't listen to and handle errors from `session.closed` synchronously when the session opens (I think doing so is quite uncommon) then by default any remote client can crash the server. Tiny independent fix.

See the test for a demo: `closed` wasn't marked as handled, and so any error would trigger a unhandledRejection, which exits the process by default.



<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
