### PR TITLE
stream: refactor unnecessary optional chaining away

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -848,15 +848,15 @@ class DefaultReadRequest {
   }
 
   [kChunk](value) {
-    this[kState].resolve?.({ done: false, value });
+    this[kState].resolve({ done: false, value });
   }
 
   [kClose]() {
-    this[kState].resolve?.({ done: true, value: undefined });
+    this[kState].resolve({ done: true, value: undefined });
   }
 
   [kError](error) {
-    this[kState].reject?.(error);
+    this[kState].reject(error);
   }
 
   get promise() { return this[kState].promise; }
@@ -868,15 +868,15 @@ class ReadIntoRequest {
   }
 
   [kChunk](value) {
-    this[kState].resolve?.({ done: false, value });
+    this[kState].resolve({ done: false, value });
   }
 
   [kClose](value) {
-    this[kState].resolve?.({ done: true, value });
+    this[kState].resolve({ done: true, value });
   }
 
   [kError](error) {
-    this[kState].reject?.(error);
+    this[kState].reject(error);
   }
 
   get promise() { return this[kState].promise; }
@@ -2169,7 +2169,7 @@ function readableStreamCancel(stream, reason) {
 function readableStreamClose(stream) {
   assert(stream[kState].state === 'readable');
   stream[kState].state = 'closed';
-  stream[kState].closedPromise?.resolve?.();
+  stream[kState].closedPromise?.resolve();
   const {
     reader,
   } = stream[kState];
@@ -2177,7 +2177,7 @@ function readableStreamClose(stream) {
   if (reader === undefined)
     return;
 
-  reader[kState].close?.resolve?.();
+  reader[kState].close?.resolve();
 
   if (readableStreamHasDefaultReader(stream)) {
     for (let n = 0; n < reader[kState].readRequests.length; n++)
@@ -2193,7 +2193,7 @@ function readableStreamError(stream, error) {
   const closedPromiseCache = stream[kState].closedPromise;
   if (closedPromiseCache !== undefined) {
     setPromiseHandled(closedPromiseCache.promise);
-    closedPromiseCache.reject?.(error);
+    closedPromiseCache.reject(error);
   }
 
   const {
@@ -2206,7 +2206,7 @@ function readableStreamError(stream, error) {
   const closeCache = reader[kState].close;
   if (closeCache !== undefined) {
     setPromiseHandled(closeCache.promise);
-    closeCache.reject?.(error);
+    closeCache.reject(error);
   }
 
   if (readableStreamHasDefaultReader(stream)) {
@@ -2400,7 +2400,7 @@ function readableStreamReaderGenericRelease(reader) {
   const closeCache = reader[kState].close;
   if (stream[kState].state === 'readable') {
     if (closeCache !== undefined) {
-      closeCache.reject?.(lazyReadableReleasedError());
+      closeCache.reject(lazyReadableReleasedError());
       setPromiseHandled(closeCache.promise);
     }
   } else {

--- a/lib/internal/webstreams/transfer.js
+++ b/lib/internal/webstreams/transfer.js
@@ -192,7 +192,7 @@ class CrossRealmTransformWritableSink {
       switch (type) {
         case 'pull':
           if (this[kState].backpressurePromise !== undefined)
-            this[kState].backpressurePromise.resolve?.();
+            this[kState].backpressurePromise.resolve();
           this[kState].backpressurePromise = undefined;
           break;
         case 'error':
@@ -200,7 +200,7 @@ class CrossRealmTransformWritableSink {
             this[kState].controller,
             value);
           if (this[kState].backpressurePromise !== undefined)
-            this[kState].backpressurePromise.resolve?.();
+            this[kState].backpressurePromise.resolve();
           this[kState].backpressurePromise = undefined;
           break;
       }

--- a/lib/internal/webstreams/transformstream.js
+++ b/lib/internal/webstreams/transformstream.js
@@ -432,7 +432,7 @@ function transformStreamUnblockWrite(stream) {
 function transformStreamSetBackpressure(stream, backpressure) {
   assert(stream[kState].backpressure !== backpressure);
   if (stream[kState].backpressureChange.promise !== undefined)
-    stream[kState].backpressureChange.resolve?.();
+    stream[kState].backpressureChange.resolve();
   stream[kState].backpressureChange = PromiseWithResolvers();
   stream[kState].backpressure = backpressure;
 }

--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -744,7 +744,7 @@ function writableStreamClose(stream) {
   stream[kState].closeRequest = PromiseWithResolvers();
   const { promise } = stream[kState].closeRequest;
   if (writer !== undefined && backpressure && state === 'writable')
-    writer[kState].ready?.resolve?.();
+    writer[kState].ready?.resolve();
   writableStreamDefaultControllerClose(controller);
   return promise;
 }
@@ -761,7 +761,7 @@ function writableStreamUpdateBackpressure(stream, backpressure) {
       // dropping the cache lets the next observation derive it.
       writer[kState].ready = undefined;
     } else {
-      writer[kState].ready?.resolve?.();
+      writer[kState].ready?.resolve();
     }
   }
   stream[kState].backpressure = backpressure;
@@ -790,14 +790,14 @@ function writableStreamRejectCloseAndClosedPromiseIfNeeded(stream) {
   assert(stream[kState].state === 'errored');
   if (stream[kState].closeRequest.promise !== undefined) {
     assert(stream[kState].inFlightCloseRequest.promise === undefined);
-    stream[kState].closeRequest.reject?.(stream[kState].storedError);
+    stream[kState].closeRequest.reject(stream[kState].storedError);
     stream[kState].closeRequest = kNilRequest;
   }
 
   const closedPromiseCache = stream[kState].closedPromise;
   if (closedPromiseCache !== undefined) {
     setPromiseHandled(closedPromiseCache.promise);
-    closedPromiseCache.reject?.(stream[kState].storedError);
+    closedPromiseCache.reject(stream[kState].storedError);
   }
 
   const {
@@ -807,7 +807,7 @@ function writableStreamRejectCloseAndClosedPromiseIfNeeded(stream) {
     const closeCache = writer[kState].close;
     if (closeCache !== undefined) {
       setPromiseHandled(closeCache.promise);
-      closeCache.reject?.(stream[kState].storedError);
+      closeCache.reject(stream[kState].storedError);
     }
   }
 }
@@ -840,7 +840,7 @@ function writableStreamHasOperationMarkedInFlight(stream) {
 
 function writableStreamFinishInFlightWriteWithError(stream, error) {
   assert(stream[kState].inFlightWriteRequest.promise !== undefined);
-  stream[kState].inFlightWriteRequest.reject?.(error);
+  stream[kState].inFlightWriteRequest.reject(error);
   stream[kState].inFlightWriteRequest = kNilRequest;
   assert(stream[kState].state === 'writable' ||
          stream[kState].state === 'erroring');
@@ -849,18 +849,18 @@ function writableStreamFinishInFlightWriteWithError(stream, error) {
 
 function writableStreamFinishInFlightWrite(stream) {
   assert(stream[kState].inFlightWriteRequest.promise !== undefined);
-  stream[kState].inFlightWriteRequest.resolve?.();
+  stream[kState].inFlightWriteRequest.resolve();
   stream[kState].inFlightWriteRequest = kNilRequest;
 }
 
 function writableStreamFinishInFlightCloseWithError(stream, error) {
   assert(stream[kState].inFlightCloseRequest.promise !== undefined);
-  stream[kState].inFlightCloseRequest.reject?.(error);
+  stream[kState].inFlightCloseRequest.reject(error);
   stream[kState].inFlightCloseRequest = kNilRequest;
   assert(stream[kState].state === 'writable' ||
          stream[kState].state === 'erroring');
   if (stream[kState].pendingAbortRequest.abort.promise !== undefined) {
-    stream[kState].pendingAbortRequest.abort.reject?.(error);
+    stream[kState].pendingAbortRequest.abort.reject(error);
     stream[kState].pendingAbortRequest = kNilPendingAbortRequest;
   }
   writableStreamDealWithRejection(stream, error);
@@ -868,19 +868,19 @@ function writableStreamFinishInFlightCloseWithError(stream, error) {
 
 function writableStreamFinishInFlightClose(stream) {
   assert(stream[kState].inFlightCloseRequest.promise !== undefined);
-  stream[kState].inFlightCloseRequest.resolve?.();
+  stream[kState].inFlightCloseRequest.resolve();
   stream[kState].inFlightCloseRequest = kNilRequest;
   if (stream[kState].state === 'erroring') {
     stream[kState].storedError = undefined;
     if (stream[kState].pendingAbortRequest.abort.promise !== undefined) {
-      stream[kState].pendingAbortRequest.abort.resolve?.();
+      stream[kState].pendingAbortRequest.abort.resolve();
       stream[kState].pendingAbortRequest = kNilPendingAbortRequest;
     }
   }
   stream[kState].state = 'closed';
   if (stream[kState].writer !== undefined)
-    stream[kState].writer[kState].close?.resolve?.();
-  stream[kState].closedPromise?.resolve?.();
+    stream[kState].writer[kState].close?.resolve();
+  stream[kState].closedPromise?.resolve();
   assert(stream[kState].pendingAbortRequest.abort.promise === undefined);
   assert(stream[kState].storedError === undefined);
 }
@@ -892,7 +892,7 @@ function writableStreamFinishErroring(stream) {
   stream[kState].controller[kError]();
   const storedError = stream[kState].storedError;
   for (let n = 0; n < stream[kState].writeRequests.length; n++)
-    stream[kState].writeRequests[n].reject?.(storedError);
+    stream[kState].writeRequests[n].reject(storedError);
   stream[kState].writeRequests = [];
 
   if (stream[kState].pendingAbortRequest.abort.promise === undefined) {
@@ -903,18 +903,18 @@ function writableStreamFinishErroring(stream) {
   const abortRequest = stream[kState].pendingAbortRequest;
   stream[kState].pendingAbortRequest = kNilPendingAbortRequest;
   if (abortRequest.wasAlreadyErroring) {
-    abortRequest.abort.reject?.(storedError);
+    abortRequest.abort.reject(storedError);
     writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
     return;
   }
   PromisePrototypeThen(
     stream[kState].controller[kAbort](abortRequest.reason),
     () => {
-      abortRequest.abort.resolve?.();
+      abortRequest.abort.resolve();
       writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
     },
     (error) => {
-      abortRequest.abort.reject?.(error);
+      abortRequest.abort.reject(error);
       writableStreamRejectCloseAndClosedPromiseIfNeeded(stream);
     });
 }
@@ -1019,7 +1019,7 @@ function writableStreamDefaultWriterGetDesiredSize(writer) {
 function writableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error) {
   const ready = writer[kState].ready;
   if (ready !== undefined && isPromisePending(ready.promise)) {
-    ready.reject?.(error);
+    ready.reject(error);
     setPromiseHandled(ready.promise);
   } else {
     // The spec replaces [[readyPromise]] with a promise rejected with the
@@ -1032,7 +1032,7 @@ function writableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error) {
 function writableStreamDefaultWriterEnsureClosedPromiseRejected(writer, error) {
   const close = writer[kState].close;
   if (close !== undefined && isPromisePending(close.promise)) {
-    close.reject?.(error);
+    close.reject(error);
     setPromiseHandled(close.promise);
   } else {
     // See writableStreamDefaultWriterEnsureReadyPromiseRejected.


### PR DESCRIPTION
According to https://adventures.nodeland.dev/archive/noop-functions-vs-optional-chaining-a-performance/, we should shave a few cycles
Most of those have become unnecessary since https://github.com/nodejs/node/pull/63876