### PR TITLE
test: remove impact of tier-up changes in worker stack size test

### DIFF
--- a/test/parallel/test-worker-stack-overflow-stack-size.js
+++ b/test/parallel/test-worker-stack-overflow-stack-size.js
@@ -8,6 +8,14 @@ const { Worker } = require('worker_threads');
 // Verify that Workers don't care about --stack-size, as they have their own
 // fixed and known stack sizes.
 
+// The depth of the stack depends not only on the stack size, but also on the size of each
+// stack frame, which in turn depends on which tier the recursive function happens to be
+// running at when the overflow occurs. Under load the background tier-up can land at a
+// non-deterministic point in the recursion and flake the test. Keep the recursive
+// function in the interpreter with %NeverOptimizeFunction() so the frame size -
+// and thus the depth - is deterministic.
+v8.setFlagsFromString('--allow-natives-syntax');
+
 async function runWorker(options = {}) {
   const empiricalStackDepth = new Uint32Array(new SharedArrayBuffer(4));
   const worker = new Worker(`
@@ -16,6 +24,7 @@ async function runWorker(options = {}) {
     empiricalStackDepth[0]++;
     f();
   }
+  %NeverOptimizeFunction(f);
   f();`, {
     eval: true,
     workerData: { empiricalStackDepth },


### PR DESCRIPTION
Background: this is flaking in the canary as https://chromium-review.googlesource.com/c/v8/v8/+/7761796 made the function eligible for maglev tier-up. Locally this made the flake disappear for me. Opening against the main branch since it makes sense here anyway.

The depth of the stack depends not only on the stack size, but also on the size of each stack frame, which in turn depends on which tier the recursive function happens to be running at when the overflow occurs. Under load the background tier-up can land at a non-deterministic point in the recursion and flake the test. Keep the recursive function in the interpreter with %NeverOptimizeFunction() so the frame size - and thus the depth - is deterministic.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
