### PR TITLE
tty: add raw-vt and io raw modes

### DIFF
--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -71,7 +71,7 @@ A `boolean` that is always `true` for `tty.ReadStream` instances.
 added: v0.7.7
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/64140
     description: The `mode` argument supports `'raw-vt'` and `'io'`.
 -->
 

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -72,10 +72,10 @@ added: v0.7.7
 changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/64140
-    description: The `mode` argument supports `'raw-vt'` and `'io'`.
+    description: The `mode` argument supports `'raw'` and `'io'`.
 -->
 
-* `mode` {boolean|string} If `true` or `'raw-vt'`, configures the
+* `mode` {boolean|string} If `true` or `'raw'`, configures the
   `tty.ReadStream` to operate as a raw device. If `'io'`, configures the
   `tty.ReadStream` to operate in binary-safe I/O mode. If `false`, configures
   the `tty.ReadStream` to operate in its default mode. The `readStream.isRaw`
@@ -105,8 +105,8 @@ added: REPLACEME
 * {boolean|string}
 
 The current raw mode for the `tty.ReadStream`. This is `false` when the stream
-is in its default mode, `'raw-vt'` when raw input mode is enabled, and `'io'`
-when binary-safe I/O mode is enabled.
+is in its default mode, `'raw'` when raw input mode is enabled, and `'io'` when
+binary-safe I/O mode is enabled.
 
 ## Class: `tty.WriteStream`
 

--- a/doc/api/tty.md
+++ b/doc/api/tty.md
@@ -69,12 +69,18 @@ A `boolean` that is always `true` for `tty.ReadStream` instances.
 
 <!-- YAML
 added: v0.7.7
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/REPLACEME
+    description: The `mode` argument supports `'raw-vt'` and `'io'`.
 -->
 
-* `mode` {boolean} If `true`, configures the `tty.ReadStream` to operate as a
-  raw device. If `false`, configures the `tty.ReadStream` to operate in its
-  default mode. The `readStream.isRaw` property will be set to the resulting
-  mode.
+* `mode` {boolean|string} If `true` or `'raw-vt'`, configures the
+  `tty.ReadStream` to operate as a raw device. If `'io'`, configures the
+  `tty.ReadStream` to operate in binary-safe I/O mode. If `false`, configures
+  the `tty.ReadStream` to operate in its default mode. The `readStream.isRaw`
+  property will be set to whether the stream is in raw mode, and the
+  `readStream.rawMode` property will be set to the resulting mode.
 * Returns: {this} The read stream instance.
 
 Allows configuration of `tty.ReadStream` so that it operates as a raw device.
@@ -85,6 +91,22 @@ by the terminal is disabled, including echoing input
 characters. <kbd>Ctrl</kbd>+<kbd>C</kbd> will no longer cause a `SIGINT` when
 in this mode. This mode does not affect terminal output processing, such as
 newline translation on Unix terminals.
