### PR TITLE
doc: add diagnostics_channel bypass API documentation

### DIFF
--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -293,6 +293,32 @@ function exportTraces(data) {
 }
 ```
 
+```cjs
+const diagnostics_channel = require('node:diagnostics_channel');
+const { request } = require('node:http');
+
+const { channel, bypass } = diagnostics_channel;
+
+// A unique token identifying this APM tool
+const kMyTracer = Symbol('my-tracer');
+
+// Subscribe to HTTP requests, but opt into bypass
+channel('http.client.request').subscribe((message) => {
+  console.log('HTTP request:', message.url);
+}, { bypassId: kMyTracer });
+
+// When exporting traces internally, use bypass() so the
+// above subscriber is NOT triggered for this internal request
+function exportTraces(data) {
+  bypass(kMyTracer, () => {
+    // This HTTP request will NOT trigger the subscriber above
+    request('https://my-apm-backend.example.com/traces', {
+      method: 'POST',
+    });
+  });
+}
+```
+
 Without `bypass()`, the internal `exportTraces()` HTTP request
 would trigger the subscriber, which would try to export a trace
 of the export, causing infinite recursion.
@@ -300,6 +326,22 @@ of the export, causing infinite recursion.
 The bypass context propagates across async boundaries:
 
 ```mjs
