### PR TITLE
stream: resume flow when an errored pipe destination is removed

### DIFF
--- a/lib/internal/streams/readable.js
+++ b/lib/internal/streams/readable.js
@@ -985,9 +985,13 @@ Readable.prototype.pipe = function(dest, pipeOpts) {
     // specific writer, then it would cause it to never start
     // flowing again.
     // So, if this is awaiting a drain, then we just call it now.
-    // If we don't know, then assume that we are waiting for one.
-    if (ondrain && state.awaitDrainWriters &&
-        (!dest._writableState || dest._writableState.needDrain))
+    // `pipeOnDrain` only removes this destination from the awaiting-drain set
+    // and resumes the source once nothing else is awaiting a drain, so it is
+    // safe to call unconditionally and no-ops when this writer wasn't awaiting
+    // a drain. Guarding on `needDrain` used to skip this for a destination that
+    // errored synchronously, leaving it stuck in the set and starving other
+    // destinations piped from the same source (see #53185).
+    if (ondrain && state.awaitDrainWriters)
       ondrain();
   }
 

--- a/test/parallel/test-stream-pipe-multiple-destinations-error.js
+++ b/test/parallel/test-stream-pipe-multiple-destinations-error.js
@@ -1,0 +1,48 @@
+'use strict';
+const common = require('../common');
+
+// Regression test for https://github.com/nodejs/node/issues/53185
+// When a source is piped to multiple destinations and one destination errors
+// synchronously in `_write`, the source must keep flowing to the remaining
+// healthy destination(s) instead of stalling forever.
+
+const assert = require('assert');
+const { PassThrough, Writable, finished } = require('stream');
+
+const source = new PassThrough({ highWaterMark: 16 * 1024 });
+
+// A destination that errors synchronously on its first write.
+const failing = new Writable({
+  highWaterMark: 16 * 1024,
+  write(chunk, encoding, callback) {
+    callback(new Error('boom'));
+  },
+});
+failing.on('error', common.mustCall());
+
+// A healthy destination that counts everything it receives.
+let received = 0;
+const healthy = new Writable({
+  highWaterMark: 16 * 1024,
+  write(chunk, encoding, callback) {
+    received += chunk.length;
+    callback();
+  },
+});
+
+source.pipe(failing);
+source.pipe(healthy);
+
+// Two chunks each larger than the highWaterMark so that `write()` returns
+// false and the source is paused awaiting a drain.
+const chunk = Buffer.alloc(20000, 'a');
+source.write(chunk);
+source.write(chunk);
+source.end();
+
+finished(healthy, common.mustSucceed(() => {
+  // Without the fix, the errored destination stays in the source's
+  // awaitDrainWriters set, the source never resumes, and `healthy` only
+  // receives the first chunk.
+  assert.strictEqual(received, chunk.length * 2);
+}));


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/53185

### Problem

When a source is piped to two destinations and one destination errors synchronously in `_write()`, the source stops flowing to the *healthy* destination as well. This is a regression from v20.10.0 (bisected to #50014 in the issue), where the healthy destination received all the data.

### Cause

After #50014 ("avoid unnecessary drain for sync stream"), a synchronous `write()` to a destination that errors returns `false` without setting `needDrain`. On the readable side, `pause()` adds that destination to `state.awaitDrainWriters` and pauses the source. When the errored destination unpipes, `cleanup()` only re-invokes the source's drain handler when `dest._writableState.needDrain` is set — which is now false for the sync-errored destination. So the dead destination is never removed from `awaitDrainWriters`, `pipeOnDrain` never sees an empty set, and the source stays paused, starving the healthy destination.

### Fix

Call the drain handler unconditionally in `cleanup()`. `pipeOnDrain` only removes the given destination from `awaitDrainWriters` and resumes the source once nothing else is awaiting a drain, so calling it is safe and no-ops when the destination wasn't awaiting a drain. This restores the pre-20.10 behavior (matching the direction @mcollina noted on the issue).

### Test

`test/parallel/test-stream-pipe-multiple-destinations-error.js` pipes a source to a synchronously-erroring destination and a healthy counting destination, writes two over-highWaterMark chunks, and asserts the healthy destination receives everything. It fails on current `main` (the source stalls and the healthy destination only gets the first chunk) and passes with this change.
