### PR TITLE
quic: fix crash when no onstream handler is set with unistream

### DIFF
--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -761,7 +761,8 @@ class DefaultApplication final : public Session::Application {
         return false;
       }
 
-      // The stream was created, but was immediately destroyed because there's no onstream handler.
+      // The stream was created, but was immediately destroyed because there's
+      // no onstream handler.
       if (stream->is_destroyed()) [[unlikely]] {
         return true;
       }

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -760,6 +760,11 @@ class DefaultApplication final : public Session::Application {
         // during the onstream callback (via MakeCallback re-entrancy).
         return false;
       }
+
+      // The stream was created, but was immediately destroyed because there's no onstream handler.
+      if (stream->is_destroyed()) [[unlikely]] {
+        return true;
+      }
     } else {
       stream = BaseObjectPtr<Stream>(Stream::From(stream_user_data));
       if (!stream) {

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -860,11 +860,11 @@ struct Session::Impl final : public MemoryRetainer {
       }
     }
 
-    endpoint->RemoveSession(config_.scid, remote_address_);
-
     auto& binding = BindingData::Get(env());
     if (stats_slot_) GetSessionStatsArena(binding).ReleaseSlot(stats_slot_);
     if (state_slot_) GetSessionStateArena(binding).ReleaseSlot(state_slot_);
+
+    endpoint->RemoveSession(config_.scid, remote_address_);
   }
 
   void MemoryInfo(MemoryTracker* tracker) const override {

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1325,6 +1325,10 @@ bool Stream::is_pending() const {
   return state()->pending;
 }
 
+bool Stream::is_destroyed() const {
+  return stats()->destroyed_at != 0;
+}
+
 stream_id Stream::id() const {
   return state()->id;
 }

--- a/src/quic/streams.h
+++ b/src/quic/streams.h
@@ -267,6 +267,9 @@ class Stream final : public AsyncWrap,
   // to be created.
   bool is_pending() const;
 
+  // True if the stream is already destroyed.
+  bool is_destroyed() const;
+
   // True if we've completely sent all outbound data for this stream.
   // Importantly, this does not necessarily mean that we are completely
   // done with the outbound data. We may still be waiting on outbound

--- a/test/parallel/test-quic-stream-uni-no-onstream.mjs
+++ b/test/parallel/test-quic-stream-uni-no-onstream.mjs
@@ -3,17 +3,17 @@
 // The client creates a uni stream with no onstream.
 // Verify that this causes no crash.
 
-import {hasQuic, skip, mustCall} from '../common/index.mjs';
-import {createPrivateKey} from 'node:crypto';
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import { createPrivateKey } from 'node:crypto';
 import * as fixtures from '../common/fixtures.mjs';
 
-const {readKey} = fixtures;
+const { readKey } = fixtures;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
 
-const {listen, connect} = await import('../common/quic.mjs');
+const { listen, connect } = await import('../common/quic.mjs');
 
 const serverKey = createPrivateKey(readKey('agent1-key.pem'));
 const serverCert = readKey('agent1-cert.pem');

--- a/test/parallel/test-quic-stream-uni-no-onstream.mjs
+++ b/test/parallel/test-quic-stream-uni-no-onstream.mjs
@@ -4,7 +4,6 @@
 // Verify that this causes no crash.
 
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
-import { createPrivateKey } from 'node:crypto';
 import * as fixtures from '../common/fixtures.mjs';
 
 const { readKey } = fixtures;
@@ -13,6 +12,7 @@ if (!hasQuic) {
   skip('QUIC is not enabled');
 }
 
+const { createPrivateKey } = await import('node:crypto');
 const { listen, connect } = await import('../common/quic.mjs');
 
 const serverKey = createPrivateKey(readKey('agent1-key.pem'));

--- a/test/parallel/test-quic-stream-uni-no-onstream.mjs
+++ b/test/parallel/test-quic-stream-uni-no-onstream.mjs
@@ -1,0 +1,47 @@
+// Flags: --experimental-quic --no-warnings
+// Test: client-initiated unidirectional stream with no onstream
+// The client creates a uni stream with no onstream.
+// Verify that this causes no crash.
+
+import {hasQuic, skip, mustCall} from '../common/index.mjs';
+import {createPrivateKey} from 'node:crypto';
+import * as fixtures from '../common/fixtures.mjs';
+
+const {readKey} = fixtures;
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const {listen, connect} = await import('../common/quic.mjs');
+
+const serverKey = createPrivateKey(readKey('agent1-key.pem'));
+const serverCert = readKey('agent1-cert.pem');
+
+const done = Promise.withResolvers();
+
+const serverEndpoint = await listen(mustCall(async (session) => {
+  await session.opened;
+  done.resolve();
+}), {
+  sni: { '*': { keys: [serverKey], certs: [serverCert] } },
+  alpn: ['repro'],
+});
+
+const clientSession = await connect(serverEndpoint.address, {
+  servername: 'localhost',
+  alpn: 'repro',
+  ca: serverCert,
+});
+
+await clientSession.opened;
+
+await clientSession.createUnidirectionalStream({
+  body: 'something something darkside',
+});
+
+await done.promise;
+
+await clientSession.close();
+
+await serverEndpoint.close();


### PR DESCRIPTION
This started as a fix for #64030 (unidirectional stream crashing when there's no `onstream` handler). Which was caused by JS synchronously destroying the stream (because there was no handler) and native code still trying to access it.

While testing that, I also ran into teardown issues around `destroy()` in the same repro. I ended up including this one too, because without it I couldn't test cleanly. `Session::Impl::~Impl()` could drop the last owner of the `Session`, then keep using `session_->env()` afterward. I changed the order so anything that still needs env() runs before the session can disappear.