### PR TITLE
doc: recommend node-stress-single-test for flaky tests

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -296,8 +296,7 @@ label to the pull request.
 
 * [`node-stress-single-test`](https://ci.nodejs.org/job/node-stress-single-test/)
   can run a group of tests over and over on a specific platform. Use it to check
-  that the tests are reliable. When fixing a flaky test, it is recommended to
-  run this job to verify the test remains stable under repeated runs.
+  that the tests are reliable (i.e. not flaky).
 
 * [`node-test-commit-v8-linux`](https://ci.nodejs.org/job/node-test-commit-v8-linux/)
   runs the standard V8 tests. Run it when updating V8 in Node.js or floating new

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -296,7 +296,8 @@ label to the pull request.
 
 * [`node-stress-single-test`](https://ci.nodejs.org/job/node-stress-single-test/)
   can run a group of tests over and over on a specific platform. Use it to check
-  that the tests are reliable.
+  that the tests are reliable. When fixing a flaky test, it is recommended to
+  run this job to verify the test remains stable under repeated runs.
 
 * [`node-test-commit-v8-linux`](https://ci.nodejs.org/job/node-test-commit-v8-linux/)
   runs the standard V8 tests. Run it when updating V8 in Node.js or floating new

--- a/onboarding.md
+++ b/onboarding.md
@@ -287,7 +287,7 @@ needs to be pointed out separately during the onboarding.
   access to the projects coverity project as outlined in [static-analysis][].
 * If you are interested in helping out with CI reliability, check out the
   [reliability repository][] and [guide on how to deal with CI flakes][]. When
-  fixing a flaky test in `test/sequentual`, it is recommended to run
+  fixing a flaky test in `test/sequential`, it is recommended to run
   [`node-stress-single-test`][] on both the main branch and the test branch
   to verify the fix makes the test more stable under repeated runs. It is also
   good for tests in `test/parallel`, but not very reliable because the job runs

--- a/onboarding.md
+++ b/onboarding.md
@@ -288,7 +288,7 @@ needs to be pointed out separately during the onboarding.
 * If you are interested in helping out with CI reliability, check out the
   [reliability repository][] and [guide on how to deal with CI flakes][]. When
   fixing a flaky test, it is recommended to run [`node-stress-single-test`][]
-  to verify the test remains stable under repeated runs.
+  on both the main branch and the test branch to verify the fix makes the test more stable under repeated runs.
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
 [Labels]: doc/contributing/collaborator-guide.md#labels

--- a/onboarding.md
+++ b/onboarding.md
@@ -290,7 +290,7 @@ needs to be pointed out separately during the onboarding.
   fixing a flaky test in `test/sequential`, it is recommended to run
   [`node-stress-single-test`][] on both the main branch and the test branch
   to verify the fix makes the test more stable under repeated runs. It is also
-  good for tests in `test/parallel`, but not very reliable because the job runs
+  good for tests in `test/parallel`, but not as reliable because the job runs
   the test sequentially.
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md

--- a/onboarding.md
+++ b/onboarding.md
@@ -287,8 +287,11 @@ needs to be pointed out separately during the onboarding.
   access to the projects coverity project as outlined in [static-analysis][].
 * If you are interested in helping out with CI reliability, check out the
   [reliability repository][] and [guide on how to deal with CI flakes][]. When
-  fixing a flaky test, it is recommended to run [`node-stress-single-test`][]
-  on both the main branch and the test branch to verify the fix makes the test more stable under repeated runs.
+  fixing a flaky test in `test/sequentual`, it is recommended to run
+  [`node-stress-single-test`][] on both the main branch and the test branch
+  to verify the fix makes the test more stable under repeated runs. It is also
+  good for tests in `test/parallel`, but not very reliable because the job runs
+  the test sequentially.
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
 [Labels]: doc/contributing/collaborator-guide.md#labels

--- a/onboarding.md
+++ b/onboarding.md
@@ -286,7 +286,9 @@ needs to be pointed out separately during the onboarding.
 * If you are interested in helping to fix coverity reports consider requesting
   access to the projects coverity project as outlined in [static-analysis][].
 * If you are interested in helping out with CI reliability, check out the
-  [reliability repository][] and [guide on how to deal with CI flakes][].
+  [reliability repository][] and [guide on how to deal with CI flakes][]. When
+  fixing a flaky test, it is recommended to run [`node-stress-single-test`][]
+  to verify the test remains stable under repeated runs.
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
 [Labels]: doc/contributing/collaborator-guide.md#labels
@@ -296,6 +298,7 @@ needs to be pointed out separately during the onboarding.
 [`author-ready`]: doc/contributing/collaborator-guide.md#author-ready-pull-requests
 [`core-validate-commit`]: https://github.com/nodejs/core-validate-commit
 [`git-node`]: https://github.com/nodejs/node-core-utils/blob/HEAD/docs/git-node.md
+[`node-stress-single-test`]: https://ci.nodejs.org/job/node-stress-single-test/
 [`node-test-pull-request`]: https://ci.nodejs.org/job/node-test-pull-request/
 [guide on how to deal with CI flakes]: https://github.com/nodejs/test?tab=readme-ov-file#protocols-in-improving-ci-reliability
 [participants' expenses]: https://github.com/openjs-foundation/cross-project-council/blob/main/community-fund/COMMUNITY_FUND_POLICY.md#community-fund-rules

--- a/onboarding.md
+++ b/onboarding.md
@@ -287,11 +287,9 @@ needs to be pointed out separately during the onboarding.
   access to the projects coverity project as outlined in [static-analysis][].
 * If you are interested in helping out with CI reliability, check out the
   [reliability repository][] and [guide on how to deal with CI flakes][]. When
-  fixing a flaky test in `test/sequential`, it is recommended to run
-  [`node-stress-single-test`][] on both the main branch and the test branch
-  to verify the fix makes the test more stable under repeated runs. It is also
-  good for tests in `test/parallel`, but not as reliable because the job runs
-  the test sequentially.
+  fixing a flaky test, it is recommended to run [`node-stress-single-test`][]
+  on both the main branch and the test branch to verify the fix makes the test
+  more stable under repeated runs.
 
 [Code of Conduct]: https://github.com/nodejs/admin/blob/HEAD/CODE_OF_CONDUCT.md
 [Labels]: doc/contributing/collaborator-guide.md#labels


### PR DESCRIPTION
Recommend `node-stress-single-test` in the collaborator guide and onboarding
docs for validating fixes to flaky tests.

Refs: https://openjs-foundation.slack.com/archives/C03BJP63CH0/p1782716150521499