+// bypass() works across Promise boundaries
+await bypass(kMyTracer, async () => {
+  await someAsyncOperation(); // still bypassed
+  channel('http.client.request').publish(data); // subscriber skipped
+});
+
+// And across timers
+bypass(kMyTracer, () => {
+  setImmediate(() => {
+    // Still bypassed here
+    channel('http.client.request').publish(data);
+  });
+});
+```
+
+```cjs
 // bypass() works across Promise boundaries
 await bypass(kMyTracer, async () => {
   await someAsyncOperation(); // still bypassed
@@ -580,6 +622,19 @@ ch.subscribe((message) => {
 }, { bypassId: kMyTool });
 ```
 
+```cjs
+const diagnostics_channel = require('node:diagnostics_channel');
+
+const { channel, bypass } = diagnostics_channel;
+const kMyTool = Symbol('my-tool');
+const ch = channel('http.client.request');
+
+// This handler will be skipped when bypass(kMyTool, fn) is active
+ch.subscribe((message) => {
+  // handle message
+}, { bypassId: kMyTool });
+```
+
 #### `channel.unsubscribe(onMessage)`
 
 <!-- YAML
@@ -693,6 +748,21 @@ To opt this bound store into bypass behavior:
 ```mjs
 import diagnostics_channel from 'node:diagnostics_channel';
 import { AsyncLocalStorage } from 'node:async_hooks';
+
+const { channel, bypass } = diagnostics_channel;
+const kMyTool = Symbol('my-tool');
+const ch = channel('http.client.request');
+const store = new AsyncLocalStorage();
+
+// This store will NOT be entered when bypass(kMyTool, fn) is active
+ch.bindStore(store, (data) => ({ requestId: data.id }), {
+  bypassId: kMyTool,
+});
+```
+
+```cjs
+const diagnostics_channel = require('node:diagnostics_channel');
+const { AsyncLocalStorage } = require('node:async_hooks');
 
 const { channel, bypass } = diagnostics_channel;
 const kMyTool = Symbol('my-tool');
@@ -972,6 +1042,28 @@ To opt all TracingChannel handlers into bypass behavior:
 
 ```mjs
 import diagnostics_channel from 'node:diagnostics_channel';
+
+const { tracingChannel, bypass } = diagnostics_channel;
+const kMyTool = Symbol('my-tool');
+const tc = tracingChannel('my-operation');
+
+// All TracingChannel events skipped when bypass(kMyTool) is active
+tc.subscribe({
+  start(message) { /* ... */ },
+  end(message) { /* ... */ },
+  asyncStart(message) { /* ... */ },
+  asyncEnd(message) { /* ... */ },
+}, { bypassId: kMyTool });
+
+bypass(kMyTool, () => {
+  tc.traceSync(() => {
+    // start and end handlers are NOT called
+  });
+});
+```
+
+```cjs
+const diagnostics_channel = require('node:diagnostics_channel');
 
 const { tracingChannel, bypass } = diagnostics_channel;
 const kMyTool = Symbol('my-tool');

--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -286,9 +286,10 @@ channel('http.client.request').subscribe((message) => {
 function exportTraces(data) {
   bypass(kMyTracer, () => {
     // This HTTP request will NOT trigger the subscriber above
-    request('https://my-apm-backend.example.com/traces', {
+    const req = request('https://my-apm-backend.example.com/traces', {
       method: 'POST',
     });
+    req.end();
   });
 }
 ```

--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -1085,7 +1085,7 @@ tc.subscribe({
 
 bypass(kMyTool, () => {
   tc.traceSync(() => {
-    // start and end handlers are NOT called
+    // Start and end handlers are NOT called
   });
 });
 ```
@@ -1107,7 +1107,7 @@ tc.subscribe({
 
 bypass(kMyTool, () => {
   tc.traceSync(() => {
-    // start and end handlers are NOT called
+    // Start and end handlers are NOT called
   });
 });
 ```

--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -72,6 +72,13 @@ if (channel.hasSubscribers) {
 
 // Unsubscribe from the channel
 diagnostics_channel.unsubscribe('my-channel', onMessage);
+
+// Use bypass() to skip opted-in subscribers during internal calls
+const kMyTool = Symbol('my-tool');
+diagnostics_channel.channel('my-channel').subscribe(onMessage, { bypassId: kMyTool });
+diagnostics_channel.bypass(kMyTool, () => {
+  // onMessage will NOT be called for publishes inside here
+});
 ```
 
 ```cjs
@@ -97,6 +104,13 @@ if (channel.hasSubscribers) {
 
 // Unsubscribe from the channel
 diagnostics_channel.unsubscribe('my-channel', onMessage);
+
+// Use bypass() to skip opted-in subscribers during internal calls
+const kMyTool = Symbol('my-tool');
+diagnostics_channel.channel('my-channel').subscribe(onMessage, { bypassId: kMyTool });
+diagnostics_channel.bypass(kMyTool, () => {
+  // onMessage will NOT be called for publishes inside here
+});
 ```
 
 #### `diagnostics_channel.hasSubscribers(name)`
@@ -229,6 +243,92 @@ function onMessage(message, name) {
 diagnostics_channel.subscribe('my-channel', onMessage);
 
 diagnostics_channel.unsubscribe('my-channel', onMessage);
+```
+
+#### `diagnostics_channel.bypass(key, fn[, thisArg[, ...args]])`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* `key` {symbol|Object} The bypass identity token. Must match the
+  `bypassId` used when subscribing.
+* `fn` {Function} The function to run with bypass active.
+* `thisArg` {any} The receiver to use for the function call.
+* `...args` {any} Optional arguments to pass to the function.
+* Returns: {any} The return value of `fn`.
+
+Runs `fn` with the given `key` active in the current async context.
+Any channel subscribers or bound stores that were registered with
+`{ bypassId: key }` will be skipped for the duration of `fn` and
+any async continuations (Promises, timers, microtasks) within it.
+
+This is designed for observability tooling (APM agents, tracers)
+that need to prevent recursive instrumentation when their own
+internal code calls into an instrumented library.
+
+```mjs
+import diagnostics_channel from 'node:diagnostics_channel';
+import { request } from 'node:http';
+
+const { channel, bypass } = diagnostics_channel;
+
+// A unique token identifying this APM tool
+const kMyTracer = Symbol('my-tracer');
+
+// Subscribe to HTTP requests, but opt into bypass
+channel('http.client.request').subscribe((message) => {
+  console.log('HTTP request:', message.url);
+}, { bypassId: kMyTracer });
+
+// When exporting traces internally, use bypass() so the
+// above subscriber is NOT triggered for this internal request
+function exportTraces(data) {
+  bypass(kMyTracer, () => {
+    // This HTTP request will NOT trigger the subscriber above
+    request('https://my-apm-backend.example.com/traces', {
+      method: 'POST',
+    });
+  });
+}
+```
+
+Without `bypass()`, the internal `exportTraces()` HTTP request
+would trigger the subscriber, which would try to export a trace
+of the export, causing infinite recursion.
+
+The bypass context propagates across async boundaries:
+
+```mjs
+// bypass() works across Promise boundaries
+await bypass(kMyTracer, async () => {
+  await someAsyncOperation(); // still bypassed
+  channel('http.client.request').publish(data); // subscriber skipped
+});
+
+// And across timers
+bypass(kMyTracer, () => {
+  setImmediate(() => {
+    // Still bypassed here
+    channel('http.client.request').publish(data);
+  });
+});
+```
+
+Multiple tools can each use their own `bypassId` without
+interfering with each other:
+
+```mjs
+const kToolA = Symbol('tool-a');
+const kToolB = Symbol('tool-b');
+
+channel('http.client.request').subscribe(handlerA, { bypassId: kToolA });
+channel('http.client.request').subscribe(handlerB, { bypassId: kToolB });
+
+// Only handlerA is skipped, handlerB still fires
+bypass(kToolA, () => {
+  channel('http.client.request').publish(data);
+});
 ```
 
 #### `diagnostics_channel.tracingChannel(nameOrChannels)`
@@ -414,7 +514,7 @@ channel.publish({
 });
 ```
 
-#### `channel.subscribe(onMessage)`
+#### `channel.subscribe(onMessage[, options])`
 
 <!-- YAML
 added:
@@ -436,6 +536,10 @@ changes:
 * `onMessage` {Function} The handler to receive channel messages
   * `message` {any} The message data
   * `name` {string|symbol} The name of the channel
+* `options` {Object}
+  * `bypassId` {symbol|Object} An optional identity token. When
+    provided, this subscriber will be skipped while
+    [`diagnostics_channel.bypass()`][] is active with the same key.
 
 Register a message handler to subscribe to this channel. This message handler
 will be run synchronously whenever a message is published to the channel. Any
@@ -459,6 +563,21 @@ const channel = diagnostics_channel.channel('my-channel');
 channel.subscribe((message, name) => {
   // Received data
 });
+```
+
+To opt this subscriber into bypass behavior:
+
+```mjs
+import diagnostics_channel from 'node:diagnostics_channel';
+
+const { channel, bypass } = diagnostics_channel;
+const kMyTool = Symbol('my-tool');
+const ch = channel('http.client.request');
+
+// This handler will be skipped when bypass(kMyTool, fn) is active
+ch.subscribe((message) => {
+  // handle message
+}, { bypassId: kMyTool });
 ```
 
 #### `channel.unsubscribe(onMessage)`
@@ -520,7 +639,7 @@ channel.subscribe(onMessage);
 channel.unsubscribe(onMessage);
 ```
 
-#### `channel.bindStore(store[, transform])`
+#### `channel.bindStore(store[, transform[, options]])`
 
 <!-- YAML
 added:
@@ -532,6 +651,10 @@ added:
 
 * `store` {AsyncLocalStorage} The store to which to bind the context data
 * `transform` {Function} Transform context data before setting the store context
+* `options` {Object}
+  * `bypassId` {symbol|Object} An optional identity token. When
+    provided, this bound store will be skipped while
+    [`diagnostics_channel.bypass()`][] is active with the same key.
 
 When [`channel.runStores(context, ...)`][] is called, the given context data
 will be applied to any store bound to the channel. If the store has already been
@@ -562,6 +685,23 @@ const channel = diagnostics_channel.channel('my-channel');
 
 channel.bindStore(store, (data) => {
   return { data };
+});
+```
+
+To opt this bound store into bypass behavior:
+
+```mjs
+import diagnostics_channel from 'node:diagnostics_channel';
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+const { channel, bypass } = diagnostics_channel;
+const kMyTool = Symbol('my-tool');
+const ch = channel('http.client.request');
+const store = new AsyncLocalStorage();
+
+// This store will NOT be entered when bypass(kMyTool, fn) is active
+ch.bindStore(store, (data) => ({ requestId: data.id }), {
+  bypassId: kMyTool,
 });
 ```
 
@@ -756,7 +896,7 @@ simplify the process of producing events for tracing application flow.
 single `TracingChannel` at the top-level of the file rather than creating them
 dynamically.
 
-#### `tracingChannel.subscribe(subscribers)`
+#### `tracingChannel.subscribe(subscribers[, options])`
 
 <!-- YAML
 added:
@@ -770,6 +910,11 @@ added:
   * `asyncStart` {Function} The [`asyncStart` event][] subscriber
   * `asyncEnd` {Function} The [`asyncEnd` event][] subscriber
   * `error` {Function} The [`error` event][] subscriber
+* `options` {Object}
+  * `bypassId` {symbol|Object} An optional identity token. When
+    provided, ALL handlers (start, end, asyncStart, asyncEnd, error)
+    will be skipped while [`diagnostics_channel.bypass()`][] is
+    active with the same key.
 
 Helper to subscribe a collection of functions to the corresponding channels.
 This is the same as calling [`channel.subscribe(onMessage)`][] on each channel
@@ -820,6 +965,30 @@ channels.subscribe({
   error(message) {
     // Handle error message
   },
+});
+```
+
+To opt all TracingChannel handlers into bypass behavior:
+
+```mjs
+import diagnostics_channel from 'node:diagnostics_channel';
+
+const { tracingChannel, bypass } = diagnostics_channel;
+const kMyTool = Symbol('my-tool');
+const tc = tracingChannel('my-operation');
+
+// All TracingChannel events skipped when bypass(kMyTool) is active
+tc.subscribe({
+  start(message) { /* ... */ },
+  end(message) { /* ... */ },
+  asyncStart(message) { /* ... */ },
+  asyncEnd(message) { /* ... */ },
+}, { bypassId: kMyTool });
+
+bypass(kMyTool, () => {
+  tc.traceSync(() => {
+    // start and end handlers are NOT called
+  });
 });
 ```
 
@@ -1927,6 +2096,7 @@ Emitted when a new thread is created.
 [`channel.unsubscribe(onMessage)`]: #channelunsubscribeonmessage
 [`channel.withStoreScope(data)`]: #channelwithstorescopedata
 [`child_process.spawn()`]: child_process.md#child_processspawncommand-args-options
+[`diagnostics_channel.bypass()`]: #diagnostics_channelbypasskey-fn-thisarg-args
 [`diagnostics_channel.channel(name)`]: #diagnostics_channelchannelname
 [`diagnostics_channel.subscribe(name, onMessage)`]: #diagnostics_channelsubscribename-onmessage
 [`diagnostics_channel.tracingChannel()`]: #diagnostics_channeltracingchannelnameorchannels

--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -373,6 +373,23 @@ bypass(kToolA, () => {
 });
 ```
 
+```cjs
+const diagnostics_channel = require('node:diagnostics_channel');
+
+const { channel, bypass } = diagnostics_channel;
+
+const kToolA = Symbol('tool-a');
+const kToolB = Symbol('tool-b');
+
+channel('http.client.request').subscribe(handlerA, { bypassId: kToolA });
+channel('http.client.request').subscribe(handlerB, { bypassId: kToolB });
+
+// Only handlerA is skipped, handlerB still fires
+bypass(kToolA, () => {
+  channel('http.client.request').publish(data);
+});
+```
+
 #### `diagnostics_channel.tracingChannel(nameOrChannels)`
 
 <!-- YAML
@@ -563,6 +580,9 @@ added:
  - v15.1.0
  - v14.17.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63651
+    description: Added `options.bypassId` parameter.
   - version:
     - v24.8.0
     - v22.20.0
@@ -700,6 +720,10 @@ channel.unsubscribe(onMessage);
 added:
  - v19.9.0
  - v18.19.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63651
+    description: Added `options.bypassId` parameter.
 -->
 
 > Stability: 1 - Experimental
@@ -972,6 +996,10 @@ dynamically.
 added:
  - v19.9.0
  - v18.19.0
+changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/63651
+    description: Added `options.bypassId` parameter.
 -->
 
 * `subscribers` {Object} Set of [TracingChannel Channels][] subscribers

--- a/doc/api/diagnostics_channel.md
+++ b/doc/api/diagnostics_channel.md
@@ -312,9 +312,10 @@ channel('http.client.request').subscribe((message) => {
 function exportTraces(data) {
   bypass(kMyTracer, () => {
     // This HTTP request will NOT trigger the subscriber above
-    request('https://my-apm-backend.example.com/traces', {
+    const req = request('https://my-apm-backend.example.com/traces', {
       method: 'POST',
     });
+    req.end();
   });
 }
 ```
@@ -329,32 +330,30 @@ The bypass context propagates across async boundaries:
 // bypass() works across Promise boundaries
 await bypass(kMyTracer, async () => {
   await someAsyncOperation(); // still bypassed
-  channel('http.client.request').publish(data); // subscriber skipped
+  channel('http.client.request').publish({}); // subscriber skipped
 });
 
 // And across timers
 bypass(kMyTracer, () => {
   setImmediate(() => {
     // Still bypassed here
-    channel('http.client.request').publish(data);
+    channel('http.client.request').publish({});
   });
 });
 ```
 
 ```cjs
-// bypass() works across Promise boundaries
-await bypass(kMyTracer, async () => {
-  await someAsyncOperation(); // still bypassed
-  channel('http.client.request').publish(data); // subscriber skipped
-});
-
-// And across timers
-bypass(kMyTracer, () => {
-  setImmediate(() => {
-    // Still bypassed here
-    channel('http.client.request').publish(data);
+(async () => {
+  await bypass(kMyTracer, async () => {
+    await someAsyncOperation();
+    channel('http.client.request').publish({});
   });
-});
+  bypass(kMyTracer, () => {
+    setImmediate(() => {
+      channel('http.client.request').publish({});
+    });
+  });
+})();
 ```
 
 Multiple tools can each use their own `bypassId` without
@@ -369,7 +368,7 @@ channel('http.client.request').subscribe(handlerB, { bypassId: kToolB });
 
 // Only handlerA is skipped, handlerB still fires
 bypass(kToolA, () => {
-  channel('http.client.request').publish(data);
+  channel('http.client.request').publish({});
 });
 ```
 
@@ -386,7 +385,7 @@ channel('http.client.request').subscribe(handlerB, { bypassId: kToolB });
 
 // Only handlerA is skipped, handlerB still fires
 bypass(kToolA, () => {
-  channel('http.client.request').publish(data);
+  channel('http.client.request').publish({});
 });
 ```
 


### PR DESCRIPTION
Documents the new bypass API introduced in #63651:

- `diagnostics_channel.bypass(key, fn[, thisArg[, ...args]])`
- `channel.subscribe(handler, { bypassId })`
- `channel.bindStore(store, transform, { bypassId })`
- `tracingChannel.subscribe(handlers, { bypassId })`

Includes full parameter docs, APM use case example,
multi-vendor coordination example, async boundary examples,
and both MJS and CJS code samples throughout.

Refs: #63651