### PR TITLE
doc: remove obsolete --napi-modules doc entry

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2004,14 +2004,6 @@ node --max-old-space-size-percentage=50 index.js
 node --max-old-space-size-percentage=75 index.js
 ```
 
-### `--napi-modules`
-
-<!-- YAML
-added: v7.10.0
--->
-
-This option is a no-op. It is kept for compatibility.
-
 ### `--network-family-autoselection-attempt-timeout`
 
 <!-- YAML
@@ -3857,7 +3849,6 @@ one is included in the list below.
 * `--localstorage-file`
 * `--max-http-header-size`
 * `--max-old-space-size-percentage`
-* `--napi-modules`
 * `--network-family-autoselection-attempt-timeout`
 * `--no-addons`
 * `--no-async-context-frame`

--- a/doc/node.1
+++ b/doc/node.1
@@ -1069,9 +1069,6 @@ node --max-old-space-size-percentage=50 index.js
 node --max-old-space-size-percentage=75 index.js
 .Ed
 .
-.It Fl -napi-modules
-This option is a no-op. It is kept for compatibility.
-.
 .It Fl -network-family-autoselection-attempt-timeout
 Sets the default value for the network family autoselection attempt timeout.
 For more information, see \fBnet.getDefaultAutoSelectFamilyAttemptTimeout()\fR.
@@ -2038,8 +2035,6 @@ one is included in the list below.
 \fB--max-http-header-size\fR
 .It
 \fB--max-old-space-size-percentage\fR
-.It
-\fB--napi-modules\fR
 .It
 \fB--network-family-autoselection-attempt-timeout\fR
 .It

--- a/test/node-api/test_fatal/test2.js
+++ b/test/node-api/test_fatal/test2.js
@@ -12,7 +12,7 @@ if (process.argv[2] === 'child') {
 }
 
 const p = child_process.spawnSync(
-  process.execPath, [ '--napi-modules', __filename, 'child' ]);
+  process.execPath, [ __filename, 'child' ]);
 assert.ifError(p.error);
 assert.ok(p.stderr.toString().includes(
   'FATAL ERROR: test_fatal::Test fatal message'));

--- a/test/parallel/test-process-env-allowed-flags-are-documented.js
+++ b/test/parallel/test-process-env-allowed-flags-are-documented.js
@@ -133,6 +133,7 @@ assert(undocumented.delete('--experimental-global-customevent'));
 assert(undocumented.delete('--experimental-global-webcrypto'));
 assert(undocumented.delete('--experimental-report'));
 assert(undocumented.delete('--experimental-worker'));
+assert(undocumented.delete('--napi-modules'));
 assert(undocumented.delete('--node-snapshot'));
 assert(undocumented.delete('--no-node-snapshot'));
 assert(undocumented.delete('--loader'));


### PR DESCRIPTION
`--napi-modules` has been a no-op for a long time. Remove it from the doc.

It is still kept as a no-op option.