### PR TITLE
test_runner: apply run() name filters with isolation none

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -284,6 +284,12 @@ class FileTest extends Test {
     this.timeout = null;
   }
 
+  willBeFilteredByName() {
+    // A FileTest represents a test file, not a named test. Name filters are
+    // applied to the tests inside of the file by the child process.
+    return false;
+  }
+
   #skipReporting() {
     return this.#reportedChildren > 0 && (!this.error || this.error.failureType === kSubtestsFailed);
   }
@@ -935,6 +941,15 @@ function run(options = kEmptyObject) {
     randomSeed,
     testTagFilters,
   };
+
+  if (isolation === 'none') {
+    // Tests run in this process, so the name filters must be applied to the
+    // root test's configuration. Under isolation 'process' the filters are
+    // forwarded to each child process via --test-name-pattern and
+    // --test-skip-pattern instead.
+    globalOptions.testNamePatterns = testNamePatterns ?? globalOptions.testNamePatterns;
+    globalOptions.testSkipPatterns = testSkipPatterns ?? globalOptions.testSkipPatterns;
+  }
 
   const root = createTestTree(rootTestOptions, globalOptions);
   let testFiles = files ?? createTestFileList(globPatterns, cwd);

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -213,6 +213,43 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
     assert.strictEqual(result[5], '# tests 1\n');
   });
 
+  it('should apply testNamePatterns and testSkipPatterns with isolation \'none\'', async () => {
+    const stream = run({
+      files: [join(testFixtures, 'default-behavior/test/skip_by_name.cjs')],
+      isolation: 'none',
+      testNamePatterns: [/should/],
+      testSkipPatterns: [/skipped/],
+    });
+    stream.on('test:fail', common.mustNotCall());
+    stream.on('test:pass', common.mustCall((event) => {
+      assert.strictEqual(event.name, 'this should be executed');
+    }, 1));
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+  });
+
+  it('should run tests with testNamePatterns in watch mode with isolation \'none\'', async () => {
+    // The name filters must not be applied to the file level test that wraps
+    // the spawned process. Without this, no test ever runs.
+    const controller = new AbortController();
+    const passes = [];
+    const stream = run({
+      files: [join(testFixtures, 'default-behavior/test/skip_by_name.cjs')],
+      watch: true,
+      isolation: 'none',
+      signal: controller.signal,
+      testNamePatterns: [/executed/],
+    });
+    stream.on('test:pass', (event) => {
+      passes.push(event.name);
+      controller.abort();
+    });
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of stream);
+    assert.ok(passes.length > 0);
+    assert.ok(!passes.includes('this should be skipped'));
+  });
+
   it('should pass only to children', async () => {
     const result = await run({
       files: [join(testFixtures, 'test_only.js')],


### PR DESCRIPTION
### Problem

`run()` validates `testNamePatterns` and `testSkipPatterns` and forwards them to spawned processes as `--test-name-pattern`/`--test-skip-pattern` flags, but never applies them to the root test's configuration. With `isolation: 'none'` there are no spawned processes — the test files are imported into the current process — so both options were silently ignored and every test ran.

The same filters do work as CLI flags under `--test-isolation=none` because the test runner entry point passes the memoized `parseCommandLine()` options object to `run()`, which spreads it into the root configuration.

### Fix

Apply the validated patterns to the root test configuration when `isolation` is `'none'`.

Doing only that would break watch mode with `isolation: 'none'`, where a file level test with an empty name wraps the single spawned process: the name filter would reject it and no test would ever run. The equivalent breakage is observable today on the CLI, where `node --test --watch --test-isolation=none --test-name-pattern=...` runs nothing. Since a `FileTest` represents a test file rather than a named test — the patterns are applied to the tests inside the file by the spawned process — it is now exempt from name filtering, like `TestHook` already is.

Fixes: https://github.com/nodejs/node/issues/64359