### PR TITLE
test: bypass proxy env in inspector network fetch test

### DIFF
--- a/test/parallel/test-inspector-network-fetch.js
+++ b/test/parallel/test-inspector-network-fetch.js
@@ -12,9 +12,13 @@ const http = require('node:http');
 const https = require('node:https');
 const inspector = require('node:inspector/promises');
 
-// Disable certificate validation for the global fetch.
+// Disable certificate validation for the global fetch. Also bypass any proxy
+// configured through the environment (http_proxy/https_proxy) so that ambient
+// proxy settings do not route the requests through a proxy, which would change
+// the observed request URLs and make the test fail.
 const undici = require('internal/deps/undici/undici');
 undici.setGlobalDispatcher(new undici.EnvHttpProxyAgent({
+  noProxy: '*',
   connect: {
     rejectUnauthorized: false,
   },


### PR DESCRIPTION
`test-inspector-network-fetch` installs an `EnvHttpProxyAgent` as the global dispatcher only to disable TLS certificate validation for its local self-signed HTTPS server. However, `EnvHttpProxyAgent` also honors the ambient `http_proxy`/`https_proxy` environment variables, so in an environment where a proxy is configured the requests to `http://something.invalid/` are routed through the proxy. This makes the request `origin` the proxy and the request `path` an absolute-form target, so the URL reported to `Network.requestWillBeSent` becomes a malformed concatenation such as
`http://127.0.0.1:7769http://something.invalid/`, and the assertions on the request URL fail.

Pass `noProxy: '*'` so the dispatcher never routes through a proxy while still disabling certificate validation, making the test independent of ambient proxy configuration.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
