### PR TITLE
meta: make benchmark category a dropdown

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -16,8 +16,62 @@ on:
         description: The expect HEAD of the PR
       category:
         required: true
-        type: string
-        description: The category (or categories) of tests to run, for example buffers, cluster etc. Maps to a folders in node/benchmark
+        type: choice
+        description: The category of tests to run. Maps to a folder in node/benchmark
+        options:
+          - abort_controller
+          - assert
+          - async_hooks
+          - blob
+          - buffers
+          - child_process
+          - cluster
+          - console
+          - crypto
+          - dgram
+          - diagnostics_channel
+          - dns
+          - domain
+          - error
+          - es
+          - esm
+          - events
+          - ffi
+          - fs
+          - http
+          - http2
+          - https
+          - internal
+          - mime
+          - misc
+          - module
+          - napi
+          - net
+          - os
+          - path
+          - perf_hooks
+          - permission
+          - process
+          - querystring
+          - readline
+          - source_map
+          - sqlite
+          - streams
+          - string_decoder
+          - test_runner
+          - timers
+          - tls
+          - ts
+          - url
+          - util
+          - v8
+          - validators
+          - vm
+          - websocket
+          - webstorage
+          - webstreams
+          - worker
+          - zlib
       filter:
         type: string
         description: A substring to restrict the benchmarks to run in a category. e.g. `net-c2c`

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,7 +17,7 @@ on:
       category:
         required: true
         type: choice
-        description: The category of tests to run. Maps to a folder in node/benchmark
+        description: The category of tests to run. Maps to a folder in node/benchmark. Ignored when `categories` is set.
         options:
           - abort_controller
           - assert
@@ -72,6 +72,9 @@ on:
           - webstreams
           - worker
           - zlib
+      categories:
+        type: string
+        description: Space-separated list of categories to run. Overrides `category` when set, for running multiple categories at once.
       filter:
         type: string
         description: A substring to restrict the benchmarks to run in a category. e.g. `net-c2c`
@@ -182,7 +185,7 @@ jobs:
                   --filter "$FILTER" \
                   --runs ${{ inputs.runs }} \
                   --old ./base_node --new ./node \
-                  -- ${{ inputs.category }} \
+                  -- ${{ inputs.categories || inputs.category }} \
                 | tee /dev/stderr \
                 > ${{ matrix.system }}.csv
                 echo "> [!WARNING] "


### PR DESCRIPTION
Turn the benchmark workflow `category` input into a dropdown instead of a free-form string.