### PR TITLE
stream: reject push iterator.throw() with error

### DIFF
--- a/lib/internal/streams/iter/push.js
+++ b/lib/internal/streams/iter/push.js
@@ -668,7 +668,7 @@ function createReadable(queue) {
         },
         async throw(error) {
           queue.consumerThrow(error);
-          return { __proto__: null, done: true, value: undefined };
+          throw error;
         },
       };
     },

--- a/test/parallel/test-stream-iter-push-writer.js
+++ b/test/parallel/test-stream-iter-push-writer.js
@@ -147,10 +147,16 @@ async function testOndrainRejectsOnConsumerThrow() {
   // Consumer throws via iterator.throw() before draining enough
   // to clear backpressure. The drain should reject.
   const iter = readable[Symbol.asyncIterator]();
-  await iter.throw(new Error('consumer error'));
+  const err = new Error('consumer error');
+  const drainRejects = assert.rejects(drainPromise, (e) => e === err);
+  const pendingWriteRejects = pendingWrite.catch(() => {});
+  await assert.rejects(
+    () => iter.throw(err),
+    (e) => e === err,
+  );
 
-  await assert.rejects(drainPromise, /consumer error/);
-  await pendingWrite.catch(() => {}); // Ignore write rejection
+  await drainRejects;
+  await pendingWriteRejects; // Ignore write rejection
 }
 
 async function testWritev() {
@@ -281,12 +287,28 @@ async function testConsumerThrowRejectsWrites() {
   writer.writeSync('a');
 
   const iter = readable[Symbol.asyncIterator]();
-  await iter.throw(new Error('consumer boom'));
+  const err = new Error('consumer boom');
+  await assert.rejects(
+    () => iter.throw(err),
+    (e) => e === err,
+  );
 
   // Subsequent async writes should reject with the consumer's error
   await assert.rejects(
     () => writer.write('x'),
     { message: 'consumer boom' },
+  );
+}
+
+async function testConsumerThrowRejectsWithThrownError() {
+  const { readable } = push();
+
+  const iter = readable[Symbol.asyncIterator]();
+  const err = new Error('boom');
+
+  await assert.rejects(
+    () => iter.throw(err),
+    (e) => e === err,
   );
 }
 
@@ -351,14 +373,16 @@ async function testConsumerThrowRejectsPendingRead() {
   await new Promise(setImmediate);
 
   const err = new Error('consumer read boom');
-  const throwResult = await iter.throw(err);
-  assert.strictEqual(throwResult.value, undefined);
-  assert.strictEqual(throwResult.done, true);
-
-  await assert.rejects(
+  const readRejects = assert.rejects(
     () => readPromise,
     (e) => e === err,
   );
+  await assert.rejects(
+    () => iter.throw(err),
+    (e) => e === err,
+  );
+
+  await readRejects;
 }
 
 // end() while writes are pending rejects those writes
@@ -504,6 +528,7 @@ Promise.all([
   testWriteUint8Array(),
   testOndrainWaitsForDrain(),
   testConsumerThrowRejectsWrites(),
+  testConsumerThrowRejectsWithThrownError(),
   testEndResolvesPendingRead(),
   testFailRejectsPendingRead(),
   testFailRejectsFutureReadWithFalsyReason(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64378

This updates `stream/iter` push readable iterators so
`iterator.throw(error)` rejects with the supplied error instead of
resolving with `{ done: true, value: undefined }`.

The existing cancellation behavior is preserved: pending reads, writes,
and drain waiters still observe the consumer error.

---

Assisted-by: openai:gpt-5.5