### PR TITLE
path: fix win32 normalize false-positive on reserved names

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -471,7 +471,7 @@ const win32 = {
       } while ((index = StringPrototypeIndexOf(path, ':', index + 1)) !== -1);
     }
     const colonIndex = StringPrototypeIndexOf(path, ':');
-    if (isWindowsReservedName(path, colonIndex)) {
+    if (colonIndex !== -1 && isWindowsReservedName(path, colonIndex)) {
       return `.\\${device ?? ''}${tail}`;
     }
     if (device === undefined) {

--- a/test/parallel/test-path-normalize.js
+++ b/test/parallel/test-path-normalize.js
@@ -69,6 +69,17 @@ assert.strictEqual(path.win32.normalize('//server/share/dir/../../../?/D:/file')
 assert.strictEqual(path.win32.normalize('//server/goodshare/../badshare/file'),
                    '\\\\server\\goodshare\\badshare\\file');
 
+// A path is only a Windows reserved device name when the reserved name is
+// followed by a colon. A name that merely starts with a reserved name (and has
+// no colon) must be left untouched and not be prefixed with `.\`.
+assert.strictEqual(path.win32.normalize('CONx'), 'CONx');
+assert.strictEqual(path.win32.normalize('NULs'), 'NULs');
+assert.strictEqual(path.win32.normalize('LPT1x'), 'LPT1x');
+assert.strictEqual(path.win32.normalize('PRNzzz'), 'PRNzzz');
+assert.strictEqual(path.win32.normalize('CON'), 'CON');
+// With a trailing colon the reserved-name handling still applies.
+assert.strictEqual(path.win32.normalize('CON:'), '.\\CON:.');
+
 assert.strictEqual(path.posix.normalize('./fixtures///b/../b/c.js'),
                    'fixtures/b/c.js');
 assert.strictEqual(path.posix.normalize('/foo/../../../bar'), '/bar');


### PR DESCRIPTION
`path.win32.normalize()` checked for Windows reserved device names (CON, NUL, PRN, LPT1, etc.) without first ensuring the path actually contained a colon. When no colon was present, `indexOf(':')` returned -1 and `isWindowsReservedName()` sliced off the last character instead of slicing up to a colon, so any filename equal to a reserved name plus one trailing character was wrongly treated as a device and prefixed with `.\` — e.g. `normalize('CONx')` returned `.\CONx` instead of `CONx`.

Guard the check with `colonIndex !== -1`, matching the other reserved name call sites which are already guarded by `colonIndex > 0`.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
