### PR TITLE
sqlite: fix stale column count in StatementSync.all()

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -2865,12 +2865,16 @@ MaybeLocal<Value> StatementExecutionHelper::All(Environment* env,
   Isolate* isolate = env->isolate();
   EscapableHandleScope scope(isolate);
   int r;
-  int num_cols = sqlite3_column_count(stmt);
+  int num_cols = 0;
   LocalVector<Value> rows(isolate);
   LocalVector<Value> row_values(isolate);
   LocalVector<Name> row_keys(isolate);
 
   while ((r = sqlite3_step(stmt)) == SQLITE_ROW) {
+    if (num_cols == 0) {
+      num_cols = sqlite3_column_count(stmt);
+    }
+
     if (ExtractRowValues(env, stmt, num_cols, use_big_ints, &row_values)
             .IsNothing()) {
       return MaybeLocal<Value>();

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -83,6 +83,33 @@ suite('StatementSync.prototype.all()', () => {
       { __proto__: null, key: 'key2', val: 'val2' },
     ]);
   });
+
+  test('reflects an added column on first use after the schema changes', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+    db.exec('CREATE TABLE storage(key TEXT, val TEXT)');
+    db.prepare('INSERT INTO storage (key, val) VALUES (?, ?)').run('key1', 'val1');
+
+    const stmt = db.prepare('SELECT * FROM storage ORDER BY key');
+    db.exec("ALTER TABLE storage ADD COLUMN extra TEXT DEFAULT 'def'");
+    t.assert.deepStrictEqual(stmt.all(), [
+      { __proto__: null, key: 'key1', val: 'val1', extra: 'def' },
+    ]);
+  });
+
+  test('reflects a dropped column on first use after the schema changes', (t) => {
+    const db = new DatabaseSync(nextDb());
+    t.after(() => { db.close(); });
+    db.exec('CREATE TABLE storage(key TEXT, val TEXT, extra TEXT)');
+    db.prepare('INSERT INTO storage (key, val, extra) VALUES (?, ?, ?)')
+      .run('key1', 'val1', 'x');
+
+    const stmt = db.prepare('SELECT * FROM storage ORDER BY key');
+    db.exec('ALTER TABLE storage DROP COLUMN extra');
+    t.assert.deepStrictEqual(stmt.all(), [
+      { __proto__: null, key: 'key1', val: 'val1' },
+    ]);
+  });
 });
 
 suite('StatementSync.prototype.iterate()', () => {

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -53,6 +53,29 @@ suite('StatementSync.prototype.get()', () => {
     const stmt = db.prepare('SELECT 1 as __proto__, 2 as constructor, 3 as toString');
     t.assert.deepStrictEqual(stmt.get(), { __proto__: null, ['__proto__']: 1, constructor: 2, toString: 3 });
   });
+
+  test('reflects an added column after the schema changes', (t) => {
+    using db = new DatabaseSync(':memory:');
+    db.exec('CREATE TABLE storage(key TEXT, val TEXT)');
+    db.prepare('INSERT INTO storage (key, val) VALUES (?, ?)').run('key1', 'val1');
+    const stmt = db.prepare('SELECT * FROM storage ORDER BY key');
+    db.exec("ALTER TABLE storage ADD COLUMN extra TEXT DEFAULT 'def'");
+    t.assert.deepStrictEqual(stmt.get(), {
+      __proto__: null, key: 'key1', val: 'val1', extra: 'def',
+    });
+  });
+
+  test('reflects a dropped column after the schema changes', (t) => {
+    using db = new DatabaseSync(':memory:');
+    db.exec('CREATE TABLE storage(key TEXT, val TEXT, extra TEXT)');
+    db.prepare('INSERT INTO storage (key, val, extra) VALUES (?, ?, ?)')
+      .run('key1', 'val1', 'x');
+    const stmt = db.prepare('SELECT * FROM storage ORDER BY key');
+    db.exec('ALTER TABLE storage DROP COLUMN extra');
+    t.assert.deepStrictEqual(stmt.get(), {
+      __proto__: null, key: 'key1', val: 'val1',
+    });
+  });
 });
 
 suite('StatementSync.prototype.all()', () => {
@@ -84,12 +107,10 @@ suite('StatementSync.prototype.all()', () => {
     ]);
   });
 
