### PR TITLE
fs: fix cp symlink and EEXIST handling on Windows

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3680,6 +3680,12 @@ std::vector<std::string> normalizePathToArray(
     const std::filesystem::path& path) {
   std::vector<std::string> parts;
   std::filesystem::path absPath = std::filesystem::absolute(path);
+#ifdef _WIN32
+  auto wstr = absPath.wstring();
+  if (wstr.starts_with(L"\\\\?\\")) {
+    absPath = std::filesystem::path(wstr.substr(4));
+  }
+#endif
   for (const auto& part : absPath) {
     if (!part.empty()) parts.push_back(part.string());
   }
@@ -3818,6 +3824,12 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
           }
           auto symlink_target_absolute = std::filesystem::weakly_canonical(
               std::filesystem::absolute(src / symlink_target));
+#ifdef _WIN32
+          auto wstr = symlink_target_absolute.wstring();
+          if (wstr.starts_with(L"\\\\?\\")) {
+            symlink_target_absolute = std::filesystem::path(wstr.substr(4));
+          }
+#endif
           if (dir_entry.is_directory()) {
             std::filesystem::create_directory_symlink(
                 symlink_target_absolute, dest_file_path, error);
@@ -3841,7 +3853,7 @@ static void CpSyncCopyDir(const FunctionCallbackInfo<Value>& args) {
         std::filesystem::copy_file(
             dir_entry.path(), dest_file_path, file_copy_opts, error);
         if (error) {
-          if (error.value() == EEXIST) {
+          if (error == std::errc::file_exists) {
             THROW_ERR_FS_CP_EEXIST(isolate,
                                    "[ERR_FS_CP_EEXIST]: Target already exists: "
                                    "cp returned EEXIST (%s already exists)",

--- a/test/parallel/parallel.status
+++ b/test/parallel/parallel.status
@@ -25,10 +25,8 @@ test-inspector-network-fetch: PASS, FLAKY
 # https://github.com/nodejs/node/issues/54808
 test-async-context-frame: PASS, FLAKY
 # https://github.com/nodejs/node/issues/59636
-test-fs-cp-sync-error-on-exist: SKIP
 test-fs-cp-sync-symlink-points-to-dest-error: SKIP
 test-fs-cp-async-symlink-points-to-dest: SKIP
-test-fs-cp-sync-unicode-folder-names: SKIP
 
 # https://github.com/nodejs/node/issues/56751
 test-without-async-context-frame: PASS, FLAKY


### PR DESCRIPTION
## fs: fix cp symlink and EEXIST handling on Windows

On Windows, `fs.cp`/`fs.cpSync` had two bugs:

- Paths from `std::filesystem` carried the `\\?\` extended-length prefix, breaking path comparison and symlink targets. Now stripped.
- The `EEXIST` check used the raw POSIX value, which never matched on Windows. Now compares against `std::errc::file_exists`.

Re-enables 2 tests that were skipped for this issue.

Fixes: https://github.com/nodejs/node/issues/59636