### PR TITLE
test: unmark flaky http2-large-file for Win

### DIFF
--- a/test/sequential/sequential.status
+++ b/test/sequential/sequential.status
@@ -13,10 +13,6 @@ test-watch-mode-inspect: PASS, FLAKY
 # https://github.com/nodejs/node/issues/47409
 test-http2-large-file: PASS, FLAKY
 
-[$system==win32]
-# https://github.com/nodejs/node/issues/47409
-test-http2-large-file: PASS, FLAKY
-
 [$system==linux]
 # https://github.com/nodejs/node/issues/54817
 test-http-server-request-timeouts-mixed: PASS, FLAKY


### PR DESCRIPTION
## test: unmark flaky http2-large-file for Windows

`test-http2-large-file` is marked FLAKY in the `[$system==win32]` section, but it is already marked FLAKY in the `[true]` section, which applies to all platforms including Windows. The Windows entry is therefore redundant.