### PR TITLE
module: enable import support for addons by default

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1039,9 +1039,13 @@ It is possible to run code containing inline types unless the
 added:
   - v23.6.0
   - v22.20.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/xxx
+    description: This is enabled by default.
 -->
 
-> Stability: 1.0 - Early development
+> Stability: 1.2 - Release candidate
 
 Enable experimental import support for `.node` addons.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -1041,7 +1041,7 @@ added:
   - v22.20.0
 changes:
   - version: REPLACEME
-    pr-url: https://github.com/nodejs/node/pull/xxx
+    pr-url: https://github.com/nodejs/node/pull/64221
     description: This is enabled by default.
 -->
 

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -126,7 +126,7 @@ class EnvironmentOptions : public Options {
   bool require_module = true;
   std::string dns_result_order;
   bool enable_source_maps = false;
-  bool experimental_addon_modules = EXPERIMENTALS_DEFAULT_VALUE;
+  bool experimental_addon_modules = true;
   bool experimental_eventsource = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_ffi = EXPERIMENTALS_DEFAULT_VALUE;
   bool experimental_websocket = true;


### PR DESCRIPTION
Enable experimental import support for `.node` addons by default.