### PR TITLE
test: deflake test-net-listen-ipv6only

### DIFF
--- a/test/sequential/test-net-listen-ipv6only.js
+++ b/test/sequential/test-net-listen-ipv6only.js
@@ -11,9 +11,13 @@ const net = require('net');
 
 const host = '::';
 const server = net.createServer();
+// Use a fixed port and run this test sequentially. The assertion below relies
+// on nothing else listening on the IPv4 side of the chosen port; with an
+// ephemeral port under parallel execution another test can occupy that IPv4
+// port, making the connection succeed instead of being refused.
 server.listen({
   host,
-  port: 0,
+  port: common.PORT,
   ipv6Only: true,
 }, common.mustCall(() => {
   const { port } = server.address();


### PR DESCRIPTION
`test-net-listen-ipv6only` connects to the IPv4 side of an ephemeral port
expecting `ECONNREFUSED`, but never reserves that port, so under parallel
execution another test can occupy it and the connection succeeds instead —
making the test flaky (it passes reliably in isolation).

Move the test to `test/sequential/` and use a fixed `common.PORT` so it no
longer competes with other tests for the same port. This is the same fix
previously applied to the sibling cluster variants (#26298, #32381, #32398).

Fixes: https://github.com/nodejs/node/issues/64172
