### PR TITLE
test: increase timeout in consumed-timeout test

### DIFF
--- a/test/parallel/test-http-server-consumed-timeout.js
+++ b/test/parallel/test-http-server-consumed-timeout.js
@@ -7,7 +7,7 @@ const http = require('http');
 
 const durationBetweenIntervals = [];
 let timeoutTooShort = false;
-const TIMEOUT = common.platformTimeout(200);
+const TIMEOUT = common.platformTimeout(1000);
 const INTERVAL = Math.floor(TIMEOUT / 8);
 
 runTest(TIMEOUT);


### PR DESCRIPTION
Increase the timeout used by `test-http-server-consumed-timeout` from
`common.platformTimeout(200)` to `common.platformTimeout(1000)`.

This test is intentionally timing-sensitive. On slower or more contended
hosts, especially in CI, timer delays can cause the request timeout to
fire even though the behavior under test is correct.

Using a larger timeout reduces false positives without changing the
semantics of the test.

Refs: https://ci.nodejs.org/job/node-stress-single-test/764/

---

Assisted-by: openai:gpt-5.5