### PR TITLE
stream: expose ReadableStreamTee

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -112,6 +112,8 @@ For more details refer to the relevant documentation:
 added: REPLACEME
 -->
 
+> Stability: 1 - Experimental
+
 * `stream` {ReadableStream}
 * `cloneForBranch2` {boolean} When `true`, chunks enqueued into the second
   branch are cloned from chunks enqueued into the first branch. **Default:**

--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -106,6 +106,26 @@ For more details refer to the relevant documentation:
 
 ## API
 
+### `ReadableStreamTee(stream[, cloneForBranch2])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `stream` {ReadableStream}
+* `cloneForBranch2` {boolean} When `true`, chunks enqueued into the second
+  branch are cloned from chunks enqueued into the first branch. **Default:**
+  `false`.
+* Returns: {ReadableStream\[]} Two {ReadableStream} branches.
+
+Runs the WHATWG `ReadableStreamTee` abstract operation on `stream`.
+
+This differs from `readableStream.tee()` only when `cloneForBranch2` is
+`true`. The `tee()` method always passes `false`, while other web platform
+specifications, such as Fetch body cloning, pass `true` so that the second
+branch receives cloned chunks and consumption of one branch cannot mutate chunks
+seen by the other.
+
 ### Class: `ReadableStream`
 
 <!-- YAML

--- a/lib/stream/web.js
+++ b/lib/stream/web.js
@@ -18,7 +18,19 @@ const {
   ReadableStreamBYOBRequest,
   ReadableByteStreamController,
   ReadableStreamDefaultController,
+  isReadableStream,
+  readableStreamTee,
 } = require('internal/webstreams/readablestream');
+
+const {
+  codes: {
+    ERR_INVALID_ARG_TYPE,
+  },
+} = require('internal/errors');
+
+const {
+  validateBoolean,
+} = require('internal/validators');
 
 const {
   ByteLengthQueuingStrategy,
@@ -35,8 +47,17 @@ const {
   DecompressionStream,
 } = require('internal/webstreams/compression');
 
+function ReadableStreamTee(stream, cloneForBranch2 = false) {
+  if (!isReadableStream(stream)) {
+    throw new ERR_INVALID_ARG_TYPE('stream', 'ReadableStream', stream);
+  }
+  validateBoolean(cloneForBranch2, 'cloneForBranch2');
+  return readableStreamTee(stream, cloneForBranch2);
+}
+
 module.exports = {
   ReadableStream,
+  ReadableStreamTee,
   ReadableStreamDefaultReader,
   ReadableStreamBYOBReader,
   ReadableStreamBYOBRequest,

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -15,6 +15,7 @@ const {
   ByteLengthQueuingStrategy,
   CountQueuingStrategy,
   ReadableStream,
+  ReadableStreamTee,
   ReadableStreamDefaultReader,
   ReadableStreamDefaultController,
   ReadableByteStreamController,
@@ -1525,6 +1526,28 @@ class Source {
   assert.rejects(reader.cancel(), {
     code: 'ERR_INVALID_STATE',
   }).then(common.mustCall());
+}
+
+{
+  // Test public ReadableStreamTee() cloneForBranch2 argument
+  assert.strictEqual(typeof ReadableStreamTee, 'function');
+  const chunk = new Uint8Array([65]);
+  const readable = new ReadableStream({
+    start(controller) {
+      controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+  const [r1, r2] = ReadableStreamTee(readable, true);
+
+  (async () => {
+    const { value: value1 } = await r1.getReader().read();
+    assert.strictEqual(value1[0], 65);
+    value1[0] = 66;
+
+    const { value: value2 } = await r2.getReader().read();
+    assert.strictEqual(value2[0], 65);
+  })().then(common.mustCall());
 }
 
 {


### PR DESCRIPTION
Refs: https://github.com/nodejs/undici/issues/5358

Expose `ReadableStreamTee()` so Fetch body clone can use `cloneForBranch2`.
