### PR TITLE
repl: reject --watch without script

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -993,6 +993,13 @@ static ExitCode InitializeNodeWithArgsInternal(
     exit_code =
         ProcessGlobalArgsInternal(argv, exec_argv, errors, kDisallowedInEnvvar);
     if (exit_code != ExitCode::kNoFailure) return exit_code;
+
+    auto env_opts = per_process::cli_options->per_isolate->per_env;
+    if (env_opts->watch_mode && !env_opts->test_runner &&
+        env_opts->watch_mode_paths.empty() && argv->size() < 2) {
+      errors->push_back("--watch requires specifying a file");
+      return ExitCode::kInvalidCommandLineArgument;
+    }
   }
 
   // Set the process.title immediately after processing argv if --title is set.

--- a/src/node_options.cc
+++ b/src/node_options.cc
@@ -266,8 +266,6 @@ void EnvironmentOptions::CheckOptions(std::vector<std::string>* errors,
     } else if (test_runner_force_exit) {
       errors->push_back("either --watch or --test-force-exit "
                         "can be used, not both");
-    } else if (!test_runner && watch_mode_paths.empty() && argv->size() < 1) {
-      errors->push_back("--watch requires specifying a file");
     }
 
 #ifndef ALLOW_ATTACHING_DEBUGGER_IN_WATCH_MODE

--- a/test/sequential/test-watch-mode-watch-flags.mjs
+++ b/test/sequential/test-watch-mode-watch-flags.mjs
@@ -51,6 +51,15 @@ async function runNode({
 tmpdir.refresh();
 
 describe('watch mode - watch flags', { concurrency: !process.env.TEST_PARALLEL, timeout: 60_000 }, () => {
+  it('should require a file to watch', async () => {
+    const { code, signal, stderr, stdout } = await common.spawnPromisified(execPath, ['--watch']);
+
+    assert.strictEqual(code, 9);
+    assert.strictEqual(signal, null);
+    assert.match(stderr, /--watch requires specifying a file/);
+    assert.strictEqual(stdout, '');
+  });
+
   it('when multiple `--watch` flags are provided should run as if only one was', async () => {
     const projectDir = tmpdir.resolve('project-multi-flag');
     mkdirSync(projectDir);


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64135

This updates watch mode option validation so that `node --watch` without a script exits with an option error instead of falling through to the REPL.

Previously, the validation checked whether the argument list had fewer than one item. However, the argument list still contains the Node executable itself, so `node --watch` was not treated as missing a script. The check now requires at least two arguments, meaning the executable plus a script file.

A regression test has been added to confirm that `node --watch`:

- exits with code `9`
- prints `--watch requires specifying a file`
- does not write to stdout

Tested with:

```console
$ ./node --watch < /dev/null
./node: --watch requires specifying a file

$ ./node --test --test-name-pattern="require a file to watch" test/sequential/test-watch-mode-watch-flags.mjs
✔ should require a file to watch