### PR TITLE
dns: stop using deprecated functions in `SetServers`

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2110,15 +2110,9 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
 
   uint32_t len = arr->Length();
 
-  if (len == 0) {
-    int rv = ares_set_servers(channel->cares_channel(), nullptr);
-    return args.GetReturnValue().Set(rv);
-  }
-
-  std::vector<ares_addr_port_node> servers(len);
-  ares_addr_port_node* last = nullptr;
-
-  int err;
+  // An empty list clears all configured servers. ares_set_servers_ports_csv()
+  // treats an empty string as "blank all servers".
+  std::string csv;
 
   for (uint32_t i = 0; i < len; i++) {
     Local<Value> val;
@@ -2143,37 +2137,27 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
     node::Utf8Value ip(env->isolate(), ipValue);
     int port = portValue->Int32Value(env->context()).FromJust();
 
-    ares_addr_port_node* cur = &servers[i];
+    if (!csv.empty()) csv += ',';
 
-    cur->tcp_port = cur->udp_port = port;
+    // Incoming CSV format expected by c-ares: host[:port][,host[:port]]...
+    // IPv6 addresses must be wrapped in square brackets.
     switch (fam) {
       case 4:
-        cur->family = AF_INET;
-        err = uv_inet_pton(AF_INET, *ip, &cur->addr);
+        csv += *ip;
         break;
       case 6:
-        cur->family = AF_INET6;
-        err = uv_inet_pton(AF_INET6, *ip, &cur->addr);
+        csv += '[';
+        csv += *ip;
+        csv += ']';
         break;
       default:
         UNREACHABLE("Bad address family");
     }
-
-    if (err)
-      break;
-
-    cur->next = nullptr;
-
-    if (last != nullptr)
-      last->next = cur;
-
-    last = cur;
+    csv += ':';
+    csv += std::to_string(port);
   }
 
-  if (err == 0)
-    err = ares_set_servers_ports(channel->cares_channel(), servers.data());
-  else
-    err = ARES_EBADSTR;
+  int err = ares_set_servers_ports_csv(channel->cares_channel(), csv.c_str());
 
   if (err == ARES_SUCCESS)
     channel->set_is_servers_default(false);

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -130,11 +130,14 @@ const portsExpected = [
   '4.4.4.4',
   '2001:4860:4860::8888',
   '103.238.225.181:666',
-  '[fe80::483a:5aff:fee6:1f04]:666',
-  'fe80::483a:5aff:fee6:1f04',
 ];
 dns.setServers(ports);
 assert.deepStrictEqual(dns.getServers(), portsExpected);
+
+// Link-local IPv6 addresses require a zone index (scope id) to be usable;
+// c-ares drops link-local servers configured without one.
+dns.setServers(['[fe80::483a:5aff:fee6:1f04]%eth0']);
+assert.deepStrictEqual(dns.getServers(), []);
 
 dns.setServers([]);
 assert.deepStrictEqual(dns.getServers(), []);


### PR DESCRIPTION
Fixes the following warnings:

```
../../src/cares_wrap.cc:2047:11: warning: 'ares_get_servers_ports' is deprecated: Use ares_get_servers_csv instead [-Wdeprecated-declarations]
 2047 |   int r = ares_get_servers_ports(channel->cares_channel(), &servers);
      |           ^
/nix/store/655p6if1xf6r88nnr876x7xmclflyx2z-c-ares-1.34.7-dev/include/ares.h:1187:1: note: 'ares_get_servers_ports' has been explicitly marked deprecated here
 1187 | CARES_DEPRECATED_FOR(ares_get_servers_csv)
      | ^
/nix/store/655p6if1xf6r88nnr876x7xmclflyx2z-c-ares-1.34.7-dev/include/ares.h:153:22: note: expanded from macro 'CARES_DEPRECATED_FOR'
  153 |       __attribute__((deprecated("Use " #f " instead")))
      |                      ^
../../src/cares_wrap.cc:2092:14: warning: 'ares_set_servers' is deprecated: Use ares_set_servers_csv instead [-Wdeprecated-declarations]
 2092 |     int rv = ares_set_servers(channel->cares_channel(), nullptr);
      |              ^
/nix/store/655p6if1xf6r88nnr876x7xmclflyx2z-c-ares-1.34.7-dev/include/ares.h:1168:14: note: 'ares_set_servers' has been explicitly marked deprecated here
 1168 | CARES_EXTERN CARES_DEPRECATED_FOR(ares_set_servers_csv) int ares_set_servers(
      |              ^
/nix/store/655p6if1xf6r88nnr876x7xmclflyx2z-c-ares-1.34.7-dev/include/ares.h:153:22: note: expanded from macro 'CARES_DEPRECATED_FOR'
  153 |       __attribute__((deprecated("Use " #f " instead")))
      |                      ^
../../src/cares_wrap.cc:2152:11: warning: 'ares_set_servers_ports' is deprecated: Use ares_set_servers_ports_csv instead [-Wdeprecated-declarations]
 2152 |     err = ares_set_servers_ports(channel->cares_channel(), servers.data());
      |           ^
/nix/store/655p6if1xf6r88nnr876x7xmclflyx2z-c-ares-1.34.7-dev/include/ares.h:1172:1: note: 'ares_set_servers_ports' has been explicitly marked deprecated here
 1172 | CARES_DEPRECATED_FOR(ares_set_servers_ports_csv)
      | ^
/nix/store/655p6if1xf6r88nnr876x7xmclflyx2z-c-ares-1.34.7-dev/include/ares.h:153:22: note: expanded from macro 'CARES_DEPRECATED_FOR'
  153 |       __attribute__((deprecated("Use " #f " instead")))
      |                      ^
```

See https://c-ares.org/docs/ares_set_servers.html#Notes:

> Deprecated functions as of c-ares 1.24.0 due to inability to set all available server options. Use [`ares_set_servers_csv`](https://c-ares.org/docs/ares_set_servers_csv.html).

The required test change indicates this is a breaking change, I've tried working around it but couldn't find a way

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
