### PR TITLE
diagnostics_channel: replace using with try-finally

### DIFF
--- a/lib/diagnostics_channel.js
+++ b/lib/diagnostics_channel.js
@@ -88,8 +88,8 @@ class RunStoresScope {
   #stack;
 
   constructor(activeChannel, data) {
-    // eslint-disable-next-line no-restricted-globals
-    using stack = new DisposableStack();
+    // TODO: use native DisposableStack once supported in core
+    const stack = [];
 
     // Enter stores using withScope
     if (activeChannel._stores) {
@@ -109,7 +109,7 @@ class RunStoresScope {
           }
         }
 
-        stack.use(store.withScope(newContext));
+        ArrayPrototypePush(stack, store.withScope(newContext));
       }
     }
 
@@ -117,11 +117,19 @@ class RunStoresScope {
     activeChannel.publish(data);
 
     // Transfer ownership of the stack
-    this.#stack = stack.move();
+    // TODO: Restore stack.move() when DisposableStack is restored in core to avoid broken behavior.
+    this.#stack = stack;
   }
 
   [SymbolDispose]() {
-    this.#stack[SymbolDispose]();
+    if (this.#stack !== undefined) {
+      const stack = this.#stack;
+      this.#stack = undefined;
+
+      for (let i = stack.length - 1; i >= 0; i--) {
+        stack[i][SymbolDispose]();
+      }
+    }
   }
 }
 
@@ -197,9 +205,12 @@ class ActiveChannel {
   }
 
   runStores(data, fn, thisArg, ...args) {
-    // eslint-disable-next-line no-unused-vars
-    using scope = this.withStoreScope(data);
-    return ReflectApply(fn, thisArg, args);
+    const scope = this.withStoreScope(data);
+    try {
+      return ReflectApply(fn, thisArg, args);
+    } finally {
+      scope[SymbolDispose]();
+    }
   }
 }
 
@@ -396,9 +407,12 @@ class BoundedChannel {
 
   run(context, fn, thisArg, ...args) {
     context ??= {};
-    // eslint-disable-next-line no-unused-vars
-    using scope = this.withScope(context);
-    return ReflectApply(fn, thisArg, args);
+    const scope = this.withScope(context);
+    try {
+      return ReflectApply(fn, thisArg, args);
+    } finally {
+      scope[SymbolDispose]();
+    }
   }
 }
 
@@ -520,9 +534,8 @@ class TracingChannel {
     }
 
     const { error } = this;
+    const scope = this.#callWindow.withScope(context);
 
-    // eslint-disable-next-line no-unused-vars
-    using scope = this.#callWindow.withScope(context);
     try {
       const result = ReflectApply(fn, thisArg, args);
       context.result = result;
@@ -531,6 +544,8 @@ class TracingChannel {
       context.error = err;
       error.publish(context);
       throw err;
+    } finally {
+      scope[SymbolDispose]();
     }
   }
 
@@ -550,9 +565,9 @@ class TracingChannel {
       context.error = err;
       error.publish(context);
       // Use continuation window for asyncStart/asyncEnd
-      // eslint-disable-next-line no-unused-vars
-      using scope = continuationWindow.withScope(context);
+      const scope = continuationWindow.withScope(context);
       // TODO: Is there a way to have asyncEnd _after_ the continuation?
+      scope[SymbolDispose]();
     }
 
     function onRejectWithRethrow(err) {
@@ -563,14 +578,14 @@ class TracingChannel {
     function onResolve(result) {
       context.result = result;
       // Use continuation window for asyncStart/asyncEnd
-      // eslint-disable-next-line no-unused-vars
-      using scope = continuationWindow.withScope(context);
+      const scope = continuationWindow.withScope(context);
       // TODO: Is there a way to have asyncEnd _after_ the continuation?
+      scope[SymbolDispose]();
       return result;
     }
 
-    // eslint-disable-next-line no-unused-vars
-    using scope = this.#callWindow.withScope(context);
+    const scope = this.#callWindow.withScope(context);
+
     try {
       const result = ReflectApply(fn, thisArg, args);
       // If the return value is not a thenable, return it directly with a warning.
@@ -595,6 +610,8 @@ class TracingChannel {
       context.error = err;
       error.publish(context);
       throw err;
+    } finally {
+      scope[SymbolDispose]();
     }
   }
 
@@ -615,23 +632,28 @@ class TracingChannel {
       }
 
       // Use continuation window for asyncStart/asyncEnd around callback
-      // eslint-disable-next-line no-unused-vars
-      using scope = continuationWindow.withScope(context);
-      return ReflectApply(callback, this, arguments);
+      const scope = continuationWindow.withScope(context);
+      try {
+        return ReflectApply(callback, this, arguments);
+      } finally {
+        scope[SymbolDispose]();
+      }
     }
 
     const callback = ArrayPrototypeAt(args, position);
     validateFunction(callback, 'callback');
     ArrayPrototypeSplice(args, position, 1, wrappedCallback);
 
-    // eslint-disable-next-line no-unused-vars
-    using scope = this.#callWindow.withScope(context);
+    const scope = this.#callWindow.withScope(context);
+
     try {
       return ReflectApply(fn, thisArg, args);
     } catch (err) {
       context.error = err;
       error.publish(context);
       throw err;
+    } finally {
+      scope[SymbolDispose]();
     }
   }
 }

--- a/test/parallel/test-diagnostics-channel-no-erm.js
+++ b/test/parallel/test-diagnostics-channel-no-erm.js
@@ -1,0 +1,11 @@
+// Flags: --no-js-explicit-resource-management
+'use strict';
+
+require('../common');
+const { tracingChannel } = require('diagnostics_channel');
+
+// This test ensures that using diagnostics_channel does not cause a segfault
+// when explicit resource management is disabled in V8.
+// Refs: https://github.com/nodejs/node/issues/64230
+
+tracingChannel('foo').traceSync(() => {});


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fixes: #64230

### Description
This PR replaces instances of the experimental `using` syntax with `try...finally` blocks inside `lib/diagnostics_channel.js`. 

Since Explicit Resource Management is still a flagged feature in V8, encountering `using` in core causes a segfault when running Node with the `--no-js-explicit-resource-management` flag. This refactor maintains the exact same resource cleanup semantics by manually calling `[SymbolDispose]()` in a `finally` block, avoiding the flagged syntax entirely.

### Example of Refactor

**Before:**
```javascript
using scope = this.withStoreScope(data);
return ReflectApply(fn, thisArg, args);
```
**After**
```javascript
const scope = this.withStoreScope(data);
try {
  return ReflectApply(fn, thisArg, args);
} finally {
  scope[SymbolDispose]();
}
```