### PR TITLE
vfs: prevent stack overflow in recursive readdir on circular symlinks

### DIFF
--- a/lib/internal/vfs/providers/memory.js
+++ b/lib/internal/vfs/providers/memory.js
@@ -2,6 +2,7 @@
 
 const {
   ArrayFrom,
+  ArrayPrototypePop,
   ArrayPrototypePush,
   DateNow,
   SafeMap,
@@ -612,59 +613,73 @@ class MemoryProvider extends VirtualProvider {
    */
   #readdirRecursive(dirEntry, dirPath, withFileTypes) {
     const results = [];
+    // Directories on the current traversal path. A directory reached again
+    // through a symlink cycle is not descended into (but is still listed).
     const active = new SafeSet();
 
-    const walk = (entry, currentPath, relativePath) => {
-      if (active.has(entry)) {
-        return;
-      }
-
+    // Traverse depth-first with an explicit stack instead of recursion, so a
+    // deeply nested tree cannot exhaust the call stack. Each frame is a
+    // directory being walked together with a snapshot of its children and the
+    // index of the next child to visit.
+    const enter = (entry, currentPath, relativePath) => {
+      this.#ensurePopulated(entry, currentPath);
       active.add(entry);
-      try {
-        this.#ensurePopulated(entry, currentPath);
-
-        for (const { 0: name, 1: childEntry } of entry.children) {
-          const childRelative = relativePath ?
-            relativePath + '/' + name : name;
-
-          if (withFileTypes) {
-            let type;
-            if (childEntry.isSymbolicLink()) {
-              type = UV_DIRENT_LINK;
-            } else if (childEntry.isDirectory()) {
-              type = UV_DIRENT_DIR;
-            } else {
-              type = UV_DIRENT_FILE;
-            }
-            ArrayPrototypePush(results,
-                               new Dirent(childRelative, type, dirPath));
-          } else {
-            ArrayPrototypePush(results, childRelative);
-          }
-
-          // Follow symlinks to directories for recursive traversal.
-          // Track the active traversal path to avoid symlink cycles.
-          let resolvedChild = childEntry;
-          if (childEntry.isSymbolicLink()) {
-            const targetPath = this.#resolveSymlinkTarget(
-              pathPosix.join(currentPath, name), childEntry.target,
-            );
-            const result = this.#lookupEntry(targetPath, true, 0);
-            if (result.entry) {
-              resolvedChild = result.entry;
-            }
-          }
-          if (resolvedChild.isDirectory()) {
-            const childPath = pathPosix.join(currentPath, name);
-            walk(resolvedChild, childPath, childRelative);
-          }
-        }
-      } finally {
-        active.delete(entry);
-      }
+      ArrayPrototypePush(stack, {
+        entry,
+        currentPath,
+        relativePath,
+        children: ArrayFrom(entry.children),
+        index: 0,
+      });
     };
 
-    walk(dirEntry, dirPath, '');
+    const stack = [];
+    enter(dirEntry, dirPath, '');
+
+    while (stack.length > 0) {
+      const frame = stack[stack.length - 1];
+      if (frame.index >= frame.children.length) {
+        active.delete(frame.entry);
+        ArrayPrototypePop(stack);
+        continue;
+      }
+
+      const { 0: name, 1: childEntry } = frame.children[frame.index++];
+      const childRelative = frame.relativePath ?
+        frame.relativePath + '/' + name : name;
+
+      if (withFileTypes) {
+        let type;
+        if (childEntry.isSymbolicLink()) {
+          type = UV_DIRENT_LINK;
+        } else if (childEntry.isDirectory()) {
+          type = UV_DIRENT_DIR;
+        } else {
+          type = UV_DIRENT_FILE;
+        }
+        ArrayPrototypePush(results, new Dirent(childRelative, type, dirPath));
+      } else {
+        ArrayPrototypePush(results, childRelative);
+      }
+
+      // Follow symlinks to directories for recursive traversal, skipping any
+      // directory already on the active path to avoid symlink cycles.
+      let resolvedChild = childEntry;
+      if (childEntry.isSymbolicLink()) {
+        const targetPath = this.#resolveSymlinkTarget(
+          pathPosix.join(frame.currentPath, name), childEntry.target,
+        );
+        const result = this.#lookupEntry(targetPath, true, 0);
+        if (result.entry) {
+          resolvedChild = result.entry;
+        }
+      }
+      if (resolvedChild.isDirectory() && !active.has(resolvedChild)) {
+        enter(resolvedChild, pathPosix.join(frame.currentPath, name),
+              childRelative);
+      }
+    }
+
     return results;
   }
 

--- a/test/parallel/test-vfs-readdir-symlink-recursive.js
+++ b/test/parallel/test-vfs-readdir-symlink-recursive.js
@@ -105,3 +105,32 @@ assert.ok(
   assert.ok(dirents.some((d) => d.name === 'sub' && d.isDirectory()));
   assert.ok(dirents.some((d) => d.name === 'lnk' && d.isSymbolicLink()));
 }
+
+// Recursive readdir on a deeply nested tree must not exhaust the call stack.
+// The iterative traversal introduced in this fix handles arbitrarily deep trees
+// without recursion, so this should complete without a RangeError.
+{
+  const DEPTH = 1000;
+  const v = vfs.create();
+
+  // Build /deep/0/1/2/.../999/leaf.txt
+  let path = '/deep';
+  v.mkdirSync(path);
+  for (let i = 0; i < DEPTH; i++) {
+    path += `/${i}`;
+    v.mkdirSync(path);
+  }
+  v.writeFileSync(`${path}/leaf.txt`, 'deep');
+
+  const entries = v.readdirSync('/deep', { recursive: true });
+
+  // Every intermediate directory and the leaf file must appear.
+  assert.strictEqual(entries.length, DEPTH + 1);
+
+  // Build the expected relative path to the leaf file.
+  const expectedLeaf = Array.from({ length: DEPTH }, (_, i) => i).join('/') + '/leaf.txt';
+  assert.ok(
+    entries.includes(expectedLeaf),
+    `Expected '${expectedLeaf}' in deep-tree entries`,
+  );
+}


### PR DESCRIPTION
MemoryProvider#readdirSync with `recursive: true` follows symlinks to directories during traversal but did not bound the number of symlinks followed along a branch. A circular symlink therefore caused unbounded recursion in the internal walk() helper until the call stack was exhausted, crashing the process with `RangeError: Maximum call stack size exceeded`. Both the synchronous and promise-based variants were affected. The existing kMaxSymlinkDepth guard in #lookupEntry did not help, because walk() resolved each symlink target with a fresh depth of zero.

Track the number of symlink hops along the current branch and stop recursing once it would exceed kMaxSymlinkDepth, mirroring the ELOOP guard in #lookupEntry and the behavior of the real filesystem, which follows directory symlinks until the OS symlink limit is reached. The entries themselves are still listed, so non-circular symlinks continue to be followed as before.

Fixes: https://github.com/nodejs/node/issues/64148

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
