### PR TITLE
vm: enable interception on global restricted properties

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -41,7 +41,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.24',
+    'v8_embedder_string': '-node.25',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/include/v8-template.h
+++ b/deps/v8/include/v8-template.h
@@ -684,6 +684,13 @@ enum class PropertyHandlerFlags {
   kHasNoSideEffect = 1 << 2,
 
   /**
+   * The interceptor may return non-configurable (PropertyAttribute::DontDelete)
+   * properties. When set on a global object's interceptor, it will be consulted
+   * during HasRestrictedGlobalProperty checks for lexical declarations.
+   */
+  kHasDontDeleteProperty = 1 << 3,
+
+  /**
    * This flag is used to distinguish which callbacks were provided -
    * GenericNamedPropertyXXXCallback (old signature) or
    * NamedPropertyXXXCallback (new signature).

--- a/deps/v8/src/api/api.cc
+++ b/deps/v8/src/api/api.cc
@@ -1613,6 +1613,8 @@ i::DirectHandle<i::InterceptorInfo> CreateInterceptorInfo(
       !(flags & PropertyHandlerFlags::kOnlyInterceptStrings));
   obj->set_non_masking(flags & PropertyHandlerFlags::kNonMasking);
   obj->set_has_no_side_effect(flags & PropertyHandlerFlags::kHasNoSideEffect);
+  obj->set_has_dont_delete_property(
+      flags & PropertyHandlerFlags::kHasDontDeleteProperty);
 
   if (data.IsEmpty()) {
     data = v8::Undefined(reinterpret_cast<v8::Isolate*>(i_isolate));

--- a/deps/v8/src/execution/execution.cc
+++ b/deps/v8/src/execution/execution.cc
@@ -230,18 +230,14 @@ MaybeDirectHandle<Context> NewScriptContext(
     }
 
     if (IsLexicalVariableMode(mode)) {
-      LookupIterator lookup_it(isolate, global_object, name, global_object,
-                               LookupIterator::OWN_SKIP_INTERCEPTOR);
-      Maybe<PropertyAttributes> maybe =
-          JSReceiver::GetPropertyAttributes(&lookup_it);
-      // Can't fail since the we looking up own properties on the global object
-      // skipping interceptors.
-      CHECK(!maybe.IsNothing());
-      if ((maybe.FromJust() & DONT_DELETE) != 0) {
-        // ES#sec-globaldeclarationinstantiation 5.a:
+      Maybe<bool> has_restricted = JSGlobalObject::HasRestrictedGlobalProperty(
+          isolate, global_object, name);
+      if (has_restricted.IsNothing()) return MaybeDirectHandle<Context>();
+      if (has_restricted.FromJust()) {
+        // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation 3.a:
         // If envRec.HasVarDeclaration(name) is true, throw a SyntaxError
         // exception.
-        // ES#sec-globaldeclarationinstantiation 5.d:
+        // https://tc39.es/ecma262/#sec-globaldeclarationinstantiation 3.d:
         // If hasRestrictedGlobal is true, throw a SyntaxError exception.
         MessageLocation location(script, 0, 1);
         isolate->ThrowAt(isolate->factory()->NewSyntaxError(

--- a/deps/v8/src/objects/api-callbacks-inl.h
+++ b/deps/v8/src/objects/api-callbacks-inl.h
@@ -203,6 +203,8 @@ BOOL_ACCESSORS(InterceptorInfo, flags, has_no_side_effect,
 // TODO(ishell): remove once all the Api changes are done.
 BOOL_ACCESSORS(InterceptorInfo, flags, has_new_callbacks_signature,
                HasNewCallbacksSignatureBit::kShift)
+BOOL_ACCESSORS(InterceptorInfo, flags, has_dont_delete_property,
+               HasDontDeletePropertyBit::kShift)
 
 void InterceptorInfo::RemoveCallbackRedirectionForSerialization(
     IsolateForSandbox isolate) {

--- a/deps/v8/src/objects/api-callbacks.h
+++ b/deps/v8/src/objects/api-callbacks.h
@@ -182,6 +182,7 @@ class InterceptorInfo
   // TODO(ishell): remove support for old signatures once they go through
   // Api deprecation process.
   DECL_BOOLEAN_ACCESSORS(has_new_callbacks_signature)
+  DECL_BOOLEAN_ACCESSORS(has_dont_delete_property)
 
   DEFINE_TORQUE_GENERATED_INTERCEPTOR_INFO_FLAGS()
 

--- a/deps/v8/src/objects/api-callbacks.tq
+++ b/deps/v8/src/objects/api-callbacks.tq
@@ -8,6 +8,7 @@ bitfield struct InterceptorInfoFlags extends uint31 {
   named: bool: 1 bit;
   has_no_side_effect: bool: 1 bit;
   has_new_callbacks_signature: bool: 1 bit;
+  has_dont_delete_property: bool: 1 bit;
 }
 
 extern class InterceptorInfo extends HeapObject {

--- a/deps/v8/src/objects/js-objects.cc
+++ b/deps/v8/src/objects/js-objects.cc
@@ -5786,6 +5786,24 @@ void JSGlobalObject::InvalidatePropertyCell(DirectHandle<JSGlobalObject> global,
 }
 
 // static
+Maybe<bool> JSGlobalObject::HasRestrictedGlobalProperty(
+    Isolate* isolate, DirectHandle<JSGlobalObject> global,
+    DirectHandle<Name> name) {
+  LookupIterator::Configuration config = LookupIterator::OWN_SKIP_INTERCEPTOR;
+  if (global->HasNamedInterceptor() &&
+      global->GetNamedInterceptor()->has_dont_delete_property()) {
+    config = LookupIterator::OWN;
+  }
+  LookupIterator it(isolate, global, name, global, config);
+  Maybe<PropertyAttributes> maybe = JSReceiver::GetPropertyAttributes(&it);
+  if (maybe.IsNothing()) return Nothing<bool>();
+  // Global var and function bindings (except those that are introduced by
+  // non-strict direct eval) are non-configurable and are therefore restricted
+  // global properties.
+  return Just((maybe.FromJust() & DONT_DELETE) != 0);
+}
+
+// static
 MaybeDirectHandle<JSDate> JSDate::New(Isolate* isolate,
                                       DirectHandle<JSFunction> constructor,
                                       DirectHandle<JSReceiver> new_target,

--- a/deps/v8/src/objects/js-objects.h
+++ b/deps/v8/src/objects/js-objects.h
@@ -1218,6 +1218,11 @@ class JSGlobalObject
   static void InvalidatePropertyCell(DirectHandle<JSGlobalObject> object,
                                      DirectHandle<Name> name);
 
+  // https://tc39.es/ecma262/#sec-hasrestrictedglobalproperty
+  static Maybe<bool> HasRestrictedGlobalProperty(
+      Isolate* isolate, DirectHandle<JSGlobalObject> global,
+      DirectHandle<Name> name);
+
   inline bool IsDetached();
   inline Tagged<NativeContext> native_context();
 

--- a/deps/v8/test/cctest/test-api-interceptors.cc
+++ b/deps/v8/test/cctest/test-api-interceptors.cc
@@ -834,6 +834,49 @@ THREADED_TEST(InterceptorFunctionRedeclareWithQueryCallback) {
   v8::Script::Compile(ctx, code).ToLocalChecked()->Run(ctx).ToLocalChecked();
 }
 
+// A lexical declaration must throw when the interceptor reports the property
+// as non-configurable (DontDelete), per HasRestrictedGlobalProperty checks in
+// https://tc39.es/ecma262/#sec-globaldeclarationinstantiation.
+THREADED_TEST(LexicalDeclThrowsForRestrictedGlobalViaInterceptor) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Local<v8::FunctionTemplate> templ =
+      v8::FunctionTemplate::New(CcTest::isolate());
+
+  v8::Local<ObjectTemplate> object_template = templ->InstanceTemplate();
+  object_template->SetHandler(v8::NamedPropertyHandlerConfiguration(
+      nullptr, nullptr, QueryCallbackSetDontDelete, nullptr, nullptr,
+      v8::Local<v8::Value>(),
+      v8::PropertyHandlerFlags::kHasDontDeleteProperty));
+  v8::Local<v8::Context> ctx =
+      v8::Context::New(CcTest::isolate(), nullptr, object_template);
+
+  v8::TryCatch try_catch(CcTest::isolate());
+  v8::Local<v8::String> code = v8_str("let x;");
+  CHECK(v8::Script::Compile(ctx, code).ToLocalChecked()->Run(ctx).IsEmpty());
+  CHECK(try_catch.HasCaught());
+}
+
+// Without kHasDontDeleteProperty, the interceptor is not consulted for
+// HasRestrictedGlobalProperty and lexical declarations succeed.
+THREADED_TEST(LexicalDeclSucceedsWithoutRestrictedGlobalFlag) {
+  v8::HandleScope scope(CcTest::isolate());
+  LocalContext env;
+  v8::Local<v8::FunctionTemplate> templ =
+      v8::FunctionTemplate::New(CcTest::isolate());
+
+  v8::Local<ObjectTemplate> object_template = templ->InstanceTemplate();
+  object_template->SetHandler(v8::NamedPropertyHandlerConfiguration(
+      nullptr, nullptr, QueryCallbackSetDontDelete));
+  v8::Local<v8::Context> ctx =
+      v8::Context::New(CcTest::isolate(), nullptr, object_template);
+
+  v8::TryCatch try_catch(CcTest::isolate());
+  v8::Local<v8::String> code = v8_str("let x;");
+  CHECK(!v8::Script::Compile(ctx, code).ToLocalChecked()->Run(ctx).IsEmpty());
+  CHECK(!try_catch.HasCaught());
+}
+
 // Regression test for chromium bug 656648.
 // Do not crash on non-masking, intercepting setter callbacks.
 THREADED_TEST(NonMaskingInterceptor) {

--- a/src/node_contextify.cc
+++ b/src/node_contextify.cc
@@ -170,16 +170,18 @@ void ContextifyContext::InitializeGlobalTemplates(IsolateData* isolate_data) {
   Local<ObjectTemplate> global_object_template =
       global_func_template->InstanceTemplate();
 
-  NamedPropertyHandlerConfiguration config(
-      PropertyGetterCallback,
-      PropertySetterCallback,
-      PropertyQueryCallback,
-      PropertyDeleterCallback,
-      PropertyEnumeratorCallback,
-      PropertyDefinerCallback,
-      PropertyDescriptorCallback,
-      {},
-      PropertyHandlerFlags::kHasNoSideEffect);
+  PropertyHandlerFlags flags = static_cast<PropertyHandlerFlags>(
+      static_cast<int>(PropertyHandlerFlags::kHasNoSideEffect) |
+      static_cast<int>(PropertyHandlerFlags::kHasDontDeleteProperty));
+  NamedPropertyHandlerConfiguration config(PropertyGetterCallback,
+                                           PropertySetterCallback,
+                                           PropertyQueryCallback,
+                                           PropertyDeleterCallback,
+                                           PropertyEnumeratorCallback,
+                                           PropertyDefinerCallback,
+                                           PropertyDescriptorCallback,
+                                           {},
+                                           flags);
 
   IndexedPropertyHandlerConfiguration indexed_config(
       IndexedPropertyGetterCallback,
@@ -190,7 +192,7 @@ void ContextifyContext::InitializeGlobalTemplates(IsolateData* isolate_data) {
       IndexedPropertyDefinerCallback,
       IndexedPropertyDescriptorCallback,
       {},
-      PropertyHandlerFlags::kHasNoSideEffect);
+      flags);
 
   global_object_template->SetHandler(config);
   global_object_template->SetHandler(indexed_config);

--- a/test/parallel/test-vm-global-restricted-property.js
+++ b/test/parallel/test-vm-global-restricted-property.js
@@ -1,0 +1,20 @@
+'use strict';
+require('../common');
+const assert = require('assert');
+
+const vm = require('vm');
+
+const ctx = vm.createContext({});
+
+// Define a non-configurable ("restricted") property on the context global.
+vm.runInContext(
+  "Object.defineProperty(this, 'foo', { value: 1, configurable: false });",
+  ctx
+);
+
+// https://tc39.es/ecma262/#sec-globaldeclarationinstantiation 3.d:
+// If hasRestrictedGlobal is true, throw a SyntaxError exception.
+assert.throws(
+  () => vm.runInContext('let foo = 2;', ctx),
+  vm.runInContext('SyntaxError', ctx),
+);


### PR DESCRIPTION
#### deps: V8: backport a05321ebd98e

Original commit message:

    [execution] Lookup interceptor for RestrictedGlobalProperty

    When the script context looks up if a global property is
    restricted, it should also query the global interceptor.

    To avoid calling the interceptor for every declaration
    unconditionally, an interceptor has to be defined with
    `PropertyHandlerFlags::kHasDontDeleteProperty`
    to intercept restricted global property queries.

    Refs: https://github.com/nodejs/node/issues/63715
    Refs: https://github.com/nodejs/node/issues/52634

    Change-Id: I623ff285c4e8773d8ee7f681cbad68ba24bd3f40
    Reviewed-on: https://chromium-review.googlesource.com/c/v8/v8/+/7898818
    Reviewed-by: Leszek Swirski <leszeks@chromium.org>
    Reviewed-by: Igor Sheludko <ishell@chromium.org>
    Commit-Queue: Igor Sheludko <ishell@chromium.org>
    Cr-Commit-Position: refs/heads/main@{#108280}

Refs: https://github.com/v8/v8/commit/a05321ebd98e3bff3c6bba3df02895a49d6ad2fb


#### vm: enable interception on global restricted properties

Fixes: https://github.com/nodejs/node/issues/63715