### PR TITLE
build: suppress clang errors building libffi on Windows

### DIFF
--- a/deps/libffi/libffi.gyp
+++ b/deps/libffi/libffi.gyp
@@ -204,6 +204,13 @@
         },
       ],
       'conditions': [
+        ['OS == "win" and clang == 1', {
+          'msvs_settings': {
+            'VCCLCompilerTool': {
+              'AdditionalOptions': ['-Wno-incompatible-pointer-types'],
+            },
+          },
+        }],
         ['OS == "win" and (target_arch == "x64" or target_arch == "x86_64")', {
           'actions': [
             {


### PR DESCRIPTION
After the latest libffi update, a macro is passing an `int *` as a `long *` in win32 builds, which makes clang unhappy.

Refs: #64040