### PR TITLE
doc: add missing option to man page

### DIFF
--- a/doc/node.1
+++ b/doc/node.1
@@ -745,6 +745,9 @@ Enable experimental \fBimport.meta.resolve()\fR parent URL support, which allows
 passing a second \fBparentURL\fR argument for contextual resolution.
 Previously gated the entire \fBimport.meta.resolve\fR feature.
 .
+.It Fl -experimental-import-text
+Enable experimental support for importing modules with \fBwith { type: 'text' }\fR.
+.
 .It Fl -experimental-inspector-network-resource
 Enable experimental support for inspector network resources.
 .
@@ -1957,6 +1960,8 @@ one is included in the list below.
 \fB--experimental-ffi\fR
 .It
 \fB--experimental-import-meta-resolve\fR
+.It
+\fB--experimental-import-text\fR
 .It
 \fB--experimental-json-modules\fR
 .It


### PR DESCRIPTION
Add missing `--experimental-import-text` option to `doc/node.1`.

Refs: https://github.com/nodejs/node/pull/62300

---

Unfortunately there was a race between https://github.com/nodejs/node/pull/62300 and https://github.com/nodejs/node/pull/64091 that meant this was not caught by the CI.

Test is currently broken on `main`, e.g. https://github.com/nodejs/node/actions/runs/28242359195/job/83672237078#step:9:1311
```console
=== release test-cli-node-cli-manpage-options ===
Path: parallel/test-cli-node-cli-manpage-options
Error: --- stderr ---
node:internal/modules/run_main:107
    triggerUncaughtException(
    ^

AssertionError [ERR_ASSERTION]: The following flag (present in `doc/api/cli.md`) is missing in the `doc/node.1` file: "--experimental-import-text"
    at file:///home/runner/work/node/node/node/test/parallel/test-cli-node-cli-manpage-options.mjs:48:14
    at process.processTicksAndRejections (node:internal/process/task_queues:104:5) {
  generatedMessage: false,
  code: 'ERR_ASSERTION',
  actual: undefined,
  expected: undefined,
  operator: 'fail',
  diff: 'simple'
}

Node.js v27.0.0-pre
Command: out/Release/node /home/runner/work/node/node/node/test/parallel/test-cli-node-cli-manpage-options.mjs

===
=== 1 tests failed
===

Failed tests:
out/Release/node /home/runner/work/node/node/node/test/parallel/test-cli-node-cli-manpage-options.mjs
make: *** [Makefile:645: test-ci] Error 1
```

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
