### PR TITLE
test: normalize Windows crash in debugger test normalization

### DIFF
--- a/test/common/debugger-probe.js
+++ b/test/common/debugger-probe.js
@@ -4,25 +4,33 @@ const assert = require('assert');
 const { spawnSyncAndExit } = require('./child_process');
 
 // Work around a pre-existing inspector issue: if the debuggee exits too quickly
-// the inspector can segfault while tearing down. For now normalize the segfault
+// the inspector can crash while tearing down. For now normalize the crash
 // back to the expected terminal event (e.g. "completed" or "miss")
 // until the upstream bug is fixed.
 // See https://github.com/nodejs/node/issues/62765
 // https://github.com/nodejs/node/issues/58245
+// The crash shows up as with exit code 3221225477 on Windows, or signal
+// SIGSEGV on other platforms.
 const probeTargetExitSignal = 'SIGSEGV';
+// 0xC0000005 STATUS_ACCESS_VIOLATION on Windows
+const probeTargetExitCode = 3221225477;
 
 function isProbeSegvTeardown(result) {
   if (result?.event !== 'error') { return false; }
   const error = result.error;
-  if (error?.signal !== probeTargetExitSignal) { return false; }
+  if (error?.signal !== probeTargetExitSignal && error?.exitCode !== probeTargetExitCode) { return false; }
   return error.code === 'probe_target_exit' || error.code === 'probe_failure';
 }
 
 function findProbeSegvTeardownLine(output) {
   const signalPrefix = `Target exited with signal ${probeTargetExitSignal}`;
-  if (output.startsWith(signalPrefix)) { return 0; }
-  const idx = output.indexOf(`\n${signalPrefix}`);
-  return idx === -1 ? -1 : idx + 1;
+  const codePrefix = `Target exited with code ${probeTargetExitCode}`;
+  for (const prefix of [signalPrefix, codePrefix]) {
+    if (output.startsWith(prefix)) { return 0; }
+    const idx = output.indexOf(`\n${prefix}`);
+    if (idx !== -1) { return idx + 1; }
+  }
+  return -1;
 }
 
 // Replace volatile fields in a probe report (stack frames, Node.js version,


### PR DESCRIPTION
The inspector can crash on teardown when the debuggee exits quickly, previously we ignored it for debugger tests as that's likely an upstream issue unrelated to Node.js's own debugger utilities, but the detection only matches patterns on UNIX-y platforms. On Windows this manifests as exit code 3221225477 (0xC0000005 STATUS_ACCESS_VIOLATION) instead of SIGSEGV. Extend the helper to recognize and normalize both variants.

See https://github.com/nodejs/reliability/blob/main/reports/2026-07-06.md

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
