### PR TITLE
lib: reject string "0" in validatePort when allowZero is false

### DIFF
--- a/lib/internal/validators.js
+++ b/lib/internal/validators.js
@@ -438,7 +438,7 @@ const validatePort = hideStackFrames((port, name = 'Port', allowZero = true) => 
       (typeof port === 'string' && StringPrototypeTrim(port).length === 0) ||
       +port !== (+port >>> 0) ||
       port > 0xFFFF ||
-      (port === 0 && !allowZero)) {
+      (+port === 0 && !allowZero)) {
     throw new ERR_SOCKET_BAD_PORT(name, port, allowZero);
   }
   return port | 0;

--- a/test/parallel/test-internal-validators-validateport.js
+++ b/test/parallel/test-internal-validators-validateport.js
@@ -21,3 +21,17 @@ for (let n = 0; n <= 0xFFFF; n++) {
 ].forEach((i) => assert.throws(() => validatePort(i), {
   code: 'ERR_SOCKET_BAD_PORT'
 }));
+
+// When allowZero is false, every form of zero must be rejected, including
+// the string forms that coerce to 0. Refs: the zero check must coerce the
+// value the same way the rest of the validation does (`+port`).
+[
+  0, '0', ' 0 ', '00', '0x0', '0o0', '0b0',
+].forEach((i) => assert.throws(() => validatePort(i, 'Port', false), {
+  code: 'ERR_SOCKET_BAD_PORT'
+}));
+
+// With allowZero left at its default (true), those same values are accepted.
+[
+  0, '0', ' 0 ', '00', '0x0', '0o0', '0b0',
+].forEach((i) => assert.strictEqual(validatePort(i), 0));


### PR DESCRIPTION
The allowZero guard compared the raw value with `port === 0`, but validatePort accepts strings and coerces them with `+port` in every other clause. Since `'0' === 0` is false, string forms of zero ('0', ' 0 ', '00', '0x0', ...) slipped past the guard when allowZero was false, while the numeric 0 was correctly rejected.

This is reachable via dgram's send(), connect(), and bind(), which call validatePort(port, 'Port', false): passing '0' was silently accepted instead of throwing ERR_SOCKET_BAD_PORT.

Coerce the value with `+port` so the zero check matches the rest of the validation.

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
