### PR TITLE
doc: add note about restricted CI to pull-requests.md

### DIFF
--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -540,6 +540,13 @@ specific details of how to do this are included in the new collaborator
 test run for you as approvals for the pull request come in.
 If not, you can ask a collaborator or triager to start a CI run.
 
+CI access is only available to collaborators and members of the platform
+teams.  If you are not yet in one of those teams then you will need someone
+to relay the results to you.  If a CI has been completed and failed and a
+day or so has passed, it will be worth commenting in the issue to say you
+cannot see what failed and to politely request in the PR that someone gives
+you that information.
+
 Ideally, the code change will pass ("be green") on all platform configurations
 supported by Node.js. This means that all tests pass and there are no linting
 errors. In reality, however, it is not uncommon for the CI infrastructure itself


### PR DESCRIPTION
Fixes https://github.com/nodejs/node/issues/64318

I did consider referencing the place where this was discussed and the timeframe where it was implemented but as a "current state" with a useful recommendation I think this is probably the right approach.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
