### PR TITLE
buffer: add fast api for isUtf8 and isAscii

### DIFF
--- a/src/node_buffer.cc
+++ b/src/node_buffer.cc
@@ -1360,19 +1360,58 @@ void FastSwap64(Local<Value> receiver,
 
 static CFunction fast_swap64(CFunction::Make(FastSwap64));
 
+struct ValidationResult {
+  bool is_valid;
+  bool was_detached;
+};
+
+static ValidationResult ValidateUtf8(Local<Value> value) {
+  ArrayBufferViewContents<char> abv(value);
+  bool was_detached = abv.WasDetached();
+  return {!was_detached && simdutf::validate_utf8(abv.data(), abv.length()),
+          was_detached};
+}
+
 static void IsUtf8(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsTypedArray() || args[0]->IsArrayBuffer() ||
         args[0]->IsSharedArrayBuffer());
-  ArrayBufferViewContents<char> abv(args[0]);
 
-  if (abv.WasDetached()) {
+  const ValidationResult result = ValidateUtf8(args[0]);
+  if (result.was_detached) {
     return node::THROW_ERR_INVALID_STATE(
         env, "Cannot validate on a detached buffer");
   }
 
-  args.GetReturnValue().Set(simdutf::validate_utf8(abv.data(), abv.length()));
+  args.GetReturnValue().Set(result.is_valid);
+}
+
+static bool FastIsUtf8(Local<Value> receiver,
+                       Local<Value> value,
+                       // NOLINTNEXTLINE(runtime/references)
+                       FastApiCallbackOptions& options) {
+  TRACK_V8_FAST_API_CALL("buffer.isUtf8");
+  HandleScope scope(options.isolate);
+
+  const ValidationResult result = ValidateUtf8(value);
+  if (result.was_detached) {
+    node::THROW_ERR_INVALID_STATE(options.isolate,
+                                  "Cannot validate on a detached buffer");
+    return false;
+  }
+  return result.is_valid;
+}
+
+static CFunction fast_is_utf8(CFunction::Make(FastIsUtf8));
+
+static ValidationResult ValidateAscii(Local<Value> value) {
+  ArrayBufferViewContents<char> abv(value);
+  bool was_detached = abv.WasDetached();
+  return {
+      !was_detached &&
+          !simdutf::validate_ascii_with_errors(abv.data(), abv.length()).error,
+      was_detached};
 }
 
 static void IsAscii(const FunctionCallbackInfo<Value>& args) {
@@ -1380,16 +1419,33 @@ static void IsAscii(const FunctionCallbackInfo<Value>& args) {
   CHECK_EQ(args.Length(), 1);
   CHECK(args[0]->IsTypedArray() || args[0]->IsArrayBuffer() ||
         args[0]->IsSharedArrayBuffer());
-  ArrayBufferViewContents<char> abv(args[0]);
 
-  if (abv.WasDetached()) {
+  const ValidationResult result = ValidateAscii(args[0]);
+  if (result.was_detached) {
     return node::THROW_ERR_INVALID_STATE(
         env, "Cannot validate on a detached buffer");
   }
 
-  args.GetReturnValue().Set(
-      !simdutf::validate_ascii_with_errors(abv.data(), abv.length()).error);
+  args.GetReturnValue().Set(result.is_valid);
 }
+
+static bool FastIsAscii(Local<Value> receiver,
+                        Local<Value> value,
+                        // NOLINTNEXTLINE(runtime/references)
+                        FastApiCallbackOptions& options) {
+  TRACK_V8_FAST_API_CALL("buffer.isAscii");
+  HandleScope scope(options.isolate);
+
+  const ValidationResult result = ValidateAscii(value);
+  if (result.was_detached) {
+    node::THROW_ERR_INVALID_STATE(options.isolate,
+                                  "Cannot validate on a detached buffer");
+    return false;
+  }
+  return result.is_valid;
+}
+
+static CFunction fast_is_ascii(CFunction::Make(FastIsAscii));
 
 void SetBufferPrototype(const FunctionCallbackInfo<Value>& args) {
   Realm* realm = Realm::GetCurrent(args);
@@ -1762,8 +1818,9 @@ void Initialize(Local<Object> target,
   SetFastMethod(context, target, "swap32", Swap32, &fast_swap32);
   SetFastMethod(context, target, "swap64", Swap64, &fast_swap64);
 
-  SetMethodNoSideEffect(context, target, "isUtf8", IsUtf8);
-  SetMethodNoSideEffect(context, target, "isAscii", IsAscii);
+  SetFastMethodNoSideEffect(context, target, "isUtf8", IsUtf8, &fast_is_utf8);
+  SetFastMethodNoSideEffect(
+      context, target, "isAscii", IsAscii, &fast_is_ascii);
 
   target
       ->Set(context,
@@ -1836,7 +1893,9 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(fast_swap64);
 
   registry->Register(IsUtf8);
+  registry->Register(fast_is_utf8);
   registry->Register(IsAscii);
+  registry->Register(fast_is_ascii);
 
   registry->Register(StringSlice<ASCII>);
   registry->Register(StringSlice<BASE64>);

--- a/test/parallel/test-buffer-isutf8-isascii-fast.js
+++ b/test/parallel/test-buffer-isutf8-isascii-fast.js
@@ -1,0 +1,34 @@
+// Flags: --expose-internals --no-warnings --allow-natives-syntax
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { Buffer, isAscii, isUtf8 } = require('buffer');
+
+const ascii = Buffer.from('hello');
+const utf8 = Buffer.from('hello \xc4\x9f');
+
+function testFastIsAscii() {
+  assert.strictEqual(isAscii(ascii), true);
+}
+
+function testFastIsUtf8() {
+  assert.strictEqual(isUtf8(utf8), true);
+}
+
+eval('%PrepareFunctionForOptimization(isAscii)');
+testFastIsAscii();
+eval('%OptimizeFunctionOnNextCall(isAscii)');
+testFastIsAscii();
+
+eval('%PrepareFunctionForOptimization(isUtf8)');
+testFastIsUtf8();
+eval('%OptimizeFunctionOnNextCall(isUtf8)');
+testFastIsUtf8();
+
+if (common.isDebug) {
+  const { internalBinding } = require('internal/test/binding');
+  const { getV8FastApiCallCount } = internalBinding('debug');
+  assert.strictEqual(getV8FastApiCallCount('buffer.isAscii'), 1);
+  assert.strictEqual(getV8FastApiCallCount('buffer.isUtf8'), 1);
+}


### PR DESCRIPTION
I like V8's fast api constraints, so I'm in the process of checking if there are any easy wins that we haven't yet spotted

Benchmarks (3 run avg, M5 Pro):

```sh
   Benchmark               Baseline avg       New avg      Delta
  ━━━━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━
   isAscii short             35,991,851    41,781,518    +16.09%
  ──────────────────────  ──────────────  ────────────  ─────────
   isAscii long              36,288,837    41,568,699    +14.55%
  ──────────────────────  ──────────────  ────────────  ─────────
   isUtf8 regular short      62,235,173    77,679,543    +24.82%
  ──────────────────────  ──────────────  ────────────  ─────────
   isUtf8 unicode short      54,727,530    67,448,276    +23.24%
  ──────────────────────  ──────────────  ────────────  ─────────
   isUtf8 regular long       21,936,234    23,323,246     +6.32%
  ──────────────────────  ──────────────  ────────────  ─────────
   isUtf8 unicode long        1,415,756     1,424,730     +0.63%
```

main:

```sh
./node benchmark/run.js --filter buffer-isutf8 --filter buffer-isascii buffers
buffers/buffer-isascii.js
buffers/buffer-isascii.js input="hello world" length="short" n=20000000: 36,815,465.272773266
buffers/buffer-isascii.js input="hello world" length="long" n=20000000: 36,183,770.13174511
buffers/buffer-isascii.js input="hello world" length="short" n=20000000: 36,618,408.943863295
buffers/buffer-isascii.js input="hello world" length="long" n=20000000: 35,746,630.542265736
buffers/buffer-isascii.js input="hello world" length="short" n=20000000: 36,457,306.78481872
buffers/buffer-isascii.js input="hello world" length="long" n=20000000: 36,401,698.177805796

buffers/buffer-isutf8.js
buffers/buffer-isutf8.js input="regular string" length="short" n=20000000: 62,364,681.698319875
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="short" n=20000000: 55,971,859.319343686
buffers/buffer-isutf8.js input="regular string" length="long" n=20000000: 22,072,747.830241162
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="long" n=20000000: 1,428,668.0720477349
buffers/buffer-isutf8.js input="regular string" length="short" n=20000000: 61,692,629.901998825
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="short" n=20000000: 55,769,467.558882594
buffers/buffer-isutf8.js input="regular string" length="long" n=20000000: 21,656,043.985478327
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="long" n=20000000: 1,411,666.258768642
buffers/buffer-isutf8.js input="regular string" length="short" n=20000000: 60,205,383.199316956
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="short" n=20000000: 54,345,813.96273032
buffers/buffer-isutf8.js input="regular string" length="long" n=20000000: 21,706,677.55977208
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="long" n=20000000: 1,417,130.332308522
```

branch:

```sh
./node benchmark/run.js --filter buffer-isutf8 --filter buffer-isascii buffers
buffers/buffer-isascii.js
buffers/buffer-isascii.js input="hello world" length="short" n=20000000: 42,042,571.75319534
buffers/buffer-isascii.js input="hello world" length="long" n=20000000: 41,993,784.33620464
buffers/buffer-isascii.js input="hello world" length="short" n=20000000: 41,651,213.719283365
buffers/buffer-isascii.js input="hello world" length="long" n=20000000: 41,547,685.95250074
buffers/buffer-isascii.js input="hello world" length="short" n=20000000: 41,650,769.262218766
buffers/buffer-isascii.js input="hello world" length="long" n=20000000: 41,164,626.14506766

buffers/buffer-isutf8.js
buffers/buffer-isutf8.js input="regular string" length="short" n=20000000: 78,129,501.6021431
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="short" n=20000000: 67,884,812.56127538
buffers/buffer-isutf8.js input="regular string" length="long" n=20000000: 23,347,893.348125998
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="long" n=20000000: 1,438,952.7056895334
buffers/buffer-isutf8.js input="regular string" length="short" n=20000000: 78,384,482.64411178
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="short" n=20000000: 68,071,405.20227206
buffers/buffer-isutf8.js input="regular string" length="long" n=20000000: 23,444,653.604879595
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="long" n=20000000: 1,421,397.567430693
buffers/buffer-isutf8.js input="regular string" length="short" n=20000000: 76,524,646.0555287
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="short" n=20000000: 66,388,609.0424605
buffers/buffer-isutf8.js input="regular string" length="long" n=20000000: 23,177,192.30868906
buffers/buffer-isutf8.js input="∀x∈ℝ: ⌈x⌉ = −⌊−x⌋" length="long" n=20000000: 1,413,840.9062698097
``` 