### PR TITLE
meta: fix linter warning in `stale.yml`

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -29,7 +29,7 @@ jobs:
     permissions:
       issues: write  # for actions/stale to close stale issues
       pull-requests: write  # for actions/stale to close stale PRs
-      actions: write # for actions/stale to cache stale saved state
+      actions: write  # for actions/stale to cache stale saved state
     if: github.repository == 'nodejs/node'
     runs-on: ubuntu-slim
     steps:


### PR DESCRIPTION
To fix the following warning:

```
  32:22     warning  too few spaces before comment: expected 2  (comments)
```