-  test('reflects an added column on first use after the schema changes', (t) => {
-    const db = new DatabaseSync(nextDb());
-    t.after(() => { db.close(); });
+  test('reflects an added column after the schema changes', (t) => {
+    using db = new DatabaseSync(':memory:');
     db.exec('CREATE TABLE storage(key TEXT, val TEXT)');
     db.prepare('INSERT INTO storage (key, val) VALUES (?, ?)').run('key1', 'val1');
-
     const stmt = db.prepare('SELECT * FROM storage ORDER BY key');
     db.exec("ALTER TABLE storage ADD COLUMN extra TEXT DEFAULT 'def'");
     t.assert.deepStrictEqual(stmt.all(), [
@@ -97,13 +118,11 @@ suite('StatementSync.prototype.all()', () => {
     ]);
   });
 
-  test('reflects a dropped column on first use after the schema changes', (t) => {
-    const db = new DatabaseSync(nextDb());
-    t.after(() => { db.close(); });
+  test('reflects a dropped column after the schema changes', (t) => {
+    using db = new DatabaseSync(':memory:');
     db.exec('CREATE TABLE storage(key TEXT, val TEXT, extra TEXT)');
     db.prepare('INSERT INTO storage (key, val, extra) VALUES (?, ?, ?)')
       .run('key1', 'val1', 'x');
-
     const stmt = db.prepare('SELECT * FROM storage ORDER BY key');
     db.exec('ALTER TABLE storage DROP COLUMN extra');
     t.assert.deepStrictEqual(stmt.all(), [
@@ -150,6 +169,29 @@ suite('StatementSync.prototype.iterate()', () => {
     for (const item of stmt.iterate()) {
       t.assert.deepStrictEqual(item, itemsLoop.shift());
     }
+  });
+
+  test('reflects an added column after the schema changes', (t) => {
+    using db = new DatabaseSync(':memory:');
+    db.exec('CREATE TABLE storage(key TEXT, val TEXT)');
+    db.prepare('INSERT INTO storage (key, val) VALUES (?, ?)').run('key1', 'val1');
+    const stmt = db.prepare('SELECT * FROM storage ORDER BY key');
+    db.exec("ALTER TABLE storage ADD COLUMN extra TEXT DEFAULT 'def'");
+    t.assert.deepStrictEqual(stmt.iterate().toArray(), [
+      { __proto__: null, key: 'key1', val: 'val1', extra: 'def' },
+    ]);
+  });
+
+  test('reflects a dropped column after the schema changes', (t) => {
+    using db = new DatabaseSync(':memory:');
+    db.exec('CREATE TABLE storage(key TEXT, val TEXT, extra TEXT)');
+    db.prepare('INSERT INTO storage (key, val, extra) VALUES (?, ?, ?)')
+      .run('key1', 'val1', 'x');
+    const stmt = db.prepare('SELECT * FROM storage ORDER BY key');
+    db.exec('ALTER TABLE storage DROP COLUMN extra');
+    t.assert.deepStrictEqual(stmt.iterate().toArray(), [
+      { __proto__: null, key: 'key1', val: 'val1' },
+    ]);
   });
 
   test('iterator keeps the prepared statement from being collected', (t) => {


### PR DESCRIPTION
If the schema changes after a statement is prepared, SQLite re-prepares it on the next `sqlite3_step()` call. `StatementSync.prototype.all()` reads the column count (`sqlite3_column_count()`) before that step, so on the first call after a schema change the count is stale.

```js
const stmt = db.prepare('SELECT * FROM t'); // 2 columns
db.exec('ALTER TABLE t ADD COLUMN c'); // reprepare pending
stmt.all(); // stale count = 2

const stmt2 = db.prepare('SELECT * FROM t'); // 3 columns
db.exec('ALTER TABLE t DROP COLUMN c'); // reprepare pending
stmt2.all(); // stale count = 3
```

`StatementSync.prototype.get()` is unaffected because it reads the count after stepping.