### PR TITLE
fs: fix close listener leak in FileHandle streams

### DIFF
--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -152,7 +152,23 @@ function importFd(stream, options) {
     stream[kHandle] = options.fd;
     stream[kFs] = FileHandleOperations(stream[kHandle]);
     stream[kHandle][kRef]();
-    options.fd.on('close', FunctionPrototypeBind(stream.close, stream));
+
+    const onclose = FunctionPrototypeBind(stream.close, stream);
+    options.fd.on('close', onclose);
+    if (options.autoClose === false) {
+      function cleanup() {
+        const handle = stream[kHandle];
+        if (handle === null)
+          return;
+        stream[kHandle] = null;
+        handle.removeListener('close', onclose);
+        handle[kUnref]();
+      }
+      stream.once('end', cleanup);
+      stream.once('finish', cleanup);
+      stream.once('error', cleanup);
+    }
+
     return options.fd.fd;
   }
 

--- a/lib/internal/fs/streams.js
+++ b/lib/internal/fs/streams.js
@@ -157,12 +157,8 @@ function importFd(stream, options) {
     options.fd.on('close', onclose);
     if (options.autoClose === false) {
       function cleanup() {
-        const handle = stream[kHandle];
-        if (handle === null)
-          return;
-        stream[kHandle] = null;
-        handle.removeListener('close', onclose);
-        handle[kUnref]();
+        options.fd.removeListener('close', onclose);
+        options.fd[kUnref]();
       }
       stream.once('end', cleanup);
       stream.once('finish', cleanup);

--- a/test/parallel/test-fs-promises-file-handle-stream.js
+++ b/test/parallel/test-fs-promises-file-handle-stream.js
@@ -42,7 +42,27 @@ async function validateRead() {
   );
 }
 
+async function validateReusedCreateReadStream() {
+  const filePath = path.resolve(tmpDir, 'tmp-reused-stream.txt');
+  fs.writeFileSync(filePath, Buffer.alloc(11, 0));
+
+  const fileHandle = await open(filePath, 'r');
+  try {
+    for (let i = 0; i < 11; i++) {
+      await buffer(fileHandle.createReadStream({
+        start: i,
+        end: i,
+        autoClose: false,
+      }));
+      assert.strictEqual(fileHandle.listenerCount('close'), 0);
+    }
+  } finally {
+    await fileHandle.close();
+  }
+}
+
 Promise.all([
   validateWrite(),
   validateRead(),
+  validateReusedCreateReadStream(),
 ]).then(common.mustCall());

--- a/test/parallel/test-fs-promises-file-handle-stream.js
+++ b/test/parallel/test-fs-promises-file-handle-stream.js
@@ -44,18 +44,36 @@ async function validateRead() {
 
 async function validateReusedCreateReadStream() {
   const filePath = path.resolve(tmpDir, 'tmp-reused-stream.txt');
-  fs.writeFileSync(filePath, Buffer.alloc(11, 0));
+  fs.writeFileSync(filePath, Buffer.from('ab', 'utf8'));
 
   const fileHandle = await open(filePath, 'r');
   try {
-    for (let i = 0; i < 11; i++) {
-      await buffer(fileHandle.createReadStream({
-        start: i,
-        end: i,
-        autoClose: false,
-      }));
-      assert.strictEqual(fileHandle.listenerCount('close'), 0);
-    }
+    await buffer(fileHandle.createReadStream({
+      start: 0,
+      end: 0,
+      autoClose: false,
+    }));
+    assert.strictEqual(fileHandle.listenerCount('close'), 0);
+
+    await buffer(fileHandle.createReadStream({
+      start: 1,
+      end: 1,
+      autoClose: false,
+    }));
+    assert.strictEqual(fileHandle.listenerCount('close'), 0);
+  } finally {
+    await fileHandle.close();
+  }
+}
+
+async function validateReusedCreateWriteStream() {
+  const filePath = path.resolve(tmpDir, 'tmp-reused-write-stream.txt');
+  const fileHandle = await open(filePath, 'w');
+  try {
+    const stream = fileHandle.createWriteStream({ autoClose: false });
+    stream.end('a');
+    await finished(stream);
+    assert.strictEqual(fileHandle.listenerCount('close'), 0);
   } finally {
     await fileHandle.close();
   }
@@ -65,4 +83,5 @@ Promise.all([
   validateWrite(),
   validateRead(),
   validateReusedCreateReadStream(),
+  validateReusedCreateWriteStream(),
 ]).then(common.mustCall());


### PR DESCRIPTION
fix: nodejs/node#64214

When autoClose is false, FileHandle.createReadStream registers a close listener on the handle. That listener is not removed after the stream finishes normally, so creating streams repeatedly on the same handle accumulates listeners.

In importFd, when autoClose is false, remove that listener and perform the corresponding unref cleanup when the stream ends (on end for read streams, on finish for write streams) or on error.