### PR TITLE
lib: use `__proto__: null` when calling `ObjectDefineProperty`

### DIFF
--- a/lib/internal/debugger/inspect_repl.js
+++ b/lib/internal/debugger/inspect_repl.js
@@ -19,15 +19,17 @@ const {
   JSONStringify,
   MathMax,
   ObjectAssign,
+  ObjectDefineProperties,
   ObjectDefineProperty,
+  ObjectGetOwnPropertyDescriptors,
   ObjectKeys,
+  ObjectSetPrototypeOf,
   ObjectValues,
   Promise,
   PromisePrototypeThen,
   PromiseResolve,
   PromiseWithResolvers,
   ReflectGetOwnPropertyDescriptor,
-  ReflectOwnKeys,
   RegExpPrototypeExec,
   SafeMap,
   SafePromiseAllReturnArrayLike,
@@ -347,18 +349,20 @@ class ScopeSnapshot {
 }
 
 function copyOwnProperties(target, source) {
-  ArrayPrototypeForEach(
-    ReflectOwnKeys(source),
-    (prop) => {
-      const desc = ReflectGetOwnPropertyDescriptor(source, prop);
-      ObjectDefineProperty(target, prop, desc);
-    });
+  const descriptors = ObjectGetOwnPropertyDescriptors(source);
+
+  const descValues = ObjectValues(descriptors);
+  for (let i = 0; i < descValues.length; ++i) {
+    ObjectSetPrototypeOf(descValues[i], null);
+  }
+
+  ObjectDefineProperties(target, descriptors);
 }
 
 function aliasProperties(target, mapping) {
   ArrayPrototypeForEach(ObjectKeys(mapping), (key) => {
     const desc = ReflectGetOwnPropertyDescriptor(target, key);
-    ObjectDefineProperty(target, mapping[key], desc);
+    ObjectDefineProperty(target, mapping[key], { __proto__: null, ...desc });
   });
 }
 

--- a/lib/internal/http2/core.js
+++ b/lib/internal/http2/core.js
@@ -3321,6 +3321,7 @@ function handleHeaderContinue(headers) {
 }
 
 const setTimeoutValue = {
+  __proto__: null,
   configurable: true,
   enumerable: true,
   writable: true,

--- a/lib/internal/per_context/domexception.js
+++ b/lib/internal/per_context/domexception.js
@@ -199,7 +199,7 @@ for (const { 0: name, 1: codeName, 2: value } of [
   // There are some more error names, but since they don't have codes assigned,
   // we don't need to care about them.
 ]) {
-  const desc = { enumerable: true, value };
+  const desc = { __proto__: null, enumerable: true, value };
   ObjectDefineProperty(DOMException, codeName, desc);
   ObjectDefineProperty(DOMExceptionPrototype, codeName, desc);
   nameToCodeMap.set(name, value);

--- a/lib/internal/test_runner/mock/mock.js
+++ b/lib/internal/test_runner/mock/mock.js
@@ -7,10 +7,14 @@ const {
   FunctionPrototypeBind,
   FunctionPrototypeCall,
   ObjectAssign,
+  ObjectDefineProperties,
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
+  ObjectGetOwnPropertyDescriptors,
   ObjectGetPrototypeOf,
   ObjectKeys,
+  ObjectSetPrototypeOf,
+  ObjectValues,
   Proxy,
   ReflectApply,
   ReflectConstruct,
@@ -146,7 +150,7 @@ class MockFunctionContext {
 
     if (typeof methodName === 'string') {
       // This is an object method spy.
-      ObjectDefineProperty(object, methodName, descriptor);
+      ObjectDefineProperty(object, methodName, { __proto__: null, ...descriptor });
     } else {
       // This is a bare function spy. There isn't much to do here but make
       // the mock call the original function.
@@ -880,13 +884,14 @@ function normalizeModuleMockOptions(options) {
 
 
 function copyOwnProperties(from, to) {
-  const keys = ObjectKeys(from);
+  const descriptors = ObjectGetOwnPropertyDescriptors(from);
 
-  for (let i = 0; i < keys.length; ++i) {
-    const key = keys[i];
-    const descriptor = ObjectGetOwnPropertyDescriptor(from, key);
-    ObjectDefineProperty(to, key, descriptor);
+  const descValues = ObjectValues(descriptors);
+  for (let i = 0; i < descValues.length; ++i) {
+    ObjectSetPrototypeOf(descValues[i], null);
   }
+
+  ObjectDefineProperties(to, descriptors);
 }
 
 function setupSharedModuleState() {

--- a/lib/internal/test_runner/mock/mock_timers.js
+++ b/lib/internal/test_runner/mock/mock_timers.js
@@ -12,6 +12,7 @@ const {
   ObjectDefineProperty,
   ObjectGetOwnPropertyDescriptor,
   ObjectGetOwnPropertyDescriptors,
+  ObjectSetPrototypeOf,
   PromiseWithResolvers,
   ReflectApply,
   Symbol,
@@ -325,7 +326,7 @@ class MockTimers {
   }
 
   #restoreOriginalAbortSignalTimeout() {
-    ObjectDefineProperty(AbortSignal, 'timeout', this.#realAbortSignalTimeout);
+    ObjectDefineProperty(AbortSignal, 'timeout', ObjectSetPrototypeOf(this.#realAbortSignalTimeout, null));
   }
 
   #createTimer(isInterval, callback, delay, ...args) {
@@ -633,7 +634,7 @@ class MockTimers {
           );
         },
         'Date': () => {
-          this.#nativeDateDescriptor = ObjectGetOwnPropertyDescriptor(globalThis, 'Date');
+          this.#nativeDateDescriptor = ObjectSetPrototypeOf(ObjectGetOwnPropertyDescriptor(globalThis, 'Date'), null);
           globalThis.Date = this.#createDate();
         },
         'AbortSignal.timeout': () => {


### PR DESCRIPTION
We have a lint rule for when the descriptor is a plain object, but it doesn't cover case where the descriptor is stored as a variable, and some instances were missing the `null` prototype.

As a reminder, setting `__proto__: null` is mandatory for property descriptor to avoid the code failing if e.g. both `Object.prototype.value` and `Object.prototype.get` are set to anything.

https://github.com/nodejs/node/blob/42fd49a4af6d62d8faf5a633af8f3cae5466b70e/doc/contributing/primordials.md?plain=1#L712-L767

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
