### PR TITLE
Add check for `Reviewed-By:` line to merge.sh

### DIFF
--- a/tools/actions/merge.sh
+++ b/tools/actions/merge.sh
@@ -56,6 +56,11 @@ git log -1 HEAD^ --pretty='format:%B' | git interpret-trailers --parse --no-divi
     echo "Refuse to squash and merge a PR landing in more than one commit"
     exit 1
   }
+git log -1 HEAD  --pretty='format:%B' | git interpret-trailers --parse --no-divider | \
+  grep -q "^Reviewed-By: " || {
+    echo "No Reviewed-By: lines in the commit message"
+    exit 1
+  }
 
 commit_title=$(git log -1 --pretty='format:%s')
 commit_body=$(git log -1 --pretty='format:%b')

--- a/tools/actions/merge.sh
+++ b/tools/actions/merge.sh
@@ -48,7 +48,7 @@ fi
 
 git log -1 HEAD  --pretty='format:%B' | git interpret-trailers --parse --no-divider | \
   grep -q -x "^PR-URL: https://github.com/$OWNER/$REPOSITORY/pull/$pr$" || {
-    echo "Invalid PR-URL trailer"
+    echo "Invalid PR-URL trailer - have you run 'git node land' to add it?"
     exit 1
   }
 git log -1 HEAD^ --pretty='format:%B' | git interpret-trailers --parse --no-divider | \
@@ -58,7 +58,7 @@ git log -1 HEAD^ --pretty='format:%B' | git interpret-trailers --parse --no-divi
   }
 git log -1 HEAD  --pretty='format:%B' | git interpret-trailers --parse --no-divider | \
   grep -q "^Reviewed-By: " || {
-    echo "No Reviewed-By: lines in the commit message"
+    echo "No Reviewed-By: lines in the commit message - have you run 'git node land' to add them?"
     exit 1
   }
 


### PR DESCRIPTION
Identified after I used `merge.sh` myself and it didn't pick up the absence of the `Reviewed-By:` lines
This will stop it happening again.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
