### PR TITLE
test: fix stale async-context-frame status entries

### DIFF
--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -22,16 +22,11 @@ test-snapshot-incompatible: SKIP
 [$system==win32]
 # https://github.com/nodejs/node/issues/59090
 test-inspector-network-fetch: PASS, FLAKY
-# https://github.com/nodejs/node/issues/54808
-test-async-context-frame: PASS, FLAKY
 # https://github.com/nodejs/node/issues/59636
 test-fs-cp-sync-error-on-exist: SKIP
 test-fs-cp-sync-symlink-points-to-dest-error: SKIP
 test-fs-cp-async-symlink-points-to-dest: SKIP
 test-fs-cp-sync-unicode-folder-names: SKIP
-
-# https://github.com/nodejs/node/issues/56751
-test-without-async-context-frame: PASS, FLAKY
 
 # Windows on ARM
 [$system==win32 && $arch==arm64]
@@ -146,7 +141,6 @@ test-http-pipeline-flood: SKIP
 test-inspector-network-fetch:  SKIP
 test-inspector-network-content-type: SKIP
 test-fetch:  SKIP
-test-without-async-context-frame: SKIP
 test-process-cpuUsage: PASS, FLAKY
 test-web-locks: SKIP
 test-http2-allow-http1-upgrade-ws: SKIP


### PR DESCRIPTION
# test: fix stale async-context-frame status entries

Drop the stale `test-async-context-frame` flaky entry from `parallel.status`.