### PR TITLE
stream: reject nested async streamables in from()

### DIFF
--- a/lib/internal/streams/iter/from.js
+++ b/lib/internal/streams/iter/from.js
@@ -263,11 +263,11 @@ function* normalizeSyncSource(source) {
  * and protocol conversions.
  * @yields {Uint8Array}
  */
-async function* normalizeAsyncValue(value) {
+async function* normalizeAsyncValue(value, allowNestedAsyncStreamables = true) {
   // Handle promises first
   if (isPromise(value)) {
     const resolved = await value;
-    yield* normalizeAsyncValue(resolved);
+    yield* normalizeAsyncValue(resolved, allowNestedAsyncStreamables);
     return;
   }
 
@@ -277,13 +277,22 @@ async function* normalizeAsyncValue(value) {
     return;
   }
 
+  if (!allowNestedAsyncStreamables &&
+      (isAsyncIterable(value) || hasProtocol(value, toAsyncStreamable))) {
+    throw new ERR_INVALID_ARG_TYPE(
+      'value',
+      ['string', 'ArrayBuffer', 'ArrayBufferView', 'Iterable', 'toStreamable'],
+      value,
+    );
+  }
+
   // Handle ToAsyncStreamable protocol (check before ToStreamable)
   if (hasProtocol(value, toAsyncStreamable)) {
     const result = FunctionPrototypeCall(value[toAsyncStreamable], value);
     if (isPromise(result)) {
-      yield* normalizeAsyncValue(await result);
+      yield* normalizeAsyncValue(await result, allowNestedAsyncStreamables);
     } else {
-      yield* normalizeAsyncValue(result);
+      yield* normalizeAsyncValue(result, allowNestedAsyncStreamables);
     }
     return;
   }
@@ -291,14 +300,14 @@ async function* normalizeAsyncValue(value) {
   // Handle ToStreamable protocol
   if (hasProtocol(value, toStreamable)) {
     const result = FunctionPrototypeCall(value[toStreamable], value);
-    yield* normalizeAsyncValue(result);
+    yield* normalizeAsyncValue(result, allowNestedAsyncStreamables);
     return;
   }
 
   // Handle arrays (which are also iterable, but check first for efficiency)
   if (ArrayIsArray(value)) {
     for (let i = 0; i < value.length; i++) {
-      yield* normalizeAsyncValue(value[i]);
+      yield* normalizeAsyncValue(value[i], allowNestedAsyncStreamables);
     }
     return;
   }
@@ -307,7 +316,7 @@ async function* normalizeAsyncValue(value) {
   // have both)
   if (isAsyncIterable(value)) {
     for await (const item of value) {
-      yield* normalizeAsyncValue(item);
+      yield* normalizeAsyncValue(item, allowNestedAsyncStreamables);
     }
     return;
   }
@@ -315,7 +324,7 @@ async function* normalizeAsyncValue(value) {
   // Handle sync iterables
   if (isSyncIterable(value)) {
     for (const item of value) {
-      yield* normalizeAsyncValue(item);
+      yield* normalizeAsyncValue(item, allowNestedAsyncStreamables);
     }
     return;
   }
@@ -392,7 +401,7 @@ async function* normalizeAsyncSource(source) {
         batch = [];
       }
       let asyncBatch = [];
-      for await (const chunk of normalizeAsyncValue(value)) {
+      for await (const chunk of normalizeAsyncValue(value, false)) {
         ArrayPrototypePush(asyncBatch, chunk);
         if (asyncBatch.length === FROM_BATCH_SIZE) {
           yield asyncBatch;

--- a/test/parallel/test-stream-iter-from-async.js
+++ b/test/parallel/test-stream-iter-from-async.js
@@ -49,6 +49,35 @@ async function testFromSyncIterableAsAsync() {
   assert.deepStrictEqual(batches[0][1], new Uint8Array([2]));
 }
 
+async function testFromSyncIterableAwaitsPromiseValues() {
+  const result = await text(from([Promise.resolve('promise-value')]));
+  assert.strictEqual(result, 'promise-value');
+}
+
+async function testFromSyncIterableRejectsNestedAsyncIterable() {
+  async function* asyncGenerator() {
+    yield 'data';
+  }
+
+  await assert.rejects(
+    () => text(from([asyncGenerator()])),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+}
+
+async function testFromSyncIterableRejectsNestedToAsyncStreamable() {
+  const obj = {
+    [Symbol.for('Stream.toAsyncStreamable')]() {
+      return 'data';
+    },
+  };
+
+  await assert.rejects(
+    () => text(from([obj])),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+}
+
 async function testFromToAsyncStreamableProtocol() {
   const sym = Symbol.for('Stream.toAsyncStreamable');
   const obj = {
@@ -232,6 +261,9 @@ Promise.all([
   testFromString(),
   testFromAsyncGenerator(),
   testFromSyncIterableAsAsync(),
+  testFromSyncIterableAwaitsPromiseValues(),
+  testFromSyncIterableRejectsNestedAsyncIterable(),
+  testFromSyncIterableRejectsNestedToAsyncStreamable(),
   testFromToAsyncStreamableProtocol(),
   testFromRejectsNonStreamable(),
   testFromEmptyArray(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64351

This updates `stream/iter.from()` so the sync-iterable fallback rejects
nested async-only streamables. When `from()` consumes a sync iterable, nested
async iterables and `toAsyncStreamable` values now throw
`ERR_INVALID_ARG_TYPE` instead of being consumed.

Promise values yielded by sync iterables are still awaited.

---

Assisted-by: openai:gpt-5.5

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
