### PR TITLE
doc: add DOMException section to errors API reference

### DIFF
--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -397,6 +397,36 @@ error object, such as a {Proxy}.
 Indicates the failure of an assertion. For details, see
 [`Class: assert.AssertionError`][].
 
+## Class: `DOMException`
+
+<!-- YAML
+added: v17.0.0
+-->
+
+* Extends: {errors.Error}
+
+Indicates an error according to the
+[Web IDL DOMException interface][Web IDL DOMException]. These errors are thrown
+by web-platform APIs in Node.js such as
+[`fetch()`][], {AbortController}, {AbortSignal}, and Web Streams.
+
+For details on the `DOMException` class, see [`Class: DOMException`][]. The
+class is also documented on [MDN][].
+
+The [`domException.name`][] property identifies the type of the exception (for
+example, `'AbortError'`). Unlike most errors in Node.js, the
+[`domException.code`][] property is a number that corresponds to a
+[legacy error code name][Web IDL error names] (for example, `20` for
+`ABORT_ERR`).
+
+Node.js-specific APIs that support {AbortSignal} (such as
+[`events.once()`][]) throw a Node.js `AbortError` (a native {errors.Error} with
+`name` of `'AbortError'` and `code` of `'ABORT_ERR'`) rather than a
+`DOMException`. To identify abort errors in either case, checking
+`err?.name === 'AbortError'` is sufficient.
+
+See also [`ABORT_ERR`][].
+
 ## Class: `RangeError`
 
 * Extends: {errors.Error}
@@ -4566,6 +4596,7 @@ An error occurred trying to allocate memory. This should never happen.
 [ICU]: intl.md#internationalization-support
 [JSON Web Key Elliptic Curve Registry]: https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve
 [JSON Web Key Types Registry]: https://www.iana.org/assignments/jose/jose.xhtml#web-key-types
+[MDN]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException
 [Native TypeScript support]: typescript.md#type-stripping
 [Node.js error codes]: #nodejs-error-codes
 [Permission Model]: permissions.md#permission-model
