### PR TITLE
tools: remove `envinfo` from our workflows

### DIFF
--- a/.github/workflows/build-tarball.yml
+++ b/.github/workflows/build-tarball.yml
@@ -82,8 +82,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Make tarball
         run: |
           export DISTTYPE=nightly
@@ -124,8 +122,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
           version: v0.16.0
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Download tarball
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:

--- a/.github/workflows/coverage-linux-without-intl.yml
+++ b/.github/workflows/coverage-linux-without-intl.yml
@@ -67,8 +67,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
           version: v0.16.0
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Install gcovr
         run: pip install gcovr==7.2
       - name: Configure

--- a/.github/workflows/coverage-linux.yml
+++ b/.github/workflows/coverage-linux.yml
@@ -67,8 +67,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
           version: v0.16.0
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Install gcovr
         run: pip install gcovr==7.2
       - name: Configure

--- a/.github/workflows/coverage-windows.yml
+++ b/.github/workflows/coverage-windows.yml
@@ -83,8 +83,6 @@ jobs:
         run: |
           rustup override set "$RUSTC_VERSION"
           rustup --version
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Build
         run: ./vcbuild.bat clang-cl v8temporal
       # TODO(bcoe): investigate tests that fail with coverage enabled

--- a/.github/workflows/daily-wpt-fyi.yml
+++ b/.github/workflows/daily-wpt-fyi.yml
@@ -43,8 +43,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
-      - name: Environment Information
-        run: npx envinfo@7.21.0
 
       # install a version and checkout
       - name: Get latest nightly

--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -23,8 +23,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Build lto
         run: |
           sudo apt-get update && sudo apt-get install ninja-build -y

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -31,8 +31,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Build
         run: NODE=$(command -v node) make doc-only
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -32,8 +32,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Lint addon docs
         run: NODE=$(command -v node) make lint-addon-docs
   lint-cpp:
@@ -48,8 +46,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Lint C/C++ files
         run: make lint-cpp
   format-cpp:
@@ -69,8 +65,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Format C/C++ files
         run: |
           make format-cpp-build
@@ -102,8 +96,6 @@ jobs:
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Lint JavaScript files
         run: |
           set +e
@@ -183,8 +175,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Lint Python
         run: |
           make lint-py-build
@@ -207,8 +197,6 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           allow-prereleases: true
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Lint YAML
         run: |
           make lint-yaml-build || true

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -79,8 +79,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
           version: v0.16.0
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       # This is needed due to https://github.com/nodejs/build/issues/3878
       - name: Cleanup
         if: runner.os == 'macOS'

--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -64,8 +64,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
           version: v0.16.0
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Build
         run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn"
       - name: Test Internet

--- a/.github/workflows/test-linux-quic.yml
+++ b/.github/workflows/test-linux-quic.yml
@@ -69,8 +69,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
           version: v0.16.0
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Build
         working-directory: node
         run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn --v8-enable-temporal-support --experimental-quic"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -80,8 +80,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
           version: v0.16.0
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       - name: Build
         working-directory: node
         run: make build-ci -j4 V=1 CONFIG_FLAGS="--error-on-warn --v8-enable-temporal-support"

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -103,8 +103,6 @@ jobs:
         uses: Mozilla-Actions/sccache-action@9e7fa8a12102821edf02ca5dbea1acd0f89a2696  # v0.0.10
         with:
           version: v0.16.0
-      - name: Environment Information
-        run: npx envinfo@7.21.0
       # The `npm ci` for this step fails a lot as part of the Test step. Run it
       # now so that we don't have to wait 2 hours for the Build step to pass
       # first before that failure happens. (And if there's something about


### PR DESCRIPTION
https://github.com/nodejs/node/pull/64117 took the approach of pinning to a specific version, which, given that it's an npm package with 0 deps, is an effective strategy. However, it adds maintenance burden (e.g. if envinfo makes a security release, somebody needs to remember to update the workflow), so here I am with a different approach: let's get rid of it. It can provide useful info if something breaks, but for most cases, it's just 5s/runner of wasted download and compute time.
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
