### PR TITLE
vfs: reject rename into descendant directory

### DIFF
--- a/lib/internal/vfs/providers/memory.js
+++ b/lib/internal/vfs/providers/memory.js
@@ -7,6 +7,7 @@ const {
   SafeMap,
   SafeSet,
   StringPrototypeReplaceAll,
+  StringPrototypeStartsWith,
   Symbol,
 } = primordials;
 
@@ -793,6 +794,11 @@ class MemoryProvider extends VirtualProvider {
 
     // Get the entry (without following symlinks for the entry itself)
     const entry = this.#getEntry(normalizedOld, 'rename', false);
+
+    if (entry.isDirectory() &&
+        StringPrototypeStartsWith(normalizedNew, `${normalizedOld}/`)) {
+      throw createEINVAL('rename', oldPath);
+    }
 
     // Validate destination parent exists (do not auto-create)
     const newParent = this.#ensureParent(normalizedNew, false, 'rename');

--- a/test/parallel/test-vfs-rename.js
+++ b/test/parallel/test-vfs-rename.js
@@ -44,3 +44,17 @@ const vfs = require('node:vfs');
   assert.strictEqual(myVfs.existsSync('/d/a.txt'), false);
   assert.strictEqual(myVfs.existsSync('/d/b.txt'), true);
 }
+
+// Renaming a directory into its own descendant throws EINVAL
+{
+  const myVfs = vfs.create();
+  myVfs.mkdirSync('/a/b', { recursive: true });
+  myVfs.writeFileSync('/a/file.txt', 'data');
+
+  assert.throws(() => myVfs.renameSync('/a', '/a/b/c'), { code: 'EINVAL' });
+  assert.deepStrictEqual(myVfs.readdirSync('/'), ['a']);
+  assert.strictEqual(myVfs.existsSync('/a'), true);
+  assert.strictEqual(myVfs.existsSync('/a/b'), true);
+  assert.strictEqual(myVfs.existsSync('/a/b/c'), false);
+  assert.strictEqual(myVfs.readFileSync('/a/file.txt', 'utf8'), 'data');
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64284

Fixes `MemoryProvider.renameSync()` so renaming a directory into its own
descendant throws `EINVAL` instead of detaching the subtree.

---

Assisted-by: openai:gpt-5.5