### PR TITLE
doc: various updates to RELEASING.md

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -54,8 +54,8 @@ required to publish a release after it has been prepared. If you are working
 on preparing a release for the first time you will be able to do most of the
 steps as a member of the backporters team and have someone else who is
 already onboarded promote the release on your behalf. Once authorized by the
-TSC as a releaser, an individual will require the following to complete releases
-themselves:
+TSC as a releaser, an individual will require the following to publish
+releases themselves:
 
 ### 1. Jenkins release access
 

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -39,19 +39,23 @@ official release builds for Node.js, hosted on <https://nodejs.org/>.
 
 ## Who can make a release?
 
-Individuals who are Members of the
-[backporters team](https://github.com/orgs/nodejs/teams/backporters) can
-land things on the staging branches and prepare releases. This is a
-prerequisite to being able to prepare a release which is the first step
-to becoming a releaser.
+There is a distinction between individuals who can "prepare" a release by
+adding the commits to the branches in github and those who can "publish" the
+releases to nodejs.org.
 
-Release authorization is given by the Node.js TSC. This is required to
-promote a release after it has been prepared. If you are working on
-preparing a release for the first time you can do most of the steps to
-prepare the proposal branch as a member of the backporters team and have
-someone else who is already onboarded promote the release on your behalf.
-Once authorized by the TSC, an individual will require the following to
-complete releases themselves:
+Individuals who are Members of the
+[backporters team](https://github.com/orgs/nodejs/teams/backporters)
+(restricted link) can land things on the staging branches and prepare
+releases including creating the proposal branches which will be discussed
+later in this document.
+
+Authorization to publish releases is given by the Node.js TSC. This is
+required to publish a release after it has been prepared. If you are working
+on preparing a release for the first time you will be able to do most of the
+steps as a member of the backporters team abd have someone else who is
+already onboarded promote the release on your behalf. Once authorized by the
+TSC as a releaser, an individual will require the following to complete releases
+themselves:
 
 ### 1. Jenkins release access
 
@@ -98,7 +102,7 @@ _dist_ user.
 
 Release builds require manual promotion by an individual with SSH access to the
 server as the _dist_ user. The
-[Node.js build team](https://github.com/nodejs/build) is able to provide this
+[Node.js build team](lhttps://github.com/nodejs/build) is able to provide this
 access to individuals authorized by the TSC.
 
 ### 3. A publicly-listed GPG key

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -52,7 +52,7 @@ later in this document.
 Authorization to publish releases is given by the Node.js TSC. This is
 required to publish a release after it has been prepared. If you are working
 on preparing a release for the first time you will be able to do most of the
-steps as a member of the backporters team abd have someone else who is
+steps as a member of the backporters team and have someone else who is
 already onboarded promote the release on your behalf. Once authorized by the
 TSC as a releaser, an individual will require the following to complete releases
 themselves:

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -542,14 +542,15 @@ are formatted correctly.
 If this release includes new APIs then it is necessary to document that they
 were first added in this version. The relevant commits should already include
 `REPLACEME` tags (see [Writing Documentation](./api-documentation.md#writing-documentation)).
-Check for the presence of these tags and then update them either `sed` or
-`perl`. Ensure that `$VERSION` is prefixed with a `v`:
 
 ```bash
 grep REPLACEME doc/api/*.md
 ```
 
-and substitute this node version with
+The above command will check for the presence of the tags and show you which
+files need to be updated.  You can then perform the replacements with one of
+the following commands using either `sed` or `perl`.  In these examples
+`$VERSION` must be prefixed with a `v`:
 
 ```bash
 sed -i "s/REPLACEME/$VERSION/g" doc/api/*.md

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -40,7 +40,7 @@ official release builds for Node.js, hosted on <https://nodejs.org/>.
 ## Who can make a release?
 
 There is a distinction between individuals who can "prepare" a release by
-adding the commits to the branches in github and those who can "publish" the
+adding the commits to the branches in GitHub and those who can "publish" the
 releases to nodejs.org.
 
 Individuals who are Members of the

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -131,9 +131,14 @@ gpg --keyserver hkps://keys.openpgp.org --recv-keys <FINGERPRINT>
 The key you use may be a child/subkey of an existing key.
 
 If you wish to also upload your key to the commonly used Ubuntu keyservers
-you can do so with `gpg --keyserver keyserver.ubuntu.com --send-keys
-<FINGERPRINT>` and check it by switching the server name in the
-`--recv-keys` operation list above to the Ubuntu keyserver.
+you can do so with
+
+```bash
+gpg --keyserver keyserver.ubuntu.com --send-keys <FINGERPRINT>
+```
+
+and check it by switching the server name in the `--recv-keys` operation
+list above to the Ubuntu keyserver.
 
 Additionally, full GPG key fingerprints for individuals authorized to release
 should be listed in the Node.js GitHub README.md file.

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -558,7 +558,7 @@ grep REPLACEME doc/api/*.md
 
 The above command will check for the presence of the tags and show you which
 files need to be updated. You can then perform the replacements with one of
-the following commands using either `sed` or `perl`.  In these examples
+the following commands using either `sed` or `perl`. In these examples
 `$VERSION` must be prefixed with a `v`:
 
 ```bash

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -1559,7 +1559,6 @@ Typical resolution: sign the release again.
 ```
 
 [Build issue tracker]: https://github.com/nodejs/build/issues/new
-[CI lockdown procedure]: https://github.com/nodejs/build/blob/HEAD/doc/jenkins-guide.md#restricting-access-for-security-releases
 [Node.js Snap management repository]: https://github.com/nodejs/snap
 [Snap]: https://snapcraft.io/node
 [`create-release-post.yml`]: https://github.com/nodejs/nodejs.org/actions/workflows/create-release-post.yml

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -42,14 +42,16 @@ official release builds for Node.js, hosted on <https://nodejs.org/>.
 Individuals who are Members of the
 [backporters team](https://github.com/orgs/nodejs/teams/backporters) can
 land things on the staging branches and prepare releases. This is a
-prerequisite to being able to prepare releases which is the first step
+prerequisite to being able to prepare a release which is the first step
 to becoming a releaser.
 
 Release authorization is given by the Node.js TSC. This is required to
 promote a release after it has been prepared. If you are working on
-preparing a release for the first time you can do that and have someone else
-who is already onboarded promote the release on your behalf. Once
-authorized by the TSC, an individual will be require the following:
+preparing a release for the first time you can do most of the steps to
+prepare the proposal branch as a member of the backporters team and have
+someone else who is already onboarded promote the release on your behalf.
+Once authorized by the TSC, an individual will require the following to
+complete releases themselves:
 
 ### 1. Jenkins release access
 
@@ -139,7 +141,8 @@ gpg --keyserver keyserver.ubuntu.com --send-keys <FINGERPRINT>
 ```
 
 and check it by switching the server name in the `--recv-keys` operation
-list above to the Ubuntu keyserver.
+list above to the Ubuntu keyserver. For more information take a look at the
+[Ubuntu GPG howto wiki page](https://help.ubuntu.com/community/GnuPrivacyGuardHowto).
 
 Additionally, full GPG key fingerprints for individuals authorized to release
 should be listed in the Node.js GitHub README.md file.
@@ -550,7 +553,7 @@ grep REPLACEME doc/api/*.md
 ```
 
 The above command will check for the presence of the tags and show you which
-files need to be updated.  You can then perform the replacements with one of
+files need to be updated. You can then perform the replacements with one of
 the following commands using either `sed` or `perl`.  In these examples
 `$VERSION` must be prefixed with a `v`:
 

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -102,7 +102,7 @@ _dist_ user.
 
 Release builds require manual promotion by an individual with SSH access to the
 server as the _dist_ user. The
-[Node.js build team](lhttps://github.com/nodejs/build) is able to provide this
+[Node.js build team](https://github.com/nodejs/build) is able to provide this
 access to individuals authorized by the TSC.
 
 ### 3. A publicly-listed GPG key

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -157,7 +157,7 @@ Notes:
 * Version strings are listed below as _"vx.y.z"_ or _"x.y.z"_. Substitute for
   the release version.
 * Examples will use the fictional release version `1.2.3`.
-* _When preparing a security release_, follow the security steps in the details
+* When preparing a _security release_, follow the security steps in the details
   sections.
 
 ### 0. Pre-release steps

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -138,7 +138,7 @@ you can do so with `gpg --keyserver keyserver.ubuntu.com --send-keys
 Additionally, full GPG key fingerprints for individuals authorized to release
 should be listed in the Node.js GitHub README.md file.
 
-> All commits to branches in `nodejs/node` other than `main` MUST be signed
+> All commits to branches in `nodejs/node` other than `main` and `actions/*` MUST be signed
 > otherwise pushing to those branches will be rejected by GitHub.
 > Run: `git config commit.gpgsign true` inside the `node` folder or use the
 > `-S` flag on your git operations (The examples in this document will

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -537,8 +537,8 @@ are formatted correctly.
 If this release includes new APIs then it is necessary to document that they
 were first added in this version. The relevant commits should already include
 `REPLACEME` tags (see [Writing Documentation](./api-documentation.md#writing-documentation)).
-Check for these tags with either `sed` or `perl` as follows, ensuring the
-`$VERSION` is prefixed with a `v`.
+Check for the presence of these tags and then update them either `sed` or
+`perl`. Ensure that `$VERSION` is prefixed with a `v`:
 
 ```bash
 grep REPLACEME doc/api/*.md

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -39,24 +39,40 @@ official release builds for Node.js, hosted on <https://nodejs.org/>.
 
 ## Who can make a release?
 
-Release authorization is given by the Node.js TSC. Once authorized, an
-individual must have the following:
+Individuals who are Members of the
+[backporters team](https://github.com/orgs/nodejs/teams/backporters) can
+land things on the staging branches and prepare releases. This is a
+prerequisite to being able to prepare releases which is the first step
+to becoming a releaser.
+
+Release authorization is given by the Node.js TSC.  This is required to
+publish a release after it has been prepared.  If you are working on
+preparing a release for the first time you can do that and have someone else
+who is already onboarded publish the release on your behalf.  Once
+authorized by the TSC, an individual will be require the following:
 
 ### 1. Jenkins release access
 
-There are three relevant Jenkins jobs that should be used for a release flow:
+There are four relevant Jenkins jobs that should be used for a release flow:
 
 **a.** **Test runs:**
 **[node-test-pull-request](https://ci.nodejs.org/job/node-test-pull-request/)**
 is used for a final full-test run to ensure that the current _HEAD_ is stable.
 
-**b.** **Nightly builds:** (optional)
+**b.** **CITGM:**
+**[citgm-smoker](https://ci.nodejs.org/job/citgm-smoker/)** is used to run
+the citgm tool which tests a build of node.js against a defined set of
+community modules.  This is used during a release process to ensure that
+none of the commonly used modules which are tested by CITGM show functional
+regressions with the new Node.js version which could impact users.
+
+**c.** **Nightly builds:** (optional)
 **[iojs+release](https://ci-release.nodejs.org/job/iojs+release/)** can be used
 to create a nightly release for the current _HEAD_ if public test releases are
 required. Builds triggered with this job are published straight to
 <https://nodejs.org/download/nightly/> and are available for public download.
 
-**c.** **Release builds:**
+**d.** **Release builds:**
 **[iojs+release](https://ci-release.nodejs.org/job/iojs+release/)** does all of
 the work to build all required release assets. Promotion of the release files is
 a manual step once they are ready (see below).
@@ -66,8 +82,8 @@ this access to individuals authorized by the TSC.
 
 ### 2. \<nodejs.org> access
 
-The _dist_ user on nodejs.org controls the assets available in
-<https://nodejs.org/download/>. <https://nodejs.org/dist/> is an alias for
+The _dist_ user on the `nodejs.org` host controls the assets available in
+<https://nodejs.org/download/>.  <https://nodejs.org/dist/> is an alias for
 <https://nodejs.org/download/release/>.
 
 The Jenkins release build workers upload their artifacts to the web server as
@@ -90,6 +106,12 @@ responsible for that release. In order to be able to verify downloaded binaries,
 the public should be able to check that the `SHASUMS256.txt` file has been
 signed by someone who has been authorized to create a release.
 
+If you do not currently have a key then you should create one with a
+suitable strength with `gpg --full-generate-key`. The default options
+(currently "ECC sign and encrypt" and "Curve 25519") are good choices and
+consistent with the
+[ssh key recommendations in the GOVERNANCE.md file](https://github.com/nodejs/Release/blob/main/GOVERNANCE.md#ssh-key-guidance).
+
 The public keys should be fetchable from a known third-party keyserver.
 The OpenPGP keyserver at <https://keys.openpgp.org/> is recommended.
 Use the [submission](https://keys.openpgp.org/upload) form to submit
@@ -108,11 +130,23 @@ gpg --keyserver hkps://keys.openpgp.org --recv-keys <FINGERPRINT>
 
 The key you use may be a child/subkey of an existing key.
 
+If you wish to also upload your key to the commonly used Ubuntu keyservers
+you can do so with `gpg --keyserver keyserver.ubuntu.com --send-keys
+<FINGERPRINT>` and check it by switching the server name in the
+`--recv-keys` operation list above to the Ubuntu keyserver.
+
 Additionally, full GPG key fingerprints for individuals authorized to release
 should be listed in the Node.js GitHub README.md file.
 
-> It is recommended to sign all commits under the Node.js repository.
-> Run: `git config commit.gpgsign true` inside the `node` folder.
+> All commits to branches in `nodejs/node` other than `main` MUST be signed
+> otherwise pushing to those branches will fail
+> Run: `git config commit.gpgsign true` inside the `node` folder or use the
+> `-S` flag on your git operations (The examples in this document will
+> include `-S` expliticlty)
+
+Note that while GitHub allows signing individual commits using an ssh key,
+that is not covered here as this will not allow you to sign releases, so you
+will need to set up a GPG signing key in GitHub.
 
 ## How to create a release
 
@@ -123,7 +157,7 @@ Notes:
 * Version strings are listed below as _"vx.y.z"_ or _"x.y.z"_. Substitute for
   the release version.
 * Examples will use the fictional release version `1.2.3`.
-* When preparing a security release, follow the security steps in the details
+* *When preparing a security release*, follow the security steps in the details
   sections.
 
 ### 0. Pre-release steps
@@ -135,13 +169,6 @@ and the release blog post is available on the project website.
 
 Build can be contacted best by opening up an issue on the [Build issue
 tracker][].
-
-When preparing a security release, contact Build at least two weekdays in
-advance of the expected release. To ensure that the security patch(es) can be
-properly tested, run a `node-test-pull-request` job against the `main` branch
-of the `nodejs-private/node-private` repository a day or so before the
-[CI lockdown procedure][] begins. This is to confirm that Jenkins can properly
-access the private repository.
 
 ### 1. Update the staging branch
 
@@ -174,11 +201,11 @@ When landing the PR add the `Backport-PR-URL:` line to each commit. Close the
 backport PR with `Landed in ...`. Update the label on the original PR from
 `backport-requested-vN.x` to `backported-to-vN.x`.
 
-You can add the `Backport-PR-URL` metadata by using `--backport` with
-`git node land`
+You can add the `Backport-PR-URL` metadata automatically when landing by
+using `--backport` with `git node land`:
 
 ```bash
-git node land --backport $PR-NUMBER
+git node land --backport $PR-NUMBER -S
 ```
 
 To determine the relevant commits, use
@@ -189,16 +216,34 @@ metadata, as well as the GitHub labels such as `semver-minor` and
 omitted from a commit, the commit will show up because it's unsure if it's a
 duplicate or not.
 
+Note that a branch-diff run can use a lot of credits and users are
+[limited by default to 5000 per hour](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10).
+It is not unusual for a run of branch-diff to
+use around 1000 of these. For this reason it is recommended that when you
+run branch-diff you redirect the output to a file and then process it. You
+can check your current usage with `gh rate_limit` if you have the GitHub CLI
+installed and configured, or using the curl command from
+[this link](https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2026-03-10)
+with authentication e.g.
+
+```
+curl -H "Authorization: token $YOURGITHUBTOKEN" -X GET https://api.github.com/rate_limit
+```
+
 For a list of commits that could be landed in a minor release on v1.x:
 
 ```bash
 N=1 sh -c 'branch-diff v$N.x-staging upstream/main --exclude-label=semver-major,dont-land-on-v$N.x,backport-requested-v$N.x,backport-blocked-v$N.x,backport-open-v$N.x,backported-to-v$N.x --filter-release --format=simple'
 ```
 
-If the target branch is an LTS line, you should also exclude the `baking-for-lts`:
+If the target branch is an LTS line, you should also exclude the
+`baking-for-lts` and use a version other than `main` (usually a tag of the
+next actively supported version which has been available for at least two
+weeks).  In this example we use v26.5.0 as the version to compare with if
+we are preparing a release for v24:
 
 ```bash
-N=1 sh -c 'branch-diff v$N.x-staging upstream/main --exclude-label=semver-major,dont-land-on-v$N.x,backport-requested-v$N.x,backport-blocked-v$N.x,backport-open-v$N.x,backported-to-v$N.x,baking-for-lts --filter-release --format=simple'
+N=24 sh -c 'branch-diff v$N.x-staging v26.5.0 --exclude-label=semver-major,dont-land-on-v$N.x,backport-requested-v$N.x,backport-blocked-v$N.x,backport-open-v$N.x,backported-to-v$N.x,baking-for-lts --filter-release --format=simple'
 ```
 
 Previously released commits and version bumps do not need to be
@@ -215,6 +260,11 @@ Carefully review the list of commits:
 
 When you are ready to cherry-pick commits, you can automate with the following
 command.
+
+Since this is slightly different from the previous branch-diff output - it
+contains only the commit shas and in revert order - you may wish to save
+this before piping it directly to `git cherry-pick` in case it does not go
+cleanly.
 
 ```bash
 N=1 sh -c 'branch-diff v$N.x-staging upstream/main --exclude-label=semver-major,dont-land-on-v$N.x,backport-requested-v$N.x,backport-blocked-v$N.x,backport-open-v$N.x,backported-to-v$N.x --filter-release --format=sha --reverse' | xargs git cherry-pick -S
@@ -351,6 +401,8 @@ This will ensure they are included in the "Notable Changes" section of the CHANG
 
 ### 3. Update `src/node_version.h`
 
+_(This step will be done automatically if you are using `create-release-proposal` or `git node release --prepare`)_
+
 Set the version for the proposed release using the following macros, which are
 already defined in `src/node_version.h`:
 
@@ -368,6 +420,8 @@ be produced with a version string that does not have a trailing pre-release tag:
 ```
 
 ### 4. Update the changelog
+
+_(This step will be done automatically if you are using `create-release-proposal` or `git node release --prepare`)_
 
 #### Step 1: Collect the formatted list of changes
 
@@ -485,7 +539,8 @@ are formatted correctly.
 If this release includes new APIs then it is necessary to document that they
 were first added in this version. The relevant commits should already include
 `REPLACEME` tags (see [Writing Documentation](./api-documentation.md#writing-documentation)).
-Check for these tags with
+Check for these tags with either `sed` or `perl` as follows, ensuring the
+`$VERSION` is prefixed with a `v`.
 
 ```bash
 grep REPLACEME doc/api/*.md
@@ -509,8 +564,6 @@ or
 perl -pi -e "s/REPLACEME/$VERSION/g" doc/api/*.md
 ```
 
-`$VERSION` should be prefixed with a `v`.
-
 If this release includes any new deprecations it is necessary to ensure that
 those are assigned a proper static deprecation code. These are listed in the
 docs (see `doc/api/deprecations.md`) and in the source as `DEP00XX`. The code
@@ -519,6 +572,8 @@ occur when the PR is landed, but a check will be made when the release build is
 run.
 
 ### 5. Create release commit
+
+_(This step will be done automatically if you are using `create-release-proposal` or `git node release --prepare`)_
 
 The `CHANGELOG.md`, `doc/changelogs/CHANGELOG_Vx.md`, `src/node_version.h`, and
 `REPLACEME` changes should be the final commit that will be tagged for the
@@ -560,6 +615,8 @@ Otherwise, you will leak the commits before the security release.
 </details>
 
 ### 6. Propose release on GitHub
+
+_(This step will be done automatically if you are using `create-release-proposal` or `git node release --prepare`)_
 
 Push the release branch to `nodejs/node`, not to your own fork. This allows
 release branches to more easily be passed between members of the release team if
@@ -612,12 +669,17 @@ purpose. Run it once with the base `vx.x` branch as a reference and with the
 proposal branch to check if new regressions could be introduced in the
 ecosystem.
 
-Use `ncu-ci` to compare `vx.x` run (10) and proposal branch (11)
+Use `ncu-ci` with the two build numbers from the `citgm-smoker` job to
+compare the base `vx.x` run (10) and the new proposal branch (11).
 
 ```bash
 npm i -g @node-core/utils
 ncu-ci citgm 10 11
 ```
+
+Note that a number of the modules tested by CITGM are not completely
+reliable so differences shown by the comparison are not immediately cause
+for concern.
 
 <details>
 <summary>Security release</summary>

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -205,7 +205,7 @@ You can add the `Backport-PR-URL` metadata automatically when landing by
 using `--backport` with `git node land`:
 
 ```bash
-git node land --backport $PR-NUMBER -S
+git node land -S --backport $PR-NUMBER
 ```
 
 To determine the relevant commits, use
@@ -806,7 +806,7 @@ Once you have produced builds that you're happy with you can either run
 `git node release --promote`:
 
 ```bash
-git node release --promote https://github.com/nodejs/node/pull/XXXX -S
+git node release -S --promote https://github.com/nodejs/node/pull/XXXX
 ```
 
 to automate the remaining steps until step 16 or you can perform it manually
@@ -822,11 +822,10 @@ fetch the proposal from using the `--fetch-from` flag.
 When promoting several releases, you can pass multiple URLs:
 
 ```bash
-git node release --promote \
+git node release -S --promote \
   --fetch-from git@github.com:nodejs-private/node-private.git \
   https://github.com/nodejs-private/node-private/pull/XXXX \
-  https://github.com/nodejs-private/node-private/pull/XXXX \
-  -S
+  https://github.com/nodejs-private/node-private/pull/XXXX
 ```
 
 </details>

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -61,10 +61,11 @@ is used for a final full-test run to ensure that the current _HEAD_ is stable.
 
 **b.** **CitGM:**
 **[citgm-smoker](https://ci.nodejs.org/job/citgm-smoker/)** is used to run
-the CitGM tool which tests a build of Node.js against a defined set of
-community modules.  This is used during a release process to ensure that
-none of the commonly used modules which are tested by CitGM show functional
-regressions with the new Node.js version which could impact users.
+the [CitGM](https://github.com/nodejs/citgm/) tool which tests a build of
+Node.js against a defined set of community modules.  This is used during a
+release process to ensure that none of the commonly used modules which are
+tested by CitGM show functional regressions with the new Node.js version
+which could impact users.
 
 **c.** **Nightly builds:** (optional)
 **[iojs+release](https://ci-release.nodejs.org/job/iojs+release/)** can be used
@@ -144,7 +145,8 @@ Additionally, full GPG key fingerprints for individuals authorized to release
 should be listed in the Node.js GitHub README.md file.
 
 > All commits to branches in `nodejs/node` other than `main` and `actions/*` MUST be signed
-> otherwise pushing to those branches will be rejected by GitHub.
+> otherwise pushing to those branches will be rejected by the GitHub rules
+> enforced by the Node.js project.
 > Run: `git config commit.gpgsign true` inside the `node` folder or use the
 > `-S` flag on your git operations (The examples in this document will
 > include `-S` expliticlty)

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -237,10 +237,8 @@ N=1 sh -c 'branch-diff v$N.x-staging upstream/main --exclude-label=semver-major,
 ```
 
 If the target branch is an LTS line, you should also exclude the
-`baking-for-lts` and use a version other than `main` (usually a tag of the
-next actively supported version which has been available for at least two
-weeks).  In this example we use v26.5.0 as the version to compare with if
-we are preparing a release for v24:
+`baking-for-lts` and use a Current version released at least two weeks before the expected release date.
+In this example we use 25.5.0 as the base version to prepare a release for Node.js 24:
 
 ```bash
 N=24 sh -c 'branch-diff v$N.x-staging v26.5.0 --exclude-label=semver-major,dont-land-on-v$N.x,backport-requested-v$N.x,backport-blocked-v$N.x,backport-open-v$N.x,backported-to-v$N.x,baking-for-lts --filter-release --format=simple'

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -131,7 +131,8 @@ gpg --keyserver hkps://keys.openpgp.org --recv-keys <FINGERPRINT>
 The key you use may be a child/subkey of an existing key.
 
 If you wish to also upload your key to the commonly used Ubuntu keyservers
-you can do so with `gpg --keyserver keyserver.ubuntu.com --send-keys <FINGERPRINT>` and check it by switching the server name in the
+you can do so with `gpg --keyserver keyserver.ubuntu.com --send-keys
+<FINGERPRINT>` and check it by switching the server name in the
 `--recv-keys` operation list above to the Ubuntu keyserver.
 
 Additionally, full GPG key fingerprints for individuals authorized to release

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -59,11 +59,11 @@ There are four relevant Jenkins jobs that should be used for a release flow:
 **[node-test-pull-request](https://ci.nodejs.org/job/node-test-pull-request/)**
 is used for a final full-test run to ensure that the current _HEAD_ is stable.
 
-**b.** **CITGM:**
+**b.** **CitGM:**
 **[citgm-smoker](https://ci.nodejs.org/job/citgm-smoker/)** is used to run
-the citgm tool which tests a build of node.js against a defined set of
+the CitGM tool which tests a build of Node.js against a defined set of
 community modules.  This is used during a release process to ensure that
-none of the commonly used modules which are tested by CITGM show functional
+none of the commonly used modules which are tested by CitGM show functional
 regressions with the new Node.js version which could impact users.
 
 **c.** **Nightly builds:** (optional)
@@ -131,8 +131,7 @@ gpg --keyserver hkps://keys.openpgp.org --recv-keys <FINGERPRINT>
 The key you use may be a child/subkey of an existing key.
 
 If you wish to also upload your key to the commonly used Ubuntu keyservers
-you can do so with `gpg --keyserver keyserver.ubuntu.com --send-keys
-<FINGERPRINT>` and check it by switching the server name in the
+you can do so with `gpg --keyserver keyserver.ubuntu.com --send-keys <FINGERPRINT>` and check it by switching the server name in the
 `--recv-keys` operation list above to the Ubuntu keyserver.
 
 Additionally, full GPG key fingerprints for individuals authorized to release
@@ -144,7 +143,7 @@ should be listed in the Node.js GitHub README.md file.
 > `-S` flag on your git operations (The examples in this document will
 > include `-S` expliticlty)
 
-Note that while GitHub allows signing individual commits using an ssh key,
+While GitHub allows signing individual commits using an ssh key,
 that is not covered here as this will not allow you to sign releases, so you
 will need to set up a GPG signing key in GitHub.
 
@@ -157,7 +156,7 @@ Notes:
 * Version strings are listed below as _"vx.y.z"_ or _"x.y.z"_. Substitute for
   the release version.
 * Examples will use the fictional release version `1.2.3`.
-* *When preparing a security release*, follow the security steps in the details
+* _When preparing a security release_, follow the security steps in the details
   sections.
 
 ### 0. Pre-release steps
@@ -216,7 +215,7 @@ metadata, as well as the GitHub labels such as `semver-minor` and
 omitted from a commit, the commit will show up because it's unsure if it's a
 duplicate or not.
 
-Note that a branch-diff run can use a lot of credits and users are
+A `branch-diff` run can use a lot of credits and users are
 [limited by default to 5000 per hour](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2026-03-10).
 It is not unusual for a run of branch-diff to
 use around 1000 of these. For this reason it is recommended that when you
@@ -226,7 +225,7 @@ installed and configured, or using the curl command from
 [this link](https://docs.github.com/en/rest/rate-limit/rate-limit?apiVersion=2026-03-10)
 with authentication e.g.
 
-```
+```bash
 curl -H "Authorization: token $YOURGITHUBTOKEN" -X GET https://api.github.com/rate_limit
 ```
 
@@ -677,7 +676,7 @@ npm i -g @node-core/utils
 ncu-ci citgm 10 11
 ```
 
-Note that a number of the modules tested by CITGM are not completely
+A number of the modules tested by CitGM are not completely
 reliable so differences shown by the comparison are not immediately cause
 for concern.
 

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -45,10 +45,10 @@ land things on the staging branches and prepare releases. This is a
 prerequisite to being able to prepare releases which is the first step
 to becoming a releaser.
 
-Release authorization is given by the Node.js TSC.  This is required to
-publish a release after it has been prepared.  If you are working on
+Release authorization is given by the Node.js TSC. This is required to
+promote a release after it has been prepared. If you are working on
 preparing a release for the first time you can do that and have someone else
-who is already onboarded publish the release on your behalf.  Once
+who is already onboarded promote the release on your behalf. Once
 authorized by the TSC, an individual will be require the following:
 
 ### 1. Jenkins release access

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -139,7 +139,7 @@ Additionally, full GPG key fingerprints for individuals authorized to release
 should be listed in the Node.js GitHub README.md file.
 
 > All commits to branches in `nodejs/node` other than `main` MUST be signed
-> otherwise pushing to those branches will fail
+> otherwise pushing to those branches will be rejected by GitHub.
 > Run: `git config commit.gpgsign true` inside the `node` folder or use the
 > `-S` flag on your git operations (The examples in this document will
 > include `-S` expliticlty)

--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -260,7 +260,7 @@ When you are ready to cherry-pick commits, you can automate with the following
 command.
 
 Since this is slightly different from the previous branch-diff output - it
-contains only the commit shas and in revert order - you may wish to save
+contains only the commit SHAs and in revert order - you may wish to save
 this before piping it directly to `git cherry-pick` in case it does not go
 cleanly.
 


### PR DESCRIPTION
List of updates based on my recent experience [preparing 24.18.0](https://github.com/nodejs/node/pull/64062).

If anyone thinks that something in this list shouldn't be here let me know, or if any of the list of things I haven't included should be added (or are not actually correct) then let me know.

- Clarify permissions needed to be able to prepare a release
- Add CitGM to the "relevant jenkins jobs" section
- Clarify GPG key creation process and algorithms
- Also suggest that GPG keys can be published to ubuntu's keyservers
- Clarify that signed commits on release branches are required
- Add note about branch-diff using significant github API credits
- Explicit note to each section which can be skipped with the new automation

On the last point here, I did consider making those things which can now be done via automation into collapsed sections but since there are already collapsed sections in several of them for security releases I decided against it. Thoughts welcome...

### Things I haven't included

A few things from my notes from preparing 24.18.0 that I considered adding but left out:
- An example of using `git bisect` to track down a problem after doing the initial large set of cherry-picks. I suspect I'm not the only person with scripts they use, but perhaps we could have something for people to use (or do we already?). I've left anything like this out as it should perhaps be somewhere more generic like the collaborator guide.
<details>
<summary>for example here is the script I use with `git bisect` script</summary>

Not that the `taskset` is something I add to stop the build taking over my machine by limiting which cores it uses:
```
 echo -n SXAEC: `date +%T` ': '
 git log --pretty=format:"%h %ad | %s%d [%an]" --graph --date=short | head -1
 rm -rf out
 make clean 
 ./configure
 time taskset -c 0-12 make -j12 V= || exit 1
 time taskset -c 0-12 make test-ci V= CI_JS_SUITES=parallel CI_NATIVE_SUITES=
# time taskset -c 0-12 make test-ci V=
 exit $?
```
</details>

- A note about the automated workflow chosing a new semver major .0.0 version if it detects a commit with a `PR-URL:` that was originall semver-major even if it has been patched for the backported such that it isn't semver-major. This will mean having to skip use of the automation.
- The final commit with the version should NOT have `Signed-off by` at the end (i.e. don't use `-s`) otherwise it will fail the `lint-release-commit` check because the PR-URL is not the last line of the commit.
- I was tempted to give an example of an `awk` script to convert the initial branch diff output to the "SHA only" version for feeding to `git cherry-pick` but it felt safer to just suggest running it again.

Also related: https://github.com/nodejs/node/pull/64070 which was something spotted during my release prep :-)

<!--
Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