+
+When in binary-safe I/O mode, terminal output processing is also disabled.
+This corresponds to libuv's `UV_TTY_MODE_IO` mode and is not supported on
+Windows.
+
+### `readStream.rawMode`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* {boolean|string}
+
+The current raw mode for the `tty.ReadStream`. This is `false` when the stream
+is in its default mode, `'raw-vt'` when raw input mode is enabled, and `'io'`
+when binary-safe I/O mode is enabled.
 
 ## Class: `tty.WriteStream`
 

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -82,11 +82,11 @@ ObjectSetPrototypeOf(ReadStream.prototype, net.Socket.prototype);
 ObjectSetPrototypeOf(ReadStream, net.Socket);
 
 ReadStream.prototype.setRawMode = function(mode) {
-  const rawMode = mode === 'io' ? 'io' : (mode ? 'raw-vt' : false);
+  const rawMode = mode === 'io' ? 'io' : (mode ? 'raw' : false);
   let ttyMode = UV_TTY_MODE_NORMAL;
   if (rawMode === 'io') {
     ttyMode = UV_TTY_MODE_IO;
-  } else if (rawMode === 'raw-vt') {
+  } else if (rawMode === 'raw') {
     ttyMode = UV_TTY_MODE_RAW_VT;
   }
   const err = this._handle?.setRawMode(ttyMode);

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -37,6 +37,7 @@ const {
 const {
   ErrnoException,
   codes: {
+    ERR_INVALID_ARG_VALUE,
     ERR_INVALID_FD,
     ERR_TTY_INIT_FAILED,
   },
@@ -82,7 +83,15 @@ ObjectSetPrototypeOf(ReadStream.prototype, net.Socket.prototype);
 ObjectSetPrototypeOf(ReadStream, net.Socket);
 
 ReadStream.prototype.setRawMode = function(mode) {
-  const rawMode = mode === 'io' ? 'io' : (mode ? 'raw' : false);
+  let rawMode;
+  if (mode === 'io' || mode === 'raw') {
+    rawMode = mode;
+  } else if (typeof mode === 'string') {
+    throw new ERR_INVALID_ARG_VALUE(
+      'mode', mode, "must be true, false, 'raw', or 'io'");
+  } else {
+    rawMode = mode ? 'raw' : false;
+  }
   let ttyMode = UV_TTY_MODE_NORMAL;
   if (rawMode === 'io') {
     ttyMode = UV_TTY_MODE_IO;

--- a/lib/tty.js
+++ b/lib/tty.js
@@ -27,7 +27,13 @@ const {
 } = primordials;
 
 const net = require('net');
-const { TTY, isTTY } = internalBinding('tty_wrap');
+const {
+  TTY,
+  UV_TTY_MODE_IO,
+  UV_TTY_MODE_NORMAL,
+  UV_TTY_MODE_RAW_VT,
+  isTTY,
+} = internalBinding('tty_wrap');
 const {
   ErrnoException,
   codes: {
@@ -68,20 +74,28 @@ function ReadStream(fd, options) {
   });
 
   this.isRaw = false;
+  this.rawMode = false;
   this.isTTY = true;
 }
 
 ObjectSetPrototypeOf(ReadStream.prototype, net.Socket.prototype);
 ObjectSetPrototypeOf(ReadStream, net.Socket);
 
-ReadStream.prototype.setRawMode = function(flag) {
-  flag = !!flag;
-  const err = this._handle?.setRawMode(flag);
+ReadStream.prototype.setRawMode = function(mode) {
+  const rawMode = mode === 'io' ? 'io' : (mode ? 'raw-vt' : false);
+  let ttyMode = UV_TTY_MODE_NORMAL;
+  if (rawMode === 'io') {
+    ttyMode = UV_TTY_MODE_IO;
+  } else if (rawMode === 'raw-vt') {
+    ttyMode = UV_TTY_MODE_RAW_VT;
+  }
+  const err = this._handle?.setRawMode(ttyMode);
   if (err) {
     this.emit('error', new ErrnoException(err, 'setRawMode'));
     return this;
   }
-  this.isRaw = flag;
+  this.isRaw = rawMode !== false;
+  this.rawMode = rawMode;
   return this;
 };
 

--- a/src/tty_wrap.cc
+++ b/src/tty_wrap.cc
@@ -68,6 +68,9 @@ void TTYWrap::Initialize(Local<Object> target,
   SetProtoMethod(isolate, t, "setRawMode", SetRawMode);
 
   SetMethodNoSideEffect(context, target, "isTTY", IsTTY);
+  NODE_DEFINE_CONSTANT(target, UV_TTY_MODE_NORMAL);
+  NODE_DEFINE_CONSTANT(target, UV_TTY_MODE_IO);
+  NODE_DEFINE_CONSTANT(target, UV_TTY_MODE_RAW_VT);
 
   Local<Value> func;
   if (t->GetFunction(context).ToLocal(&func) &&
@@ -124,9 +127,10 @@ void TTYWrap::SetRawMode(const FunctionCallbackInfo<Value>& args) {
   // sequences at all on Windows, such as bracketed paste mode.
   // The Node.js readline implementation handles differences between
   // these modes.
-  int err = uv_tty_set_mode(
-      &wrap->handle_,
-      args[0]->IsTrue() ? UV_TTY_MODE_RAW_VT : UV_TTY_MODE_NORMAL);
+  Environment* env = Environment::GetCurrent(args);
+  int mode;
+  if (!args[0]->Int32Value(env->context()).To(&mode)) return;
+  int err = uv_tty_set_mode(&wrap->handle_, static_cast<uv_tty_mode_t>(mode));
   args.GetReturnValue().Set(err);
 }
 

--- a/test/pseudo-tty/test-set-raw-mode-modes.js
+++ b/test/pseudo-tty/test-set-raw-mode-modes.js
@@ -4,12 +4,12 @@ const assert = require('assert');
 const { spawnSync } = require('child_process');
 
 function isOnlcrEnabled() {
-  const { stdout, status } = spawnSync('stty', ['-a'], {
+  const { stdout, stderr, status } = spawnSync('stty', ['-a'], {
     encoding: 'utf8',
-    stdio: ['inherit', 'pipe', 'inherit'],
+    stdio: ['inherit', 'pipe', 'pipe'],
   });
 
-  assert.strictEqual(status, 0);
+  assert.strictEqual(status, 0, stderr);
   return /(?:^|[\s;])onlcr(?:[\s;]|$)/.test(stdout);
 }
 

--- a/test/pseudo-tty/test-set-raw-mode-modes.js
+++ b/test/pseudo-tty/test-set-raw-mode-modes.js
@@ -1,0 +1,36 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+const { spawnSync } = require('child_process');
+
+function isOnlcrEnabled() {
+  const { stdout, status } = spawnSync('stty', ['-a'], {
+    encoding: 'utf8',
+    stdio: ['inherit', 'pipe', 'inherit'],
+  });
+
+  assert.strictEqual(status, 0);
+  return /(?:^|[\s;])onlcr(?:[\s;]|$)/.test(stdout);
+}
+
+process.stdin.setRawMode(true);
+console.log(`raw=${isOnlcrEnabled()}`);
+assert.strictEqual(process.stdin.isRaw, true);
+assert.strictEqual(process.stdin.rawMode, 'raw-vt');
+
+process.stdin.setRawMode(false);
+console.log(`normal=${process.stdin.isRaw}`);
+assert.strictEqual(process.stdin.rawMode, false);
+
+process.stdin.setRawMode('raw-vt');
+console.log(`raw-vt=${isOnlcrEnabled()}`);
+assert.strictEqual(process.stdin.isRaw, true);
+assert.strictEqual(process.stdin.rawMode, 'raw-vt');
+
+process.stdin.setRawMode(false);
+process.stdin.setRawMode('io');
+console.log(`io=${isOnlcrEnabled()}`);
+assert.strictEqual(process.stdin.isRaw, true);
+assert.strictEqual(process.stdin.rawMode, 'io');
+
+process.stdin.setRawMode(false);

--- a/test/pseudo-tty/test-set-raw-mode-modes.js
+++ b/test/pseudo-tty/test-set-raw-mode-modes.js
@@ -21,6 +21,13 @@ assert.strictEqual(process.stdin.rawMode, 'raw');
 process.stdin.setRawMode(false);
 console.log(`normal=${process.stdin.isRaw}`);
 assert.strictEqual(process.stdin.rawMode, false);
+assert.throws(
+  () => process.stdin.setRawMode('raw-vt'),
+  {
+    code: 'ERR_INVALID_ARG_VALUE',
+    name: 'TypeError',
+  });
+assert.strictEqual(process.stdin.rawMode, false);
 
 process.stdin.setRawMode('raw');
 console.log(`raw-string=${isOnlcrEnabled()}`);

--- a/test/pseudo-tty/test-set-raw-mode-modes.js
+++ b/test/pseudo-tty/test-set-raw-mode-modes.js
@@ -16,16 +16,16 @@ function isOnlcrEnabled() {
 process.stdin.setRawMode(true);
 console.log(`raw=${isOnlcrEnabled()}`);
 assert.strictEqual(process.stdin.isRaw, true);
-assert.strictEqual(process.stdin.rawMode, 'raw-vt');
+assert.strictEqual(process.stdin.rawMode, 'raw');
 
 process.stdin.setRawMode(false);
 console.log(`normal=${process.stdin.isRaw}`);
 assert.strictEqual(process.stdin.rawMode, false);
 
-process.stdin.setRawMode('raw-vt');
-console.log(`raw-vt=${isOnlcrEnabled()}`);
+process.stdin.setRawMode('raw');
+console.log(`raw-string=${isOnlcrEnabled()}`);
 assert.strictEqual(process.stdin.isRaw, true);
-assert.strictEqual(process.stdin.rawMode, 'raw-vt');
+assert.strictEqual(process.stdin.rawMode, 'raw');
 
 process.stdin.setRawMode(false);
 process.stdin.setRawMode('io');

--- a/test/pseudo-tty/test-set-raw-mode-modes.out
+++ b/test/pseudo-tty/test-set-raw-mode-modes.out
@@ -1,4 +1,4 @@
 raw=true
 normal=false
-raw-vt=true
+raw-string=true
 io=false

--- a/test/pseudo-tty/test-set-raw-mode-modes.out
+++ b/test/pseudo-tty/test-set-raw-mode-modes.out
@@ -1,0 +1,4 @@
+raw=true
+normal=false
+raw-vt=true
+io=false


### PR DESCRIPTION
Adds string raw-mode selection to `tty.ReadStream#setRawMode()`:

- `setRawMode(true)` keeps the existing behavior.
- `setRawMode('raw')` explicitly selects the existing Node raw mode, backed by libuv `UV_TTY_MODE_RAW_VT`.
- `setRawMode('io')` selects libuv `UV_TTY_MODE_IO` for binary-safe I/O mode on Unix.
- `readStream.rawMode` exposes the exact current mode while `readStream.isRaw` remains boolean for compatibility.
- Unknown string modes are rejected.

This is intended to address the output-processing distinction discussed in nodejs/node#63059 and follows libuv's existing `UV_TTY_MODE_IO` semantics. It preserves the current `setRawMode(true)` behavior instead of changing it.

Related libuv hardening PR: https://github.com/libuv/libuv/pull/5174

Refs: https://github.com/nodejs/node/issues/63059
Refs: https://github.com/libuv/libuv/issues/32

Local verification:

- `git diff --check` passes.
- A full local build could not complete because macOS killed Cargo `build-script-build` executables as untrusted on this machine; relying on CI for the native build and pseudo-tty test run.
