### PR TITLE
stream: prefer sync iterator in fromSync

### DIFF
--- a/lib/internal/streams/iter/from.js
+++ b/lib/internal/streams/iter/from.js
@@ -484,15 +484,20 @@ function fromSync(input) {
     return fromSync(input[toStreamable]());
   }
 
-  // Reject explicit async inputs
-  if (isAsyncIterable(input)) {
+  const isIterable = isSyncIterable(input);
+
+  // Reject explicit async-only inputs
+  if (!isIterable && isAsyncIterable(input)) {
     throw new ERR_INVALID_ARG_TYPE(
       'input',
       'a synchronous input (not AsyncIterable)',
       input,
     );
   }
-  if (typeof input === 'object' && input !== null && typeof input.then === 'function') {
+  if (!isIterable &&
+      typeof input === 'object' &&
+      input !== null &&
+      typeof input.then === 'function') {
     throw new ERR_INVALID_ARG_TYPE(
       'input',
       'a synchronous input (not Promise)',
@@ -501,7 +506,7 @@ function fromSync(input) {
   }
 
   // Must be a SyncStreamable
-  if (!isSyncIterable(input)) {
+  if (!isIterable) {
     throw new ERR_INVALID_ARG_TYPE(
       'input',
       ['string', 'ArrayBuffer', 'ArrayBufferView', 'Iterable', 'toStreamable'],

--- a/test/parallel/test-stream-iter-from-sync.js
+++ b/test/parallel/test-stream-iter-from-sync.js
@@ -3,7 +3,7 @@
 
 const common = require('../common');
 const assert = require('assert');
-const { fromSync } = require('stream/iter');
+const { fromSync, textSync } = require('stream/iter');
 
 function testFromSyncString() {
   // String input should be UTF-8 encoded
@@ -186,6 +186,30 @@ function testFromSyncRejectsAsyncIterable() {
   assert.throws(() => fromSync(gen()), { code: 'ERR_INVALID_ARG_TYPE' });
 }
 
+function testFromSyncPrefersIteratorForDualIterable() {
+  const input = {
+    *[Symbol.iterator]() {
+      yield new TextEncoder().encode('sync');
+    },
+    async *[Symbol.asyncIterator]() {
+      yield new TextEncoder().encode('async');
+    },
+  };
+
+  assert.strictEqual(textSync(fromSync(input)), 'sync');
+}
+
+function testFromSyncPrefersIteratorForThenableIterable() {
+  const input = {
+    then() {},
+    *[Symbol.iterator]() {
+      yield new TextEncoder().encode('sync');
+    },
+  };
+
+  assert.strictEqual(textSync(fromSync(input)), 'sync');
+}
+
 // Promise rejected
 function testFromSyncRejectsPromise() {
   assert.throws(() => fromSync(Promise.resolve('hello')),
@@ -232,6 +256,8 @@ Promise.all([
   testFromSyncTopLevelProtocolOverIterator(),
   testFromSyncIgnoresAsyncStreamable(),
   testFromSyncRejectsAsyncIterable(),
+  testFromSyncPrefersIteratorForDualIterable(),
+  testFromSyncPrefersIteratorForThenableIterable(),
   testFromSyncRejectsPromise(),
   testFromSyncDataView(),
 ]).then(common.mustCall());


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64292

`stream/iter`'s `fromSync()` rejected any input that exposed
`Symbol.asyncIterator`, even when the same input also exposed
`Symbol.iterator`.

This updates `fromSync()` to reject only inputs without a synchronous
iteration path, allowing dual sync/async iterables and thenable sync
iterables to be consumed through their synchronous iterator.

---

Assisted-by: openai:gpt-5.5