### PR TITLE
quic: fix stall datagrams, if no pending streams

### DIFF
--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -540,7 +540,7 @@ void Session::Application::SendPendingData() {
     // We call Application::ResumeStream directly (not Session::ResumeStream)
     // to avoid creating a SendPendingDataScope — we're already inside
     // SendPendingData and re-entering would just hit nwrite=0 again.
-    if (nwrite == 0) {
+    if (nwrite == 0 && (stream_data.id >= 0 || !session_->HasPendingDatagrams())) {
       Debug(session_, "Congestion or not our turn to send");
       if (stream_data.id >= 0 && (stream_data.count > 0 || stream_data.fin)) {
         ResumeStream(stream_data.id);

--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -540,7 +540,8 @@ void Session::Application::SendPendingData() {
     // We call Application::ResumeStream directly (not Session::ResumeStream)
     // to avoid creating a SendPendingDataScope — we're already inside
     // SendPendingData and re-entering would just hit nwrite=0 again.
-    if (nwrite == 0 && (stream_data.id >= 0 || !session_->HasPendingDatagrams())) {
+    if (nwrite == 0 &&
+        (stream_data.id >= 0 || !session_->HasPendingDatagrams())) {
       Debug(session_, "Congestion or not our turn to send");
       if (stream_data.id >= 0 && (stream_data.count > 0 || stream_data.fin)) {
         ResumeStream(stream_data.id);

--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2593,6 +2593,7 @@ datagram_id Session::SendDatagram(Store&& data) {
       return did;
     }
   }
+  Session::SendPendingDataScope send_scope(this);
 
   // Queue the datagram. It will be serialized into packets by
   // SendPendingData alongside stream data.

--- a/test/parallel/test-quic-session-preferred-address-ipv6.mjs
+++ b/test/parallel/test-quic-session-preferred-address-ipv6.mjs
@@ -100,6 +100,9 @@ const clientSession = await connect(serverEndpoint.address, {
       family: 'ipv6',
     },
   },
+  maxDatagramSendAttempts: 100, // While the connection is restablished,
+  // all the acknowledgement packets of ngtcp2 are counted as send attempts
+  // so either this or a delay, or a change in ngtcp2 interfaces
 });
 await clientSession.opened;
 

--- a/test/parallel/test-quic-session-preferred-address.mjs
+++ b/test/parallel/test-quic-session-preferred-address.mjs
@@ -78,6 +78,9 @@ const clientSession = await connect(serverEndpoint.address, {
     strictEqual(oldRemote, null);
     strictEqual(preferred, true);
   }),
+  maxDatagramSendAttempts: 100, // While the connection is restablished,
+  // all the acknowledgement packets of ngtcp2 are counted as send attempts
+  // so either this or a delay, or a change in ngtcp2 interfaces
 });
 await clientSession.opened;
 


### PR DESCRIPTION
If you are only sending datagrams and so streams,
your datagrams could stall.
There were two reasons:
i. A SendPendingDataScope in SendDatagrams was
missing.
ii. SendPendingData did not attempt to send
datagrams, if there was no stream data.

Also two tests needed changes.
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