@@ -4575,6 +4606,8 @@ An error occurred trying to allocate memory. This should never happen.
 [V8's stack trace API]: https://v8.dev/docs/stack-trace-api
 [WHATWG Supported Encodings]: util.md#whatwg-supported-encodings
 [WHATWG URL API]: url.md#the-whatwg-url-api
+[Web IDL DOMException]: https://webidl.spec.whatwg.org/#idl-DOMException
+[Web IDL error names]: https://webidl.spec.whatwg.org/#dfn-error-names-table
 [`"exports"`]: packages.md#exports
 [`"imports"`]: packages.md#imports
 [`'uncaughtException'`]: process.md#event-uncaughtexception
@@ -4582,7 +4615,9 @@ An error occurred trying to allocate memory. This should never happen.
 [`--force-fips`]: cli.md#--force-fips
 [`--no-addons`]: cli.md#--no-addons
 [`--unhandled-rejections`]: cli.md#--unhandled-rejectionsmode
+[`ABORT_ERR`]: #abort_err
 [`BoundSocket`]: net.md#class-netboundsocket
+[`Class: DOMException`]: globals.md#class-domexception
 [`Class: assert.AssertionError`]: assert.md#class-assertassertionerror
 [`ERR_INCOMPATIBLE_OPTION_PAIR`]: #err_incompatible_option_pair
 [`ERR_INVALID_ARG_TYPE`]: #err_invalid_arg_type
@@ -4609,10 +4644,13 @@ An error occurred trying to allocate memory. This should never happen.
 [`dgram.createSocket()`]: dgram.md#dgramcreatesocketoptions-callback
 [`dgram.disconnect()`]: dgram.md#socketdisconnect
 [`dgram.remoteAddress()`]: dgram.md#socketremoteaddress
+[`domException.code`]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException/code
 [`domException.name`]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException/name
 [`errno`(3) man page]: https://man7.org/linux/man-pages/man3/errno.3.html
 [`error.code`]: #errorcode
 [`error.message`]: #errormessage
+[`events.once()`]: events.md#eventsonceemitter-name-options
+[`fetch()`]: globals.md#fetch
 [`fs.Dir`]: fs.md#class-fsdir
 [`fs.cp()`]: fs.md#fscpsrc-dest-options-callback
 [`fs.readFileSync`]: fs.md#fsreadfilesyncpath-options

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -405,12 +405,9 @@ added: v17.0.0
 
 * Extends: {errors.Error}
 
-Indicates an error according to the
-[Web IDL DOMException interface][Web IDL DOMException]. These errors are thrown
-by web-platform APIs in Node.js such as
-[`fetch()`][], {AbortController}, {AbortSignal}, and Web Streams.
-
-For details on the `DOMException` class, see [`Class: DOMException`][].
+The Web IDL {DOMException} class. These errors are thrown by web-platform APIs
+in Node.js such as [`fetch()`][], {AbortController}, {AbortSignal}, and Web
+Streams.
 
 The [`domException.name`][] property identifies the type of the exception (for
 example, `'AbortError'`). Unlike most errors in Node.js, the
@@ -4604,7 +4601,6 @@ An error occurred trying to allocate memory. This should never happen.
 [V8's stack trace API]: https://v8.dev/docs/stack-trace-api
 [WHATWG Supported Encodings]: util.md#whatwg-supported-encodings
 [WHATWG URL API]: url.md#the-whatwg-url-api
-[Web IDL DOMException]: https://webidl.spec.whatwg.org/#idl-DOMException
 [Web IDL error names]: https://webidl.spec.whatwg.org/#dfn-error-names-table
 [`"exports"`]: packages.md#exports
 [`"imports"`]: packages.md#imports
@@ -4615,7 +4611,6 @@ An error occurred trying to allocate memory. This should never happen.
 [`--unhandled-rejections`]: cli.md#--unhandled-rejectionsmode
 [`ABORT_ERR`]: #abort_err
 [`BoundSocket`]: net.md#class-netboundsocket
-[`Class: DOMException`]: globals.md#class-domexception
 [`Class: assert.AssertionError`]: assert.md#class-assertassertionerror
 [`ERR_INCOMPATIBLE_OPTION_PAIR`]: #err_incompatible_option_pair
 [`ERR_INVALID_ARG_TYPE`]: #err_invalid_arg_type

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -410,8 +410,7 @@ Indicates an error according to the
 by web-platform APIs in Node.js such as
 [`fetch()`][], {AbortController}, {AbortSignal}, and Web Streams.
 
-For details on the `DOMException` class, see [`Class: DOMException`][]. The
-class is also documented on [MDN][].
+For details on the `DOMException` class, see [`Class: DOMException`][].
 
 The [`domException.name`][] property identifies the type of the exception (for
 example, `'AbortError'`). Unlike most errors in Node.js, the
@@ -4596,7 +4595,6 @@ An error occurred trying to allocate memory. This should never happen.
 [ICU]: intl.md#internationalization-support
 [JSON Web Key Elliptic Curve Registry]: https://www.iana.org/assignments/jose/jose.xhtml#web-key-elliptic-curve
 [JSON Web Key Types Registry]: https://www.iana.org/assignments/jose/jose.xhtml#web-key-types
-[MDN]: https://developer.mozilla.org/en-US/docs/Web/API/DOMException
 [Native TypeScript support]: typescript.md#type-stripping
 [Node.js error codes]: #nodejs-error-codes
 [Permission Model]: permissions.md#permission-model


### PR DESCRIPTION
Fixes #40789

Adds a `## Class: DOMException` section to `doc/api/errors.md`, following the
same cross-link pattern used for `AssertionError` (summary on the Errors page,
details on the globals page).

The section documents:

- Web IDL and MDN references for `DOMException`
- Numeric `domException.code` values (for example `20` for `ABORT_ERR`) versus
  string `error.code` values used by most Node.js errors
- The distinction between `DOMException` abort errors from web-platform APIs
  (`fetch()`, `AbortSignal.throwIfAborted()`, and similar) and Node.js
  `AbortError` (`code` of `'ABORT_ERR'`) thrown by Node-specific APIs such as
  `events.once()`
- That `err?.name === 'AbortError'` works for identifying abort errors in both
  cases

Verified locally with `node tools/lint-md/lint-md.mjs doc/api/errors.md`.