### PR TITLE
test: cover worker throwing primitive values

### DIFF
--- a/test/parallel/test-worker-error-primitive.js
+++ b/test/parallel/test-worker-error-primitive.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+const assert = require('assert');
+const { Worker } = require('worker_threads');
+
+const cases = [
+  { code: 'throw "boom";', value: 'boom' },
+  { code: 'throw 42;', value: 42 },
+  { code: 'throw 7n;', value: 7n },
+  { code: 'throw true;', value: true },
+  { code: 'throw null;', value: null },
+  { code: 'throw undefined;', value: undefined },
+  { code: 'throw Symbol.for("a");', value: Symbol.for('a') },
+];
+
+for (const { code, value } of cases) {
+  const worker = new Worker(code, { eval: true });
+  worker.on('message', common.mustNotCall());
+  worker.on('error', common.mustCall((err) => {
+    assert.strictEqual(err, value);
+  }));
+  worker.on('exit', common.mustCall((exitCode) => {
+    assert.strictEqual(exitCode, 1);
+  }));
+}


### PR DESCRIPTION
What this does: Adds a regression test asserting that when a worker throws a non-Error value (string, number, bigint, boolean, null, undefined), the parent's 'error' handler receives that value directly rather than a wrapped ERR_UNHANDLED_ERROR.

The behavior is already correct on `main`; this adds the missing coverage so #35506 can't regress.

How I tested`: python tools/test.py test/parallel/test-worker-error-primitive.js `→ passes; also ran the file directly.

Fixes: https://github.com/nodejs/node/issues/35506