### PR TITLE
doc: add note on visibility of CI failures to new contributor guide

### DIFF
--- a/doc/contributing/first-contributions.md
+++ b/doc/contributing/first-contributions.md
@@ -168,6 +168,13 @@ before approving the CI runs. Similar to the review process, be patient and resp
 the volunteers' time when you are asking for help to trigger the CI runs, this helps build
 trust to make future contributions smoother.
 
+Since read access to the CI is also restricted, one of the collaborators also will need to let
+you know about any failures unless you are a member of one of the platform teams in the Node.js
+organisation. If after a day or so from a collaborator triggering a CI your PR shows a failure
+in either the `node-test-pull-request` or `node-test-commit-*` checks it's worth adding a
+comment to the PR asking what tests are failed, as the collaborator may not realise that you
+cannot see the results directly in the CI.
+
 ### Q: The CI runs showed some failures that seem unrelated to my change. What should I do?
 
 The Node.js CIs are known to be flaky. Consult the daily reports in

--- a/doc/contributing/first-contributions.md
+++ b/doc/contributing/first-contributions.md
@@ -168,9 +168,11 @@ before approving the CI runs. Similar to the review process, be patient and resp
 the volunteers' time when you are asking for help to trigger the CI runs, this helps build
 trust to make future contributions smoother.
 
-Since read access to the Jenkins CI is also restricted, one of the collaborators also will need to
-let you know about any failures unless you are a member of one of the platform teams in the Node.js
-organisation.  If after a day or so from a collaborator triggering a Jenkins CI your PR shows a
+### Q: The Jenkins CI failed, but when I clicked the CI link, it shows "Access Denied". What should I do?
+
+Read access to the Jenkins CI is restricted to a few teams in the Node.js organization. You will
+need to ask a member of these teams (for example, any of the collaborators) to show you the details
+of the failures. If after a day or so from a collaborator triggering a Jenkins CI your PR shows a
 failure in either the `node-test-pull-request` or `node-test-commit-*` checks it's worth adding a
 comment to the PR asking what tests are failed, as the collaborator may not realise that you cannot
 see the results directly.

--- a/doc/contributing/first-contributions.md
+++ b/doc/contributing/first-contributions.md
@@ -168,12 +168,12 @@ before approving the CI runs. Similar to the review process, be patient and resp
 the volunteers' time when you are asking for help to trigger the CI runs, this helps build
 trust to make future contributions smoother.
 
-Since read access to the CI is also restricted, one of the collaborators also will need to let
-you know about any failures unless you are a member of one of the platform teams in the Node.js
-organisation. If after a day or so from a collaborator triggering a CI your PR shows a failure
-in either the `node-test-pull-request` or `node-test-commit-*` checks it's worth adding a
-comment to the PR asking what tests are failed, as the collaborator may not realise that you
-cannot see the results directly in the CI.
+Since read access to the Jenkins CI is also restricted, one of the collaborators also will need to
+let you know about any failures unless you are a member of one of the platform teams in the Node.js
+organisation.  If after a day or so from a collaborator triggering a Jenkins CI your PR shows a
+failure in either the `node-test-pull-request` or `node-test-commit-*` checks it's worth adding a
+comment to the PR asking what tests are failed, as the collaborator may not realise that you cannot
+see the results directly.
 
 ### Q: The CI runs showed some failures that seem unrelated to my change. What should I do?
 


### PR DESCRIPTION
Some new contributors won't be able to access the CI and will only see github check failures when a test run in jenkins fails we should make it clear that they will need assistance from a collaborator/platform team member to know which tests caused it to fail.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
