### PR TITLE
stream: validate writevSync chunks before queuing

### DIFF
--- a/lib/internal/streams/iter/utils.js
+++ b/lib/internal/streams/iter/utils.js
@@ -190,15 +190,14 @@ function toUint8Array(chunk) {
 }
 
 /**
- * Check if all chunks in an array are already Uint8Array (no strings).
- * Short-circuits on the first string found.
+ * Check if all chunks in an array are already Uint8Array.
+ * Short-circuits on the first non-Uint8Array chunk found.
  * @param {Array<Uint8Array|string>} chunks
  * @returns {boolean}
  */
 function allUint8Array(chunks) {
-  // Ok, well, kind of. This is more a check for "no strings"...
   for (let i = 0; i < chunks.length; i++) {
-    if (typeof chunks[i] === 'string') return false;
+    if (!isUint8Array(chunks[i])) return false;
   }
   return true;
 }

--- a/test/parallel/test-stream-iter-push-writer.js
+++ b/test/parallel/test-stream-iter-push-writer.js
@@ -171,6 +171,28 @@ async function testWritevSync() {
   assert.strictEqual(result, 'hello');
 }
 
+async function testWritevSyncInvalidChunkDoesNotQueue() {
+  const { writer, readable } = push({ highWaterMark: 10 });
+
+  assert.throws(
+    () => writer.writevSync([1]),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+
+  const iter = readable[Symbol.asyncIterator]();
+  const next = iter.next();
+  const result = await Promise.race([
+    next.then(() => 'resolved'),
+    new Promise((resolve) => setImmediate(resolve, 'pending')),
+  ]);
+  assert.strictEqual(result, 'pending');
+
+  writer.endSync();
+  const end = await next;
+  assert.strictEqual(end.value, undefined);
+  assert.strictEqual(end.done, true);
+}
+
 async function testWritevMixedTypes() {
   const { writer, readable } = push({ highWaterMark: 10 });
   // Mix strings and Uint8Arrays
@@ -494,6 +516,7 @@ Promise.all([
   testOndrainRejectsOnConsumerThrow(),
   testWritev(),
   testWritevSync(),
+  testWritevSyncInvalidChunkDoesNotQueue(),
   testWritevMixedTypes(),
   testWriteAfterEnd(),
   testWriteAfterFail(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64299

`stream/iter` now validates all `writevSync()` chunks before queueing a
batch. Previously, invalid chunks such as `[1]` could be queued first and
then throw from the queue’s byte-length accounting path, leaving invalid data
visible to the readable side.

This updates the shared chunk fast path to only skip conversion when every
entry is already a `Uint8Array`, and adds regression coverage that verifies
`writevSync([1])` throws `ERR_INVALID_ARG_TYPE` without queueing data.

---

Assisted-by: openai:gpt-5.5