### PR TITLE
stream: fix uncatchable error closing a half-open Duplex.toWeb()

### DIFF
--- a/lib/internal/webstreams/adapters.js
+++ b/lib/internal/webstreams/adapters.js
@@ -216,7 +216,7 @@ function newWritableStreamFromStreamWritable(streamWritable, options = kEmptyObj
         closed.reject(error);
         closed = undefined;
       }
-      controller.error(error);
+      controller?.error(error);
       controller = undefined;
       return;
     }
@@ -226,7 +226,7 @@ function newWritableStreamFromStreamWritable(streamWritable, options = kEmptyObj
       closed = undefined;
       return;
     }
-    controller.error(new AbortError());
+    controller?.error(new AbortError());
     controller = undefined;
   });
 

--- a/test/parallel/test-whatwg-webstreams-adapters-to-readablewritablepair.js
+++ b/test/parallel/test-whatwg-webstreams-adapters-to-readablewritablepair.js
@@ -10,6 +10,7 @@ const {
 } = require('internal/webstreams/adapters');
 
 const {
+  Duplex,
   PassThrough,
 } = require('stream');
 
@@ -253,4 +254,28 @@ const {
   assert.throws(() => newReadableWritablePairFromDuplex(null), {
     code: 'ERR_INVALID_ARG_TYPE'
   });
+}
+
+{
+  const duplex = new Duplex({
+    allowHalfOpen: false,
+    read() {},
+    write(chunk, enc, cb) { cb(); },
+    final(cb) { setImmediate(cb); },
+  });
+
+  const {
+    readable,
+    writable,
+  } = newReadableWritablePairFromDuplex(duplex);
+
+  const reader = readable.getReader();
+  const writer = writable.getWriter();
+
+  duplex.push(null);
+
+  reader.read().then(common.mustCall(({ done }) => {
+    assert.strictEqual(done, true);
+    writer.close().then(common.mustCall());
+  }));
 }


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64120

What: Fix an uncatchable `TypeError: Cannot read properties of undefined (reading 'error')` thrown from `internal/webstreams/adapters` when closing the writable side of a half-open `Duplex.toWeb()` (e.g. a net socket whose peer sent FIN).

Why: The writable adapter's `close()` has an else-branch (taken when `writableEnded` is already true) that sets `controller = undefined` but does not detach the eos listener. When the underlying writable's finish/close fires afterward, the eos callback runs controller.error(new `AbortError()`) on the now-undefined controller and throws. Because the throw happens synchronously inside the finish event emit (not in the close() promise chain), user try/catch around writer.close() cannot catch it and the process crashes.

This was latent until v26.3.0. Commit `cbee0de` (align `Readable.toWeb` termination with eos) made the readable side's eos use writable: false, so reader.read() now resolves on the readable END before the writable FINISH. With allowHalfOpen: false, that lands `writer.close()` in the exact window where `writableEnded === true` but `writableFinished === false`, triggering the null-deref.

How: Guard both `controller.error(...)` calls in the eos callback with optional chaining `(controller?.error(...))`, completing the intent that the controller is inert once close() clears it. The eos listener is intentionally kept attached so its error-handling safety net still swallows any post-close error rather than letting that become uncaught. Adds a deterministic, network-free regression test (a `Duplex` with `allowHalfOpen: false` and a `final()` that defers finish to a macrotask).

