### PR TITLE
http: create header field names as internalized strings

### DIFF
--- a/src/node_http_common.h
+++ b/src/node_http_common.h
@@ -16,6 +16,8 @@ class Environment;
 #define DEFAULT_MAX_HEADER_LIST_PAIRS 128u
 #define DEFAULT_MAX_HEADER_LENGTH 8192
 
+constexpr size_t kMaxInternalizedHeaderNameLength = 64;
+
 #define HTTP_SPECIAL_HEADERS(V)                                               \
   V(STATUS, ":status")                                                        \
   V(METHOD, ":method")                                                        \
@@ -432,7 +434,7 @@ class NgRcBufPointer : public MemoryRetainer {
         return v8::String::Empty(env->isolate());
       }
 
-      if (ptr.IsInternalizable() && len < 64) {
+      if (ptr.IsInternalizable() && len < kMaxInternalizedHeaderNameLength) {
         v8::MaybeLocal<v8::String> ret = GetInternalizedString(env, ptr);
         ptr.reset();
         return ret;

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -28,13 +28,13 @@
 #include "llhttp.h"
 #include "memory_tracker-inl.h"
 #include "node_external_reference.h"
-#include "node_http_common.h"
 #include "stream_base-inl.h"
 #include "v8.h"
 
 #include <cstdlib>  // free()
 #include <cstring>  // strdup(), strchr()
-
+#include <string_view>
+#include <unordered_set>
 
 // This is a binding to llhttp (https://github.com/nodejs/llhttp)
 // The goal is to decouple sockets from parsing for more javascript-level
@@ -107,6 +107,106 @@ const uint32_t kLenientAll =
 
 inline bool IsOWS(char c) {
   return c == ' ' || c == '\t';
+}
+
+constexpr std::string_view kKnownHeaderNames[] = {
+    "Accept-Encoding",
+    "Accept-Language",
+    "Accept-Ranges",
+    "Accept",
+    "Access-Control-Allow-Credentials",
+    "Access-Control-Allow-Headers",
+    "Access-Control-Allow-Methods",
+    "Access-Control-Allow-Origin",
+    "Access-Control-Expose-Headers",
+    "Access-Control-Request-Headers",
+    "Access-Control-Request-Method",
+    "Age",
+    "Authorization",
+    "Cache-Control",
+    "Connection",
+    "Content-Disposition",
+    "Content-Encoding",
+    "Content-Length",
+    "Content-Type",
+    "Cookie",
+    "Date",
+    "ETag",
+    "Forwarded",
+    "Host",
+    "If-Modified-Since",
+    "If-None-Match",
+    "If-Range",
+    "Last-Modified",
+    "Link",
+    "Location",
+    "Range",
+    "Referer",
+    "Server",
+    "Set-Cookie",
+    "Strict-Transport-Security",
+    "Transfer-Encoding",
+    "TE",
+    "Upgrade-Insecure-Requests",
+    "Upgrade",
+    "User-Agent",
+    "Vary",
+    "X-Content-Type-Options",
+    "X-Frame-Options",
+    "Keep-Alive",
+    "Proxy-Connection",
+    "X-XSS-Protection",
+    "Alt-Svc",
+    "Content-Security-Policy",
+    "Early-Data",
+    "Expect-CT",
+    "Origin",
+    "Purpose",
+    "Timing-Allow-Origin",
+    "X-Forwarded-For",
+    "Priority",
+    "Accept-Charset",
+    "Access-Control-Max-Age",
+    "Allow",
+    "Content-Language",
+    "Content-Location",
+    "Content-MD5",
+    "Content-Range",
+    "DNT",
+    "Expect",
+    "Expires",
+    "From",
+    "If-Match",
+    "If-Unmodified-Since",
+    "Max-Forwards",
+    "Prefer",
+    "Proxy-Authenticate",
+    "Proxy-Authorization",
+    "Refresh",
+    "Retry-After",
+    "Trailer",
+    "Tk",
+    "Via",
+    "Warning",
+    "WWW-Authenticate",
+    "HTTP2-Settings",
+};
+
+constexpr size_t kMaxKnownHeaderNameLength = [] {
+  size_t max = 0;
+  for (std::string_view name : kKnownHeaderNames) {
+    if (name.size() > max) max = name.size();
+  }
+  return max;
+}();
+
+// Only known header field names in their canonical Train-Case form may be
+// internalized. Internalizing arbitrary client-controlled names would let
+// peers pollute the isolate-wide string table.
+bool IsKnownHeaderName(const char* str, size_t size) {
+  static const std::unordered_set<std::string_view> known_names(
+      std::begin(kKnownHeaderNames), std::end(kKnownHeaderNames));
+  return known_names.contains(std::string_view(str, size));
 }
 
 class BindingData : public BaseObject {
@@ -236,13 +336,9 @@ struct StringPtr {
   }
 
   Local<String> ToInternalizedString(Environment* env) const {
-    // Only internalize short names to avoid pressuring the string table.
-    if (size_ != 0 && size_ < kMaxInternalizedHeaderNameLength) {
-      return String::NewFromOneByte(env->isolate(),
-                                    reinterpret_cast<const uint8_t*>(str_),
-                                    NewStringType::kInternalized,
-                                    size_)
-          .ToLocalChecked();
+    if (size_ <= kMaxKnownHeaderNameLength && IsKnownHeaderName(str_, size_)) {
+      return OneByteString(
+          env->isolate(), str_, size_, NewStringType::kInternalized);
     }
     return ToString(env);
   }
@@ -954,7 +1050,7 @@ class Parser : public AsyncWrap, public StreamListener {
     Local<Value> headers_v[kMaxHeaderFieldsCount * 2];
 
     for (size_t i = 0; i < num_values_; ++i) {
-      // Field names repeat across requests, so internalize them.
+      // Known field names repeat across requests, so internalize them.
       headers_v[i * 2] = fields_[i].ToInternalizedString(env());
       headers_v[i * 2 + 1] = values_[i].ToTrimmedString(env());
     }

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -65,6 +65,7 @@ using v8::Isolate;
 using v8::Local;
 using v8::LocalVector;
 using v8::MaybeLocal;
+using v8::NewStringType;
 using v8::Number;
 using v8::Object;
 using v8::ObjectTemplate;
@@ -231,6 +232,17 @@ struct StringPtr {
       return OneByteString(env->isolate(), str_, size_);
     else
       return String::Empty(env->isolate());
+  }
+
+  Local<String> ToInternalizedString(Environment* env) const {
+    if (size_ != 0) {
+      return String::NewFromOneByte(env->isolate(),
+                                    reinterpret_cast<const uint8_t*>(str_),
+                                    NewStringType::kInternalized,
+                                    size_)
+          .ToLocalChecked();
+    }
+    return String::Empty(env->isolate());
   }
 
   // Strip trailing OWS (SPC or HTAB) from string.
@@ -940,7 +952,8 @@ class Parser : public AsyncWrap, public StreamListener {
     Local<Value> headers_v[kMaxHeaderFieldsCount * 2];
 
     for (size_t i = 0; i < num_values_; ++i) {
-      headers_v[i * 2] = fields_[i].ToString(env());
+      // Field names repeat across requests, so internalize them.
+      headers_v[i * 2] = fields_[i].ToInternalizedString(env());
       headers_v[i * 2 + 1] = values_[i].ToTrimmedString(env());
     }
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -28,6 +28,7 @@
 #include "llhttp.h"
 #include "memory_tracker-inl.h"
 #include "node_external_reference.h"
+#include "node_http_common.h"
 #include "stream_base-inl.h"
 #include "v8.h"
 
@@ -235,14 +236,15 @@ struct StringPtr {
   }
 
   Local<String> ToInternalizedString(Environment* env) const {
-    if (size_ != 0) {
+    // Only internalize short names to avoid pressuring the string table.
+    if (size_ != 0 && size_ < kMaxInternalizedHeaderNameLength) {
       return String::NewFromOneByte(env->isolate(),
                                     reinterpret_cast<const uint8_t*>(str_),
                                     NewStringType::kInternalized,
                                     size_)
           .ToLocalChecked();
     }
-    return String::Empty(env->isolate());
+    return ToString(env);
   }
 
   // Strip trailing OWS (SPC or HTAB) from string.


### PR DESCRIPTION
Internalize header field names so repeated occurrences resolve to the same string in the isolate's string table, speeding up `matchKnownFields()` comparisons and `req.headers` builds.

<details>
<summary>Benchmark</summary>

```                                                                                    confidence improvement accuracy (*)   (**)  (***)
http/incoming_headers.js duration=5 w=0 headers=20 connections=50 benchmarker='wrk'         **      3.20 %       ±2.00% ±2.66% ±3.47%
http/incoming_headers.js duration=5 w=6 headers=20 connections=50 benchmarker='wrk'        ***      3.75 %       ±1.99% ±2.65% ±3.45%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 2 comparisons, you can thus expect the following amount of false-positive results:
  0.10 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.02 false positives, when considering a   1% risk acceptance (**, ***),
  0.00 false positives, when considering a 0.1% risk acceptance (***)
```
</details>