### PR TITLE
test: fix flaky watch + cwd + argv test-runner test

### DIFF
--- a/test/test-runner/test-run-watch-cwd-isolation-none-argv.mjs
+++ b/test/test-runner/test-run-watch-cwd-isolation-none-argv.mjs
@@ -2,7 +2,7 @@
 // parent process argv when spawning the watch child.
 import * as common from '../common/index.mjs';
 import assert from 'node:assert';
-import { readFileSync, writeFileSync } from 'node:fs';
+import { writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { run } from 'node:test';
 import tmpdir from '../common/tmpdir.js';
@@ -11,16 +11,13 @@ import { skipIfNoWatch } from '../common/watch.js';
 skipIfNoWatch();
 tmpdir.refresh();
 
-const marker = join(tmpdir.path, 'marker');
 writeFileSync(join(tmpdir.path, 'test.js'), `
 const test = require('node:test');
-const { writeFileSync } = require('node:fs');
 
-test('test ran from cwd', () => {
-  writeFileSync(${JSON.stringify(marker)}, 'ran');
-});
+test('test ran from cwd', () => {});
 `);
 
+const passed = [];
 const controller = new AbortController();
 const stream = run({
   cwd: tmpdir.path,
@@ -36,8 +33,9 @@ const stream = run({
 });
 
 stream.on('test:fail', common.mustNotCall());
-stream.on('test:pass', common.mustCall(1));
+stream.on('test:pass', common.mustCall((data) => passed.push(data.name), 1));
 // eslint-disable-next-line no-unused-vars
 for await (const _ of stream);
 
-assert.strictEqual(readFileSync(marker, 'utf8'), 'ran');
+// Validate the expected test ran by name:
+assert.deepStrictEqual(passed, ['test ran from cwd']);


### PR DESCRIPTION
This fixes the flaky test recently introduced in #63690.

I have seen https://github.com/nodejs/node/pull/64084 which tried to fix this as well but was closed as it didn't reproduce under stress test on main, so it couldn't be verified.

I think that that PR's diagnosis is correct (writing in the watched folder causes the flake). This PR takes a slightly different approach: removing the 'marker' file write entirely, to verify on executed test names instead (dropping any possibility of races via IO or watch behaviour, by doing zero writes during the test).

I'm pretty sure I know the exact failure scenario:

* The test runner is watching cwd
* The executed inner test writes to cwd (to the marker file)
* This triggers a change event, which re-runs the test, but debounces by 200ms (debounce defined [here](https://github.com/nodejs/node/blob/a18052e4c1b1c97b7b2771be3a81be12100b8fb1/lib/internal/test_runner/runner.js#L611))
* `test:pass` fires from the first inner run, passing the `mustCall(1)` in the outer test.
* There's now a 200ms window, for a race between `test:pass` + `test:watch:drain` firing (stopping all events and ending the test) vs the change event leading to a test re-run that fires `test:pass` a 2nd time.
* The `test:watch:drain` event can easily be delayed unpredictably, since it's fired by the child process shutdown signal from the OS (plus a few other checks & async steps en route). >200ms delay between the write & the drain => flake.

As noted there, this is hard to verify as flaky in the CI job, but it is verifiable with a manual delay:

* In the original test, add a >200ms delay inside the `test:watch:drained` if:
  ```
  }).on('data', function({ type }) {
    if (type === 'test:watch:drained') {
      setTimeout(() => {                          // <-- inject delay here
        stream.removeAllListeners('test:fail');
        stream.removeAllListeners('test:pass');
        controller.abort();
      }, 250);
    }
  });
  ```
* The test now always fails, in exactly same way as in most failed CI runs (double `test:pass`).
* I.e. if anything in CI ever delays the child proc exit (or notification of it) by 200ms like this, the test will fail.

Dropping the IO solves this, since it guarantees no watch events will fire, and removes the race entirely. With this fix in place, it now passes 100% for me with the same or larger setTimeout delays added manually.

As a more general "prove a flake fix" argument, where it's difficult to repro, personally I think "repro with a manual delay in an unpredictable-duration step" is a reasonable demo, even if the stress test passes.


<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
