### PR TITLE
tools: skip early single-approval PRs in commit queue

### DIFF
--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -33,14 +33,25 @@ jobs:
       - name: Get Pull Requests
         id: get_mergeable_prs
         run: |
-          prs=$(gh pr list \
+          seven_days_ago=$(date --date="7 days ago" +"%Y-%m-%dT%H:%M:%SZ")
+          regular_prs=$(gh pr list \
                   --repo "$GITHUB_REPOSITORY" \
                   --base "$GITHUB_REF_NAME" \
                   --label 'commit-queue' \
-                  --json 'number' \
-                  --search "created:<=$(date --date="2 days ago"  +"%Y-%m-%dT%H:%M:%S%z") -label:blocked" \
-                  -t '{{ range . }}{{ .number }} {{ end }}' \
-                  --limit 100)
+                  --json 'number,createdAt,reviews,commits' \
+                  --search "created:<=$(date --date="2 days ago"  +"%Y-%m-%dT%H:%M:%S%z") -label:blocked -label:fast-track" \
+                  --limit 100 | jq --arg seven_days_ago "$seven_days_ago" -r '
+                    .[]
+                    | . as $pr
+                    | ([.reviews[]
+                        | select(
+                            .state == "APPROVED" and
+                            .author.login != null and
+                            .submittedAt > $pr.commits[-1].committedDate
+                          )
+                        | .author.login] | unique | length) as $approvals
+                    | select($approvals >= 2 or ($approvals == 1 and .createdAt <= $seven_days_ago))
+                    | .number' | xargs)
           fast_track_prs=$(gh pr list \
                   --repo "$GITHUB_REPOSITORY" \
                   --base "$GITHUB_REF_NAME" \
@@ -50,7 +61,7 @@ jobs:
                   --json 'number' \
                   -t '{{ range . }}{{ .number }} {{ end }}' \
                   --limit 100)
-          numbers=$(echo $prs' '$fast_track_prs | jq -r -s 'unique | join(" ")')
+          numbers=$(echo "${regular_prs} ${fast_track_prs}" | xargs)
           echo "numbers=$numbers" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/doc/contributing/commit-queue.md
+++ b/doc/contributing/commit-queue.md
@@ -18,18 +18,20 @@ From a high-level, the Commit Queue works as follow:
 1. Collaborators will add `commit-queue` label to pull requests ready to land
 2. Every five minutes the queue will do the following for each mergeable pull request
    with the label:
-   1. Check if the PR also has a `request-ci` label (if it has, skip this PR
+   1. For regular pull requests without `fast-track`, skip PRs that have only one
+      approval unless they have been open for at least 7 days
+   2. Check if the PR also has a `request-ci` label (if it has, skip this PR
       since it's pending a CI run)
-   2. Check if the last Jenkins CI is finished running (if it is not, skip this
+   3. Check if the last Jenkins CI is finished running (if it is not, skip this
       PR)
-   3. Remove the `commit-queue` label
-   4. Run `git node land <pr> --oneCommitMax`
-   5. If it fails:
+   4. Remove the `commit-queue` label
+   5. Run `git node land <pr> --oneCommitMax`
+   6. If it fails:
       1. Abort `git node land` session
       2. Add `commit-queue-failed` label to the PR
       3. Leave a comment on the PR with the output from `git node land`
       4. Skip next steps, go to next PR in the queue
-   6. If it succeeds:
+   7. If it succeeds:
       1. Push the changes to nodejs/node
       2. Leave a comment on the PR with `Landed in ...`
       3. Close the PR
@@ -79,9 +81,10 @@ reasons:
 `@node-core/utils` is configured with a personal token and
 a Jenkins token from
 [@nodejs-github-bot](https://github.com/nodejs/github-bot).
-`octokit/graphql-action` is used to fetch all pull requests with the
-`commit-queue` label. The output is a JSON payload, so `jq` is used to turn
-that into a list of PR ids we can pass as arguments to
+The workflow fetches pull requests with the `commit-queue` label. For pull
+requests without `fast-track`, it filters out PRs that have only one approval
+unless they have been open for at least 7 days. The output is then turned into
+a list of PR ids we can pass as arguments to
 [`commit-queue.sh`](../../tools/actions/commit-queue.sh).
 
 > The personal token only needs permission for public repositories and to read


### PR DESCRIPTION
Filter regular commit-queue PRs in the workflow so PRs with only one
valid approval are skipped until they have been open for at least 7 days.

Keep `fast-track` PR handling unchanged.

Today, commit-queue can pick up a regular PR that is still not eligible to
land, and the failure only happens later inside `git node land`.

For example, in https://github.com/nodejs/node/pull/64163#issuecomment-4863774587, the PR had a single approval
and `commit-queue` was added before the PR had been open for 7 days.
The queue then failed during landing instead of simply skipping that PR
until it became eligible.

Refs: https://github.com/nodejs/node/pull/64163#issuecomment-4863774587

---

Assisted-by: openai:gpt-5.5