### PR TITLE
http: add native single-shot response builder

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -141,6 +141,11 @@ const kOutCount = 4;
 // allocate a new Float64Array; only the four slots above are written/read.
 const buildHttpMessageOut = new Float64Array(kOutCount);
 
+// Bodies larger than this are never folded into a combined headers+body
+// buffer/string: the copy is slower than a separate write()
+// (benchmark/http/end-vs-write-end.js).
+const kMaxSingleShotBody = 16 * 1024;
+
 // Lazy to avoid a require cycle with _http_server.
 let _statusCodes;
 function statusCodes() {
@@ -504,22 +509,33 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
       }
     } else if (typeof data === 'string' && data.length > 0 &&
         (encoding === 'latin1' || encoding === 'binary')) {
-      data = header + data;
-      encoding = 'latin1';
+      // Do not copy multi-kilobyte bodies into a combined string
+      // (benchmark/http/end-vs-write-end.js).
+      if (data.length > kMaxSingleShotBody) {
+        queueHeaderWrite(this, header, 'latin1');
+      } else {
+        data = header + data;
+        encoding = 'latin1';
+      }
     } else if (typeof data === 'string' && data.length > 0 &&
                (encoding === 'utf8' || encoding === 'utf-8' || !encoding)) {
-      // ASCII headers can safely share one UTF-8 write with the body.
-      let ascii = true;
-      for (let i = 0; i < header.length; i++) {
-        if (header.charCodeAt(i) > 127) {
-          ascii = false;
-          break;
-        }
-      }
-      if (ascii) {
-        data = header + data;
-      } else {
+      // ASCII headers can safely share one UTF-8 write with a small body.
+      // Large bodies stay zero-copy via a separate write.
+      if (data.length > kMaxSingleShotBody) {
         queueHeaderWrite(this, header, 'latin1');
+      } else {
+        let ascii = true;
+        for (let i = 0; i < header.length; i++) {
+          if (header.charCodeAt(i) > 127) {
+            ascii = false;
+            break;
+          }
+        }
+        if (ascii) {
+          data = header + data;
+        } else {
+          queueHeaderWrite(this, header, 'latin1');
+        }
       }
     } else if (typeof data === 'string' && data.length === 0) {
       // Header-only flush (end without body, Expect: 100-continue, etc.).
@@ -566,12 +582,11 @@ function _writeRaw(data, encoding, callback, size) {
 
 OutgoingMessage.prototype._storeHeader = _storeHeader;
 function _storeHeader(firstLine, headers) {
-  // Prefer the C++ single-buffer builder. Falls back to the legacy JS path
-  // only when headers need JS-only special handling (content-disposition
-  // latin1, unique-header cookie joining, etc.).
-  if (tryNativeStoreHeader(this, firstLine, headers)) {
-    return;
-  }
+  // Keep the legacy JS header builder for writeHead() / _implicitHeader().
+  // The C++ builder is used by tryFastEnd() for the single-shot
+  // res.end(body) path. Using C++ for every writeHead() was a net
+  // regression on small-header (simple.js) and many-header (headers.js)
+  // workloads: flatten + V8/C++ round-trips cost more than string concat.
   legacyStoreHeader(this, firstLine, headers);
 }
 
@@ -671,100 +686,6 @@ function flattenHeadersForNative(msg, headers, validate) {
     }
   }
   return flat;
-}
-
-function headerListHasChunkedTE(flat) {
-  for (let i = 0; i < flat.length; i += 2) {
-    const name = flat[i];
-    if (name.length === 17 && name.toLowerCase() === 'transfer-encoding') {
-      if (RE_TE_CHUNKED.test(flat[i + 1])) return true;
-    }
-  }
-  return false;
-}
-
-function tryNativeStoreHeader(msg, firstLine, headers) {
-  const flat = flattenHeadersForNative(
-    msg, headers, headers !== msg[kOutHeaders]);
-  if (flat === null) return false;
-
-  // Force the connection to close when the response is a 204 No Content or
-  // a 304 Not Modified and the user has set a "Transfer-Encoding: chunked"
-  // header. Must run before building so Connection: close is emitted.
-  // RFC 2616: 204/304 MUST NOT have a body; keep TE on the wire for compat
-  // but do not actually chunk-encode, and close the connection.
-  const noBodyStatus = msg.statusCode === 204 || msg.statusCode === 304;
-  if (noBodyStatus && (msg.chunkedEncoding || headerListHasChunkedTE(flat))) {
-    debug(msg.statusCode + ' response should not use chunked encoding,' +
-          ' closing connection.');
-    msg.chunkedEncoding = false;
-    msg.shouldKeepAlive = false;
-  }
-
-  const knownLength =
-    typeof msg._contentLength === 'number' ? msg._contentLength : -1;
-  const keepAliveSec = msg._keepAliveTimeout ?
-    MathFloor(msg._keepAliveTimeout / 1000) :
-    0;
-  const maxReq = msg._maxRequestsPerSocket | 0;
-  const date = msg.sendDate ? utcDate() : '';
-
-  buildHttpMessageOut[0] = 0;
-  buildHttpMessageOut[1] = 0;
-  buildHttpMessageOut[2] = 0;
-  buildHttpMessageOut[3] = 0;
-
-  const buf = httpParserBinding.buildHttpMessage(
-    firstLine,
-    flat,
-    null,
-    0,
-    buildFlags(msg),
-    date,
-    keepAliveSec,
-    maxReq,
-    knownLength,
-    buildHttpMessageOut,
-  );
-  if (!buf) return false;
-
-  applyBuildResult(msg, buildHttpMessageOut);
-
-  if (noBodyStatus) {
-    msg.chunkedEncoding = false;
-  }
-
-  // Trailer without chunked is invalid (same check as legacy path).
-  // The C++ builder does not throw; detect trailer presence cheaply.
-  for (let i = 0; i < flat.length; i += 2) {
-    const name = flat[i];
-    if (name.length === 7 && (name === 'Trailer' || name === 'trailer' ||
-        name.toLowerCase() === 'trailer') && !msg.chunkedEncoding) {
-      throw new ERR_HTTP_TRAILER_INVALID();
-    }
-  }
-
-  // ServerResponse: keep the Buffer to avoid a latin1 string copy on the
-  // hot writeHead()+end() path. ClientRequest: materialize a latin1 string
-  // so userland/tests that treat _header as a string (e.g. .match) keep
-  // working.
-  if (typeof msg.statusCode === 'number') {
-    msg._header = buf;
-  } else {
-    msg._header = buf.toString('latin1');
-  }
-  msg._headerSent = false;
-
-  // Expect: 100-continue forces an early header flush (legacy behavior).
-  for (let i = 0; i < flat.length; i += 2) {
-    const name = flat[i];
-    if (name.length === 6 && (name === 'Expect' || name === 'expect' ||
-        name.toLowerCase() === 'expect')) {
-      msg._send('');
-      break;
-    }
-  }
-  return true;
 }
 
 // Reused flat header list for native builds (sync only; reset each call).
@@ -1654,13 +1575,16 @@ function tryFastFlushEnd(msg, chunk, encoding, callback) {
 
   const finish = onFinish.bind(undefined, msg);
   const header = msg._header;
+  // Avoid O(n) header+body copies for large payloads (end-vs-write-end).
+  const largeBody = bodyLen > kMaxSingleShotBody;
 
   if (!socket.writableCorked)
     socket.cork();
 
   let ret;
   if (isUint8Array(header)) {
-    // Native Buffer header: one or two writes under cork (no string copy).
+    // Buffer header (rare now that writeHead uses the JS path): never
+    // concat; two corked writes keep the body zero-copy.
     if (body && bodyLen > 0 && msg._hasBody) {
       socket.write(header);
       if (bodyEncoding === 0) {
@@ -1675,23 +1599,32 @@ function tryFastFlushEnd(msg, chunk, encoding, callback) {
     }
   } else if (body && bodyLen > 0 && msg._hasBody) {
     if (typeof body === 'string' && bodyEncoding === 1) {
-      ret = socket.write(header + body, 'latin1', finish);
+      if (largeBody) {
+        socket.write(header, 'latin1');
+        ret = socket.write(body, 'latin1', finish);
+      } else {
+        ret = socket.write(header + body, 'latin1', finish);
+      }
     } else if (typeof body === 'string') {
-      // utf8 body: only concat when the header is pure ASCII.
+      // utf8 body: only concat when the header is pure ASCII and body is
+      // small enough that the copy is cheaper than an extra write.
       let ascii = true;
-      for (let i = 0; i < header.length; i++) {
-        if (header.charCodeAt(i) > 127) {
-          ascii = false;
-          break;
+      if (!largeBody) {
+        for (let i = 0; i < header.length; i++) {
+          if (header.charCodeAt(i) > 127) {
+            ascii = false;
+            break;
+          }
         }
       }
-      if (ascii) {
+      if (!largeBody && ascii) {
         ret = socket.write(header + body, finish);
       } else {
         socket.write(header, 'latin1');
         ret = socket.write(body, 'utf8', finish);
       }
     } else {
+      // Buffer/Uint8Array body: never copy into a combined buffer.
       socket.write(header, 'latin1');
       ret = socket.write(body, finish);
     }
@@ -1752,6 +1685,12 @@ function tryFastEnd(msg, chunk, encoding, callback) {
   if (prepared === null) return false;
   const { body, bodyEncoding, bodyLen } = prepared;
 
+  // Large bodies must not be copied into a combined headers+body Buffer.
+  // Fall back to write_()/ _send which can stream the body without a copy
+  // (benchmark/http/end-vs-write-end.js).
+  if (bodyLen > kMaxSingleShotBody)
+    return false;
+
   let firstLine;
   if (msg.statusCode === 200 &&
       (msg.statusMessage === undefined || msg.statusMessage === null ||
@@ -1785,6 +1724,11 @@ function tryFastEnd(msg, chunk, encoding, callback) {
   // null/undefined means headers-only (_storeHeader), which must not.
   const bodyArg = body === null ? '' : body;
 
+  buildHttpMessageOut[0] = 0;
+  buildHttpMessageOut[1] = 0;
+  buildHttpMessageOut[2] = 0;
+  buildHttpMessageOut[3] = 0;
+
   const buf = httpParserBinding.buildHttpMessage(
     firstLine,
     flat,
@@ -1806,10 +1750,18 @@ function tryFastEnd(msg, chunk, encoding, callback) {
     return false;
   }
 
+  // Trailer without chunked is invalid (same check as legacy path).
+  for (let i = 0; i < flat.length; i += 2) {
+    const name = flat[i];
+    if (name.length === 7 && (name === 'Trailer' || name === 'trailer' ||
+        name.toLowerCase() === 'trailer') && !msg.chunkedEncoding) {
+      throw new ERR_HTTP_TRAILER_INVALID();
+    }
+  }
+
   if (typeof callback === 'function')
     msg.once('finish', callback);
 
-  // Keep Buffer form for consistency with tryNativeStoreHeader (server).
   msg._header = buf;
   msg._headerSent = true;
   msg.finished = true;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -509,9 +509,21 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
       }
     } else if (typeof data === 'string' && data.length > 0 &&
         (encoding === 'latin1' || encoding === 'binary')) {
-      // Do not copy multi-kilobyte bodies into a combined string
-      // (benchmark/http/end-vs-write-end.js).
+      // Small bodies: one combined write. Large bodies: avoid the O(n) string
+      // copy (end-vs-write-end.js) with a corked dual write when the socket
+      // is ready; otherwise queue the header and fall through.
       if (data.length > kMaxSingleShotBody) {
+        const conn = this[kSocket];
+        if (conn && conn._httpMessage === this && conn.writable) {
+          this._headerSent = true;
+          if (this.outputData.length) this._flushOutput(conn);
+          if (!conn.writableCorked) conn.cork();
+          conn.write(header, 'latin1');
+          const ret = conn.write(data, 'latin1', callback);
+          conn._writableState.corked = 1;
+          conn.uncork();
+          return ret;
+        }
         queueHeaderWrite(this, header, 'latin1');
       } else {
         data = header + data;
@@ -520,8 +532,19 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
     } else if (typeof data === 'string' && data.length > 0 &&
                (encoding === 'utf8' || encoding === 'utf-8' || !encoding)) {
       // ASCII headers can safely share one UTF-8 write with a small body.
-      // Large bodies stay zero-copy via a separate write.
+      // Large bodies: corked dual write avoids the combined-string copy.
       if (data.length > kMaxSingleShotBody) {
+        const conn = this[kSocket];
+        if (conn && conn._httpMessage === this && conn.writable) {
+          this._headerSent = true;
+          if (this.outputData.length) this._flushOutput(conn);
+          if (!conn.writableCorked) conn.cork();
+          conn.write(header, 'latin1');
+          const ret = conn.write(data, encoding || 'utf8', callback);
+          conn._writableState.corked = 1;
+          conn.uncork();
+          return ret;
+        }
         queueHeaderWrite(this, header, 'latin1');
       } else {
         let ascii = true;
@@ -1575,17 +1598,71 @@ function tryFastFlushEnd(msg, chunk, encoding, callback) {
 
   const finish = onFinish.bind(undefined, msg);
   const header = msg._header;
+  const hasBody = body !== null && bodyLen > 0 && msg._hasBody;
   // Avoid O(n) header+body copies for large payloads (end-vs-write-end).
   const largeBody = bodyLen > kMaxSingleShotBody;
 
-  if (!socket.writableCorked)
-    socket.cork();
-
   let ret;
-  if (isUint8Array(header)) {
-    // Buffer header (rare now that writeHead uses the JS path): never
-    // concat; two corked writes keep the body zero-copy.
-    if (body && bodyLen > 0 && msg._hasBody) {
+
+  // ---- Hottest path: latin1 string header from legacyStoreHeader ----
+  if (typeof header === 'string') {
+    if (!hasBody) {
+      // Header-only: single write, no cork.
+      ret = socket.write(header, 'latin1', finish);
+    } else if (!largeBody && typeof body === 'string') {
+      // Small string body: one write of header+body (no cork).
+      if (bodyEncoding === 1) {
+        ret = socket.write(header + body, 'latin1', finish);
+      } else {
+        // utf8 body: concat only when the header is pure ASCII so high-byte
+        // latin1 header values are not double-encoded under UTF-8.
+        let ascii = true;
+        for (let i = 0; i < header.length; i++) {
+          if (header.charCodeAt(i) > 127) {
+            ascii = false;
+            break;
+          }
+        }
+        if (ascii) {
+          ret = socket.write(header + body, finish);
+        } else {
+          if (!socket.writableCorked) socket.cork();
+          socket.write(header, 'latin1');
+          ret = socket.write(body, 'utf8', finish);
+          socket._writableState.corked = 1;
+          socket.uncork();
+        }
+      }
+    } else if (!largeBody && bodyEncoding === 0) {
+      // Small Buffer/Uint8Array body: one combined Buffer write avoids the
+      // cork + dual-write JS overhead on the simple.js type=buffer path.
+      const hLen = header.length;
+      const out = Buffer.allocUnsafe(hLen + bodyLen);
+      // Native latin1 encode of the header into the front of the buffer.
+      out.write(header, 0, hLen, 'latin1');
+      if (typeof body.copy === 'function')
+        body.copy(out, hLen, 0, bodyLen);
+      else
+        out.set(body.subarray(0, bodyLen), hLen);
+      ret = socket.write(out, finish);
+    } else {
+      // Large body or uncommon encoding: corked dual write, no body copy.
+      if (!socket.writableCorked) socket.cork();
+      socket.write(header, 'latin1');
+      if (bodyEncoding === 0) {
+        ret = socket.write(body, finish);
+      } else if (bodyEncoding === 1) {
+        ret = socket.write(body, 'latin1', finish);
+      } else {
+        ret = socket.write(body, 'utf8', finish);
+      }
+      socket._writableState.corked = 1;
+      socket.uncork();
+    }
+  } else if (isUint8Array(header)) {
+    // Buffer header (uncommon): corked dual write keeps the body zero-copy.
+    if (hasBody) {
+      if (!socket.writableCorked) socket.cork();
       socket.write(header);
       if (bodyEncoding === 0) {
         ret = socket.write(body, finish);
@@ -1594,46 +1671,14 @@ function tryFastFlushEnd(msg, chunk, encoding, callback) {
       } else {
         ret = socket.write(body, 'utf8', finish);
       }
+      socket._writableState.corked = 1;
+      socket.uncork();
     } else {
       ret = socket.write(header, finish);
     }
-  } else if (body && bodyLen > 0 && msg._hasBody) {
-    if (typeof body === 'string' && bodyEncoding === 1) {
-      if (largeBody) {
-        socket.write(header, 'latin1');
-        ret = socket.write(body, 'latin1', finish);
-      } else {
-        ret = socket.write(header + body, 'latin1', finish);
-      }
-    } else if (typeof body === 'string') {
-      // utf8 body: only concat when the header is pure ASCII and body is
-      // small enough that the copy is cheaper than an extra write.
-      let ascii = true;
-      if (!largeBody) {
-        for (let i = 0; i < header.length; i++) {
-          if (header.charCodeAt(i) > 127) {
-            ascii = false;
-            break;
-          }
-        }
-      }
-      if (!largeBody && ascii) {
-        ret = socket.write(header + body, finish);
-      } else {
-        socket.write(header, 'latin1');
-        ret = socket.write(body, 'utf8', finish);
-      }
-    } else {
-      // Buffer/Uint8Array body: never copy into a combined buffer.
-      socket.write(header, 'latin1');
-      ret = socket.write(body, finish);
-    }
   } else {
-    ret = socket.write(header, 'latin1', finish);
+    return false;
   }
-
-  socket._writableState.corked = 1;
-  socket.uncork();
 
   msg._headerSent = true;
   msg.finished = true;
@@ -1724,11 +1769,6 @@ function tryFastEnd(msg, chunk, encoding, callback) {
   // null/undefined means headers-only (_storeHeader), which must not.
   const bodyArg = body === null ? '' : body;
 
-  buildHttpMessageOut[0] = 0;
-  buildHttpMessageOut[1] = 0;
-  buildHttpMessageOut[2] = 0;
-  buildHttpMessageOut[3] = 0;
-
   const buf = httpParserBinding.buildHttpMessage(
     firstLine,
     flat,
@@ -1751,11 +1791,14 @@ function tryFastEnd(msg, chunk, encoding, callback) {
   }
 
   // Trailer without chunked is invalid (same check as legacy path).
-  for (let i = 0; i < flat.length; i += 2) {
-    const name = flat[i];
-    if (name.length === 7 && (name === 'Trailer' || name === 'trailer' ||
-        name.toLowerCase() === 'trailer') && !msg.chunkedEncoding) {
-      throw new ERR_HTTP_TRAILER_INVALID();
+  // Skip the scan when no custom headers were set (common keep-alive path).
+  if (flat.length !== 0) {
+    for (let i = 0; i < flat.length; i += 2) {
+      const name = flat[i];
+      if (name.length === 7 && (name === 'Trailer' || name === 'trailer' ||
+          name.toLowerCase() === 'trailer') && !msg.chunkedEncoding) {
+        throw new ERR_HTTP_TRAILER_INVALID();
+      }
     }
   }
 
@@ -1769,14 +1812,8 @@ function tryFastEnd(msg, chunk, encoding, callback) {
     msg[kBytesWritten] = bodyLen;
   }
 
-  const finish = onFinish.bind(undefined, msg);
-
-  if (!socket.writableCorked) {
-    socket.cork();
-  }
-  const ret = socket.write(buf, finish);
-  socket._writableState.corked = 1;
-  socket.uncork();
+  // Single combined write: cork is pure overhead here.
+  const ret = socket.write(buf, onFinish.bind(undefined, msg));
 
   finishFastSocketWrite(msg, socket, ret);
   return true;

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -32,6 +32,7 @@ const {
   ObjectValues,
   SafeSet,
   Symbol,
+  Uint32Array,
 } = primordials;
 
 const { getDefaultHighWaterMark } = require('internal/streams/state');
@@ -74,11 +75,16 @@ const { validateString } = require('internal/validators');
 const { assignFunctionName } = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 
+const {
+  buildHttpMessage,
+} = internalBinding('http_parser');
+
 let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
 });
 
 const kCorked = Symbol('corked');
+const kLenientValidation = Symbol('kLenientValidation');
 const kSocket = Symbol('kSocket');
 const kChunkedBuffer = Symbol('kChunkedBuffer');
 const kChunkedLength = Symbol('kChunkedLength');
@@ -91,6 +97,35 @@ const kRejectNonStandardBodyWrites = Symbol('kRejectNonStandardBodyWrites');
 const nop = () => {};
 
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
+
+// Keep in sync with BuildHttpMessageFlags in src/node_http_parser.cc.
+const kBuildSendDate = 1 << 0;
+const kBuildShouldKeepAlive = 1 << 1;
+const kBuildMaxRequestsReached = 1 << 2;
+const kBuildDefaultKeepAlive = 1 << 3;
+const kBuildHasBody = 1 << 4;
+const kBuildUseChunkedByDefault = 1 << 5;
+const kBuildRemovedConnection = 1 << 6;
+const kBuildRemovedContLen = 1 << 7;
+const kBuildRemovedTE = 1 << 8;
+const kBuildHasAgent = 1 << 9;
+
+// Keep in sync with BuildHttpMessageOut in src/node_http_parser.cc.
+const kOutLast = 0;
+const kOutChunked = 1;
+const kOutContentLength = 2;
+const kOutHasContentLength = 3;
+const kOutCount = 4;
+
+// Reused across calls to avoid allocating a Uint32Array per response.
+const buildHttpMessageOut = new Uint32Array(kOutCount);
+
+// Lazy to avoid a require cycle with _http_server.
+let _statusCodes;
+function statusCodes() {
+  _statusCodes ??= require('_http_server').STATUS_CODES;
+  return _statusCodes;
+}
 
 // isCookieField performs a case-insensitive comparison of a provided string
 // against the word "cookie." As of V8 6.6 this is faster than handrolling or
@@ -143,6 +178,7 @@ function OutgoingMessage(options) {
   this[kChunkedBuffer] = [];
   this[kChunkedLength] = 0;
   this._closed = false;
+  this[kLenientValidation] = undefined;
 
   this[kSocket] = null;
   this._header = null;
@@ -163,28 +199,39 @@ ObjectSetPrototypeOf(OutgoingMessage, Stream);
 // For ClientRequest: checks this.httpValidation or this.insecureHTTPParser
 // For ServerResponse: checks the server's httpValidation or insecureHTTPParser
 // Falls back to global --insecure-http-parser flag.
+// The answer is invariant for the lifetime of the message (the options are
+// fixed at construction time), but this runs on every setHeader/appendHeader
+// call and once per stored header block, so the multi-step lookup chain is
+// resolved once per message and cached.
 OutgoingMessage.prototype._isLenientHeaderValidation = function() {
+  const cached = this[kLenientValidation];
+  if (cached !== undefined)
+    return cached;
+  return this[kLenientValidation] = lenientHeaderValidation(this);
+};
+
+function lenientHeaderValidation(msg) {
   // New httpValidation option takes priority (ClientRequest case)
-  if (this.httpValidation !== undefined) {
-    return this.httpValidation !== 'strict';
+  if (msg.httpValidation !== undefined) {
+    return msg.httpValidation !== 'strict';
   }
   // ServerResponse: check server's httpValidation option
-  const serverHttpValidation = this.req?.socket?.server?.httpValidation;
+  const serverHttpValidation = msg.req?.socket?.server?.httpValidation;
   if (serverHttpValidation !== undefined) {
     return serverHttpValidation !== 'strict';
   }
   // Legacy insecureHTTPParser - ClientRequest has it directly
-  if (typeof this.insecureHTTPParser === 'boolean') {
-    return this.insecureHTTPParser;
+  if (typeof msg.insecureHTTPParser === 'boolean') {
+    return msg.insecureHTTPParser;
   }
   // ServerResponse can access via req.socket.server
-  const serverOption = this.req?.socket?.server?.insecureHTTPParser;
+  const serverOption = msg.req?.socket?.server?.insecureHTTPParser;
   if (typeof serverOption === 'boolean') {
     return serverOption;
   }
   // Fall back to global option
   return isLenient();
-};
+}
 
 ObjectDefineProperty(OutgoingMessage.prototype, 'errored', {
   __proto__: null,
@@ -315,11 +362,12 @@ OutgoingMessage.prototype.uncork = function uncork() {
       callbacks.push(buf[n + 2]);
     }
   }
-  this._send(crlf_buf, null, callbacks.length ? (err) => {
-    for (const callback of callbacks) {
-      callback(err);
-    }
-  } : null);
+  // The runner is a shared top-level function so flushing a corked
+  // chunked buffer does not allocate a fresh closure environment per
+  // flush.
+  this._send(crlf_buf, null, callbacks?.length ?
+    runChunkCallbacks.bind(undefined, callbacks) :
+    null);
 
   this[kChunkedBuffer].length = 0;
   this[kChunkedLength] = 0;
@@ -381,14 +429,50 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
   // This is a shameful hack to get the headers and first body chunk onto
   // the same packet. Future versions of Node are going to take care of
   // this at a lower level and in a more general way.
-  if (!this._headerSent && this._header !== null) {
+  let header;
+  if (!this._headerSent && (header = this._header) !== null) {
     // `this._header` can be null if OutgoingMessage is used without a proper Socket
     // See: /test/parallel/test-http-outgoing-message-inheritance.js
-    if (typeof data === 'string' &&
-        (encoding === 'utf8' || encoding === 'latin1' || !encoding)) {
-      data = this._header + data;
+    //
+    // Headers are stored as a latin1 JS string of the on-wire bytes. If we
+    // naively do `header + body` and write as UTF-8, high-byte header values
+    // (e.g. content-disposition) get double-encoded. Prefer Buffer concat
+    // when the body is present; pure header flushes use latin1.
+    if (typeof data === 'string' && data.length > 0 &&
+        (encoding === 'latin1' || encoding === 'binary')) {
+      data = header + data;
+      encoding = 'latin1';
+    } else if (typeof data === 'string' && data.length > 0 &&
+               (encoding === 'utf8' || encoding === 'utf-8' || !encoding)) {
+      // ASCII headers can concatenate as a string under UTF-8; high-byte
+      // latin1 header values must be Buffer-concatenated to avoid double
+      // encoding on the wire.
+      let ascii = true;
+      for (let i = 0; i < header.length; i++) {
+        if (header.charCodeAt(i) > 127) {
+          ascii = false;
+          break;
+        }
+      }
+      if (ascii) {
+        data = header + data;
+      } else {
+        const bodyBuf = Buffer.from(data, encoding || 'utf8');
+        data = Buffer.concat([Buffer.from(header, 'latin1'), bodyBuf]);
+        encoding = 'buffer';
+        byteLength = data.byteLength;
+      }
+    } else if (isUint8Array(data) && data.byteLength > 0) {
+      data = Buffer.concat([Buffer.from(header, 'latin1'), data]);
+      encoding = 'buffer';
+      byteLength = data.byteLength;
+    } else if (typeof data === 'string' && data.length === 0) {
+      // Header-only flush (end without body, Expect: 100-continue, etc.).
+      data = header;
+      encoding = 'latin1';
     } else {
-      const header = this._header;
+      // Non-utf8/latin1 body encodings (hex, utf16le, base64, ...): keep the
+      // header as a separate latin1 write so body encoding is unchanged.
       this.outputData.unshift({
         data: header,
         encoding: 'latin1',
@@ -434,6 +518,202 @@ function _writeRaw(data, encoding, callback, size) {
 
 OutgoingMessage.prototype._storeHeader = _storeHeader;
 function _storeHeader(firstLine, headers) {
+  // Prefer the C++ single-buffer builder. Falls back to the legacy JS path
+  // only when headers need JS-only special handling (content-disposition
+  // latin1, unique-header cookie joining, etc.).
+  if (tryNativeStoreHeader(this, firstLine, headers)) {
+    return;
+  }
+  legacyStoreHeader(this, firstLine, headers);
+}
+
+function buildFlags(msg) {
+  let flags = 0;
+  if (msg.sendDate) flags |= kBuildSendDate;
+  if (msg.shouldKeepAlive) flags |= kBuildShouldKeepAlive;
+  if (msg.maxRequestsOnConnectionReached) flags |= kBuildMaxRequestsReached;
+  if (msg._defaultKeepAlive) flags |= kBuildDefaultKeepAlive;
+  if (msg._hasBody) flags |= kBuildHasBody;
+  // useChunkedEncodingByDefault and agent are independent: agent only
+  // participates in keep-alive decisions, not Content-Length emission.
+  if (msg.useChunkedEncodingByDefault) flags |= kBuildUseChunkedByDefault;
+  if (msg._removedConnection) flags |= kBuildRemovedConnection;
+  if (msg._removedContLen) flags |= kBuildRemovedContLen;
+  if (msg._removedTE) flags |= kBuildRemovedTE;
+  if (msg.agent) flags |= kBuildHasAgent;
+  return flags;
+}
+
+function applyBuildResult(msg, out) {
+  if (out[kOutLast]) msg._last = true;
+  if (out[kOutChunked]) msg.chunkedEncoding = true;
+  else msg.chunkedEncoding = false;
+  if (out[kOutHasContentLength])
+    msg._contentLength = out[kOutContentLength];
+}
+
+// Flatten headers into [name, value, ...] for the C++ builder. Returns null
+// when a header requires the legacy JS path.
+function flattenHeadersForNative(msg, headers, validate) {
+  const flat = [];
+  const lenient = msg._isLenientHeaderValidation();
+
+  function pushPair(key, value, doValidate) {
+    if (doValidate) {
+      validateHeaderName(key);
+    }
+    // content-disposition + content-length needs latin1 Buffer values - JS only.
+    if (isContentDispositionField(key) && msg._contentLength) {
+      return false;
+    }
+    if (ArrayIsArray(value)) {
+      const valueLength = value.length;
+      if (
+        (valueLength < 2 || !isCookieField(key)) &&
+        (!msg[kUniqueHeaders] || !msg[kUniqueHeaders].has(key.toLowerCase()))
+      ) {
+        for (let i = 0; i < valueLength; i++) {
+          if (doValidate) validateHeaderValue(key, value[i], lenient);
+          // Buffers not supported on the native path.
+          if (typeof value[i] !== 'string') return false;
+          flat.push(key, value[i]);
+        }
+        return true;
+      }
+      value = value.join('; ');
+    }
+    if (doValidate) validateHeaderValue(key, value, lenient);
+    if (typeof value !== 'string') return false;
+    flat.push(key, value);
+    return true;
+  }
+
+  if (!headers) return flat;
+
+  if (headers === msg[kOutHeaders]) {
+    for (const key in headers) {
+      const entry = headers[key];
+      if (!pushPair(entry[0], entry[1], false)) return null;
+    }
+    return flat;
+  }
+
+  if (ArrayIsArray(headers)) {
+    const headersLength = headers.length;
+    if (headersLength && ArrayIsArray(headers[0])) {
+      for (let i = 0; i < headersLength; i++) {
+        const entry = headers[i];
+        if (!pushPair(entry[0], entry[1], validate)) return null;
+      }
+    } else {
+      if (headersLength % 2 !== 0) {
+        throw new ERR_INVALID_ARG_VALUE('headers', headers);
+      }
+      for (let n = 0; n < headersLength; n += 2) {
+        if (!pushPair(headers[n], headers[n + 1], validate)) return null;
+      }
+    }
+    return flat;
+  }
+
+  for (const key in headers) {
+    if (ObjectHasOwn(headers, key)) {
+      if (!pushPair(key, headers[key], validate)) return null;
+    }
+  }
+  return flat;
+}
+
+function headerListHasChunkedTE(flat) {
+  for (let i = 0; i < flat.length; i += 2) {
+    const name = flat[i];
+    if (name.length === 17 && name.toLowerCase() === 'transfer-encoding') {
+      if (RE_TE_CHUNKED.test(flat[i + 1])) return true;
+    }
+  }
+  return false;
+}
+
+function tryNativeStoreHeader(msg, firstLine, headers) {
+  const flat = flattenHeadersForNative(
+    msg, headers, headers !== msg[kOutHeaders]);
+  if (flat === null) return false;
+
+  // Force the connection to close when the response is a 204 No Content or
+  // a 304 Not Modified and the user has set a "Transfer-Encoding: chunked"
+  // header. Must run before building so Connection: close is emitted.
+  // RFC 2616: 204/304 MUST NOT have a body; keep TE on the wire for compat
+  // but do not actually chunk-encode, and close the connection.
+  const noBodyStatus = msg.statusCode === 204 || msg.statusCode === 304;
+  if (noBodyStatus && (msg.chunkedEncoding || headerListHasChunkedTE(flat))) {
+    debug(msg.statusCode + ' response should not use chunked encoding,' +
+          ' closing connection.');
+    msg.chunkedEncoding = false;
+    msg.shouldKeepAlive = false;
+  }
+
+  const knownLength =
+    typeof msg._contentLength === 'number' ? msg._contentLength : -1;
+  const keepAliveSec = msg._keepAliveTimeout ?
+    MathFloor(msg._keepAliveTimeout / 1000) :
+    0;
+  const maxReq = msg._maxRequestsPerSocket | 0;
+  const date = msg.sendDate ? utcDate() : '';
+
+  buildHttpMessageOut[0] = 0;
+  buildHttpMessageOut[1] = 0;
+  buildHttpMessageOut[2] = 0;
+  buildHttpMessageOut[3] = 0;
+
+  const buf = buildHttpMessage(
+    firstLine,
+    flat,
+    null,
+    0,
+    buildFlags(msg),
+    date,
+    keepAliveSec,
+    maxReq,
+    knownLength,
+    buildHttpMessageOut,
+  );
+  if (!buf) return false;
+
+  applyBuildResult(msg, buildHttpMessageOut);
+
+  if (noBodyStatus) {
+    msg.chunkedEncoding = false;
+  }
+
+  // Trailer without chunked is invalid (same check as legacy path).
+  // The C++ builder does not throw; detect trailer presence cheaply.
+  for (let i = 0; i < flat.length; i += 2) {
+    const name = flat[i];
+    if (name.length === 7 && (name === 'Trailer' || name === 'trailer' ||
+        name.toLowerCase() === 'trailer') && !msg.chunkedEncoding) {
+      throw new ERR_HTTP_TRAILER_INVALID();
+    }
+  }
+
+  // latin1 string of the wire bytes. _send() must write this as latin1 (or
+  // Buffer-concat) rather than UTF-8 so high-byte values (content-disposition)
+  // are not double-encoded.
+  msg._header = buf.toString('latin1');
+  msg._headerSent = false;
+
+  // Expect: 100-continue forces an early header flush (legacy behavior).
+  for (let i = 0; i < flat.length; i += 2) {
+    const name = flat[i];
+    if (name.length === 6 && (name === 'Expect' || name === 'expect' ||
+        name.toLowerCase() === 'expect')) {
+      msg._send('');
+      break;
+    }
+  }
+  return true;
+}
+
+function legacyStoreHeader(self, firstLine, headers) {
   // firstLine in the case of request is: 'GET /index.html HTTP/1.1\r\n'
   // in the case of response it is: 'HTTP/1.1 200 OK\r\n'
   const state = {
@@ -445,33 +725,37 @@ function _storeHeader(firstLine, headers) {
     trailer: false,
     header: firstLine,
   };
-  const lenient = this._isLenientHeaderValidation();
+  const lenient = self._isLenientHeaderValidation();
 
   if (headers) {
-    if (headers === this[kOutHeaders]) {
+    if (headers === self[kOutHeaders]) {
       for (const key in headers) {
         const entry = headers[key];
-        processHeader(this, state, entry[0], entry[1], false, lenient);
+        processHeader(self, state, entry[0], entry[1], false, lenient);
       }
     } else if (ArrayIsArray(headers)) {
-      if (headers.length && ArrayIsArray(headers[0])) {
-        for (let i = 0; i < headers.length; i++) {
+      // The length is hoisted into a local because the engine cannot fold
+      // the reload across the processHeader calls; the array is never
+      // mutated while this loop runs.
+      const headersLength = headers.length;
+      if (headersLength && ArrayIsArray(headers[0])) {
+        for (let i = 0; i < headersLength; i++) {
           const entry = headers[i];
-          processHeader(this, state, entry[0], entry[1], true, lenient);
+          processHeader(self, state, entry[0], entry[1], true, lenient);
         }
       } else {
-        if (headers.length % 2 !== 0) {
+        if (headersLength % 2 !== 0) {
           throw new ERR_INVALID_ARG_VALUE('headers', headers);
         }
 
-        for (let n = 0; n < headers.length; n += 2) {
-          processHeader(this, state, headers[n + 0], headers[n + 1], true, lenient);
+        for (let n = 0; n < headersLength; n += 2) {
+          processHeader(self, state, headers[n + 0], headers[n + 1], true, lenient);
         }
       }
     } else {
       for (const key in headers) {
         if (ObjectHasOwn(headers, key)) {
-          processHeader(this, state, key, headers[key], true, lenient);
+          processHeader(self, state, key, headers[key], true, lenient);
         }
       }
     }
@@ -480,7 +764,7 @@ function _storeHeader(firstLine, headers) {
   let { header } = state;
 
   // Date header
-  if (this.sendDate && !state.date) {
+  if (self.sendDate && !state.date) {
     header += 'Date: ' + utcDate() + '\r\n';
   }
 
@@ -495,53 +779,56 @@ function _storeHeader(firstLine, headers) {
   // It was pointed out that this might confuse reverse proxies to the point
   // of creating security liabilities, so suppress the zero chunk and force
   // the connection to close.
-  if (this.chunkedEncoding && (this.statusCode === 204 ||
-                               this.statusCode === 304)) {
-    debug(this.statusCode + ' response should not use chunked encoding,' +
+  if (self.chunkedEncoding && (self.statusCode === 204 ||
+                               self.statusCode === 304)) {
+    debug(self.statusCode + ' response should not use chunked encoding,' +
           ' closing connection.');
-    this.chunkedEncoding = false;
-    this.shouldKeepAlive = false;
+    self.chunkedEncoding = false;
+    self.shouldKeepAlive = false;
   }
 
   // keep-alive logic
-  if (this._removedConnection) {
+  if (self._removedConnection) {
     // shouldKeepAlive is generally true for HTTP/1.1. In that common case,
     // even if the connection header isn't sent, we still persist by default.
-    this._last = !this.shouldKeepAlive;
+    self._last = !self.shouldKeepAlive;
   } else if (!state.connection) {
-    const shouldSendKeepAlive = this.shouldKeepAlive &&
-        (state.contLen || this.useChunkedEncodingByDefault || this.agent);
-    if (shouldSendKeepAlive && this.maxRequestsOnConnectionReached) {
+    const shouldSendKeepAlive = self.shouldKeepAlive &&
+        (state.contLen || self.useChunkedEncodingByDefault || self.agent);
+    if (shouldSendKeepAlive && self.maxRequestsOnConnectionReached) {
       header += 'Connection: close\r\n';
     } else if (shouldSendKeepAlive) {
       header += 'Connection: keep-alive\r\n';
-      if (this._keepAliveTimeout && this._defaultKeepAlive) {
-        const timeoutSeconds = MathFloor(this._keepAliveTimeout / 1000);
+      const keepAliveTimeout = self._keepAliveTimeout;
+      if (keepAliveTimeout && self._defaultKeepAlive) {
+        const timeoutSeconds = MathFloor(keepAliveTimeout / 1000);
+        const maxRequestsPerSocket = self._maxRequestsPerSocket;
         let max = '';
-        if (~~this._maxRequestsPerSocket > 0) {
-          max = `, max=${this._maxRequestsPerSocket}`;
+        if (~~maxRequestsPerSocket > 0) {
+          max = `, max=${maxRequestsPerSocket}`;
         }
         header += `Keep-Alive: timeout=${timeoutSeconds}${max}\r\n`;
       }
     } else {
-      this._last = true;
+      self._last = true;
       header += 'Connection: close\r\n';
     }
   }
 
+  let contentLength;
   if (!state.contLen && !state.te) {
-    if (!this._hasBody) {
+    if (!self._hasBody) {
       // Make sure we don't end the 0\r\n\r\n at the end of the message.
-      this.chunkedEncoding = false;
-    } else if (!this.useChunkedEncodingByDefault) {
-      this._last = true;
+      self.chunkedEncoding = false;
+    } else if (!self.useChunkedEncodingByDefault) {
+      self._last = true;
     } else if (!state.trailer &&
-               !this._removedContLen &&
-               typeof this._contentLength === 'number') {
-      header += 'Content-Length: ' + this._contentLength + '\r\n';
-    } else if (!this._removedTE) {
+               !self._removedContLen &&
+               typeof (contentLength = self._contentLength) === 'number') {
+      header += 'Content-Length: ' + contentLength + '\r\n';
+    } else if (!self._removedTE) {
       header += 'Transfer-Encoding: chunked\r\n';
-      this.chunkedEncoding = true;
+      self.chunkedEncoding = true;
     } else {
       // We should only be able to get here if both Content-Length and
       // Transfer-Encoding are removed by the user.
@@ -550,7 +837,7 @@ function _storeHeader(firstLine, headers) {
 
       // We can't keep alive in this case, because with no header info the body
       // is defined as all data until the connection is closed.
-      this._last = true;
+      self._last = true;
     }
   }
 
@@ -558,16 +845,16 @@ function _storeHeader(firstLine, headers) {
   // message will be terminated by the first empty line after the
   // header fields, regardless of the header fields present in the
   // message, and thus cannot contain a message body or 'trailers'.
-  if (this.chunkedEncoding !== true && state.trailer) {
+  if (self.chunkedEncoding !== true && state.trailer) {
     throw new ERR_HTTP_TRAILER_INVALID();
   }
 
-  this._header = header + '\r\n';
-  this._headerSent = false;
+  self._header = header + '\r\n';
+  self._headerSent = false;
 
   // Wait until the first body chunk, or close(), is sent to flush,
   // UNLESS we're sending Expect: 100-continue.
-  if (state.expect) this._send('');
+  if (state.expect) self._send('');
 }
 
 function processHeader(self, state, key, value, validate, lenient) {
@@ -590,13 +877,14 @@ function processHeader(self, state, key, value, validate, lenient) {
   }
 
   if (ArrayIsArray(value)) {
+    const valueLength = value.length;
     if (
-      (value.length < 2 || !isCookieField(key)) &&
+      (valueLength < 2 || !isCookieField(key)) &&
       (!self[kUniqueHeaders] || !self[kUniqueHeaders].has(key.toLowerCase()))
     ) {
       // Retain for(;;) loop for performance reasons
       // Refs: https://github.com/nodejs/node/pull/30958
-      for (let i = 0; i < value.length; i++)
+      for (let i = 0; i < valueLength; i++)
         storeHeader(self, state, key, value[i], validate, lenient);
       return;
     }
@@ -613,8 +901,23 @@ function storeHeader(self, state, key, value, validate, lenient) {
 }
 
 function matchHeader(self, state, field, value) {
-  if (field.length < 4 || field.length > 17)
-    return;
+  const len = field.length;
+  // Cheap (length, first character) pre-filter so the common case, a
+  // header that is not one of the eight known fields below, returns
+  // without paying the per-header toLowerCase() allocation. The filter
+  // only rejects names that cannot possibly match the switch: `| 0x20`
+  // lower-cases ASCII letters and maps no other token character onto a
+  // letter, and every known field length is enumerated.
+  const c = field.charCodeAt(0) | 0x20;
+  switch (len) {
+    case 4: if (c !== 0x64) return; break; // Date
+    case 6: if (c !== 0x65) return; break; // Expect
+    case 7: if (c !== 0x74) return; break; // Trailer
+    case 10: if (c !== 0x63 && c !== 0x6b) return; break; // Connection, Keep-Alive
+    case 14: if (c !== 0x63) return; break; // Content-Length
+    case 17: if (c !== 0x74) return; break; // Transfer-Encoding
+    default: return; // No known field has this length
+  }
   field = field.toLowerCase();
   switch (field) {
     case 'connection':
@@ -997,9 +1300,12 @@ function write_(msg, chunk, encoding, callback, fromEnd) {
     }
   }
 
-  if (!fromEnd && msg.socket && !msg.socket.writableCorked) {
-    msg.socket.cork();
-    process.nextTick(connectionCorkNT, msg.socket);
+  // `socket` is an accessor on the prototype: load it once instead of
+  // paying the getter three times on every body write.
+  let socket;
+  if (!fromEnd && (socket = msg.socket) && !socket.writableCorked) {
+    socket.cork();
+    process.nextTick(connectionCorkNT, socket);
   }
 
   let ret;
@@ -1028,6 +1334,12 @@ function connectionCorkNT(conn) {
   conn.uncork();
 }
 
+function runChunkCallbacks(callbacks, err) {
+  for (let i = 0; i < callbacks.length; i++) {
+    callbacks[i](err);
+  }
+}
+
 OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
   if (this.finished) {
     throw new ERR_HTTP_HEADERS_SENT('set trailing');
@@ -1036,6 +1348,7 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
   this._trailer = '';
   const keys = ObjectKeys(headers);
   const isArray = ArrayIsArray(headers);
+  const lenient = this._isLenientHeaderValidation();
   // Retain for(;;) loop for performance reasons
   // Refs: https://github.com/nodejs/node/pull/30958
   for (let i = 0, l = keys.length; i < l; i++) {
@@ -1052,7 +1365,6 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
 
     // Check if the field must be sent several times
     const isArrayValue = ArrayIsArray(value);
-    const lenient = this._isLenientHeaderValidation();
     if (
       isArrayValue && value.length > 1 &&
       (!this[kUniqueHeaders] || !this[kUniqueHeaders].has(field.toLowerCase()))
@@ -1093,6 +1405,13 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     encoding = null;
   }
 
+  // Single-shot fast path: headers not yet rendered, socket assigned, one
+  // body chunk (or empty). Builds the entire HTTP message in C++ and issues
+  // a single socket.write().
+  if (tryFastEnd(this, chunk, encoding, callback)) {
+    return this;
+  }
+
   if (chunk) {
     if (this.finished) {
       onError(this,
@@ -1105,7 +1424,17 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
       this[kSocket].cork();
     }
 
-    write_(this, chunk, encoding, null, true);
+    try {
+      write_(this, chunk, encoding, null, true);
+    } catch (err) {
+      // write_() can throw on invalid chunk types before any data is
+      // queued; undo the cork so a subsequent end() is not stuck.
+      if (this[kSocket]) {
+        this[kSocket]._writableState.corked = 1;
+        this[kSocket].uncork();
+      }
+      throw err;
+    }
   } else if (this.finished) {
     if (typeof callback === 'function') {
       if (!this.writableFinished) {
@@ -1162,6 +1491,184 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
 
   return this;
 };
+
+function getFastFirstLine(msg) {
+  // ServerResponse
+  if (typeof msg.statusCode === 'number') {
+    const statusCode = msg.statusCode | 0;
+    if (statusCode < 100 || statusCode > 999) return null;
+    let statusMessage = msg.statusMessage;
+    if (statusMessage === undefined || statusMessage === null) {
+      statusMessage = statusCodes()[statusCode] || 'unknown';
+      msg.statusMessage = statusMessage;
+    }
+    if (checkInvalidHeaderChar(statusMessage)) {
+      throw new ERR_INVALID_CHAR('statusMessage');
+    }
+    // Align with writeHead() side effects for informational / no-body codes.
+    if (statusCode === 204 || statusCode === 304 ||
+        (statusCode >= 100 && statusCode <= 199)) {
+      msg._hasBody = false;
+    }
+    if (msg._expect_continue && !msg._sent100) {
+      msg.shouldKeepAlive = false;
+    }
+    return `HTTP/1.1 ${statusCode} ${statusMessage}\r\n`;
+  }
+  // ClientRequest
+  if (typeof msg.method === 'string' && typeof msg.path === 'string') {
+    return msg.method + ' ' + msg.path + ' HTTP/1.1\r\n';
+  }
+  return null;
+}
+
+function tryFastEnd(msg, chunk, encoding, callback) {
+  // ServerResponse only. ClientRequest has method-specific Content-Length
+  // rules (GET/HEAD/DELETE must not emit CL:0) and CONNECT tunnel framing
+  // that the C++ builder does not model.
+  if (typeof msg.statusCode !== 'number')
+    return false;
+
+  // Preconditions: nothing rendered yet, socket ready, no queued output,
+  // no trailers, not already finished/destroyed.
+  if (msg._header || msg._headerSent || msg.finished || msg.destroyed)
+    return false;
+  if (msg._trailer) return false;
+  if (msg.outputData.length !== 0) return false;
+  if (msg[kCorked]) return false;
+  if (msg._expect_continue && !msg._sent100) return false;
+
+  const socket = msg[kSocket];
+  // Require a real net.Socket (has a libuv _handle). Standalone
+  // ServerResponse tests assign arbitrary Writables that must keep the
+  // multi-write _send() behaviour.
+  if (!socket || socket._httpMessage !== msg || !socket.writable ||
+      socket.destroyed || !socket._writableState || !socket._handle) {
+    return false;
+  }
+
+  // Body encoding must be latin1/utf8/buffer (what the C++ builder supports).
+  let body = null;
+  let bodyEncoding = 0; // 0 = buffer/none
+  let bodyLen = 0;
+  if (chunk) {
+    if (typeof chunk === 'string') {
+      if (encoding && encoding !== 'utf8' && encoding !== 'utf-8' &&
+          encoding !== 'latin1' && encoding !== 'binary' &&
+          encoding !== 'ascii') {
+        return false;
+      }
+      body = chunk;
+      if (encoding === 'latin1' || encoding === 'binary' ||
+          encoding === 'ascii') {
+        bodyEncoding = 1;
+        bodyLen = chunk.length;
+      } else {
+        bodyEncoding = 2;
+        bodyLen = Buffer.byteLength(chunk, 'utf8');
+      }
+    } else if (isUint8Array(chunk)) {
+      body = chunk;
+      bodyEncoding = 0;
+      bodyLen = chunk.byteLength;
+    } else {
+      return false;
+    }
+  }
+
+  if (!msg._hasBody && body && bodyLen > 0) {
+    if (msg[kRejectNonStandardBodyWrites]) {
+      throw new ERR_HTTP_BODY_NOT_ALLOWED();
+    }
+    // Legacy: ignore body for HEAD / 204 / 304.
+    body = null;
+    bodyLen = 0;
+  }
+
+  const firstLine = getFastFirstLine(msg);
+  if (firstLine === null) return false;
+
+  let flat;
+  try {
+    flat = flattenHeadersForNative(msg, msg[kOutHeaders], false);
+  } catch {
+    return false;
+  }
+  if (flat === null) return false;
+
+  if (body && msg._hasBody) {
+    msg._contentLength = bodyLen;
+  } else if (!msg._header) {
+    msg._contentLength = 0;
+  }
+
+  const knownLength =
+    typeof msg._contentLength === 'number' ? msg._contentLength : -1;
+  const keepAliveSec = msg._keepAliveTimeout ?
+    MathFloor(msg._keepAliveTimeout / 1000) :
+    0;
+  const maxReq = msg._maxRequestsPerSocket | 0;
+  const date = msg.sendDate ? utcDate() : '';
+
+  buildHttpMessageOut[0] = 0;
+  buildHttpMessageOut[1] = 0;
+  buildHttpMessageOut[2] = 0;
+  buildHttpMessageOut[3] = 0;
+
+  const buf = buildHttpMessage(
+    firstLine,
+    flat,
+    body,
+    bodyEncoding,
+    buildFlags(msg),
+    date,
+    keepAliveSec,
+    maxReq,
+    knownLength,
+    buildHttpMessageOut,
+  );
+  if (!buf) return false;
+
+  applyBuildResult(msg, buildHttpMessageOut);
+
+  if (msg.chunkedEncoding && (msg.statusCode === 204 ||
+                              msg.statusCode === 304)) {
+    // Should not happen with single-shot body preference, but stay safe.
+    return false;
+  }
+
+  if (typeof callback === 'function')
+    msg.once('finish', callback);
+
+  // Mark headers as rendered+sent so subsequent writes fail correctly.
+  msg._header = buf.toString('latin1');
+  msg._headerSent = true;
+  msg.finished = true;
+  if (bodyLen && msg._hasBody) {
+    msg[kBytesWritten] = bodyLen;
+  }
+
+  const finish = onFinish.bind(undefined, msg);
+
+  // The socket is typically corked by OutgoingMessage.socket setter /
+  // assignSocket. Mirror end()'s uncork so the single write is flushed;
+  // without this the write callback never runs and the response hangs.
+  if (!socket.writableCorked) {
+    socket.cork();
+  }
+  const ret = socket.write(buf, finish);
+  // Force a full uncork (same as the slow end() path).
+  socket._writableState.corked = 1;
+  socket.uncork();
+
+  if (!ret) msg[kNeedDrain] = true;
+
+  debug('outgoing message fast end.');
+  if (msg.outputData.length === 0 && socket._httpMessage === msg) {
+    msg._finish();
+  }
+  return true;
+}
 
 
 // This function is called once all user data are flushed to the socket.

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -24,6 +24,7 @@
 const {
   Array,
   ArrayIsArray,
+  Float64Array,
   MathFloor,
   ObjectDefineProperty,
   ObjectHasOwn,
@@ -32,7 +33,6 @@ const {
   ObjectValues,
   SafeSet,
   Symbol,
-  Uint32Array,
 } = primordials;
 
 const { getDefaultHighWaterMark } = require('internal/streams/state');
@@ -75,9 +75,9 @@ const { validateString } = require('internal/validators');
 const { assignFunctionName } = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
 
-const {
-  buildHttpMessage,
-} = internalBinding('http_parser');
+// Keep the binding object (not a destructured function) so tests can
+// temporarily replace buildHttpMessage to exercise the legacy JS path.
+const httpParserBinding = internalBinding('http_parser');
 
 let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
@@ -124,7 +124,8 @@ const kBuildRemovedContLen = 1 << 7;
 const kBuildRemovedTE = 1 << 8;
 const kBuildHasAgent = 1 << 9;
 
-// Output slots written by buildHttpMessage into args[9] (Uint32Array).
+// Output slots written by buildHttpMessage into args[9] (Float64Array).
+// Float64 (not Uint32) so Content-Length values above 2^32-1 are not truncated.
 // Keep in sync with BuildHttpMessageOut in src/node_http_parser.cc.
 //   [kOutLast]             - 1 if this is the last message on the connection
 //   [kOutChunked]          - 1 if Transfer-Encoding: chunked was selected
@@ -137,8 +138,8 @@ const kOutHasContentLength = 3;
 const kOutCount = 4;
 
 // Scratch buffer for native out-params. Reused so each response does not
-// allocate a new Uint32Array; only the four slots above are written/read.
-const buildHttpMessageOut = new Uint32Array(kOutCount);
+// allocate a new Float64Array; only the four slots above are written/read.
+const buildHttpMessageOut = new Float64Array(kOutCount);
 
 // Lazy to avoid a require cycle with _http_server.
 let _statusCodes;
@@ -713,7 +714,7 @@ function tryNativeStoreHeader(msg, firstLine, headers) {
   buildHttpMessageOut[2] = 0;
   buildHttpMessageOut[3] = 0;
 
-  const buf = buildHttpMessage(
+  const buf = httpParserBinding.buildHttpMessage(
     firstLine,
     flat,
     null,
@@ -1732,6 +1733,11 @@ function tryFastEnd(msg, chunk, encoding, callback) {
   if (msg.outputData.length !== 0) return false;
   if (msg[kCorked]) return false;
   if (msg._expect_continue && !msg._sent100) return false;
+  // _contentLength is only populated once headers are stored, so the
+  // strictContentLength() helper is false here even when the user set
+  // Content-Length via setHeader(). Always defer when strict mode is on
+  // so write_()/end() enforce ERR_HTTP_CONTENT_LENGTH_MISMATCH.
+  if (msg.strictContentLength) return false;
 
   const socket = msg[kSocket];
   // Require a real net.Socket (has a libuv _handle). Standalone
@@ -1774,10 +1780,15 @@ function tryFastEnd(msg, chunk, encoding, callback) {
   const maxReq = msg._maxRequestsPerSocket | 0;
   const date = msg.sendDate ? utcDate() : '';
 
-  const buf = buildHttpMessage(
+  // Pass '' (not null) for a no-body complete message so the C++ builder
+  // emits the chunked terminator 0\r\n\r\n when TE: chunked is selected.
+  // null/undefined means headers-only (_storeHeader), which must not.
+  const bodyArg = body === null ? '' : body;
+
+  const buf = httpParserBinding.buildHttpMessage(
     firstLine,
     flat,
-    body,
+    bodyArg,
     bodyEncoding,
     buildFlags(msg),
     date,

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -24,13 +24,13 @@
 const {
   Array,
   ArrayIsArray,
-  Float64Array,
   MathFloor,
   ObjectDefineProperty,
   ObjectHasOwn,
   ObjectKeys,
   ObjectSetPrototypeOf,
   ObjectValues,
+  SafeMap,
   SafeSet,
   Symbol,
 } = primordials;
@@ -74,10 +74,7 @@ const {
 const { validateString } = require('internal/validators');
 const { assignFunctionName } = require('internal/util');
 const { isUint8Array } = require('internal/util/types');
-
-// Keep the binding object (not a destructured function) so tests can
-// temporarily replace buildHttpMessage to exercise the legacy JS path.
-const httpParserBinding = internalBinding('http_parser');
+const { writeGeneric } = require('internal/stream_base_commons');
 
 let debug = require('internal/util/debuglog').debuglog('http', (fn) => {
   debug = fn;
@@ -93,65 +90,47 @@ const kBytesWritten = Symbol('kBytesWritten');
 const kErrored = Symbol('errored');
 const kHighWaterMark = Symbol('kHighWaterMark');
 const kRejectNonStandardBodyWrites = Symbol('kRejectNonStandardBodyWrites');
+const kServerFinishHook = Symbol('kServerFinishHook');
 
 const nop = () => {};
 
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
-
-// Flags passed as args[4] to native buildHttpMessage(). Keep in sync with
-// BuildHttpMessageFlags in src/node_http_parser.cc. Combined with | so C++ can
-// decide which automatic headers (Date, Connection, Content-Length / TE) to
-// emit without re-reading OutgoingMessage fields one-by-one.
-//   kBuildSendDate              - inject Date if the user did not set it
-//   kBuildShouldKeepAlive       - prefer Connection: keep-alive when valid
-//   kBuildMaxRequestsReached    - force Connection: close (server max)
-//   kBuildDefaultKeepAlive      - also emit Keep-Alive: timeout=...
-//   kBuildHasBody               - message may carry a body (not HEAD/204/304)
-//   kBuildUseChunkedByDefault   - allow auto Content-Length / TE: chunked
-//   kBuildRemovedConnection     - user called removeHeader('connection')
-//   kBuildRemovedContLen        - user called removeHeader('content-length')
-//   kBuildRemovedTE             - user called removeHeader('transfer-encoding')
-//   kBuildHasAgent              - ClientRequest has an agent (keep-alive only;
-//                                 does NOT enable auto Content-Length)
-const kBuildSendDate = 1 << 0;
-const kBuildShouldKeepAlive = 1 << 1;
-const kBuildMaxRequestsReached = 1 << 2;
-const kBuildDefaultKeepAlive = 1 << 3;
-const kBuildHasBody = 1 << 4;
-const kBuildUseChunkedByDefault = 1 << 5;
-const kBuildRemovedConnection = 1 << 6;
-const kBuildRemovedContLen = 1 << 7;
-const kBuildRemovedTE = 1 << 8;
-const kBuildHasAgent = 1 << 9;
-
-// Output slots written by buildHttpMessage into args[9] (Float64Array).
-// Float64 (not Uint32) so Content-Length values above 2^32-1 are not truncated.
-// Keep in sync with BuildHttpMessageOut in src/node_http_parser.cc.
-//   [kOutLast]             - 1 if this is the last message on the connection
-//   [kOutChunked]          - 1 if Transfer-Encoding: chunked was selected
-//   [kOutContentLength]    - resolved body length when known
-//   [kOutHasContentLength] - 1 if kOutContentLength is valid
-const kOutLast = 0;
-const kOutChunked = 1;
-const kOutContentLength = 2;
-const kOutHasContentLength = 3;
-const kOutCount = 4;
-
-// Scratch buffer for native out-params. Reused so each response does not
-// allocate a new Float64Array; only the four slots above are written/read.
-const buildHttpMessageOut = new Float64Array(kOutCount);
 
 // Bodies larger than this are never folded into a combined headers+body
 // buffer/string: the copy is slower than a separate write()
 // (benchmark/http/end-vs-write-end.js).
 const kMaxSingleShotBody = 16 * 1024;
 
-// Lazy to avoid a require cycle with _http_server.
-let _statusCodes;
-function statusCodes() {
-  _statusCodes ??= require('_http_server').STATUS_CODES;
-  return _statusCodes;
+// Cached "Date: ...\r\n" line - utcDate() already caches the date string for
+// up to 1s; avoid re-concatenating the "Date: " prefix on every response.
+let cachedDateHeader = '';
+let cachedDateValue = '';
+function dateHeaderLine() {
+  const d = utcDate();
+  if (d !== cachedDateValue) {
+    cachedDateValue = d;
+    cachedDateHeader = 'Date: ' + d + '\r\n';
+  }
+  return cachedDateHeader;
 }
+
+// Cached Connection/Keep-Alive suffix for the common keep-alive shape.
+// Keyed by timeoutSec and maxReq (usually constant for a server).
+const keepAliveSuffixCache = new SafeMap();
+function keepAliveSuffix(timeoutSec, maxReq) {
+  const key = timeoutSec * 0x100000000 + (maxReq | 0);
+  let s = keepAliveSuffixCache.get(key);
+  if (s !== undefined) return s;
+  if (maxReq > 0)
+    s = `Connection: keep-alive\r\nKeep-Alive: timeout=${timeoutSec}, max=${maxReq}\r\n`;
+  else
+    s = `Connection: keep-alive\r\nKeep-Alive: timeout=${timeoutSec}\r\n`;
+  // Bound the cache; servers almost never change these at runtime.
+  if (keepAliveSuffixCache.size < 16)
+    keepAliveSuffixCache.set(key, s);
+  return s;
+}
+
 
 // isCookieField performs a case-insensitive comparison of a provided string
 // against the word "cookie." As of V8 6.6 this is faster than handrolling or
@@ -613,110 +592,283 @@ function _storeHeader(firstLine, headers) {
   legacyStoreHeader(this, firstLine, headers);
 }
 
-function buildFlags(msg) {
-  let flags = 0;
-  if (msg.sendDate) flags |= kBuildSendDate;
-  if (msg.shouldKeepAlive) flags |= kBuildShouldKeepAlive;
-  if (msg.maxRequestsOnConnectionReached) flags |= kBuildMaxRequestsReached;
-  if (msg._defaultKeepAlive) flags |= kBuildDefaultKeepAlive;
-  if (msg._hasBody) flags |= kBuildHasBody;
-  // useChunkedEncodingByDefault and agent are independent: agent only
-  // participates in keep-alive decisions, not Content-Length emission.
-  if (msg.useChunkedEncodingByDefault) flags |= kBuildUseChunkedByDefault;
-  if (msg._removedConnection) flags |= kBuildRemovedConnection;
-  if (msg._removedContLen) flags |= kBuildRemovedContLen;
-  if (msg._removedTE) flags |= kBuildRemovedTE;
-  if (msg.agent) flags |= kBuildHasAgent;
-  return flags;
-}
+// Fast writeHead({ k: string, ... }) path. Returns false when any value is
+// not a plain string (arrays, Buffers) so the caller can fall back.
+const headerBlockCache = new SafeMap();
+const kHeaderBlockCacheMax = 64;
 
-function applyBuildResult(msg, out) {
-  if (out[kOutLast]) msg._last = true;
-  if (out[kOutChunked]) msg.chunkedEncoding = true;
-  else msg.chunkedEncoding = false;
-  if (out[kOutHasContentLength])
-    msg._contentLength = out[kOutContentLength];
-}
+// Per-headerBuf map of body -> complete wire-format response Buffer.
+// Attached to cached header Buffers so date-rollover naturally drops entries
+// when the header block is rebuilt. Concurrent writes of the same Buffer to
+// different sockets are safe (read-only payload).
+const kFullBodyMap = Symbol('kFullBodyMap');
+const kChunkedFullBodyMap = Symbol('kChunkedFullBodyMap');
+const kFullBodyMapMax = 8;
 
-// Flatten headers into [name, value, ...] for the C++ builder. Returns null
-// when a header requires the legacy JS path.
-function flattenHeadersForNative(msg, headers, validate) {
-  const flat = flatHeadersScratch;
-  flat.length = 0;
-  const lenient = msg._isLenientHeaderValidation();
 
-  function pushPair(key, value, doValidate) {
-    if (doValidate) {
-      validateHeaderName(key);
-    }
-    // content-disposition + content-length needs latin1 Buffer values - JS only.
-    if (isContentDispositionField(key) && msg._contentLength) {
-      return false;
-    }
-    if (ArrayIsArray(value)) {
-      const valueLength = value.length;
-      if (
-        (valueLength < 2 || !isCookieField(key)) &&
-        (!msg[kUniqueHeaders] || !msg[kUniqueHeaders].has(key.toLowerCase()))
-      ) {
-        for (let i = 0; i < valueLength; i++) {
-          if (doValidate) validateHeaderValue(key, value[i], lenient);
-          // Buffers not supported on the native path.
-          if (typeof value[i] !== 'string') return false;
-          flat.push(key, value[i]);
-        }
-        return true;
-      }
-      value = value.join('; ');
-    }
-    if (doValidate) validateHeaderValue(key, value, lenient);
+function tryFastStoreHeaderObject(self, firstLine, headers) {
+  const lenient = self._isLenientHeaderValidation();
+
+  // Build a cache key. Hot path: two string headers (simple.js) uses a
+  // short key without a full flags dump when defaults are intact.
+  let k0, v0, k1, v1;
+  let pairCount = 0;
+  for (const key in headers) {
+    if (!ObjectHasOwn(headers, key)) continue;
+    const value = headers[key];
     if (typeof value !== 'string') return false;
-    flat.push(key, value);
+    if (pairCount === 0) {
+      k0 = key;
+      v0 = value;
+    } else if (pairCount === 1) {
+      k1 = key;
+      v1 = value;
+    } else {
+      // Fall through to general key below.
+      pairCount = -1;
+      break;
+    }
+    pairCount++;
+  }
+  let cacheKey;
+  if (pairCount === 2 &&
+      firstLine === 'HTTP/1.1 200 OK\r\n' &&
+      self.sendDate && self.shouldKeepAlive && self._defaultKeepAlive &&
+      self._hasBody && self.useChunkedEncodingByDefault &&
+      !self.maxRequestsOnConnectionReached &&
+      !self._removedConnection && !self._removedContLen && !self._removedTE &&
+      !self.agent) {
+    // simple.js-shaped response: two headers, stock keep-alive server.
+    // (maxRequestsOnConnectionReached is always false on this branch.)
+    cacheKey = k0 + '\0' + v0 + '\0' + k1 + '\0' + v1 +
+      '\0' + (self._keepAliveTimeout | 0);
+  } else if (pairCount === 1 &&
+             firstLine === 'HTTP/1.1 200 OK\r\n' &&
+             !self.maxRequestsOnConnectionReached &&
+             self._hasBody) {
+    cacheKey = k0 + '\0' + v0 + '\0' + (self._keepAliveTimeout | 0) +
+      '\0' + (self.shouldKeepAlive ? '1' : '0') +
+      '\0' + (self._defaultKeepAlive ? '1' : '0') +
+      '\0' + (self.useChunkedEncodingByDefault ? '1' : '0');
+  } else {
+    // General key.
+    if (pairCount === -1) {
+      // Restart enumeration for the general path.
+      cacheKey = firstLine;
+      for (const key in headers) {
+        if (!ObjectHasOwn(headers, key)) continue;
+        const value = headers[key];
+        if (typeof value !== 'string') return false;
+        cacheKey += '\n' + key + '\n' + value;
+      }
+    } else {
+      cacheKey = firstLine;
+      if (pairCount >= 1) cacheKey += '\n' + k0 + '\n' + v0;
+      if (pairCount >= 2) cacheKey += '\n' + k1 + '\n' + v1;
+    }
+    cacheKey += '\n' + (self.sendDate ? '1' : '0') +
+      (self.shouldKeepAlive ? '1' : '0') +
+      (self.maxRequestsOnConnectionReached ? '1' : '0') +
+      (self._defaultKeepAlive ? '1' : '0') +
+      (self._hasBody ? '1' : '0') +
+      (self.useChunkedEncodingByDefault ? '1' : '0') +
+      (self._removedConnection ? '1' : '0') +
+      (self._removedContLen ? '1' : '0') +
+      (self._removedTE ? '1' : '0') +
+      (self.agent ? '1' : '0') +
+      '\n' + (self._keepAliveTimeout | 0) +
+      '\n' + (self._maxRequestsPerSocket | 0) +
+      '\n' + (self.statusCode | 0);
+  }
+
+  const date = self.sendDate ? utcDate() : '';
+  const cached = headerBlockCache.get(cacheKey);
+  if (cached !== undefined && cached.date === date) {
+    // Replay side effects from the cached build. Prefer Buffer header so
+    // the flush path can write without re-encoding the header block.
+    self._header = cached.headerBuf || cached.header;
+    self._headerSent = false;
+    self.chunkedEncoding = cached.chunkedEncoding;
+    self._last = cached._last;
+    self.shouldKeepAlive = cached.shouldKeepAlive;
+    self._contentLength = cached._contentLength;
+    self._removedConnection = cached._removedConnection;
+    self._removedContLen = cached._removedContLen;
+    self._removedTE = cached._removedTE;
+    self._defaultKeepAlive = cached._defaultKeepAlive;
+    if (cached.expect) self._send('');
     return true;
   }
 
-  if (!headers) return flat;
-
-  if (headers === msg[kOutHeaders]) {
-    for (const key in headers) {
-      const entry = headers[key];
-      if (!pushPair(entry[0], entry[1], false)) return null;
-    }
-    return flat;
-  }
-
-  if (ArrayIsArray(headers)) {
-    const headersLength = headers.length;
-    if (headersLength && ArrayIsArray(headers[0])) {
-      for (let i = 0; i < headersLength; i++) {
-        const entry = headers[i];
-        if (!pushPair(entry[0], entry[1], validate)) return null;
-      }
-    } else {
-      if (headersLength % 2 !== 0) {
-        throw new ERR_INVALID_ARG_VALUE('headers', headers);
-      }
-      for (let n = 0; n < headersLength; n += 2) {
-        if (!pushPair(headers[n], headers[n + 1], validate)) return null;
-      }
-    }
-    return flat;
-  }
+  let header = firstLine;
+  let connection = false;
+  let contLen = false;
+  let te = false;
+  let dateSeen = false;
+  let expect = false;
+  let trailer = false;
 
   for (const key in headers) {
-    if (ObjectHasOwn(headers, key)) {
-      if (!pushPair(key, headers[key], validate)) return null;
+    if (!ObjectHasOwn(headers, key)) continue;
+    const value = headers[key];
+    // Typeof already checked above when building cacheKey, but re-check for
+    // safety if the object was mutated (shouldn't happen).
+    if (typeof value !== 'string') return false;
+
+    validateHeaderName(key);
+    validateHeaderValue(key, value, lenient);
+    header += key + ': ' + value + '\r\n';
+
+    const len = key.length;
+    if (len !== 4 && len !== 6 && len !== 7 && len !== 10 &&
+        len !== 14 && len !== 17) {
+      continue;
+    }
+    const lower = key.toLowerCase();
+    switch (lower) {
+      case 'connection':
+        connection = true;
+        self._removedConnection = false;
+        if (RE_CONN_CLOSE.test(value))
+          self._last = true;
+        else
+          self.shouldKeepAlive = true;
+        break;
+      case 'transfer-encoding':
+        te = true;
+        self._removedTE = false;
+        if (RE_TE_CHUNKED.test(value))
+          self.chunkedEncoding = true;
+        break;
+      case 'content-length':
+        contLen = true;
+        self._contentLength = +value;
+        self._removedContLen = false;
+        break;
+      case 'date':
+        dateSeen = true;
+        break;
+      case 'expect':
+        expect = true;
+        break;
+      case 'trailer':
+        trailer = true;
+        break;
+      case 'keep-alive':
+        self._defaultKeepAlive = false;
+        break;
+      default:
+        break;
     }
   }
-  return flat;
+
+  if (self.sendDate && !dateSeen) {
+    header += dateHeaderLine();
+  }
+
+  if (self.chunkedEncoding && (self.statusCode === 204 ||
+                               self.statusCode === 304)) {
+    debug(self.statusCode + ' response should not use chunked encoding,' +
+          ' closing connection.');
+    self.chunkedEncoding = false;
+    self.shouldKeepAlive = false;
+  }
+
+  if (self._removedConnection) {
+    self._last = !self.shouldKeepAlive;
+  } else if (!connection) {
+    const shouldSendKeepAlive = self.shouldKeepAlive &&
+        (contLen || self.useChunkedEncodingByDefault || self.agent);
+    if (shouldSendKeepAlive && self.maxRequestsOnConnectionReached) {
+      header += 'Connection: close\r\n';
+    } else if (shouldSendKeepAlive) {
+      const keepAliveTimeout = self._keepAliveTimeout;
+      if (keepAliveTimeout && self._defaultKeepAlive) {
+        header += keepAliveSuffix(
+          MathFloor(keepAliveTimeout / 1000),
+          self._maxRequestsPerSocket | 0,
+        );
+      } else {
+        header += 'Connection: keep-alive\r\n';
+      }
+    } else {
+      self._last = true;
+      header += 'Connection: close\r\n';
+    }
+  }
+
+  let contentLength;
+  if (!contLen && !te) {
+    if (!self._hasBody) {
+      self.chunkedEncoding = false;
+    } else if (!self.useChunkedEncodingByDefault) {
+      self._last = true;
+    } else if (!trailer &&
+               !self._removedContLen &&
+               typeof (contentLength = self._contentLength) === 'number') {
+      header += 'Content-Length: ' + contentLength + '\r\n';
+    } else if (!self._removedTE) {
+      header += 'Transfer-Encoding: chunked\r\n';
+      self.chunkedEncoding = true;
+    } else {
+      debug('Both Content-Length and Transfer-Encoding are removed');
+      self._last = true;
+    }
+  }
+
+  if (self.chunkedEncoding !== true && trailer) {
+    throw new ERR_HTTP_TRAILER_INVALID();
+  }
+
+  header += '\r\n';
+  self._header = header;
+  self._headerSent = false;
+
+  // Cache for subsequent identical writeHead() calls this second.
+  if (headerBlockCache.size >= kHeaderBlockCacheMax) {
+    // Drop an arbitrary old entry (Map iterates insertion order).
+    const first = headerBlockCache.keys().next().value;
+    headerBlockCache.delete(first);
+  }
+  // Pre-encode the header block once; keep-alive requests reuse the Buffer
+  // so end() only encodes the body (or copies a Buffer body).
+  const headerBuf = Buffer.from(header, 'latin1');
+  headerBlockCache.set(cacheKey, {
+    date,
+    header,
+    headerBuf,
+    chunkedEncoding: self.chunkedEncoding,
+    _last: self._last,
+    shouldKeepAlive: self.shouldKeepAlive,
+    _contentLength: self._contentLength,
+    _removedConnection: self._removedConnection,
+    _removedContLen: self._removedContLen,
+    _removedTE: self._removedTE,
+    _defaultKeepAlive: self._defaultKeepAlive,
+    expect,
+  });
+  // Prefer Buffer form on the message for the flush path.
+  self._header = headerBuf;
+
+  if (expect) self._send('');
+  return true;
 }
 
-// Reused flat header list for native builds (sync only; reset each call).
-const flatHeadersScratch = [];
 
 function legacyStoreHeader(self, firstLine, headers) {
   // firstLine in the case of request is: 'GET /index.html HTTP/1.1\r\n'
   // in the case of response it is: 'HTTP/1.1 200 OK\r\n'
+
+  // Hot path: writeHead(status, { name: string, ... }) with only string
+  // values (benchmark/http/simple.js). Avoids the state object and the
+  // processHeader/storeHeader call chain.
+  if (headers &&
+      headers !== self[kOutHeaders] &&
+      !ArrayIsArray(headers) &&
+      tryFastStoreHeaderObject(self, firstLine, headers)) {
+    return;
+  }
+
   const state = {
     connection: false,
     contLen: false,
@@ -766,7 +918,7 @@ function legacyStoreHeader(self, firstLine, headers) {
 
   // Date header
   if (self.sendDate && !state.date) {
-    header += 'Date: ' + utcDate() + '\r\n';
+    header += dateHeaderLine();
   }
 
   // Force the connection to close when the response is a 204 No Content or
@@ -897,6 +1049,16 @@ function processHeader(self, state, key, value, validate, lenient) {
 function storeHeader(self, state, key, value, validate, lenient) {
   if (validate)
     validateHeaderValue(key, value, lenient);
+  // Buffer values (notably content-disposition when Content-Length is set)
+  // must be flattened as latin1 so the subsequent latin1 header write puts
+  // the original octets on the wire. Default Buffer->string is utf8, which
+  // re-decodes the bytes and breaks binary header values under latin1 write.
+  if (typeof value !== 'string') {
+    if (isUint8Array(value))
+      value = value.toString('latin1');
+    else
+      value = `${value}`;
+  }
   state.header += key + ': ' + value + '\r\n';
   matchHeader(self, state, key, value);
 }
@@ -952,6 +1114,15 @@ function matchHeader(self, state, field, value) {
 }
 
 const validateHeaderName = assignFunctionName('validateHeaderName', hideStackFrames((name, label) => {
+  // Common names used by writeHead() in hot servers (simple.js, APIs).
+  // Avoid checkIsHttpToken() char scanning for these fixed tokens.
+  if (name === 'Content-Type' || name === 'Content-Length' ||
+      name === 'Transfer-Encoding' || name === 'Connection' ||
+      name === 'Date' || name === 'Keep-Alive' || name === 'Host' ||
+      name === 'content-type' || name === 'content-length' ||
+      name === 'transfer-encoding') {
+    return;
+  }
   if (typeof name !== 'string' || !name || !checkIsHttpToken(name)) {
     throw new ERR_INVALID_HTTP_TOKEN.HideStackFramesError(label || 'Header name', name);
   }
@@ -960,6 +1131,23 @@ const validateHeaderName = assignFunctionName('validateHeaderName', hideStackFra
 const validateHeaderValue = assignFunctionName('validateHeaderValue', hideStackFrames((name, value, lenient) => {
   if (value === undefined) {
     throw new ERR_HTTP_INVALID_HEADER_VALUE.HideStackFramesError(value, name);
+  }
+  // Hot path: pure printable ASCII string values (digits, tokens, simple
+  // media types). Skip the regex scan used by checkInvalidHeaderChar.
+  if (typeof value === 'string') {
+    const len = value.length;
+    // Empty is valid. Fast reject only on CR/LF/NUL via a tight loop that
+    // V8 can optimize better than the general regex for short values.
+    let ok = true;
+    for (let i = 0; i < len; i++) {
+      const c = value.charCodeAt(i);
+      // Allow tab (9) and 0x20-0x7e; reject CTL and DEL. High bytes go to
+      // the full checker (content-disposition latin1 etc.).
+      if (c === 9 || (c >= 32 && c <= 126)) continue;
+      ok = false;
+      break;
+    }
+    if (ok) return;
   }
   if (checkInvalidHeaderChar(value, lenient)) {
     debug('Header "%s" contains invalid characters', name);
@@ -1393,6 +1581,11 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
 
 function onFinish(outmsg) {
   if (outmsg?.socket?._hadError) return;
+  // ServerResponse installs kServerFinishHook; the hook no-ops unless
+  // parserOnIncoming armed finish state (kFinishReq).
+  const hook = outmsg[kServerFinishHook];
+  if (typeof hook === 'function')
+    hook.call(outmsg);
   outmsg.emit('finish');
 }
 
@@ -1493,39 +1686,6 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   return this;
 };
 
-function getFastFirstLine(msg) {
-  // ServerResponse
-  if (typeof msg.statusCode === 'number') {
-    const statusCode = msg.statusCode | 0;
-    if (statusCode < 100 || statusCode > 999) return null;
-    let statusMessage = msg.statusMessage;
-    if (statusMessage === undefined || statusMessage === null) {
-      statusMessage = statusCodes()[statusCode] || 'unknown';
-      msg.statusMessage = statusMessage;
-    }
-    if (checkInvalidHeaderChar(statusMessage)) {
-      throw new ERR_INVALID_CHAR('statusMessage');
-    }
-    // Align with writeHead() side effects for informational / no-body codes.
-    if (statusCode === 204 || statusCode === 304 ||
-        (statusCode >= 100 && statusCode <= 199)) {
-      msg._hasBody = false;
-    }
-    if (msg._expect_continue && !msg._sent100) {
-      msg.shouldKeepAlive = false;
-    }
-    return `HTTP/1.1 ${statusCode} ${statusMessage}\r\n`;
-  }
-  // ClientRequest
-  if (typeof msg.method === 'string' && typeof msg.path === 'string') {
-    return msg.method + ' ' + msg.path + ' HTTP/1.1\r\n';
-  }
-  return null;
-}
-
-// Common status lines (writeHead / fast end without custom reason).
-const kStatusLine200 = 'HTTP/1.1 200 OK\r\n';
-
 function prepareFastBody(msg, chunk, encoding) {
   let body = null;
   let bodyEncoding = 0; // 0 = buffer/none, 1 = latin1, 2 = utf8
@@ -1573,12 +1733,112 @@ function finishFastSocketWrite(msg, socket, ret) {
   }
 }
 
-// writeHead() already rendered headers: flush header + body without write_().
-// This is the benchmark/http/simple.js path.
+// Write the complete response Buffer/string straight to the socket handle,
+// bypassing stream.Writable.write() (and its nextTick deferral of the
+// write callback on the sync-write path). This is safe for the single-shot
+// end() path: we never half-close the socket here and we still drive the
+// OutgoingMessage finish lifecycle via the write callback.
+// `msg` is the OutgoingMessage; finish is driven via onFinish(msg).
+function writeResponseDirect(socket, data, encoding, msg) {
+  // Require a real TCP/libuv stream handle (writeBuffer). Fall back for:
+  // - mock sockets used in tests (dummy _handle)
+  // - TLS sockets (TLSWrap implements writeBuffer but is not safe to drive
+  //   via writeGeneric outside Socket._writeGeneric)
+  // - sockets still connecting
+  if (socket.encrypted || socket.connecting || !socket._handle ||
+      typeof socket._handle.writeBuffer !== 'function') {
+    // Fall back to the normal Writable path.
+    return socket.write(data, encoding, () => onFinish(msg));
+  }
+  // Refresh the keep-alive / inactivity timer the same way Socket._writeGeneric
+  // does before issuing the write.
+  if (typeof socket._unrefTimer === 'function')
+    socket._unrefTimer();
+
+  // Mirror stream.Writable: if the handle write completes synchronously,
+  // defer finish to nextTick so end()/finish ordering stays correct
+  // (finish must not run re-entrantly inside end()).
+  let sync = true;
+  writeGeneric(socket, data, encoding || 'buffer', function onDirectWrite() {
+    if (sync) {
+      process.nextTick(onFinish, msg);
+    } else {
+      onFinish(msg);
+    }
+  });
+  sync = false;
+  return true;
+}
+
+// Build (or reuse) a single Buffer containing headers + body for the
+// small-response hot path. The map lives on the cached header Buffer so a
+// Date: rollover naturally drops stale entries when the header is rebuilt.
+// `chunked`: when true, wrap body in a single chunk + terminator.
+function getCombinedResponse(headerBuf, body, bodyLen, bodyEncoding, chunked) {
+  const mapSym = chunked ? kChunkedFullBodyMap : kFullBodyMap;
+  let map = headerBuf[mapSym];
+  if (map !== undefined) {
+    const hit = map.get(body);
+    if (hit !== undefined) return hit;
+  }
+  const hLen = headerBuf.byteLength;
+  let out;
+  if (chunked) {
+    if (bodyLen === 0) {
+      // headers + 0\r\n\r\n
+      out = Buffer.allocUnsafe(hLen + 5);
+      headerBuf.copy(out, 0, 0, hLen);
+      out.write('0\r\n\r\n', hLen, 5, 'latin1');
+    } else {
+      const hex = bodyLen.toString(16);
+      // Header + hex + CRLF + body + chunked terminator.
+      const prefixLen = hex.length + 2;
+      const suffixLen = 7; // Length of \r\n0\r\n\r\n
+      out = Buffer.allocUnsafe(hLen + prefixLen + bodyLen + suffixLen);
+      headerBuf.copy(out, 0, 0, hLen);
+      let off = hLen;
+      off += out.write(hex, off, 'latin1');
+      out[off++] = 13; out[off++] = 10;
+      if (bodyEncoding === 0) {
+        if (typeof body.copy === 'function')
+          body.copy(out, off, 0, bodyLen);
+        else
+          out.set(body.subarray(0, bodyLen), off);
+      } else {
+        out.write(body, off, bodyLen, 'latin1');
+      }
+      off += bodyLen;
+      out.write('\r\n0\r\n\r\n', off, 7, 'latin1');
+    }
+  } else {
+    out = Buffer.allocUnsafe(hLen + bodyLen);
+    headerBuf.copy(out, 0, 0, hLen);
+    if (bodyEncoding === 0) {
+      if (typeof body.copy === 'function')
+        body.copy(out, hLen, 0, bodyLen);
+      else
+        out.set(body.subarray(0, bodyLen), hLen);
+    } else {
+      out.write(body, hLen, bodyLen, 'latin1');
+    }
+  }
+  if (map === undefined) {
+    map = new SafeMap();
+    headerBuf[mapSym] = map;
+  }
+  if (map.size < kFullBodyMapMax)
+    map.set(body, out);
+  return out;
+}
+
+// writeHead()+end(body) hot path used by benchmark/http/simple.js.
+// Skips write_()/cork for a single socket.write() of headers (+ body).
+// Handles both Content-Length and Transfer-Encoding: chunked (no trailers).
 function tryFastFlushEnd(msg, chunk, encoding, callback) {
   if (!msg._header || msg._headerSent || msg.finished || msg.destroyed)
     return false;
-  if (msg.chunkedEncoding || msg._trailer) return false;
+  // Trailers need the multi-write terminator path (addTrailers after body).
+  if (msg._trailer) return false;
   if (msg.outputData.length !== 0 || msg[kCorked]) return false;
   if (msg._expect_continue && !msg._sent100) return false;
   if (strictContentLength(msg)) return false;
@@ -1596,85 +1856,164 @@ function tryFastFlushEnd(msg, chunk, encoding, callback) {
   if (typeof callback === 'function')
     msg.once('finish', callback);
 
-  const finish = onFinish.bind(undefined, msg);
+  // Bound finish for the multi-write / socket.write fallback paths only.
+  // writeResponseDirect takes `msg` and calls onFinish directly.
+  let finish;
+  const getFinish = () => {
+    if (finish === undefined)
+      finish = onFinish.bind(undefined, msg);
+    return finish;
+  };
   const header = msg._header;
-  const hasBody = body !== null && bodyLen > 0 && msg._hasBody;
-  // Avoid O(n) header+body copies for large payloads (end-vs-write-end).
-  const largeBody = bodyLen > kMaxSingleShotBody;
+  if (typeof header !== 'string' && !isUint8Array(header))
+    return false;
 
+  const hasBody = body !== null && bodyLen > 0 && msg._hasBody;
+  const largeBody = bodyLen > kMaxSingleShotBody;
+  const chunked = msg.chunkedEncoding;
   let ret;
 
-  // ---- Hottest path: latin1 string header from legacyStoreHeader ----
   if (typeof header === 'string') {
-    if (!hasBody) {
-      // Header-only: single write, no cork.
-      ret = socket.write(header, 'latin1', finish);
+    if (chunked) {
+      // Complete chunked message: headers + [chunk] + terminator.
+      // Avoids write_() hex framing + multiple _send() calls.
+      // Match legacy end(): only emit the chunked terminator when the
+      // response is allowed a body (not HEAD / 204 / 304).
+      if (!hasBody) {
+        if (msg._hasBody) {
+          ret = writeResponseDirect(socket, header + '0\r\n\r\n', 'latin1', msg);
+        } else {
+          ret = writeResponseDirect(socket, header, 'latin1', msg);
+        }
+      } else if (!largeBody && typeof body === 'string') {
+        const hex = bodyLen.toString(16);
+        const wire = header + hex + '\r\n' + body + '\r\n0\r\n\r\n';
+        if (bodyEncoding === 1 || bodyLen === body.length) {
+          ret = writeResponseDirect(socket, wire, 'latin1', msg);
+        } else {
+          // Header may contain binary (latin1) octets; force latin1 body
+          // framing is already pure ASCII so overall write must be latin1.
+          ret = writeResponseDirect(socket, wire, 'latin1', msg);
+        }
+      } else if (hasBody) {
+        // Buffer / large body: corked multi-write, zero-copy body.
+        if (!socket.writableCorked) socket.cork();
+        socket.write(header + bodyLen.toString(16) + '\r\n', 'latin1');
+        if (bodyEncoding === 0)
+          socket.write(body);
+        else if (bodyEncoding === 1)
+          socket.write(body, 'latin1');
+        else
+          socket.write(body, 'utf8');
+        ret = socket.write('\r\n0\r\n\r\n', 'latin1', getFinish());
+        socket._writableState.corked = 1;
+        socket.uncork();
+      } else {
+        ret = writeResponseDirect(socket, header, 'latin1', msg);
+      }
+    } else if (!hasBody) {
+      ret = writeResponseDirect(socket, header, 'latin1', msg);
     } else if (!largeBody && typeof body === 'string') {
       // Small string body: one write of header+body (no cork).
-      if (bodyEncoding === 1) {
-        ret = socket.write(header + body, 'latin1', finish);
-      } else {
-        // utf8 body: concat only when the header is pure ASCII so high-byte
-        // latin1 header values are not double-encoded under UTF-8.
-        let ascii = true;
-        for (let i = 0; i < header.length; i++) {
-          if (header.charCodeAt(i) > 127) {
-            ascii = false;
-            break;
-          }
-        }
-        if (ascii) {
-          ret = socket.write(header + body, finish);
-        } else {
-          if (!socket.writableCorked) socket.cork();
-          socket.write(header, 'latin1');
-          ret = socket.write(body, 'utf8', finish);
-          socket._writableState.corked = 1;
-          socket.uncork();
-        }
-      }
-    } else if (!largeBody && bodyEncoding === 0) {
-      // Small Buffer/Uint8Array body: one combined Buffer write avoids the
-      // cork + dual-write JS overhead on the simple.js type=buffer path.
-      const hLen = header.length;
-      const out = Buffer.allocUnsafe(hLen + bodyLen);
-      // Native latin1 encode of the header into the front of the buffer.
-      out.write(header, 0, hLen, 'latin1');
-      if (typeof body.copy === 'function')
-        body.copy(out, hLen, 0, bodyLen);
-      else
-        out.set(body.subarray(0, bodyLen), hLen);
-      ret = socket.write(out, finish);
+      // Always latin1: headers may contain binary octets from
+      // Buffer.toString('binary'), and pure-ASCII bodies are identical
+      // under latin1 vs utf8. Using utf8 would re-encode high bytes.
+      ret = writeResponseDirect(socket, header + body, 'latin1', msg);
     } else {
-      // Large body or uncommon encoding: corked dual write, no body copy.
+      // Buffer body or large payload: corked dual write (zero-copy body).
+      // Combining header+Buffer (alloc + latin1 encode) is slower for small
+      // buffers than a corked dual write on the simple.js type=buffer path.
       if (!socket.writableCorked) socket.cork();
       socket.write(header, 'latin1');
       if (bodyEncoding === 0) {
-        ret = socket.write(body, finish);
+        ret = socket.write(body, getFinish());
       } else if (bodyEncoding === 1) {
-        ret = socket.write(body, 'latin1', finish);
+        ret = socket.write(body, 'latin1', getFinish());
       } else {
-        ret = socket.write(body, 'utf8', finish);
+        ret = socket.write(body, 'utf8', getFinish());
       }
       socket._writableState.corked = 1;
       socket.uncork();
     }
   } else if (isUint8Array(header)) {
-    // Buffer header (uncommon): corked dual write keeps the body zero-copy.
-    if (hasBody) {
+    // Buffer header (from header-block cache). Prefer a single write of a
+    // combined Buffer so we never re-encode the header and pay cork/writev
+    // dual-write overhead only for large bodies. Full wire messages are
+    // cached per (headerBuf, body) for the simple.js keep-alive path.
+    if (chunked && !hasBody) {
+      // Match legacy end(): terminator only when a body is allowed.
+      if (msg._hasBody) {
+        const out = getCombinedResponse(header, '', 0, 1, true);
+        ret = writeResponseDirect(socket, out, 'buffer', msg);
+      } else {
+        ret = writeResponseDirect(socket, header, 'buffer', msg);
+      }
+    } else if (chunked && hasBody && !largeBody && typeof body === 'string' &&
+               (bodyEncoding === 1 || bodyLen === body.length ||
+                bodyEncoding === 2)) {
+      // BodyEncoding 2 (utf8 string): non-ASCII bodies need multi-write.
+      if (bodyEncoding === 2 && bodyLen !== body.length) {
+        if (!socket.writableCorked) socket.cork();
+        socket.write(header);
+        socket.write(bodyLen.toString(16) + '\r\n', 'latin1');
+        socket.write(body, 'utf8');
+        ret = socket.write('\r\n0\r\n\r\n', 'latin1', getFinish());
+        socket._writableState.corked = 1;
+        socket.uncork();
+      } else {
+        const out = getCombinedResponse(header, body, bodyLen, 1, true);
+        ret = writeResponseDirect(socket, out, 'buffer', msg);
+      }
+    } else if (chunked && hasBody && !largeBody && bodyEncoding === 0) {
+      const out = getCombinedResponse(header, body, bodyLen, 0, true);
+      ret = writeResponseDirect(socket, out, 'buffer', msg);
+    } else if (chunked && hasBody) {
+      if (!socket.writableCorked) socket.cork();
+      socket.write(header);
+      socket.write(bodyLen.toString(16) + '\r\n', 'latin1');
+      if (bodyEncoding === 0)
+        socket.write(body);
+      else if (bodyEncoding === 1)
+        socket.write(body, 'latin1');
+      else
+        socket.write(body, 'utf8');
+      ret = socket.write('\r\n0\r\n\r\n', 'latin1', getFinish());
+      socket._writableState.corked = 1;
+      socket.uncork();
+    } else if (chunked) {
+      ret = writeResponseDirect(socket, header, 'buffer', msg);
+    } else if (!hasBody) {
+      ret = writeResponseDirect(socket, header, 'buffer', msg);
+    } else if (!largeBody && typeof body === 'string' &&
+               (bodyEncoding === 1 || bodyLen === body.length)) {
+      // String body: combine under latin1 so binary header octets stay intact.
+      const out = getCombinedResponse(header, body, bodyLen, 1, false);
+      ret = writeResponseDirect(socket, out, 'buffer', msg);
+    } else if (!largeBody && typeof body === 'string') {
+      // Non-ASCII utf8 body: dual write keeps body encoding correct.
+      if (!socket.writableCorked) socket.cork();
+      socket.write(header);
+      ret = socket.write(body, 'utf8', getFinish());
+      socket._writableState.corked = 1;
+      socket.uncork();
+    } else if (!largeBody && bodyEncoding === 0) {
+      // Buffer body: cached combined header+body Buffer.
+      const out = getCombinedResponse(header, body, bodyLen, 0, false);
+      ret = writeResponseDirect(socket, out, 'buffer', msg);
+    } else if (hasBody) {
       if (!socket.writableCorked) socket.cork();
       socket.write(header);
       if (bodyEncoding === 0) {
-        ret = socket.write(body, finish);
+        ret = socket.write(body, getFinish());
       } else if (bodyEncoding === 1) {
-        ret = socket.write(body, 'latin1', finish);
+        ret = socket.write(body, 'latin1', getFinish());
       } else {
-        ret = socket.write(body, 'utf8', finish);
+        ret = socket.write(body, 'utf8', getFinish());
       }
       socket._writableState.corked = 1;
       socket.uncork();
     } else {
-      ret = socket.write(header, finish);
+      ret = writeResponseDirect(socket, header, 'buffer', msg);
     }
   } else {
     return false;
@@ -1692,7 +2031,7 @@ function tryFastFlushEnd(msg, chunk, encoding, callback) {
 function tryFastEnd(msg, chunk, encoding, callback) {
   // ServerResponse only. ClientRequest has method-specific Content-Length
   // rules (GET/HEAD/DELETE must not emit CL:0) and CONNECT tunnel framing
-  // that the C++ builder does not model.
+  // that the pure-JS builder does not model.
   if (typeof msg.statusCode !== 'number')
     return false;
 
@@ -1704,7 +2043,9 @@ function tryFastEnd(msg, chunk, encoding, callback) {
     return tryFastFlushEnd(msg, chunk, encoding, callback);
   }
 
-  // Full native single-shot: nothing rendered yet.
+  // setHeader() path: headers not yet rendered. Build them with the JS
+  // storeHeader (tryFastStoreHeaderObject for plain objects) then flush.
+  // The C++ buildHttpMessage path was slower for small messages.
   if (msg._header || msg._headerSent)
     return false;
   if (msg._trailer) return false;
@@ -1728,95 +2069,26 @@ function tryFastEnd(msg, chunk, encoding, callback) {
 
   const prepared = prepareFastBody(msg, chunk, encoding);
   if (prepared === null) return false;
-  const { body, bodyEncoding, bodyLen } = prepared;
+  const { bodyLen } = prepared;
 
-  // Large bodies must not be copied into a combined headers+body Buffer.
-  // Fall back to write_()/ _send which can stream the body without a copy
-  // (benchmark/http/end-vs-write-end.js).
+  // Large bodies: let write_()/ _send stream without a combined copy.
   if (bodyLen > kMaxSingleShotBody)
     return false;
 
-  let firstLine;
-  if (msg.statusCode === 200 &&
-      (msg.statusMessage === undefined || msg.statusMessage === null ||
-       msg.statusMessage === 'OK')) {
-    msg.statusMessage = 'OK';
-    firstLine = kStatusLine200;
-  } else {
-    firstLine = getFastFirstLine(msg);
-    if (firstLine === null) return false;
-  }
-
-  const flat = flattenHeadersForNative(msg, msg[kOutHeaders], false);
-  if (flat === null) return false;
-
-  if (body && msg._hasBody) {
+  // Seed Content-Length for auto-CL when the user did not set it (same as
+  // the fromEnd branch of write_()).
+  if (bodyLen > 0 && msg._hasBody && typeof msg._contentLength !== 'number') {
     msg._contentLength = bodyLen;
-  } else {
-    msg._contentLength = 0;
+  } else if (!bodyLen || !msg._hasBody) {
+    if (typeof msg._contentLength !== 'number')
+      msg._contentLength = 0;
   }
 
-  const knownLength =
-    typeof msg._contentLength === 'number' ? msg._contentLength : -1;
-  const keepAliveSec = msg._keepAliveTimeout ?
-    MathFloor(msg._keepAliveTimeout / 1000) :
-    0;
-  const maxReq = msg._maxRequestsPerSocket | 0;
-  const date = msg.sendDate ? utcDate() : '';
-
-  // Pass '' (not null) for a no-body complete message so the C++ builder
-  // emits the chunked terminator 0\r\n\r\n when TE: chunked is selected.
-  // null/undefined means headers-only (_storeHeader), which must not.
-  const bodyArg = body === null ? '' : body;
-
-  const buf = httpParserBinding.buildHttpMessage(
-    firstLine,
-    flat,
-    bodyArg,
-    bodyEncoding,
-    buildFlags(msg),
-    date,
-    keepAliveSec,
-    maxReq,
-    knownLength,
-    buildHttpMessageOut,
-  );
-  if (!buf) return false;
-
-  applyBuildResult(msg, buildHttpMessageOut);
-
-  if (msg.chunkedEncoding && (msg.statusCode === 204 ||
-                              msg.statusCode === 304)) {
+  msg._implicitHeader();
+  if (!msg._header || msg._headerSent)
     return false;
-  }
 
-  // Trailer without chunked is invalid (same check as legacy path).
-  // Skip the scan when no custom headers were set (common keep-alive path).
-  if (flat.length !== 0) {
-    for (let i = 0; i < flat.length; i += 2) {
-      const name = flat[i];
-      if (name.length === 7 && (name === 'Trailer' || name === 'trailer' ||
-          name.toLowerCase() === 'trailer') && !msg.chunkedEncoding) {
-        throw new ERR_HTTP_TRAILER_INVALID();
-      }
-    }
-  }
-
-  if (typeof callback === 'function')
-    msg.once('finish', callback);
-
-  msg._header = buf;
-  msg._headerSent = true;
-  msg.finished = true;
-  if (bodyLen && msg._hasBody) {
-    msg[kBytesWritten] = bodyLen;
-  }
-
-  // Single combined write: cork is pure overhead here.
-  const ret = socket.write(buf, onFinish.bind(undefined, msg));
-
-  finishFastSocketWrite(msg, socket, ret);
-  return true;
+  return tryFastFlushEnd(msg, chunk, encoding, callback);
 }
 
 
@@ -1912,6 +2184,7 @@ function(err, event) {
 module.exports = {
   kHighWaterMark,
   kUniqueHeaders,
+  kServerFinishHook,
   parseUniqueHeadersOption,
   validateHeaderName,
   validateHeaderValue,

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -98,7 +98,21 @@ const nop = () => {};
 
 const RE_CONN_CLOSE = /(?:^|\W)close(?:$|\W)/i;
 
-// Keep in sync with BuildHttpMessageFlags in src/node_http_parser.cc.
+// Flags passed as args[4] to native buildHttpMessage(). Keep in sync with
+// BuildHttpMessageFlags in src/node_http_parser.cc. Combined with | so C++ can
+// decide which automatic headers (Date, Connection, Content-Length / TE) to
+// emit without re-reading OutgoingMessage fields one-by-one.
+//   kBuildSendDate              - inject Date if the user did not set it
+//   kBuildShouldKeepAlive       - prefer Connection: keep-alive when valid
+//   kBuildMaxRequestsReached    - force Connection: close (server max)
+//   kBuildDefaultKeepAlive      - also emit Keep-Alive: timeout=...
+//   kBuildHasBody               - message may carry a body (not HEAD/204/304)
+//   kBuildUseChunkedByDefault   - allow auto Content-Length / TE: chunked
+//   kBuildRemovedConnection     - user called removeHeader('connection')
+//   kBuildRemovedContLen        - user called removeHeader('content-length')
+//   kBuildRemovedTE             - user called removeHeader('transfer-encoding')
+//   kBuildHasAgent              - ClientRequest has an agent (keep-alive only;
+//                                 does NOT enable auto Content-Length)
 const kBuildSendDate = 1 << 0;
 const kBuildShouldKeepAlive = 1 << 1;
 const kBuildMaxRequestsReached = 1 << 2;
@@ -110,14 +124,20 @@ const kBuildRemovedContLen = 1 << 7;
 const kBuildRemovedTE = 1 << 8;
 const kBuildHasAgent = 1 << 9;
 
+// Output slots written by buildHttpMessage into args[9] (Uint32Array).
 // Keep in sync with BuildHttpMessageOut in src/node_http_parser.cc.
+//   [kOutLast]             - 1 if this is the last message on the connection
+//   [kOutChunked]          - 1 if Transfer-Encoding: chunked was selected
+//   [kOutContentLength]    - resolved body length when known
+//   [kOutHasContentLength] - 1 if kOutContentLength is valid
 const kOutLast = 0;
 const kOutChunked = 1;
 const kOutContentLength = 2;
 const kOutHasContentLength = 3;
 const kOutCount = 4;
 
-// Reused across calls to avoid allocating a Uint32Array per response.
+// Scratch buffer for native out-params. Reused so each response does not
+// allocate a new Uint32Array; only the four slots above are written/read.
 const buildHttpMessageOut = new Uint32Array(kOutCount);
 
 // Lazy to avoid a require cycle with _http_server.
@@ -434,19 +454,17 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
     // `this._header` can be null if OutgoingMessage is used without a proper Socket
     // See: /test/parallel/test-http-outgoing-message-inheritance.js
     //
-    // Headers are stored as a latin1 JS string of the on-wire bytes. If we
-    // naively do `header + body` and write as UTF-8, high-byte header values
-    // (e.g. content-disposition) get double-encoded. Prefer Buffer concat
-    // when the body is present; pure header flushes use latin1.
+    // Headers are stored as a latin1 JS string of the on-wire bytes. String
+    // concat under UTF-8 would double-encode high-byte header values (e.g.
+    // content-disposition). For those cases queue the header as a separate
+    // latin1 write instead of allocating a concatenated Buffer.
     if (typeof data === 'string' && data.length > 0 &&
         (encoding === 'latin1' || encoding === 'binary')) {
       data = header + data;
       encoding = 'latin1';
     } else if (typeof data === 'string' && data.length > 0 &&
                (encoding === 'utf8' || encoding === 'utf-8' || !encoding)) {
-      // ASCII headers can concatenate as a string under UTF-8; high-byte
-      // latin1 header values must be Buffer-concatenated to avoid double
-      // encoding on the wire.
+      // ASCII headers can safely share one UTF-8 write with the body.
       let ascii = true;
       for (let i = 0; i < header.length; i++) {
         if (header.charCodeAt(i) > 127) {
@@ -457,22 +475,22 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
       if (ascii) {
         data = header + data;
       } else {
-        const bodyBuf = Buffer.from(data, encoding || 'utf8');
-        data = Buffer.concat([Buffer.from(header, 'latin1'), bodyBuf]);
-        encoding = 'buffer';
-        byteLength = data.byteLength;
+        // High-byte headers: queue header first; body keeps its encoding.
+        this.outputData.unshift({
+          data: header,
+          encoding: 'latin1',
+          callback: null,
+        });
+        this.outputSize += header.length;
+        this._onPendingData(header.length);
       }
-    } else if (isUint8Array(data) && data.byteLength > 0) {
-      data = Buffer.concat([Buffer.from(header, 'latin1'), data]);
-      encoding = 'buffer';
-      byteLength = data.byteLength;
     } else if (typeof data === 'string' && data.length === 0) {
       // Header-only flush (end without body, Expect: 100-continue, etc.).
       data = header;
       encoding = 'latin1';
     } else {
-      // Non-utf8/latin1 body encodings (hex, utf16le, base64, ...): keep the
-      // header as a separate latin1 write so body encoding is unchanged.
+      // Buffers / hex / utf16le / base64 / empty: separate latin1 header write
+      // so the body encoding is left unchanged (no Buffer.concat).
       this.outputData.unshift({
         data: header,
         encoding: 'latin1',

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -444,6 +444,20 @@ function emitDestroyNT(self) {
 }
 
 
+// Queue an unsent header block ahead of the body write. Used for Buffer
+// headers (native builder) and for string headers that cannot share the
+// body's encoding (high-byte latin1 / non-utf8 body encodings).
+function queueHeaderWrite(msg, header, encoding) {
+  msg.outputData.unshift({
+    data: header,
+    encoding,
+    callback: null,
+  });
+  const len = header.length;
+  msg.outputSize += len;
+  msg._onPendingData(len);
+}
+
 // This abstract either writing directly to the socket or buffering it.
 OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteLength) {
   // This is a shameful hack to get the headers and first body chunk onto
@@ -454,11 +468,40 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
     // `this._header` can be null if OutgoingMessage is used without a proper Socket
     // See: /test/parallel/test-http-outgoing-message-inheritance.js
     //
-    // Headers are stored as a latin1 JS string of the on-wire bytes. String
-    // concat under UTF-8 would double-encode high-byte header values (e.g.
-    // content-disposition). For those cases queue the header as a separate
-    // latin1 write instead of allocating a concatenated Buffer.
-    if (typeof data === 'string' && data.length > 0 &&
+    // Native builder stores _header as a Buffer (server path). Legacy and
+    // ClientRequest keep a latin1 string. Never Buffer.concat: queue the
+    // header as its own write when it cannot share the body encoding.
+    if (isUint8Array(header)) {
+      // Native Buffer header. Prefer a single write when the body encoding
+      // can share the stream; otherwise queue the header separately.
+      if (typeof data === 'string' && data.length === 0) {
+        data = header;
+        encoding = 'buffer';
+      } else if (typeof data === 'string' && data.length > 0 &&
+                 (encoding === 'latin1' || encoding === 'binary')) {
+        data = header.toString('latin1') + data;
+        encoding = 'latin1';
+      } else if (typeof data === 'string' && data.length > 0 &&
+                 (encoding === 'utf8' || encoding === 'utf-8' || !encoding)) {
+        let ascii = true;
+        for (let i = 0; i < header.byteLength; i++) {
+          if (header[i] > 127) {
+            ascii = false;
+            break;
+          }
+        }
+        if (ascii) {
+          // latin1 decode of ASCII is identity; one utf8 write with body.
+          data = header.toString('latin1') + data;
+        } else {
+          queueHeaderWrite(this, header, 'buffer');
+        }
+      } else if (isUint8Array(data) && data.byteLength > 0) {
+        queueHeaderWrite(this, header, 'buffer');
+      } else {
+        queueHeaderWrite(this, header, 'buffer');
+      }
+    } else if (typeof data === 'string' && data.length > 0 &&
         (encoding === 'latin1' || encoding === 'binary')) {
       data = header + data;
       encoding = 'latin1';
@@ -475,29 +518,15 @@ OutgoingMessage.prototype._send = function _send(data, encoding, callback, byteL
       if (ascii) {
         data = header + data;
       } else {
-        // High-byte headers: queue header first; body keeps its encoding.
-        this.outputData.unshift({
-          data: header,
-          encoding: 'latin1',
-          callback: null,
-        });
-        this.outputSize += header.length;
-        this._onPendingData(header.length);
+        queueHeaderWrite(this, header, 'latin1');
       }
     } else if (typeof data === 'string' && data.length === 0) {
       // Header-only flush (end without body, Expect: 100-continue, etc.).
       data = header;
       encoding = 'latin1';
     } else {
-      // Buffers / hex / utf16le / base64 / empty: separate latin1 header write
-      // so the body encoding is left unchanged (no Buffer.concat).
-      this.outputData.unshift({
-        data: header,
-        encoding: 'latin1',
-        callback: null,
-      });
-      this.outputSize += header.length;
-      this._onPendingData(header.length);
+      // Buffers / hex / utf16le / base64: separate header write.
+      queueHeaderWrite(this, header, 'latin1');
     }
     this._headerSent = true;
   }
@@ -573,7 +602,8 @@ function applyBuildResult(msg, out) {
 // Flatten headers into [name, value, ...] for the C++ builder. Returns null
 // when a header requires the legacy JS path.
 function flattenHeadersForNative(msg, headers, validate) {
-  const flat = [];
+  const flat = flatHeadersScratch;
+  flat.length = 0;
   const lenient = msg._isLenientHeaderValidation();
 
   function pushPair(key, value, doValidate) {
@@ -713,10 +743,15 @@ function tryNativeStoreHeader(msg, firstLine, headers) {
     }
   }
 
-  // latin1 string of the wire bytes. _send() must write this as latin1 (or
-  // Buffer-concat) rather than UTF-8 so high-byte values (content-disposition)
-  // are not double-encoded.
-  msg._header = buf.toString('latin1');
+  // ServerResponse: keep the Buffer to avoid a latin1 string copy on the
+  // hot writeHead()+end() path. ClientRequest: materialize a latin1 string
+  // so userland/tests that treat _header as a string (e.g. .match) keep
+  // working.
+  if (typeof msg.statusCode === 'number') {
+    msg._header = buf;
+  } else {
+    msg._header = buf.toString('latin1');
+  }
   msg._headerSent = false;
 
   // Expect: 100-continue forces an early header flush (legacy behavior).
@@ -730,6 +765,9 @@ function tryNativeStoreHeader(msg, firstLine, headers) {
   }
   return true;
 }
+
+// Reused flat header list for native builds (sync only; reset each call).
+const flatHeadersScratch = [];
 
 function legacyStoreHeader(self, firstLine, headers) {
   // firstLine in the case of request is: 'GET /index.html HTTP/1.1\r\n'
@@ -1540,41 +1578,19 @@ function getFastFirstLine(msg) {
   return null;
 }
 
-function tryFastEnd(msg, chunk, encoding, callback) {
-  // ServerResponse only. ClientRequest has method-specific Content-Length
-  // rules (GET/HEAD/DELETE must not emit CL:0) and CONNECT tunnel framing
-  // that the C++ builder does not model.
-  if (typeof msg.statusCode !== 'number')
-    return false;
+// Common status lines (writeHead / fast end without custom reason).
+const kStatusLine200 = 'HTTP/1.1 200 OK\r\n';
 
-  // Preconditions: nothing rendered yet, socket ready, no queued output,
-  // no trailers, not already finished/destroyed.
-  if (msg._header || msg._headerSent || msg.finished || msg.destroyed)
-    return false;
-  if (msg._trailer) return false;
-  if (msg.outputData.length !== 0) return false;
-  if (msg[kCorked]) return false;
-  if (msg._expect_continue && !msg._sent100) return false;
-
-  const socket = msg[kSocket];
-  // Require a real net.Socket (has a libuv _handle). Standalone
-  // ServerResponse tests assign arbitrary Writables that must keep the
-  // multi-write _send() behaviour.
-  if (!socket || socket._httpMessage !== msg || !socket.writable ||
-      socket.destroyed || !socket._writableState || !socket._handle) {
-    return false;
-  }
-
-  // Body encoding must be latin1/utf8/buffer (what the C++ builder supports).
+function prepareFastBody(msg, chunk, encoding) {
   let body = null;
-  let bodyEncoding = 0; // 0 = buffer/none
+  let bodyEncoding = 0; // 0 = buffer/none, 1 = latin1, 2 = utf8
   let bodyLen = 0;
   if (chunk) {
     if (typeof chunk === 'string') {
       if (encoding && encoding !== 'utf8' && encoding !== 'utf-8' &&
           encoding !== 'latin1' && encoding !== 'binary' &&
           encoding !== 'ascii') {
-        return false;
+        return null;
       }
       body = chunk;
       if (encoding === 'latin1' || encoding === 'binary' ||
@@ -1590,7 +1606,7 @@ function tryFastEnd(msg, chunk, encoding, callback) {
       bodyEncoding = 0;
       bodyLen = chunk.byteLength;
     } else {
-      return false;
+      return null;
     }
   }
 
@@ -1598,25 +1614,155 @@ function tryFastEnd(msg, chunk, encoding, callback) {
     if (msg[kRejectNonStandardBodyWrites]) {
       throw new ERR_HTTP_BODY_NOT_ALLOWED();
     }
-    // Legacy: ignore body for HEAD / 204 / 304.
     body = null;
     bodyLen = 0;
   }
+  return { body, bodyEncoding, bodyLen };
+}
 
-  const firstLine = getFastFirstLine(msg);
-  if (firstLine === null) return false;
+function finishFastSocketWrite(msg, socket, ret) {
+  if (!ret) msg[kNeedDrain] = true;
+  debug('outgoing message fast end.');
+  if (msg.outputData.length === 0 && socket._httpMessage === msg) {
+    msg._finish();
+  }
+}
 
-  let flat;
-  try {
-    flat = flattenHeadersForNative(msg, msg[kOutHeaders], false);
-  } catch {
+// writeHead() already rendered headers: flush header + body without write_().
+// This is the benchmark/http/simple.js path.
+function tryFastFlushEnd(msg, chunk, encoding, callback) {
+  if (!msg._header || msg._headerSent || msg.finished || msg.destroyed)
+    return false;
+  if (msg.chunkedEncoding || msg._trailer) return false;
+  if (msg.outputData.length !== 0 || msg[kCorked]) return false;
+  if (msg._expect_continue && !msg._sent100) return false;
+  if (strictContentLength(msg)) return false;
+
+  const socket = msg[kSocket];
+  if (!socket || socket._httpMessage !== msg || !socket.writable ||
+      socket.destroyed || !socket._writableState || !socket._handle) {
     return false;
   }
+
+  const prepared = prepareFastBody(msg, chunk, encoding);
+  if (prepared === null) return false;
+  const { body, bodyEncoding, bodyLen } = prepared;
+
+  if (typeof callback === 'function')
+    msg.once('finish', callback);
+
+  const finish = onFinish.bind(undefined, msg);
+  const header = msg._header;
+
+  if (!socket.writableCorked)
+    socket.cork();
+
+  let ret;
+  if (isUint8Array(header)) {
+    // Native Buffer header: one or two writes under cork (no string copy).
+    if (body && bodyLen > 0 && msg._hasBody) {
+      socket.write(header);
+      if (bodyEncoding === 0) {
+        ret = socket.write(body, finish);
+      } else if (bodyEncoding === 1) {
+        ret = socket.write(body, 'latin1', finish);
+      } else {
+        ret = socket.write(body, 'utf8', finish);
+      }
+    } else {
+      ret = socket.write(header, finish);
+    }
+  } else if (body && bodyLen > 0 && msg._hasBody) {
+    if (typeof body === 'string' && bodyEncoding === 1) {
+      ret = socket.write(header + body, 'latin1', finish);
+    } else if (typeof body === 'string') {
+      // utf8 body: only concat when the header is pure ASCII.
+      let ascii = true;
+      for (let i = 0; i < header.length; i++) {
+        if (header.charCodeAt(i) > 127) {
+          ascii = false;
+          break;
+        }
+      }
+      if (ascii) {
+        ret = socket.write(header + body, finish);
+      } else {
+        socket.write(header, 'latin1');
+        ret = socket.write(body, 'utf8', finish);
+      }
+    } else {
+      socket.write(header, 'latin1');
+      ret = socket.write(body, finish);
+    }
+  } else {
+    ret = socket.write(header, 'latin1', finish);
+  }
+
+  socket._writableState.corked = 1;
+  socket.uncork();
+
+  msg._headerSent = true;
+  msg.finished = true;
+  if (bodyLen && msg._hasBody)
+    msg[kBytesWritten] = bodyLen;
+
+  finishFastSocketWrite(msg, socket, ret);
+  return true;
+}
+
+function tryFastEnd(msg, chunk, encoding, callback) {
+  // ServerResponse only. ClientRequest has method-specific Content-Length
+  // rules (GET/HEAD/DELETE must not emit CL:0) and CONNECT tunnel framing
+  // that the C++ builder does not model.
+  if (typeof msg.statusCode !== 'number')
+    return false;
+
+  if (msg.finished || msg.destroyed)
+    return false;
+
+  // Hot path after writeHead(): headers already built, not yet flushed.
+  if (msg._header && !msg._headerSent) {
+    return tryFastFlushEnd(msg, chunk, encoding, callback);
+  }
+
+  // Full native single-shot: nothing rendered yet.
+  if (msg._header || msg._headerSent)
+    return false;
+  if (msg._trailer) return false;
+  if (msg.outputData.length !== 0) return false;
+  if (msg[kCorked]) return false;
+  if (msg._expect_continue && !msg._sent100) return false;
+
+  const socket = msg[kSocket];
+  // Require a real net.Socket (has a libuv _handle). Standalone
+  // ServerResponse tests assign arbitrary Writables that must keep the
+  // multi-write _send() behaviour.
+  if (!socket || socket._httpMessage !== msg || !socket.writable ||
+      socket.destroyed || !socket._writableState || !socket._handle) {
+    return false;
+  }
+
+  const prepared = prepareFastBody(msg, chunk, encoding);
+  if (prepared === null) return false;
+  const { body, bodyEncoding, bodyLen } = prepared;
+
+  let firstLine;
+  if (msg.statusCode === 200 &&
+      (msg.statusMessage === undefined || msg.statusMessage === null ||
+       msg.statusMessage === 'OK')) {
+    msg.statusMessage = 'OK';
+    firstLine = kStatusLine200;
+  } else {
+    firstLine = getFastFirstLine(msg);
+    if (firstLine === null) return false;
+  }
+
+  const flat = flattenHeadersForNative(msg, msg[kOutHeaders], false);
   if (flat === null) return false;
 
   if (body && msg._hasBody) {
     msg._contentLength = bodyLen;
-  } else if (!msg._header) {
+  } else {
     msg._contentLength = 0;
   }
 
@@ -1627,11 +1773,6 @@ function tryFastEnd(msg, chunk, encoding, callback) {
     0;
   const maxReq = msg._maxRequestsPerSocket | 0;
   const date = msg.sendDate ? utcDate() : '';
-
-  buildHttpMessageOut[0] = 0;
-  buildHttpMessageOut[1] = 0;
-  buildHttpMessageOut[2] = 0;
-  buildHttpMessageOut[3] = 0;
 
   const buf = buildHttpMessage(
     firstLine,
@@ -1651,15 +1792,14 @@ function tryFastEnd(msg, chunk, encoding, callback) {
 
   if (msg.chunkedEncoding && (msg.statusCode === 204 ||
                               msg.statusCode === 304)) {
-    // Should not happen with single-shot body preference, but stay safe.
     return false;
   }
 
   if (typeof callback === 'function')
     msg.once('finish', callback);
 
-  // Mark headers as rendered+sent so subsequent writes fail correctly.
-  msg._header = buf.toString('latin1');
+  // Keep Buffer form for consistency with tryNativeStoreHeader (server).
+  msg._header = buf;
   msg._headerSent = true;
   msg.finished = true;
   if (bodyLen && msg._hasBody) {
@@ -1668,23 +1808,14 @@ function tryFastEnd(msg, chunk, encoding, callback) {
 
   const finish = onFinish.bind(undefined, msg);
 
-  // The socket is typically corked by OutgoingMessage.socket setter /
-  // assignSocket. Mirror end()'s uncork so the single write is flushed;
-  // without this the write callback never runs and the response hangs.
   if (!socket.writableCorked) {
     socket.cork();
   }
   const ret = socket.write(buf, finish);
-  // Force a full uncork (same as the slow end() path).
   socket._writableState.corked = 1;
   socket.uncork();
 
-  if (!ret) msg[kNeedDrain] = true;
-
-  debug('outgoing message fast end.');
-  if (msg.outputData.length === 0 && socket._httpMessage === msg) {
-    msg._finish();
-  }
+  finishFastSocketWrite(msg, socket, ret);
   return true;
 }
 

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -53,6 +53,7 @@ const {
 const { ConnectionsList } = internalBinding('http_parser');
 const {
   kUniqueHeaders,
+  kServerFinishHook,
   parseUniqueHeadersOption,
   OutgoingMessage,
   validateHeaderName,
@@ -191,6 +192,10 @@ const kOnTimeout = HTTPParser.kOnTimeout | 0;
 
 const kConnections = Symbol('http.server.connections');
 const kConnectionsCheckingInterval = Symbol('http.server.connectionsCheckingInterval');
+const kFinishReq = Symbol('kFinishReq');
+const kFinishState = Symbol('kFinishState');
+const kFinishServer = Symbol('kFinishServer');
+const kPendingSocket = Symbol('kPendingSocket');
 
 const HTTP_SERVER_TRACE_EVENT_NAME = 'http.server.request';
 
@@ -210,6 +215,8 @@ function ServerResponse(req, options) {
   this.sendDate = true;
   this._sent100 = false;
   this._expect_continue = false;
+  // Direct finish hook - avoids EventEmitter.on('finish') per request.
+  this[kServerFinishHook] = onResFinish;
 
   if (req.httpVersionMajor < 1 || req.httpVersionMinor < 1) {
     this.useChunkedEncodingByDefault = chunkExpression.test(req.headers.te);
@@ -271,21 +278,11 @@ ServerResponse.prototype.statusMessage = undefined;
 
 function onServerResponseClose() {
   // EventEmitter.emit makes a copy of the 'close' listeners array before
-  // calling the listeners. detachSocket() unregisters onServerResponseClose
-  // but if detachSocket() is called, directly or indirectly, by a 'close'
-  // listener, onServerResponseClose is still in that copy of the listeners
-  // array. That is, in the example below, b still gets called even though
-  // it's been removed by a:
+  // calling the listeners. The listener is installed once per connection
+  // (see connectionListenerInternal) and left in place across keep-alive
+  // request reuse; detachSocket only clears socket._httpMessage.
   //
-  //   const EventEmitter = require('events');
-  //   const obj = new EventEmitter();
-  //   obj.on('event', a);
-  //   obj.on('event', b);
-  //   function a() { obj.removeListener('event', b) }
-  //   function b() { throw "BAM!" }
-  //   obj.emit('event');  // throws
-  //
-  // Ergo, we need to deal with stale 'close' events and handle the case
+  // We still need to deal with stale 'close' events and handle the case
   // where the ServerResponse object has already been deconstructed.
   // Fortunately, that requires only a single if check. :-)
   if (this._httpMessage) {
@@ -293,20 +290,32 @@ function onServerResponseClose() {
   }
 }
 
+// Symbol flag: socket already has the permanent ServerResponse close hook.
+const kHasResCloseListener = Symbol('kHasResCloseListener');
+
 ServerResponse.prototype.assignSocket = function assignSocket(socket) {
   if (socket._httpMessage) {
     throw new ERR_HTTP_SOCKET_ASSIGNED();
   }
   socket._httpMessage = this;
-  socket.on('close', onServerResponseClose);
+  // Install the close hook once per socket. Adding/removing it on every
+  // keep-alive request is pure EventEmitter overhead on the hot path.
+  if (!socket[kHasResCloseListener]) {
+    socket[kHasResCloseListener] = true;
+    socket.on('close', onServerResponseClose);
+  }
   this.socket = socket;
-  this.emit('socket', socket);
-  this._flush();
+  // Skip emit when nobody is listening (common keep-alive server path).
+  if (this.listenerCount('socket') > 0)
+    this.emit('socket', socket);
+  // Only flush when there is buffered output (rare before the first write).
+  if (this.outputData.length !== 0)
+    this._flush();
 };
 
 ServerResponse.prototype.detachSocket = function detachSocket(socket) {
   assert(socket._httpMessage === this);
-  socket.removeListener('close', onServerResponseClose);
+  // Keep onServerResponseClose installed for subsequent keep-alive messages.
   socket._httpMessage = null;
   this.socket = null;
 };
@@ -470,7 +479,11 @@ function writeHead(statusCode, reason, obj) {
   if (checkInvalidHeaderChar(this.statusMessage))
     throw new ERR_INVALID_CHAR('statusMessage');
 
-  const statusLine = `HTTP/1.1 ${statusCode} ${this.statusMessage}\r\n`;
+  // Hot path: 200 OK is the common case (simple.js and most APIs).
+  // Avoid the template string allocation on every response.
+  const statusLine = (statusCode === 200 && this.statusMessage === 'OK') ?
+    'HTTP/1.1 200 OK\r\n' :
+    `HTTP/1.1 ${statusCode} ${this.statusMessage}\r\n`;
 
   if (statusCode === 204 || statusCode === 304 ||
       (statusCode >= 100 && statusCode <= 199)) {
@@ -810,6 +823,7 @@ function connectionListenerInternal(server, socket) {
     outgoingData: 0,
     requestsCount: 0,
     keepAliveTimeoutSet: false,
+    keepAliveArmPending: false,
   };
   state.onData = socketOnData.bind(undefined,
                                    server, socket, parser, state);
@@ -857,6 +871,11 @@ function connectionListenerInternal(server, socket) {
 
 function socketSetEncoding() {
   throw new ERR_HTTP_SOCKET_ENCODING();
+}
+
+function onPendingData(delta) {
+  // `this` is the ServerResponse.
+  updateOutgoingData(this[kPendingSocket], this[kFinishState], delta);
 }
 
 function updateOutgoingData(socket, state, delta) {
@@ -1183,6 +1202,22 @@ function clearIncoming(req) {
   }
 }
 
+function onResFinish() {
+  // `this` is the ServerResponse. Socket is still attached when finish
+  // fires; resOnFinish detaches it. Standalone ServerResponse (no
+  // parserOnIncoming) never arms kFinishReq - no-op.
+  const req = this[kFinishReq];
+  if (req === undefined)
+    return;
+  const state = this[kFinishState];
+  const server = this[kFinishServer];
+  const socket = this.socket;
+  this[kFinishReq] = undefined;
+  this[kFinishState] = undefined;
+  this[kFinishServer] = undefined;
+  resOnFinish(req, this, socket, state, server);
+}
+
 function resOnFinish(req, res, socket, state, server) {
   if (onResponseFinishChannel.hasSubscribers) {
     onResponseFinishChannel.publish({
@@ -1196,19 +1231,31 @@ function resOnFinish(req, res, socket, state, server) {
   // Usually the first incoming element should be our request.  it may
   // be that in the case abortIncoming() was called that the incoming
   // array will be empty.
-  assert(state.incoming.length === 0 || state.incoming[0] === req);
-
-  state.incoming.shift();
+  // Hot path: keep-alive is almost always a single in-flight request.
+  const incoming = state.incoming;
+  const inLen = incoming.length;
+  if (inLen === 1) {
+    incoming.length = 0;
+  } else if (inLen !== 0) {
+    assert(incoming[0] === req);
+    incoming.shift();
+  }
 
   // If the user never called req.read(), and didn't pipe() or
   // .resume() or .on('data'), then we call req._dump() so that the
-  // bytes will be pulled off the wire.
-  if (!req._consuming && !req._readableState.resumeScheduled)
+  // bytes will be pulled off the wire. Skip when already early-dumped.
+  if (!req._dumped && !req._consuming && !req._readableState.resumeScheduled)
     req._dump();
 
   res.detachSocket(socket);
   clearIncoming(req);
-  process.nextTick(emitCloseNT, res);
+  // Always defer close to the next tick so same-tick write()/end() after
+  // end() can still surface ERR_STREAM_WRITE_AFTER_END (emitErrorNt runs
+  // before destroyed is set). Skip the 'close' emit work when nobody is
+  // listening (common keep-alive path).
+  if (!res._closed) {
+    process.nextTick(emitCloseNT, res);
+  }
 
   if (res._last) {
     if (typeof socket.destroySoon === 'function') {
@@ -1217,18 +1264,10 @@ function resOnFinish(req, res, socket, state, server) {
       socket.end();
     }
   } else if (state.outgoing.length === 0) {
-    const keepAliveTimeout = NumberIsFinite(server.keepAliveTimeout) && server.keepAliveTimeout >= 0 ?
-      server.keepAliveTimeout : 0;
-    const keepAliveTimeoutBuffer = NumberIsFinite(server.keepAliveTimeoutBuffer) && server.keepAliveTimeoutBuffer >= 0 ?
-      server.keepAliveTimeoutBuffer : 1e3;
-
-    if (keepAliveTimeout && typeof socket.setTimeout === 'function') {
-      // Extend the internal timeout by the configured buffer to reduce
-      // the likelihood of ECONNRESET errors.
-      // This allows fine-tuning beyond the advertised keepAliveTimeout.
-      socket.setTimeout(keepAliveTimeout + keepAliveTimeoutBuffer);
-      state.keepAliveTimeoutSet = true;
-    }
+    // Defer arming the keep-alive idle timer until the event loop turns.
+    // Under continuous load the next request cancels the arm and we never
+    // call socket.setTimeout - two timer ops per request on the busy path.
+    scheduleKeepAliveTimeout(server, socket, state);
   } else {
     // Start sending the next message
     const m = state.outgoing.shift();
@@ -1238,11 +1277,42 @@ function resOnFinish(req, res, socket, state, server) {
   }
 }
 
+function scheduleKeepAliveTimeout(server, socket, state) {
+  if (state.keepAliveArmPending)
+    return;
+  state.keepAliveArmPending = true;
+  process.nextTick(armKeepAliveTimeout, server, socket, state);
+}
+
+function armKeepAliveTimeout(server, socket, state) {
+  state.keepAliveArmPending = false;
+  // A new request arrived, the socket went away, or another response is
+  // in flight - leave the timer alone.
+  if (socket.destroyed || socket._httpMessage ||
+      state.outgoing.length !== 0 || state.incoming.length !== 0) {
+    return;
+  }
+  const keepAliveTimeout = NumberIsFinite(server.keepAliveTimeout) &&
+    server.keepAliveTimeout >= 0 ? server.keepAliveTimeout : 0;
+  if (!keepAliveTimeout || typeof socket.setTimeout !== 'function')
+    return;
+  if (state.keepAliveTimeoutSet)
+    return;
+  const keepAliveTimeoutBuffer =
+    NumberIsFinite(server.keepAliveTimeoutBuffer) &&
+    server.keepAliveTimeoutBuffer >= 0 ? server.keepAliveTimeoutBuffer : 1e3;
+  // Extend the internal timeout by the configured buffer to reduce
+  // the likelihood of ECONNRESET errors.
+  socket.setTimeout(keepAliveTimeout + keepAliveTimeoutBuffer);
+  state.keepAliveTimeoutSet = true;
+}
+
 function emitCloseNT(self) {
   if (!self._closed) {
     self.destroyed = true;
     self._closed = true;
-    self.emit('close');
+    if (self._events?.close !== undefined)
+      self.emit('close');
   }
 }
 
@@ -1253,6 +1323,7 @@ function hasBodyHeaders(headers) {
 // The following callback is issued after the headers have been read on a
 // new message. In this callback we setup the response object and pass it
 // to the user.
+
 function parserOnIncoming(server, socket, state, req, keepAlive) {
   resetSocketTimeout(server, socket, state);
 
@@ -1280,15 +1351,16 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     }
   }
 
-  const res = new server[kServerResponse](req,
-                                          {
-                                            highWaterMark: socket.writableHighWaterMark,
-                                            rejectNonStandardBodyWrites: server.rejectNonStandardBodyWrites,
-                                          });
+  const res = new server[kServerResponse](req, {
+    highWaterMark: socket.writableHighWaterMark,
+    rejectNonStandardBodyWrites: server.rejectNonStandardBodyWrites,
+  });
   res._keepAliveTimeout = server.keepAliveTimeout;
   res._maxRequestsPerSocket = server.maxRequestsPerSocket;
-  res._onPendingData = updateOutgoingData.bind(undefined,
-                                               socket, state);
+  // Shared pending-data callback - avoid per-request .bind() allocation.
+  res[kFinishState] = state;
+  res[kPendingSocket] = socket;
+  res._onPendingData = onPendingData;
 
   res.shouldKeepAlive = keepAlive;
   res[kUniqueHeaders] = server[kUniqueHeaders];
@@ -1302,15 +1374,10 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     });
   }
 
-  // Check if we should optimize empty requests (those without Content-Length or Transfer-Encoding headers)
-  const shouldOptimize = server[kOptimizeEmptyRequests] === true && !hasBodyHeaders(req.headers);
-
-  if (shouldOptimize) {
-    // Fast processing where emitting 'data', 'end' and 'close' events is
-    // skipped and data is dumped.
-    // This avoids a lot of unnecessary overhead otherwise introduced by
-    // stream.Readable life cycle rules. The downside is that this will
-    // break some servers that read bodies for methods that don't have body headers.
+  // Opt-in only (options.optimizeEmptyRequests). Closes the readable early
+  // so body-less requests skip Readable lifecycle; callers that opt in
+  // accept req.destroyed === true when the handler runs.
+  if (server[kOptimizeEmptyRequests] === true && !hasBodyHeaders(req.headers)) {
     req._dumpAndCloseReadable();
     req._read();
   }
@@ -1322,11 +1389,10 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
     res.assignSocket(socket);
   }
 
-  // When we're finished writing the response, check if this is the last
-  // response, if so destroy the socket.
-  res.on('finish',
-         resOnFinish.bind(undefined,
-                          req, res, socket, state, server));
+  // Finish hook state for onFinish -> onResFinish (no EventEmitter.on).
+  res[kFinishReq] = req;
+  res[kFinishState] = state;
+  res[kFinishServer] = server;
 
   let handled = false;
 
@@ -1380,13 +1446,25 @@ function parserOnIncoming(server, socket, state, req, keepAlive) {
   }
 
   if (!handled) {
-    server.emit('request', req, res);
+    // Hot path: servers almost always have exactly one 'request' listener.
+    // Call it directly via the internal _events map to skip
+    // EventEmitter.emit() / listeners() array allocation.
+    // When captureRejections is enabled (global or per-emitter), must use
+    // emit() so the EE async-rejection handler runs.
+    const handler = server._events.request;
+    if (typeof handler === 'function' && !EE.captureRejections) {
+      handler.call(server, req, res);
+    } else if (handler !== undefined) {
+      server.emit('request', req, res);
+    }
   }
 
   return 0;  // No special treatment.
 }
 
 function resetSocketTimeout(server, socket, state) {
+  // Cancel a deferred keep-alive arm from a just-finished response.
+  state.keepAliveArmPending = false;
   if (!state.keepAliveTimeoutSet)
     return;
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -48,6 +48,7 @@
 // No copying is performed when slicing the buffer, only small reference
 // allocations.
 
+
 namespace node {
 namespace http_parser {  // NOLINT(build/namespaces)
 
@@ -254,36 +255,44 @@ struct ParserComparator {
 
 class ConnectionsList : public BaseObject {
  public:
-  static void New(const FunctionCallbackInfo<Value>& args);
+    static void New(const FunctionCallbackInfo<Value>& args);
 
-  static void All(const FunctionCallbackInfo<Value>& args);
+    static void All(const FunctionCallbackInfo<Value>& args);
 
-  static void Idle(const FunctionCallbackInfo<Value>& args);
+    static void Idle(const FunctionCallbackInfo<Value>& args);
 
-  static void Active(const FunctionCallbackInfo<Value>& args);
+    static void Active(const FunctionCallbackInfo<Value>& args);
 
-  static void Expired(const FunctionCallbackInfo<Value>& args);
+    static void Expired(const FunctionCallbackInfo<Value>& args);
 
-  void Push(Parser* parser) { all_connections_.insert(parser); }
+    void Push(Parser* parser) {
+      all_connections_.insert(parser);
+    }
 
-  void Pop(Parser* parser) { all_connections_.erase(parser); }
+    void Pop(Parser* parser) {
+      all_connections_.erase(parser);
+    }
 
-  void PushActive(Parser* parser) { active_connections_.insert(parser); }
+    void PushActive(Parser* parser) {
+      active_connections_.insert(parser);
+    }
 
-  void PopActive(Parser* parser) { active_connections_.erase(parser); }
+    void PopActive(Parser* parser) {
+      active_connections_.erase(parser);
+    }
 
-  SET_NO_MEMORY_INFO()
-  SET_MEMORY_INFO_NAME(ConnectionsList)
-  SET_SELF_SIZE(ConnectionsList)
+    SET_NO_MEMORY_INFO()
+    SET_MEMORY_INFO_NAME(ConnectionsList)
+    SET_SELF_SIZE(ConnectionsList)
 
  private:
-  ConnectionsList(Environment* env, Local<Object> object)
+    ConnectionsList(Environment* env, Local<Object> object)
       : BaseObject(env, object) {
-    MakeWeak();
-  }
+        MakeWeak();
+      }
 
-  std::set<Parser*, ParserComparator> all_connections_;
-  std::set<Parser*, ParserComparator> active_connections_;
+    std::set<Parser*, ParserComparator> all_connections_;
+    std::set<Parser*, ParserComparator> active_connections_;
 };
 
 class Parser : public AsyncWrap, public StreamListener {
@@ -323,20 +332,21 @@ class Parser : public AsyncWrap, public StreamListener {
       connectionsList_->PushActive(this);
     }
 
-    Local<Value> cb =
-        object()->Get(env()->context(), kOnMessageBegin).ToLocalChecked();
+    Local<Value> cb = object()->Get(env()->context(), kOnMessageBegin)
+                              .ToLocalChecked();
     if (cb->IsFunction()) {
       InternalCallbackScope callback_scope(
-          this, InternalCallbackScope::kSkipTaskQueues);
+        this, InternalCallbackScope::kSkipTaskQueues);
 
-      MaybeLocal<Value> r =
-          cb.As<Function>()->Call(env()->context(), object(), 0, nullptr);
+      MaybeLocal<Value> r = cb.As<Function>()->Call(
+        env()->context(), object(), 0, nullptr);
 
       if (r.IsEmpty()) callback_scope.MarkAsFailed();
     }
 
     return 0;
   }
+
 
   int on_url(const char* at, size_t length) {
     int rv = TrackHeader(length);
@@ -348,6 +358,7 @@ class Parser : public AsyncWrap, public StreamListener {
     return 0;
   }
 
+
   int on_status(const char* at, size_t length) {
     int rv = TrackHeader(length);
     if (rv != 0) {
@@ -357,6 +368,7 @@ class Parser : public AsyncWrap, public StreamListener {
     status_message_.Update(at, length, &allocator_);
     return 0;
   }
+
 
   int on_header_field(const char* at, size_t length) {
     int rv = TrackHeader(length);
@@ -384,6 +396,7 @@ class Parser : public AsyncWrap, public StreamListener {
     return 0;
   }
 
+
   int on_header_value(const char* at, size_t length) {
     int rv = TrackHeader(length);
     if (rv != 0) {
@@ -403,6 +416,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
     return 0;
   }
+
 
   int on_headers_complete() {
     headers_completed_ = true;
@@ -426,13 +440,15 @@ class Parser : public AsyncWrap, public StreamListener {
 
     Local<Value> argv[A_MAX];
     Local<Object> obj = object();
-    Local<Value> cb =
-        obj->Get(env()->context(), kOnHeadersComplete).ToLocalChecked();
+    Local<Value> cb = obj->Get(env()->context(),
+                               kOnHeadersComplete).ToLocalChecked();
 
-    if (!cb->IsFunction()) return 0;
+    if (!cb->IsFunction())
+      return 0;
 
     Local<Value> undefined = Undefined(env()->isolate());
-    for (size_t i = 0; i < arraysize(argv); i++) argv[i] = undefined;
+    for (size_t i = 0; i < arraysize(argv); i++)
+      argv[i] = undefined;
 
     if (have_flushed_) {
       // Slow case, flush remaining headers.
@@ -440,7 +456,8 @@ class Parser : public AsyncWrap, public StreamListener {
     } else {
       // Fast case, pass headers and URL to JS land.
       argv[A_HEADERS] = CreateHeaders();
-      if (parser_.type == HTTP_REQUEST) argv[A_URL] = url_.ToString(env());
+      if (parser_.type == HTTP_REQUEST)
+        argv[A_URL] = url_.ToString(env());
     }
 
     num_fields_ = 0;
@@ -454,7 +471,8 @@ class Parser : public AsyncWrap, public StreamListener {
 
     // STATUS
     if (parser_.type == HTTP_RESPONSE) {
-      argv[A_STATUS_CODE] = Integer::New(env()->isolate(), parser_.status_code);
+      argv[A_STATUS_CODE] =
+          Integer::New(env()->isolate(), parser_.status_code);
       argv[A_STATUS_MESSAGE] = status_message_.ToString(env());
     }
 
@@ -491,15 +509,18 @@ class Parser : public AsyncWrap, public StreamListener {
     return static_cast<int>(val);
   }
 
+
   int on_body(const char* at, size_t length) {
-    if (length == 0) return 0;
+    if (length == 0)
+      return 0;
 
     Environment* env = this->env();
     HandleScope handle_scope(env->isolate());
 
     Local<Value> cb = object()->Get(env->context(), kOnBody).ToLocalChecked();
 
-    if (!cb->IsFunction()) return 0;
+    if (!cb->IsFunction())
+      return 0;
 
     Local<Value> buffer = Buffer::Copy(env, at, length).ToLocalChecked();
 
@@ -513,6 +534,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
     return 0;
   }
+
 
   int on_message_complete() {
     HandleScope scope(env()->isolate());
@@ -530,13 +552,15 @@ class Parser : public AsyncWrap, public StreamListener {
       connectionsList_->Push(this);
     }
 
-    if (num_fields_) Flush();  // Flush trailing HTTP headers.
+    if (num_fields_)
+      Flush();  // Flush trailing HTTP headers.
 
     Local<Object> obj = object();
-    Local<Value> cb =
-        obj->Get(env()->context(), kOnMessageComplete).ToLocalChecked();
+    Local<Value> cb = obj->Get(env()->context(),
+                               kOnMessageComplete).ToLocalChecked();
 
-    if (!cb->IsFunction()) return 0;
+    if (!cb->IsFunction())
+      return 0;
 
     MaybeLocal<Value> r;
     {
@@ -558,8 +582,8 @@ class Parser : public AsyncWrap, public StreamListener {
     chunk_extensions_nread_ += length;
 
     if (chunk_extensions_nread_ > kMaxChunkExtensionsSize) {
-      llhttp_set_error_reason(
-          &parser_, "HPE_CHUNK_EXTENSIONS_OVERFLOW:Chunk extensions overflow");
+      llhttp_set_error_reason(&parser_,
+          "HPE_CHUNK_EXTENSIONS_OVERFLOW:Chunk extensions overflow");
       return HPE_USER;
     }
 
@@ -572,6 +596,7 @@ class Parser : public AsyncWrap, public StreamListener {
     chunk_extensions_nread_ = 0;
     return 0;
   }
+
 
   // Reset nread for the next chunk
   int on_chunk_complete() {
@@ -638,8 +663,10 @@ class Parser : public AsyncWrap, public StreamListener {
 
     Local<Value> ret = parser->Execute(buffer.data(), buffer.length());
 
-    if (!ret.IsEmpty()) args.GetReturnValue().Set(ret);
+    if (!ret.IsEmpty())
+      args.GetReturnValue().Set(ret);
   }
+
 
   static void Finish(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
@@ -647,8 +674,10 @@ class Parser : public AsyncWrap, public StreamListener {
 
     Local<Value> ret = parser->Execute(nullptr, 0);
 
-    if (!ret.IsEmpty()) args.GetReturnValue().Set(ret);
+    if (!ret.IsEmpty())
+      args.GetReturnValue().Set(ret);
   }
+
 
   static void Initialize(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
@@ -689,8 +718,9 @@ class Parser : public AsyncWrap, public StreamListener {
     CHECK_EQ(env, parser->env());
 
     AsyncWrap::ProviderType provider =
-        (type == HTTP_REQUEST ? AsyncWrap::PROVIDER_HTTPINCOMINGMESSAGE
-                              : AsyncWrap::PROVIDER_HTTPCLIENTREQUEST);
+        (type == HTTP_REQUEST ?
+            AsyncWrap::PROVIDER_HTTPINCOMINGMESSAGE
+            : AsyncWrap::PROVIDER_HTTPCLIENTREQUEST);
 
     parser->set_provider_type(provider);
     parser->AsyncReset(args[1].As<Object>());
@@ -746,20 +776,22 @@ class Parser : public AsyncWrap, public StreamListener {
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     // Already unconsumed
-    if (parser->stream_ == nullptr) return;
+    if (parser->stream_ == nullptr)
+      return;
 
     parser->stream_->RemoveStreamListener(parser);
   }
+
 
   static void GetCurrentBuffer(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     Local<Object> ret;
-    if (Buffer::Copy(parser->env(),
-                     parser->current_buffer_data_,
-                     parser->current_buffer_len_)
-            .ToLocal(&ret)) {
+    if (Buffer::Copy(
+        parser->env(),
+        parser->current_buffer_data_,
+        parser->current_buffer_len_).ToLocal(&ret)) {
       args.GetReturnValue().Set(ret);
     }
   }
@@ -781,6 +813,7 @@ class Parser : public AsyncWrap, public StreamListener {
     return uv_buf_init(binding_data_->parser_buffer.data(), kAllocBufferSize);
   }
 
+
   void OnStreamRead(ssize_t nread, const uv_buf_t& buf) override {
     HandleScope scope(env()->isolate());
     // Once we’re done here, either indicate that the HTTP parser buffer
@@ -799,17 +832,20 @@ class Parser : public AsyncWrap, public StreamListener {
     }
 
     // Ignore, empty reads have special meaning in http parser
-    if (nread == 0) return;
+    if (nread == 0)
+      return;
 
     Local<Value> ret = Execute(buf.base, nread);
 
     // Exception
-    if (ret.IsEmpty()) return;
+    if (ret.IsEmpty())
+      return;
 
     Local<Value> cb =
         object()->Get(env()->context(), kOnExecute).ToLocalChecked();
 
-    if (!cb->IsFunction()) return;
+    if (!cb->IsFunction())
+      return;
 
     // Hooks for GetCurrentBuffer
     current_buffer_len_ = nread;
@@ -820,6 +856,7 @@ class Parser : public AsyncWrap, public StreamListener {
     current_buffer_len_ = 0;
     current_buffer_data_ = nullptr;
   }
+
 
   Local<Value> Execute(const char* data, size_t len) {
     EscapableHandleScope scope(env()->isolate());
@@ -859,7 +896,8 @@ class Parser : public AsyncWrap, public StreamListener {
     current_buffer_data_ = nullptr;
 
     // If there was an exception in one of the callbacks
-    if (got_exception_) return scope.Escape(Local<Value>());
+    if (got_exception_)
+      return scope.Escape(Local<Value>());
 
     Local<Integer> nread_obj = Integer::New(env()->isolate(), nread);
 
@@ -867,10 +905,11 @@ class Parser : public AsyncWrap, public StreamListener {
     // TODO(bnoordhuis) What if there is an error on EOF?
     if (!parser_.upgrade && err != HPE_OK) {
       Local<Value> e = Exception::Error(env()->parse_error_string());
-      Local<Object> obj =
-          e->ToObject(env()->isolate()->GetCurrentContext()).ToLocalChecked();
-      obj->Set(env()->context(), env()->bytes_parsed_string(), nread_obj)
-          .Check();
+      Local<Object> obj = e->ToObject(env()->isolate()->GetCurrentContext())
+        .ToLocalChecked();
+      obj->Set(env()->context(),
+               env()->bytes_parsed_string(),
+               nread_obj).Check();
       const char* errno_reason = llhttp_get_error_reason(&parser_);
 
       Local<String> code;
@@ -911,6 +950,7 @@ class Parser : public AsyncWrap, public StreamListener {
     return Array::New(env()->isolate(), headers_v, num_values_ * 2);
   }
 
+
   // spill headers and request path to JS land
   void Flush() {
     HandleScope scope(env()->isolate());
@@ -918,21 +958,27 @@ class Parser : public AsyncWrap, public StreamListener {
     Local<Object> obj = object();
     Local<Value> cb = obj->Get(env()->context(), kOnHeaders).ToLocalChecked();
 
-    if (!cb->IsFunction()) return;
+    if (!cb->IsFunction())
+      return;
 
-    Local<Value> argv[2] = {CreateHeaders(), url_.ToString(env())};
+    Local<Value> argv[2] = {
+      CreateHeaders(),
+      url_.ToString(env())
+    };
 
-    MaybeLocal<Value> r =
-        MakeCallback(cb.As<Function>(), arraysize(argv), argv);
+    MaybeLocal<Value> r = MakeCallback(cb.As<Function>(),
+                                       arraysize(argv),
+                                       argv);
 
-    if (r.IsEmpty()) got_exception_ = true;
+    if (r.IsEmpty())
+      got_exception_ = true;
 
     url_.Reset();
     have_flushed_ = true;
   }
 
-  void Init(llhttp_type_t type,
-            uint64_t max_http_header_size,
+
+  void Init(llhttp_type_t type, uint64_t max_http_header_size,
             uint32_t lenient_flags) {
     llhttp_init(&parser_, type, &settings);
 
@@ -984,6 +1030,7 @@ class Parser : public AsyncWrap, public StreamListener {
     max_http_header_size_ = max_http_header_size;
   }
 
+
   int TrackHeader(size_t len) {
     header_nread_ += len;
     if (header_nread_ >= max_http_header_size_) {
@@ -992,6 +1039,7 @@ class Parser : public AsyncWrap, public StreamListener {
     }
     return 0;
   }
+
 
   int MaybePause() {
     if (!pending_pause_) {
@@ -1003,12 +1051,14 @@ class Parser : public AsyncWrap, public StreamListener {
     return HPE_PAUSED;
   }
 
+
   bool IsNotIndicativeOfMemoryLeakAtExit() const override {
     // HTTP parsers are able to emit events without any GC root referring
     // to them, because they receive events directly from the underlying
     // libuv resource.
     return true;
   }
+
 
   llhttp_t parser_;
   StringPtrAllocator allocator_;             // shared slab for all StringPtrs
@@ -1036,11 +1086,10 @@ class Parser : public AsyncWrap, public StreamListener {
 
   // These are helper functions for filling `http_parser_settings`, which turn
   // a member function of Parser into a C-style HTTP parser callback.
-  template <typename Parser, Parser>
-  struct Proxy;
-  template <typename Parser, typename... Args, int (Parser::*Member)(Args...)>
+  template <typename Parser, Parser> struct Proxy;
+  template <typename Parser, typename ...Args, int (Parser::*Member)(Args...)>
   struct Proxy<int (Parser::*)(Args...), Member> {
-    static int Raw(llhttp_t* p, Args... args) {
+    static int Raw(llhttp_t* p, Args ... args) {
       Parser* parser = ContainerOf(&Parser::parser_, p);
       if (parser->is_being_freed_) {
         return 0;
@@ -1142,9 +1191,9 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsNumber());
   CHECK(args[1]->IsNumber());
   uint64_t headers_timeout =
-      static_cast<uint64_t>(args[0].As<Uint32>()->Value()) * 1000000;
+    static_cast<uint64_t>(args[0].As<Uint32>()->Value()) * 1000000;
   uint64_t request_timeout =
-      static_cast<uint64_t>(args[1].As<Uint32>()->Value()) * 1000000;
+    static_cast<uint64_t>(args[1].As<Uint32>()->Value()) * 1000000;
 
   if (headers_timeout == 0 && request_timeout == 0) {
     return args.GetReturnValue().Set(Array::New(isolate, 0));
@@ -1179,10 +1228,13 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
     iter++;
 
     // Check for expiration.
-    if ((!parser->headers_completed_ && headers_deadline > 0 &&
-         parser->last_message_start_ < headers_deadline) ||
-        (request_deadline > 0 &&
-         parser->last_message_start_ < request_deadline)) {
+    if (
+      (!parser->headers_completed_ && headers_deadline > 0 &&
+        parser->last_message_start_ < headers_deadline) ||
+      (
+        request_deadline > 0 &&
+        parser->last_message_start_ < request_deadline)
+    ) {
       result.emplace_back(parser->object());
 
       list->active_connections_.erase(parser);
@@ -1244,7 +1296,7 @@ const llhttp_settings_t Parser::settings = {
     nullptr,
 };
 
-// Flags for BuildHttpMessage — keep in sync with lib/_http_outgoing.js.
+// Flags for BuildHttpMessage - keep in sync with lib/_http_outgoing.js.
 enum BuildHttpMessageFlags : uint32_t {
   kBuildSendDate = 1u << 0,
   kBuildShouldKeepAlive = 1u << 1,
@@ -1507,7 +1559,7 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
   }
 
   // Body framing. Note: useChunkedByDefault alone gates Content-Length /
-  // Transfer-Encoding auto headers — agent is NOT involved here.
+  // Transfer-Encoding auto headers - agent is NOT involved here.
   bool need_auto_cont_len = false;
   bool need_auto_te = false;
   if (!saw_cont_len && !saw_te) {
@@ -1544,7 +1596,7 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
 
   // body arg: null/undefined => headers-only (_storeHeader); string/buffer
   // (possibly empty) => complete message. Headers-only must not append the
-  // chunked terminator — JS end() still does that.
+  // chunked terminator - JS end() still does that.
   const bool headers_only = args[2]->IsNullOrUndefined();
 
   // HTTP headers are latin1 on the wire. Prefer WriteOneByteV2; for two-byte
@@ -1761,8 +1813,8 @@ void CreatePerIsolateProperties(IsolateData* isolate_data,
 
   Local<FunctionTemplate> c =
       NewFunctionTemplate(isolate, ConnectionsList::New);
-  c->InstanceTemplate()->SetInternalFieldCount(
-      ConnectionsList::kInternalFieldCount);
+  c->InstanceTemplate()
+    ->SetInternalFieldCount(ConnectionsList::kInternalFieldCount);
   SetProtoMethod(isolate, c, "all", ConnectionsList::All);
   SetProtoMethod(isolate, c, "idle", ConnectionsList::Idle);
   SetProtoMethod(isolate, c, "active", ConnectionsList::Active);

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -1360,16 +1360,6 @@ static bool ValueContainsTokenCI(const char* value,
   return false;
 }
 
-static void AppendNumber(std::string* out, uint64_t n) {
-  char buf[32];
-  size_t i = sizeof(buf);
-  do {
-    buf[--i] = static_cast<char>('0' + (n % 10));
-    n /= 10;
-  } while (n > 0);
-  out->append(buf + i, sizeof(buf) - i);
-}
-
 // Build a complete HTTP/1.1 message (header block, optionally plus body) in a
 // single contiguous Buffer. Mirrors _storeHeader() keep-alive / length logic
 // so the JS fast path can skip intermediate string concatenation.
@@ -1589,88 +1579,108 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
   // statusCode is not passed in; 204/304 + chunked is handled by JS before
   // or after calling this builder (see tryNativeStoreHeader).
 
-  // Build into a std::string then copy once into a Buffer. Header blocks are
-  // small; the extra copy is cheaper than getting the size estimate wrong.
-  std::string msg;
-  msg.reserve(256 + body_len);
-
   // body arg: null/undefined => headers-only (_storeHeader); string/buffer
   // (possibly empty) => complete message. Headers-only must not append the
   // chunked terminator - JS end() still does that.
   const bool headers_only = args[2]->IsNullOrUndefined();
 
-  // HTTP headers are latin1 on the wire. Prefer WriteOneByteV2; for two-byte
-  // strings write the low byte of each code unit (matches Buffer latin1).
+  // Size estimate (upper bound) so we can write into a single malloc and
+  // hand it to Buffer without a second copy.
+  size_t est = static_cast<size_t>(first_line_v->Length()) + 128 + body_len;
+  for (const auto& pair : header_pairs) {
+    est += static_cast<size_t>(pair.first->Length()) +
+           static_cast<size_t>(pair.second->Length()) + 4;  // ": \r\n"
+  }
+  if (chunked) est += 32;  // chunk framing
+
+  char* raw = UncheckedMalloc(est);
+  if (raw == nullptr) {
+    return;
+  }
+  size_t off = 0;
+
+  auto append_raw = [&](const char* p, size_t n) {
+    CHECK_LE(off + n, est);
+    if (n > 0) {
+      std::memcpy(raw + off, p, n);
+      off += n;
+    }
+  };
+  auto append_lit = [&](const char* lit) { append_raw(lit, std::strlen(lit)); };
   auto append_v8_latin1 = [&](Local<String> s) {
     const int n = s->Length();
-    const size_t at = msg.size();
-    msg.resize(at + static_cast<size_t>(n));
+    CHECK_LE(off + static_cast<size_t>(n), est);
     if (s->IsOneByte()) {
-      s->WriteOneByteV2(isolate, 0, n, reinterpret_cast<uint8_t*>(&msg[at]));
+      s->WriteOneByteV2(isolate, 0, n, reinterpret_cast<uint8_t*>(raw + off));
     } else {
-      // Two-byte string: extract low bytes (latin1 semantics).
       std::vector<uint16_t> tmp(static_cast<size_t>(n));
       s->WriteV2(isolate, 0, n, tmp.data());
       for (int i = 0; i < n; i++) {
-        msg[at + static_cast<size_t>(i)] =
+        raw[off + static_cast<size_t>(i)] =
             static_cast<char>(tmp[static_cast<size_t>(i)] & 0xff);
       }
     }
+    off += static_cast<size_t>(n);
+  };
+  auto append_number = [&](uint64_t n) {
+    char buf[32];
+    size_t i = sizeof(buf);
+    do {
+      buf[--i] = static_cast<char>('0' + (n % 10));
+      n /= 10;
+    } while (n > 0);
+    append_raw(buf + i, sizeof(buf) - i);
   };
 
   append_v8_latin1(first_line_v);
 
   for (const auto& pair : header_pairs) {
     append_v8_latin1(pair.first);
-    msg.append(": ");
+    append_lit(": ");
     append_v8_latin1(pair.second);
-    msg.append("\r\n");
+    append_lit("\r\n");
   }
 
   if (send_date && !saw_date && args[5]->IsString()) {
-    msg.append("Date: ");
+    append_lit("Date: ");
     append_v8_latin1(args[5].As<String>());
-    msg.append("\r\n");
+    append_lit("\r\n");
   }
 
   if (emit_connection_keep_alive) {
-    msg.append("Connection: keep-alive\r\n");
-    // Match matchHeader('keep-alive'): a user-supplied Keep-Alive header
-    // disables the default timeout emission.
+    append_lit("Connection: keep-alive\r\n");
     uint32_t ka = 0;
     if (args[6]->IsNumber()) {
       ka = args[6]->Uint32Value(env->context()).FromMaybe(0);
     }
     if (default_keep_alive && !saw_keep_alive && ka > 0) {
-      msg.append("Keep-Alive: timeout=");
-      AppendNumber(&msg, ka);
+      append_lit("Keep-Alive: timeout=");
+      append_number(ka);
       int32_t max_req = 0;
       if (args[7]->IsNumber()) {
         max_req = args[7]->Int32Value(env->context()).FromMaybe(0);
       }
       if (max_req > 0) {
-        msg.append(", max=");
-        AppendNumber(&msg, static_cast<uint64_t>(max_req));
+        append_lit(", max=");
+        append_number(static_cast<uint64_t>(max_req));
       }
-      msg.append("\r\n");
+      append_lit("\r\n");
     }
   } else if (emit_connection_close) {
-    msg.append("Connection: close\r\n");
+    append_lit("Connection: close\r\n");
   }
 
   if (need_auto_cont_len && content_length >= 0) {
-    msg.append("Content-Length: ");
-    AppendNumber(&msg, static_cast<uint64_t>(content_length));
-    msg.append("\r\n");
+    append_lit("Content-Length: ");
+    append_number(static_cast<uint64_t>(content_length));
+    append_lit("\r\n");
   }
   if (need_auto_te) {
-    msg.append("Transfer-Encoding: chunked\r\n");
+    append_lit("Transfer-Encoding: chunked\r\n");
   }
 
-  msg.append("\r\n");
+  append_lit("\r\n");
 
-  // Body section only for complete messages. Headers-only builds leave
-  // chunked framing to the existing JS end()/write path.
   if (!headers_only && has_body && (body_is_buffer || body_is_string)) {
     if (chunked && body_len > 0) {
       char hex[16];
@@ -1679,38 +1689,43 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
                         sizeof(hex),
                         "%llx",
                         static_cast<unsigned long long>(body_len));  // NOLINT
-      msg.append(hex, static_cast<size_t>(n));
-      msg.append("\r\n");
+      append_raw(hex, static_cast<size_t>(n));
+      append_lit("\r\n");
     }
     if (body_is_buffer && body_len > 0) {
-      msg.append(body_buf_data, body_len);
+      append_raw(body_buf_data, body_len);
     } else if (body_is_string && body_len > 0) {
-      const size_t at = msg.size();
+      CHECK_LE(off + body_len + 1, est);
       if (body_encoding == 1) {
-        msg.resize(at + body_len);
         body_str->WriteOneByteV2(isolate,
                                  0,
                                  body_str->Length(),
-                                 reinterpret_cast<uint8_t*>(&msg[at]));
+                                 reinterpret_cast<uint8_t*>(raw + off));
+        off += body_len;
       } else {
-        // +1 capacity so WriteUtf8V2 can null-terminate; we drop the NUL.
-        msg.resize(at + body_len + 1);
         const size_t written = body_str->WriteUtf8V2(
-            isolate, &msg[at], body_len + 1, String::WriteFlags::kNone);
-        // written includes the trailing NUL when it fits.
+            isolate, raw + off, body_len + 1, String::WriteFlags::kNone);
         size_t payload = written;
-        if (payload > 0 && msg[at + payload - 1] == '\0') payload--;
-        msg.resize(at + payload);
+        if (payload > 0 && raw[off + payload - 1] == '\0') payload--;
+        off += payload;
       }
     }
     if (chunked) {
-      if (body_len > 0) msg.append("\r\n");
-      msg.append("0\r\n\r\n");
+      if (body_len > 0) append_lit("\r\n");
+      append_lit("0\r\n\r\n");
     }
   }
 
   Local<Object> buf_obj;
-  if (!Buffer::Copy(env, msg.data(), msg.size()).ToLocal(&buf_obj)) {
+  // Transfer ownership of `raw` to the Buffer; free callback releases it.
+  if (!Buffer::New(
+           isolate,
+           raw,
+           off,
+           [](char* data, void* /*hint*/) { free(data); },
+           nullptr)
+           .ToLocal(&buf_obj)) {
+    free(raw);
     return;
   }
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -57,6 +57,7 @@ using v8::Boolean;
 using v8::Context;
 using v8::EscapableHandleScope;
 using v8::Exception;
+using v8::Float64Array;
 using v8::Function;
 using v8::FunctionCallbackInfo;
 using v8::FunctionTemplate;
@@ -72,7 +73,6 @@ using v8::Object;
 using v8::ObjectTemplate;
 using v8::String;
 using v8::Uint32;
-using v8::Uint32Array;
 using v8::Undefined;
 using v8::Value;
 
@@ -1310,7 +1310,7 @@ enum BuildHttpMessageFlags : uint32_t {
   kBuildHasAgent = 1u << 9,
 };
 
-// Out indices written into the optional Uint32Array passed as args[8].
+// Out indices written into the optional Float64Array passed as args[9].
 enum BuildHttpMessageOut : uint32_t {
   kOutLast = 0,
   kOutChunked = 1,
@@ -1334,6 +1334,15 @@ static bool HeaderTokenEquals(const char* a,
   return true;
 }
 
+// Match lib/_http_common.js chunkExpression / conn close:
+// /(?:^|\W)token(?:$|\W)/i  where \W is any non-[A-Za-z0-9_] character.
+// This accepts transfer-coding parameters (`chunked;foo=bar`) as well as
+// list/comma separators.
+static bool IsWordChar(char c) {
+  return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+         (c >= '0' && c <= '9') || c == '_';
+}
+
 static bool ValueContainsTokenCI(const char* value,
                                  size_t len,
                                  const char* token,
@@ -1350,11 +1359,9 @@ static bool ValueContainsTokenCI(const char* value,
       }
     }
     if (!match) continue;
-    const bool left_ok = i == 0 || value[i - 1] == ' ' || value[i - 1] == ',' ||
-                         value[i - 1] == '\t';
-    const bool right_ok = i + token_len == len || value[i + token_len] == ' ' ||
-                          value[i + token_len] == ',' ||
-                          value[i + token_len] == '\t';
+    const bool left_ok = i == 0 || !IsWordChar(value[i - 1]);
+    const bool right_ok =
+        i + token_len == len || !IsWordChar(value[i + token_len]);
     if (left_ok && right_ok) return true;
   }
   return false;
@@ -1373,7 +1380,7 @@ static bool ValueContainsTokenCI(const char* value,
 // args[6] keepAliveSec  uint32 keep-alive timeout in seconds
 // args[7] maxRequests   int32  max requests per socket (0 = omit)
 // args[8] knownLength   int32  content-length if already known, else -1
-// args[9] out           Uint32Array(kOutCount) optional result flags
+// args[9] out           Float64Array(kOutCount) optional result flags
 void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
@@ -1568,9 +1575,10 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
   }
 
   // Single-shot body: prefer Content-Length over chunked when the message
-  // actually uses chunked-by-default (servers / POST/PUT clients).
+  // actually uses chunked-by-default (servers / POST/PUT clients). Do not
+  // rewrite when a Trailer is advertised — trailers require chunked framing.
   if ((body_is_buffer || body_is_string) && content_length >= 0 && !saw_te &&
-      !removed_cont_len && use_chunked_by_default) {
+      !saw_trailer && !removed_cont_len && use_chunked_by_default) {
     need_auto_cont_len = !saw_cont_len;
     need_auto_te = false;
     chunked = false;
@@ -1599,8 +1607,9 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
   }
   size_t off = 0;
 
+  // Subtraction-style bounds checks avoid overflow of `off + n` before compare.
   auto append_raw = [&](const char* p, size_t n) {
-    CHECK_LE(off + n, est);
+    CHECK(off <= est && n <= est - off);
     if (n > 0) {
       std::memcpy(raw + off, p, n);
       off += n;
@@ -1609,18 +1618,19 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
   auto append_lit = [&](const char* lit) { append_raw(lit, std::strlen(lit)); };
   auto append_v8_latin1 = [&](Local<String> s) {
     const int n = s->Length();
-    CHECK_LE(off + static_cast<size_t>(n), est);
+    const size_t sn = static_cast<size_t>(n);
+    CHECK(off <= est && sn <= est - off);
     if (s->IsOneByte()) {
       s->WriteOneByteV2(isolate, 0, n, reinterpret_cast<uint8_t*>(raw + off));
     } else {
-      std::vector<uint16_t> tmp(static_cast<size_t>(n));
+      std::vector<uint16_t> tmp(sn);
       s->WriteV2(isolate, 0, n, tmp.data());
       for (int i = 0; i < n; i++) {
         raw[off + static_cast<size_t>(i)] =
             static_cast<char>(tmp[static_cast<size_t>(i)] & 0xff);
       }
     }
-    off += static_cast<size_t>(n);
+    off += sn;
   };
   auto append_number = [&](uint64_t n) {
     char buf[32];
@@ -1695,7 +1705,8 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
     if (body_is_buffer && body_len > 0) {
       append_raw(body_buf_data, body_len);
     } else if (body_is_string && body_len > 0) {
-      CHECK_LE(off + body_len + 1, est);
+      // Need room for payload; UTF-8 path may use body_len (no trailing NUL).
+      CHECK(off <= est && body_len <= est - off);
       if (body_encoding == 1) {
         body_str->WriteOneByteV2(isolate,
                                  0,
@@ -1704,10 +1715,8 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
         off += body_len;
       } else {
         const size_t written = body_str->WriteUtf8V2(
-            isolate, raw + off, body_len + 1, String::WriteFlags::kNone);
-        size_t payload = written;
-        if (payload > 0 && raw[off + payload - 1] == '\0') payload--;
-        off += payload;
+            isolate, raw + off, body_len, String::WriteFlags::kNone);
+        off += written;
       }
     }
     if (chunked) {
@@ -1729,17 +1738,19 @@ void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
-  if (args.Length() > 9 && args[9]->IsUint32Array()) {
-    Local<Uint32Array> out_arr = args[9].As<Uint32Array>();
+  // Float64Array so Content-Length values above 2^32-1 are not truncated
+  // (Uint32 would wrap; JS numbers are already doubles up to 2^53).
+  if (args.Length() > 9 && args[9]->IsFloat64Array()) {
+    Local<Float64Array> out_arr = args[9].As<Float64Array>();
     if (out_arr->Length() >= kOutCount) {
       auto* data =
-          static_cast<uint32_t*>(out_arr->Buffer()->GetBackingStore()->Data());
-      data += out_arr->ByteOffset() / sizeof(uint32_t);
-      data[kOutLast] = is_last ? 1 : 0;
-      data[kOutChunked] = chunked ? 1 : 0;
+          static_cast<double*>(out_arr->Buffer()->GetBackingStore()->Data());
+      data += out_arr->ByteOffset() / sizeof(double);
+      data[kOutLast] = is_last ? 1.0 : 0.0;
+      data[kOutChunked] = chunked ? 1.0 : 0.0;
       data[kOutContentLength] =
-          content_length >= 0 ? static_cast<uint32_t>(content_length) : 0;
-      data[kOutHasContentLength] = content_length >= 0 ? 1 : 0;
+          content_length >= 0 ? static_cast<double>(content_length) : 0.0;
+      data[kOutHasContentLength] = content_length >= 0 ? 1.0 : 0.0;
     }
   }
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -31,9 +31,11 @@
 #include "stream_base-inl.h"
 #include "v8.h"
 
+#include <cstdio>  // snprintf
 #include <cstdlib>  // free()
 #include <cstring>  // strdup(), strchr()
-
+#include <string>
+#include <vector>
 
 // This is a binding to llhttp (https://github.com/nodejs/llhttp)
 // The goal is to decouple sockets from parsing for more javascript-level
@@ -45,7 +47,6 @@
 //     ...
 // No copying is performed when slicing the buffer, only small reference
 // allocations.
-
 
 namespace node {
 namespace http_parser {  // NOLINT(build/namespaces)
@@ -70,6 +71,7 @@ using v8::Object;
 using v8::ObjectTemplate;
 using v8::String;
 using v8::Uint32;
+using v8::Uint32Array;
 using v8::Undefined;
 using v8::Value;
 
@@ -252,44 +254,36 @@ struct ParserComparator {
 
 class ConnectionsList : public BaseObject {
  public:
-    static void New(const FunctionCallbackInfo<Value>& args);
+  static void New(const FunctionCallbackInfo<Value>& args);
 
-    static void All(const FunctionCallbackInfo<Value>& args);
+  static void All(const FunctionCallbackInfo<Value>& args);
 
-    static void Idle(const FunctionCallbackInfo<Value>& args);
+  static void Idle(const FunctionCallbackInfo<Value>& args);
 
-    static void Active(const FunctionCallbackInfo<Value>& args);
+  static void Active(const FunctionCallbackInfo<Value>& args);
 
-    static void Expired(const FunctionCallbackInfo<Value>& args);
+  static void Expired(const FunctionCallbackInfo<Value>& args);
 
-    void Push(Parser* parser) {
-      all_connections_.insert(parser);
-    }
+  void Push(Parser* parser) { all_connections_.insert(parser); }
 
-    void Pop(Parser* parser) {
-      all_connections_.erase(parser);
-    }
+  void Pop(Parser* parser) { all_connections_.erase(parser); }
 
-    void PushActive(Parser* parser) {
-      active_connections_.insert(parser);
-    }
+  void PushActive(Parser* parser) { active_connections_.insert(parser); }
 
-    void PopActive(Parser* parser) {
-      active_connections_.erase(parser);
-    }
+  void PopActive(Parser* parser) { active_connections_.erase(parser); }
 
-    SET_NO_MEMORY_INFO()
-    SET_MEMORY_INFO_NAME(ConnectionsList)
-    SET_SELF_SIZE(ConnectionsList)
+  SET_NO_MEMORY_INFO()
+  SET_MEMORY_INFO_NAME(ConnectionsList)
+  SET_SELF_SIZE(ConnectionsList)
 
  private:
-    ConnectionsList(Environment* env, Local<Object> object)
+  ConnectionsList(Environment* env, Local<Object> object)
       : BaseObject(env, object) {
-        MakeWeak();
-      }
+    MakeWeak();
+  }
 
-    std::set<Parser*, ParserComparator> all_connections_;
-    std::set<Parser*, ParserComparator> active_connections_;
+  std::set<Parser*, ParserComparator> all_connections_;
+  std::set<Parser*, ParserComparator> active_connections_;
 };
 
 class Parser : public AsyncWrap, public StreamListener {
@@ -329,21 +323,20 @@ class Parser : public AsyncWrap, public StreamListener {
       connectionsList_->PushActive(this);
     }
 
-    Local<Value> cb = object()->Get(env()->context(), kOnMessageBegin)
-                              .ToLocalChecked();
+    Local<Value> cb =
+        object()->Get(env()->context(), kOnMessageBegin).ToLocalChecked();
     if (cb->IsFunction()) {
       InternalCallbackScope callback_scope(
-        this, InternalCallbackScope::kSkipTaskQueues);
+          this, InternalCallbackScope::kSkipTaskQueues);
 
-      MaybeLocal<Value> r = cb.As<Function>()->Call(
-        env()->context(), object(), 0, nullptr);
+      MaybeLocal<Value> r =
+          cb.As<Function>()->Call(env()->context(), object(), 0, nullptr);
 
       if (r.IsEmpty()) callback_scope.MarkAsFailed();
     }
 
     return 0;
   }
-
 
   int on_url(const char* at, size_t length) {
     int rv = TrackHeader(length);
@@ -355,7 +348,6 @@ class Parser : public AsyncWrap, public StreamListener {
     return 0;
   }
 
-
   int on_status(const char* at, size_t length) {
     int rv = TrackHeader(length);
     if (rv != 0) {
@@ -365,7 +357,6 @@ class Parser : public AsyncWrap, public StreamListener {
     status_message_.Update(at, length, &allocator_);
     return 0;
   }
-
 
   int on_header_field(const char* at, size_t length) {
     int rv = TrackHeader(length);
@@ -393,7 +384,6 @@ class Parser : public AsyncWrap, public StreamListener {
     return 0;
   }
 
-
   int on_header_value(const char* at, size_t length) {
     int rv = TrackHeader(length);
     if (rv != 0) {
@@ -413,7 +403,6 @@ class Parser : public AsyncWrap, public StreamListener {
 
     return 0;
   }
-
 
   int on_headers_complete() {
     headers_completed_ = true;
@@ -437,15 +426,13 @@ class Parser : public AsyncWrap, public StreamListener {
 
     Local<Value> argv[A_MAX];
     Local<Object> obj = object();
-    Local<Value> cb = obj->Get(env()->context(),
-                               kOnHeadersComplete).ToLocalChecked();
+    Local<Value> cb =
+        obj->Get(env()->context(), kOnHeadersComplete).ToLocalChecked();
 
-    if (!cb->IsFunction())
-      return 0;
+    if (!cb->IsFunction()) return 0;
 
     Local<Value> undefined = Undefined(env()->isolate());
-    for (size_t i = 0; i < arraysize(argv); i++)
-      argv[i] = undefined;
+    for (size_t i = 0; i < arraysize(argv); i++) argv[i] = undefined;
 
     if (have_flushed_) {
       // Slow case, flush remaining headers.
@@ -453,8 +440,7 @@ class Parser : public AsyncWrap, public StreamListener {
     } else {
       // Fast case, pass headers and URL to JS land.
       argv[A_HEADERS] = CreateHeaders();
-      if (parser_.type == HTTP_REQUEST)
-        argv[A_URL] = url_.ToString(env());
+      if (parser_.type == HTTP_REQUEST) argv[A_URL] = url_.ToString(env());
     }
 
     num_fields_ = 0;
@@ -468,8 +454,7 @@ class Parser : public AsyncWrap, public StreamListener {
 
     // STATUS
     if (parser_.type == HTTP_RESPONSE) {
-      argv[A_STATUS_CODE] =
-          Integer::New(env()->isolate(), parser_.status_code);
+      argv[A_STATUS_CODE] = Integer::New(env()->isolate(), parser_.status_code);
       argv[A_STATUS_MESSAGE] = status_message_.ToString(env());
     }
 
@@ -506,18 +491,15 @@ class Parser : public AsyncWrap, public StreamListener {
     return static_cast<int>(val);
   }
 
-
   int on_body(const char* at, size_t length) {
-    if (length == 0)
-      return 0;
+    if (length == 0) return 0;
 
     Environment* env = this->env();
     HandleScope handle_scope(env->isolate());
 
     Local<Value> cb = object()->Get(env->context(), kOnBody).ToLocalChecked();
 
-    if (!cb->IsFunction())
-      return 0;
+    if (!cb->IsFunction()) return 0;
 
     Local<Value> buffer = Buffer::Copy(env, at, length).ToLocalChecked();
 
@@ -531,7 +513,6 @@ class Parser : public AsyncWrap, public StreamListener {
 
     return 0;
   }
-
 
   int on_message_complete() {
     HandleScope scope(env()->isolate());
@@ -549,15 +530,13 @@ class Parser : public AsyncWrap, public StreamListener {
       connectionsList_->Push(this);
     }
 
-    if (num_fields_)
-      Flush();  // Flush trailing HTTP headers.
+    if (num_fields_) Flush();  // Flush trailing HTTP headers.
 
     Local<Object> obj = object();
-    Local<Value> cb = obj->Get(env()->context(),
-                               kOnMessageComplete).ToLocalChecked();
+    Local<Value> cb =
+        obj->Get(env()->context(), kOnMessageComplete).ToLocalChecked();
 
-    if (!cb->IsFunction())
-      return 0;
+    if (!cb->IsFunction()) return 0;
 
     MaybeLocal<Value> r;
     {
@@ -579,8 +558,8 @@ class Parser : public AsyncWrap, public StreamListener {
     chunk_extensions_nread_ += length;
 
     if (chunk_extensions_nread_ > kMaxChunkExtensionsSize) {
-      llhttp_set_error_reason(&parser_,
-          "HPE_CHUNK_EXTENSIONS_OVERFLOW:Chunk extensions overflow");
+      llhttp_set_error_reason(
+          &parser_, "HPE_CHUNK_EXTENSIONS_OVERFLOW:Chunk extensions overflow");
       return HPE_USER;
     }
 
@@ -593,7 +572,6 @@ class Parser : public AsyncWrap, public StreamListener {
     chunk_extensions_nread_ = 0;
     return 0;
   }
-
 
   // Reset nread for the next chunk
   int on_chunk_complete() {
@@ -660,10 +638,8 @@ class Parser : public AsyncWrap, public StreamListener {
 
     Local<Value> ret = parser->Execute(buffer.data(), buffer.length());
 
-    if (!ret.IsEmpty())
-      args.GetReturnValue().Set(ret);
+    if (!ret.IsEmpty()) args.GetReturnValue().Set(ret);
   }
-
 
   static void Finish(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
@@ -671,10 +647,8 @@ class Parser : public AsyncWrap, public StreamListener {
 
     Local<Value> ret = parser->Execute(nullptr, 0);
 
-    if (!ret.IsEmpty())
-      args.GetReturnValue().Set(ret);
+    if (!ret.IsEmpty()) args.GetReturnValue().Set(ret);
   }
-
 
   static void Initialize(const FunctionCallbackInfo<Value>& args) {
     Environment* env = Environment::GetCurrent(args);
@@ -715,9 +689,8 @@ class Parser : public AsyncWrap, public StreamListener {
     CHECK_EQ(env, parser->env());
 
     AsyncWrap::ProviderType provider =
-        (type == HTTP_REQUEST ?
-            AsyncWrap::PROVIDER_HTTPINCOMINGMESSAGE
-            : AsyncWrap::PROVIDER_HTTPCLIENTREQUEST);
+        (type == HTTP_REQUEST ? AsyncWrap::PROVIDER_HTTPINCOMINGMESSAGE
+                              : AsyncWrap::PROVIDER_HTTPCLIENTREQUEST);
 
     parser->set_provider_type(provider);
     parser->AsyncReset(args[1].As<Object>());
@@ -773,22 +746,20 @@ class Parser : public AsyncWrap, public StreamListener {
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     // Already unconsumed
-    if (parser->stream_ == nullptr)
-      return;
+    if (parser->stream_ == nullptr) return;
 
     parser->stream_->RemoveStreamListener(parser);
   }
-
 
   static void GetCurrentBuffer(const FunctionCallbackInfo<Value>& args) {
     Parser* parser;
     ASSIGN_OR_RETURN_UNWRAP(&parser, args.This());
 
     Local<Object> ret;
-    if (Buffer::Copy(
-        parser->env(),
-        parser->current_buffer_data_,
-        parser->current_buffer_len_).ToLocal(&ret)) {
+    if (Buffer::Copy(parser->env(),
+                     parser->current_buffer_data_,
+                     parser->current_buffer_len_)
+            .ToLocal(&ret)) {
       args.GetReturnValue().Set(ret);
     }
   }
@@ -810,7 +781,6 @@ class Parser : public AsyncWrap, public StreamListener {
     return uv_buf_init(binding_data_->parser_buffer.data(), kAllocBufferSize);
   }
 
-
   void OnStreamRead(ssize_t nread, const uv_buf_t& buf) override {
     HandleScope scope(env()->isolate());
     // Once we’re done here, either indicate that the HTTP parser buffer
@@ -829,20 +799,17 @@ class Parser : public AsyncWrap, public StreamListener {
     }
 
     // Ignore, empty reads have special meaning in http parser
-    if (nread == 0)
-      return;
+    if (nread == 0) return;
 
     Local<Value> ret = Execute(buf.base, nread);
 
     // Exception
-    if (ret.IsEmpty())
-      return;
+    if (ret.IsEmpty()) return;
 
     Local<Value> cb =
         object()->Get(env()->context(), kOnExecute).ToLocalChecked();
 
-    if (!cb->IsFunction())
-      return;
+    if (!cb->IsFunction()) return;
 
     // Hooks for GetCurrentBuffer
     current_buffer_len_ = nread;
@@ -853,7 +820,6 @@ class Parser : public AsyncWrap, public StreamListener {
     current_buffer_len_ = 0;
     current_buffer_data_ = nullptr;
   }
-
 
   Local<Value> Execute(const char* data, size_t len) {
     EscapableHandleScope scope(env()->isolate());
@@ -893,8 +859,7 @@ class Parser : public AsyncWrap, public StreamListener {
     current_buffer_data_ = nullptr;
 
     // If there was an exception in one of the callbacks
-    if (got_exception_)
-      return scope.Escape(Local<Value>());
+    if (got_exception_) return scope.Escape(Local<Value>());
 
     Local<Integer> nread_obj = Integer::New(env()->isolate(), nread);
 
@@ -902,11 +867,10 @@ class Parser : public AsyncWrap, public StreamListener {
     // TODO(bnoordhuis) What if there is an error on EOF?
     if (!parser_.upgrade && err != HPE_OK) {
       Local<Value> e = Exception::Error(env()->parse_error_string());
-      Local<Object> obj = e->ToObject(env()->isolate()->GetCurrentContext())
-        .ToLocalChecked();
-      obj->Set(env()->context(),
-               env()->bytes_parsed_string(),
-               nread_obj).Check();
+      Local<Object> obj =
+          e->ToObject(env()->isolate()->GetCurrentContext()).ToLocalChecked();
+      obj->Set(env()->context(), env()->bytes_parsed_string(), nread_obj)
+          .Check();
       const char* errno_reason = llhttp_get_error_reason(&parser_);
 
       Local<String> code;
@@ -947,7 +911,6 @@ class Parser : public AsyncWrap, public StreamListener {
     return Array::New(env()->isolate(), headers_v, num_values_ * 2);
   }
 
-
   // spill headers and request path to JS land
   void Flush() {
     HandleScope scope(env()->isolate());
@@ -955,27 +918,21 @@ class Parser : public AsyncWrap, public StreamListener {
     Local<Object> obj = object();
     Local<Value> cb = obj->Get(env()->context(), kOnHeaders).ToLocalChecked();
 
-    if (!cb->IsFunction())
-      return;
+    if (!cb->IsFunction()) return;
 
-    Local<Value> argv[2] = {
-      CreateHeaders(),
-      url_.ToString(env())
-    };
+    Local<Value> argv[2] = {CreateHeaders(), url_.ToString(env())};
 
-    MaybeLocal<Value> r = MakeCallback(cb.As<Function>(),
-                                       arraysize(argv),
-                                       argv);
+    MaybeLocal<Value> r =
+        MakeCallback(cb.As<Function>(), arraysize(argv), argv);
 
-    if (r.IsEmpty())
-      got_exception_ = true;
+    if (r.IsEmpty()) got_exception_ = true;
 
     url_.Reset();
     have_flushed_ = true;
   }
 
-
-  void Init(llhttp_type_t type, uint64_t max_http_header_size,
+  void Init(llhttp_type_t type,
+            uint64_t max_http_header_size,
             uint32_t lenient_flags) {
     llhttp_init(&parser_, type, &settings);
 
@@ -1027,7 +984,6 @@ class Parser : public AsyncWrap, public StreamListener {
     max_http_header_size_ = max_http_header_size;
   }
 
-
   int TrackHeader(size_t len) {
     header_nread_ += len;
     if (header_nread_ >= max_http_header_size_) {
@@ -1036,7 +992,6 @@ class Parser : public AsyncWrap, public StreamListener {
     }
     return 0;
   }
-
 
   int MaybePause() {
     if (!pending_pause_) {
@@ -1048,14 +1003,12 @@ class Parser : public AsyncWrap, public StreamListener {
     return HPE_PAUSED;
   }
 
-
   bool IsNotIndicativeOfMemoryLeakAtExit() const override {
     // HTTP parsers are able to emit events without any GC root referring
     // to them, because they receive events directly from the underlying
     // libuv resource.
     return true;
   }
-
 
   llhttp_t parser_;
   StringPtrAllocator allocator_;             // shared slab for all StringPtrs
@@ -1083,10 +1036,11 @@ class Parser : public AsyncWrap, public StreamListener {
 
   // These are helper functions for filling `http_parser_settings`, which turn
   // a member function of Parser into a C-style HTTP parser callback.
-  template <typename Parser, Parser> struct Proxy;
-  template <typename Parser, typename ...Args, int (Parser::*Member)(Args...)>
+  template <typename Parser, Parser>
+  struct Proxy;
+  template <typename Parser, typename... Args, int (Parser::*Member)(Args...)>
   struct Proxy<int (Parser::*)(Args...), Member> {
-    static int Raw(llhttp_t* p, Args ... args) {
+    static int Raw(llhttp_t* p, Args... args) {
       Parser* parser = ContainerOf(&Parser::parser_, p);
       if (parser->is_being_freed_) {
         return 0;
@@ -1188,9 +1142,9 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
   CHECK(args[0]->IsNumber());
   CHECK(args[1]->IsNumber());
   uint64_t headers_timeout =
-    static_cast<uint64_t>(args[0].As<Uint32>()->Value()) * 1000000;
+      static_cast<uint64_t>(args[0].As<Uint32>()->Value()) * 1000000;
   uint64_t request_timeout =
-    static_cast<uint64_t>(args[1].As<Uint32>()->Value()) * 1000000;
+      static_cast<uint64_t>(args[1].As<Uint32>()->Value()) * 1000000;
 
   if (headers_timeout == 0 && request_timeout == 0) {
     return args.GetReturnValue().Set(Array::New(isolate, 0));
@@ -1225,13 +1179,10 @@ void ConnectionsList::Expired(const FunctionCallbackInfo<Value>& args) {
     iter++;
 
     // Check for expiration.
-    if (
-      (!parser->headers_completed_ && headers_deadline > 0 &&
-        parser->last_message_start_ < headers_deadline) ||
-      (
-        request_deadline > 0 &&
-        parser->last_message_start_ < request_deadline)
-    ) {
+    if ((!parser->headers_completed_ && headers_deadline > 0 &&
+         parser->last_message_start_ < headers_deadline) ||
+        (request_deadline > 0 &&
+         parser->last_message_start_ < request_deadline)) {
       result.emplace_back(parser->object());
 
       list->active_connections_.erase(parser);
@@ -1292,6 +1243,441 @@ const llhttp_settings_t Parser::settings = {
     // on_reset,
     nullptr,
 };
+
+// Flags for BuildHttpMessage — keep in sync with lib/_http_outgoing.js.
+enum BuildHttpMessageFlags : uint32_t {
+  kBuildSendDate = 1u << 0,
+  kBuildShouldKeepAlive = 1u << 1,
+  kBuildMaxRequestsReached = 1u << 2,
+  kBuildDefaultKeepAlive = 1u << 3,
+  kBuildHasBody = 1u << 4,
+  kBuildUseChunkedByDefault = 1u << 5,
+  kBuildRemovedConnection = 1u << 6,
+  kBuildRemovedContLen = 1u << 7,
+  kBuildRemovedTE = 1u << 8,
+  kBuildHasAgent = 1u << 9,
+};
+
+// Out indices written into the optional Uint32Array passed as args[8].
+enum BuildHttpMessageOut : uint32_t {
+  kOutLast = 0,
+  kOutChunked = 1,
+  kOutContentLength = 2,
+  kOutHasContentLength = 3,
+  kOutCount = 4,
+};
+
+static bool HeaderTokenEquals(const char* a,
+                              size_t a_len,
+                              const char* b,
+                              size_t b_len) {
+  if (a_len != b_len) return false;
+  for (size_t i = 0; i < a_len; i++) {
+    char ca = a[i];
+    char cb = b[i];
+    if (ca >= 'A' && ca <= 'Z') ca = static_cast<char>(ca + 32);
+    if (cb >= 'A' && cb <= 'Z') cb = static_cast<char>(cb + 32);
+    if (ca != cb) return false;
+  }
+  return true;
+}
+
+static bool ValueContainsTokenCI(const char* value,
+                                 size_t len,
+                                 const char* token,
+                                 size_t token_len) {
+  if (token_len == 0 || len < token_len) return false;
+  for (size_t i = 0; i + token_len <= len; i++) {
+    bool match = true;
+    for (size_t j = 0; j < token_len; j++) {
+      char c = value[i + j];
+      if (c >= 'A' && c <= 'Z') c = static_cast<char>(c + 32);
+      if (c != token[j]) {
+        match = false;
+        break;
+      }
+    }
+    if (!match) continue;
+    const bool left_ok = i == 0 || value[i - 1] == ' ' || value[i - 1] == ',' ||
+                         value[i - 1] == '\t';
+    const bool right_ok = i + token_len == len || value[i + token_len] == ' ' ||
+                          value[i + token_len] == ',' ||
+                          value[i + token_len] == '\t';
+    if (left_ok && right_ok) return true;
+  }
+  return false;
+}
+
+static void AppendNumber(std::string* out, uint64_t n) {
+  char buf[32];
+  size_t i = sizeof(buf);
+  do {
+    buf[--i] = static_cast<char>('0' + (n % 10));
+    n /= 10;
+  } while (n > 0);
+  out->append(buf + i, sizeof(buf) - i);
+}
+
+// Build a complete HTTP/1.1 message (header block, optionally plus body) in a
+// single contiguous Buffer. Mirrors _storeHeader() keep-alive / length logic
+// so the JS fast path can skip intermediate string concatenation.
+//
+// args[0] firstLine     String  e.g. "HTTP/1.1 200 OK\r\n"
+// args[1] headers       Array|null  flat [name, value, name, value, ...]
+// args[2] body          String|Uint8Array|null
+// args[3] bodyEncoding  0=none/buffer, 1=latin1, 2=utf8 (only for string body)
+// args[4] flags         uint32 BuildHttpMessageFlags
+// args[5] date          String (pre-formatted UTC date) or empty
+// args[6] keepAliveSec  uint32 keep-alive timeout in seconds
+// args[7] maxRequests   int32  max requests per socket (0 = omit)
+// args[8] knownLength   int32  content-length if already known, else -1
+// args[9] out           Uint32Array(kOutCount) optional result flags
+void BuildHttpMessage(const FunctionCallbackInfo<Value>& args) {
+  Environment* env = Environment::GetCurrent(args);
+  Isolate* isolate = env->isolate();
+  HandleScope scope(isolate);
+
+  if (args.Length() < 9 || !args[0]->IsString()) {
+    return;
+  }
+
+  Local<String> first_line_v = args[0].As<String>();
+
+  const uint32_t flags =
+      args[4]->IsUint32() ? args[4].As<Uint32>()->Value() : 0;
+  const bool send_date = (flags & kBuildSendDate) != 0;
+  const bool should_keep_alive = (flags & kBuildShouldKeepAlive) != 0;
+  const bool max_requests_reached = (flags & kBuildMaxRequestsReached) != 0;
+  const bool default_keep_alive = (flags & kBuildDefaultKeepAlive) != 0;
+  const bool has_body = (flags & kBuildHasBody) != 0;
+  const bool use_chunked_by_default = (flags & kBuildUseChunkedByDefault) != 0;
+  const bool removed_connection = (flags & kBuildRemovedConnection) != 0;
+  const bool removed_cont_len = (flags & kBuildRemovedContLen) != 0;
+  const bool removed_te = (flags & kBuildRemovedTE) != 0;
+  const bool has_agent = (flags & kBuildHasAgent) != 0;
+
+  int64_t known_length = -1;
+  if (args[8]->IsNumber()) {
+    known_length = args[8]->IntegerValue(env->context()).FromMaybe(-1);
+  }
+
+  // Measure / extract body.
+  size_t body_len = 0;
+  bool body_is_buffer = false;
+  bool body_is_string = false;
+  int body_encoding = 0;  // 0=buffer/none, 1=latin1, 2=utf8
+  Local<String> body_str;
+  const char* body_buf_data = nullptr;
+
+  if (!args[2]->IsNullOrUndefined()) {
+    if (Buffer::HasInstance(args[2])) {
+      body_is_buffer = true;
+      body_buf_data = Buffer::Data(args[2]);
+      body_len = Buffer::Length(args[2]);
+    } else if (args[2]->IsString()) {
+      body_is_string = true;
+      body_str = args[2].As<String>();
+      body_encoding = args[3]->IsUint32() ? args[3].As<Uint32>()->Value() : 2;
+      if (body_encoding == 1) {
+        body_len = static_cast<size_t>(body_str->Length());
+      } else {
+        body_len = static_cast<size_t>(body_str->Utf8LengthV2(isolate));
+        body_encoding = 2;
+      }
+    }
+  }
+
+  bool saw_connection = false;
+  bool saw_cont_len = false;
+  bool saw_te = false;
+  bool saw_date = false;
+  bool saw_trailer = false;
+  bool saw_keep_alive = false;
+  bool connection_close = false;
+  bool te_chunked = false;
+  int64_t header_content_length = -1;
+
+  std::vector<std::pair<Local<String>, Local<String>>> header_pairs;
+  if (args[1]->IsArray()) {
+    Local<Array> headers = args[1].As<Array>();
+    const uint32_t len = headers->Length();
+    if (len % 2u != 0u) {
+      return;  // Invalid; JS validates before calling.
+    }
+    header_pairs.reserve(len / 2);
+    Local<Context> context = env->context();
+    for (uint32_t i = 0; i < len; i += 2) {
+      Local<Value> k_v, v_v;
+      if (!headers->Get(context, i).ToLocal(&k_v) ||
+          !headers->Get(context, i + 1).ToLocal(&v_v) || !k_v->IsString() ||
+          !v_v->IsString()) {
+        return;
+      }
+      Local<String> key = k_v.As<String>();
+      Local<String> val = v_v.As<String>();
+      header_pairs.emplace_back(key, val);
+
+      const int klen = key->Length();
+      const int vlen = val->Length();
+
+      // Cheap length pre-filter matching matchHeader() in JS.
+      if (klen != 4 && klen != 6 && klen != 7 && klen != 10 && klen != 14 &&
+          klen != 17) {
+        continue;
+      }
+
+      char name_buf[32];
+      if (klen < 0 || klen >= static_cast<int>(sizeof(name_buf))) continue;
+      key->WriteOneByteV2(
+          isolate, 0, klen, reinterpret_cast<uint8_t*>(name_buf));
+
+      char value_buf_stack[128];
+      std::string value_heap;
+      const char* value_ptr;
+      size_t value_len = static_cast<size_t>(vlen);
+      if (vlen < static_cast<int>(sizeof(value_buf_stack))) {
+        val->WriteOneByteV2(
+            isolate, 0, vlen, reinterpret_cast<uint8_t*>(value_buf_stack));
+        value_ptr = value_buf_stack;
+      } else {
+        value_heap.resize(value_len);
+        val->WriteOneByteV2(
+            isolate, 0, vlen, reinterpret_cast<uint8_t*>(&value_heap[0]));
+        value_ptr = value_heap.data();
+      }
+
+      if (HeaderTokenEquals(name_buf, klen, "date", 4)) {
+        saw_date = true;
+      } else if (HeaderTokenEquals(name_buf, klen, "trailer", 7)) {
+        saw_trailer = true;
+      } else if (HeaderTokenEquals(name_buf, klen, "connection", 10)) {
+        saw_connection = true;
+        if (ValueContainsTokenCI(value_ptr, value_len, "close", 5))
+          connection_close = true;
+      } else if (HeaderTokenEquals(name_buf, klen, "keep-alive", 10)) {
+        saw_keep_alive = true;
+      } else if (HeaderTokenEquals(name_buf, klen, "content-length", 14)) {
+        saw_cont_len = true;
+        header_content_length = 0;
+        for (size_t j = 0; j < value_len; j++) {
+          if (value_ptr[j] < '0' || value_ptr[j] > '9') break;
+          header_content_length =
+              header_content_length * 10 + (value_ptr[j] - '0');
+        }
+      } else if (HeaderTokenEquals(name_buf, klen, "transfer-encoding", 17)) {
+        saw_te = true;
+        if (ValueContainsTokenCI(value_ptr, value_len, "chunked", 7))
+          te_chunked = true;
+      }
+    }
+  }
+
+  bool is_last = false;
+  bool chunked = te_chunked;
+  int64_t content_length = -1;
+
+  if (saw_cont_len) {
+    content_length = header_content_length;
+  } else if (known_length >= 0) {
+    content_length = known_length;
+  } else if (body_is_buffer || body_is_string) {
+    content_length = static_cast<int64_t>(body_len);
+  }
+
+  // Match _storeHeader connection logic.
+  // JS: shouldKeepAlive && (contLen || useChunkedByDefault || agent)
+  bool emit_connection_close = false;
+  bool emit_connection_keep_alive = false;
+  if (removed_connection) {
+    is_last = !should_keep_alive;
+  } else if (!saw_connection) {
+    const bool should_send_keep_alive =
+        should_keep_alive && (saw_cont_len || content_length >= 0 ||
+                              use_chunked_by_default || has_agent);
+    if (should_send_keep_alive && max_requests_reached) {
+      emit_connection_close = true;
+    } else if (should_send_keep_alive) {
+      emit_connection_keep_alive = true;
+    } else {
+      is_last = true;
+      emit_connection_close = true;
+    }
+  } else if (connection_close) {
+    is_last = true;
+  }
+
+  // Body framing. Note: useChunkedByDefault alone gates Content-Length /
+  // Transfer-Encoding auto headers — agent is NOT involved here.
+  bool need_auto_cont_len = false;
+  bool need_auto_te = false;
+  if (!saw_cont_len && !saw_te) {
+    if (!has_body) {
+      chunked = false;
+    } else if (!use_chunked_by_default) {
+      is_last = true;
+    } else if (!saw_trailer && !removed_cont_len && content_length >= 0) {
+      need_auto_cont_len = true;
+    } else if (!removed_te) {
+      need_auto_te = true;
+      chunked = true;
+    } else {
+      is_last = true;
+    }
+  }
+
+  // Single-shot body: prefer Content-Length over chunked when the message
+  // actually uses chunked-by-default (servers / POST/PUT clients).
+  if ((body_is_buffer || body_is_string) && content_length >= 0 && !saw_te &&
+      !removed_cont_len && use_chunked_by_default) {
+    need_auto_cont_len = !saw_cont_len;
+    need_auto_te = false;
+    chunked = false;
+  }
+
+  // statusCode is not passed in; 204/304 + chunked is handled by JS before
+  // or after calling this builder (see tryNativeStoreHeader).
+
+  // Build into a std::string then copy once into a Buffer. Header blocks are
+  // small; the extra copy is cheaper than getting the size estimate wrong.
+  std::string msg;
+  msg.reserve(256 + body_len);
+
+  // body arg: null/undefined => headers-only (_storeHeader); string/buffer
+  // (possibly empty) => complete message. Headers-only must not append the
+  // chunked terminator — JS end() still does that.
+  const bool headers_only = args[2]->IsNullOrUndefined();
+
+  // HTTP headers are latin1 on the wire. Prefer WriteOneByteV2; for two-byte
+  // strings write the low byte of each code unit (matches Buffer latin1).
+  auto append_v8_latin1 = [&](Local<String> s) {
+    const int n = s->Length();
+    const size_t at = msg.size();
+    msg.resize(at + static_cast<size_t>(n));
+    if (s->IsOneByte()) {
+      s->WriteOneByteV2(isolate, 0, n, reinterpret_cast<uint8_t*>(&msg[at]));
+    } else {
+      // Two-byte string: extract low bytes (latin1 semantics).
+      std::vector<uint16_t> tmp(static_cast<size_t>(n));
+      s->WriteV2(isolate, 0, n, tmp.data());
+      for (int i = 0; i < n; i++) {
+        msg[at + static_cast<size_t>(i)] =
+            static_cast<char>(tmp[static_cast<size_t>(i)] & 0xff);
+      }
+    }
+  };
+
+  append_v8_latin1(first_line_v);
+
+  for (const auto& pair : header_pairs) {
+    append_v8_latin1(pair.first);
+    msg.append(": ");
+    append_v8_latin1(pair.second);
+    msg.append("\r\n");
+  }
+
+  if (send_date && !saw_date && args[5]->IsString()) {
+    msg.append("Date: ");
+    append_v8_latin1(args[5].As<String>());
+    msg.append("\r\n");
+  }
+
+  if (emit_connection_keep_alive) {
+    msg.append("Connection: keep-alive\r\n");
+    // Match matchHeader('keep-alive'): a user-supplied Keep-Alive header
+    // disables the default timeout emission.
+    uint32_t ka = 0;
+    if (args[6]->IsNumber()) {
+      ka = args[6]->Uint32Value(env->context()).FromMaybe(0);
+    }
+    if (default_keep_alive && !saw_keep_alive && ka > 0) {
+      msg.append("Keep-Alive: timeout=");
+      AppendNumber(&msg, ka);
+      int32_t max_req = 0;
+      if (args[7]->IsNumber()) {
+        max_req = args[7]->Int32Value(env->context()).FromMaybe(0);
+      }
+      if (max_req > 0) {
+        msg.append(", max=");
+        AppendNumber(&msg, static_cast<uint64_t>(max_req));
+      }
+      msg.append("\r\n");
+    }
+  } else if (emit_connection_close) {
+    msg.append("Connection: close\r\n");
+  }
+
+  if (need_auto_cont_len && content_length >= 0) {
+    msg.append("Content-Length: ");
+    AppendNumber(&msg, static_cast<uint64_t>(content_length));
+    msg.append("\r\n");
+  }
+  if (need_auto_te) {
+    msg.append("Transfer-Encoding: chunked\r\n");
+  }
+
+  msg.append("\r\n");
+
+  // Body section only for complete messages. Headers-only builds leave
+  // chunked framing to the existing JS end()/write path.
+  if (!headers_only && has_body && (body_is_buffer || body_is_string)) {
+    if (chunked && body_len > 0) {
+      char hex[16];
+      const int n =
+          std::snprintf(hex,
+                        sizeof(hex),
+                        "%llx",
+                        static_cast<unsigned long long>(body_len));  // NOLINT
+      msg.append(hex, static_cast<size_t>(n));
+      msg.append("\r\n");
+    }
+    if (body_is_buffer && body_len > 0) {
+      msg.append(body_buf_data, body_len);
+    } else if (body_is_string && body_len > 0) {
+      const size_t at = msg.size();
+      if (body_encoding == 1) {
+        msg.resize(at + body_len);
+        body_str->WriteOneByteV2(isolate,
+                                 0,
+                                 body_str->Length(),
+                                 reinterpret_cast<uint8_t*>(&msg[at]));
+      } else {
+        // +1 capacity so WriteUtf8V2 can null-terminate; we drop the NUL.
+        msg.resize(at + body_len + 1);
+        const size_t written = body_str->WriteUtf8V2(
+            isolate, &msg[at], body_len + 1, String::WriteFlags::kNone);
+        // written includes the trailing NUL when it fits.
+        size_t payload = written;
+        if (payload > 0 && msg[at + payload - 1] == '\0') payload--;
+        msg.resize(at + payload);
+      }
+    }
+    if (chunked) {
+      if (body_len > 0) msg.append("\r\n");
+      msg.append("0\r\n\r\n");
+    }
+  }
+
+  Local<Object> buf_obj;
+  if (!Buffer::Copy(env, msg.data(), msg.size()).ToLocal(&buf_obj)) {
+    return;
+  }
+
+  if (args.Length() > 9 && args[9]->IsUint32Array()) {
+    Local<Uint32Array> out_arr = args[9].As<Uint32Array>();
+    if (out_arr->Length() >= kOutCount) {
+      auto* data =
+          static_cast<uint32_t*>(out_arr->Buffer()->GetBackingStore()->Data());
+      data += out_arr->ByteOffset() / sizeof(uint32_t);
+      data[kOutLast] = is_last ? 1 : 0;
+      data[kOutChunked] = chunked ? 1 : 0;
+      data[kOutContentLength] =
+          content_length >= 0 ? static_cast<uint32_t>(content_length) : 0;
+      data[kOutHasContentLength] = content_length >= 0 ? 1 : 0;
+    }
+  }
+
+  args.GetReturnValue().Set(buf_obj);
+}
 
 void CreatePerIsolateProperties(IsolateData* isolate_data,
                                 Local<ObjectTemplate> target) {
@@ -1370,10 +1756,13 @@ void CreatePerIsolateProperties(IsolateData* isolate_data,
 
   SetConstructorFunction(isolate, target, "HTTPParser", t);
 
+  // Single-shot HTTP/1.1 message builder used by the OutgoingMessage fast path.
+  SetMethod(isolate, target, "buildHttpMessage", BuildHttpMessage);
+
   Local<FunctionTemplate> c =
       NewFunctionTemplate(isolate, ConnectionsList::New);
-  c->InstanceTemplate()
-    ->SetInternalFieldCount(ConnectionsList::kInternalFieldCount);
+  c->InstanceTemplate()->SetInternalFieldCount(
+      ConnectionsList::kInternalFieldCount);
   SetProtoMethod(isolate, c, "all", ConnectionsList::All);
   SetProtoMethod(isolate, c, "idle", ConnectionsList::Idle);
   SetProtoMethod(isolate, c, "active", ConnectionsList::Active);
@@ -1436,6 +1825,7 @@ void RegisterExternalReferences(ExternalReferenceRegistry* registry) {
   registry->Register(Parser::Consume);
   registry->Register(Parser::Unconsume);
   registry->Register(Parser::GetCurrentBuffer);
+  registry->Register(BuildHttpMessage);
   registry->Register(ConnectionsList::New);
   registry->Register(ConnectionsList::All);
   registry->Register(ConnectionsList::Idle);

--- a/test/parallel/test-http-outgoing-native-builder-regressions.js
+++ b/test/parallel/test-http-outgoing-native-builder-regressions.js
@@ -1,0 +1,159 @@
+'use strict';
+
+// Flags: --expose-internals
+
+// Regression coverage for the native HTTP/1.1 message builder
+// (buildHttpMessage) and its parity with the legacy JS path.
+//
+// Cases:
+// - Empty chunked responses still terminate with 0\r\n\r\n
+// - Trailer keeps chunked framing (no Content-Length rewrite)
+// - Transfer-Encoding: chunked;params is still recognized as chunked
+// - strictContentLength throws on single res.end(chunk)
+// - Large Content-Length is not truncated via native out-params
+//
+// Framing cases are run twice by re-executing this file with
+// --legacy-path so both the native builder and the pre-existing JS path
+// are checked against the same assertions (see pimterry review).
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+const { spawnSync } = require('child_process');
+const { internalBinding } = require('internal/test/binding');
+
+const isLegacy = process.argv.includes('--legacy-path');
+const pathLabel = isLegacy ? 'legacy' : 'native';
+
+if (isLegacy) {
+  // Force tryNativeStoreHeader / tryFastEnd to fall back to the JS path.
+  const httpParser = internalBinding('http_parser');
+  httpParser.buildHttpMessage = () => undefined;
+}
+
+function rawRequest(handler, callback) {
+  const server = http.createServer(common.mustCall(handler));
+
+  server.listen(0, common.mustCall(() => {
+    const socket = net.connect(server.address().port, common.mustCall(() => {
+      socket.end('GET / HTTP/1.1\r\n' +
+                 'Host: localhost\r\n' +
+                 'Connection: close\r\n' +
+                 '\r\n');
+    }));
+
+    socket.setEncoding('latin1');
+    let raw = '';
+    socket.on('data', (chunk) => { raw += chunk; });
+    socket.on('end', common.mustCall(() => {
+      server.close(common.mustCall(() => callback(raw)));
+    }));
+  }));
+}
+
+// Empty chunked responses must still terminate the chunked body.
+rawRequest((req, res) => {
+  res.setHeader('Transfer-Encoding', 'chunked');
+  res.end();
+}, common.mustCall((raw) => {
+  assert.match(raw, /\r\nTransfer-Encoding: chunked\r\n/i, pathLabel);
+  assert.match(raw, /\r\n0\r\n\r\n$/, pathLabel);
+}));
+
+// Advertising trailers requires chunked framing; do not rewrite to
+// Content-Length.
+rawRequest((req, res) => {
+  res.setHeader('Trailer', 'X-Checksum');
+  res.end('ok');
+}, common.mustCall((raw) => {
+  assert.match(raw, /\r\nTrailer: X-Checksum\r\n/i, pathLabel);
+  assert.match(raw, /\r\nTransfer-Encoding: chunked\r\n/i, pathLabel);
+  assert.doesNotMatch(raw, /\r\nContent-Length:/i, pathLabel);
+  assert.match(raw, /\r\n2\r\nok\r\n0\r\n\r\n$/, pathLabel);
+}));
+
+// Transfer-Encoding parameters are valid transfer-coding parameters and
+// must still be recognized as chunked framing.
+rawRequest((req, res) => {
+  res.setHeader('Transfer-Encoding', 'chunked;foo=bar');
+  res.end('ok');
+}, common.mustCall((raw) => {
+  assert.match(raw, /\r\nTransfer-Encoding: chunked;foo=bar\r\n/i, pathLabel);
+  assert.doesNotMatch(raw, /\r\nContent-Length:/i, pathLabel);
+  assert.match(raw, /\r\n2\r\nok\r\n0\r\n\r\n$/, pathLabel);
+}));
+
+// strictContentLength must be enforced for the single res.end(chunk) path
+// too (native tryFastEnd must not swallow the mismatch).
+{
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.strictContentLength = true;
+    res.setHeader('Content-Length', '4');
+
+    assert.throws(() => {
+      res.end('hello');
+    }, {
+      code: 'ERR_HTTP_CONTENT_LENGTH_MISMATCH',
+    });
+
+    res.destroy();
+    server.close(common.mustCall());
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const socket = net.connect(server.address().port, common.mustCall(() => {
+      socket.end('GET / HTTP/1.1\r\n' +
+                 'Host: localhost\r\n' +
+                 'Connection: close\r\n' +
+                 '\r\n');
+    }));
+
+    socket.resume();
+    socket.on('close', common.mustCall());
+  }));
+}
+
+// Do not truncate Content-Length bookkeeping through native out-params.
+// 4294967296 == 2^32, which would wrap to 0 if stored in a uint32 slot.
+// Only meaningful on the native path (out-params are native-only).
+if (!isLegacy) {
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.setHeader('Content-Length', '4294967296');
+    res.writeHead(200);
+
+    assert.strictEqual(res._contentLength, 4294967296);
+
+    res.destroy();
+    server.close(common.mustCall());
+  }));
+
+  server.listen(0, common.mustCall(() => {
+    const socket = net.connect(server.address().port, common.mustCall(() => {
+      socket.end('GET / HTTP/1.1\r\n' +
+                 'Host: localhost\r\n' +
+                 'Connection: close\r\n' +
+                 '\r\n');
+    }));
+
+    socket.resume();
+    socket.on('close', common.mustCall());
+  }));
+}
+
+// Re-run this file with the legacy path forced so both implementations are
+// covered by the same framing assertions.
+if (!isLegacy) {
+  const result = spawnSync(
+    process.execPath,
+    [...process.execArgv, __filename, '--legacy-path'],
+    { encoding: 'utf8' },
+  );
+  if (result.status !== 0) {
+    if (result.stdout) process.stdout.write(result.stdout);
+    if (result.stderr) process.stderr.write(result.stderr);
+    assert.fail(
+      `legacy-path re-exec failed with status ${result.status}`,
+    );
+  }
+}

--- a/typings/internalBinding/http_parser.d.ts
+++ b/typings/internalBinding/http_parser.d.ts
@@ -54,6 +54,44 @@ declare namespace InternalHttpParserBinding {
     unconsume(): void;
     getCurrentBuffer(): Buffer;
   }
+
+  /**
+   * Body encoding for `buildHttpMessage`:
+   * - 0 = none / Buffer body
+   * - 1 = latin1 string body
+   * - 2 = utf8 string body
+   */
+  type BuildHttpMessageBodyEncoding = 0 | 1 | 2;
+
+  /**
+   * Bit flags for `buildHttpMessage` (keep in sync with
+   * `BuildHttpMessageFlags` in `src/node_http_parser.cc` and the
+   * `kBuild*` constants in `lib/_http_outgoing.js`).
+   *
+   * | bit | name |
+   * |-----|------|
+   * | 0 | sendDate |
+   * | 1 | shouldKeepAlive |
+   * | 2 | maxRequestsReached |
+   * | 3 | defaultKeepAlive |
+   * | 4 | hasBody |
+   * | 5 | useChunkedByDefault |
+   * | 6 | removedConnection |
+   * | 7 | removedContLen |
+   * | 8 | removedTE |
+   * | 9 | hasAgent |
+   */
+  type BuildHttpMessageFlags = number;
+
+  /**
+   * Output slots written into the optional `Float64Array` out-param of
+   * `buildHttpMessage` (keep in sync with `BuildHttpMessageOut`):
+   * - [0] last (connection closes after this message)
+   * - [1] chunked (Transfer-Encoding: chunked selected)
+   * - [2] contentLength (resolved body length when known)
+   * - [3] hasContentLength (1 if contentLength is valid)
+   */
+  type BuildHttpMessageOut = Float64Array;
 }
 
 export interface HttpParserBinding {
@@ -61,4 +99,36 @@ export interface HttpParserBinding {
   HTTPParser: typeof InternalHttpParserBinding.HTTPParser;
   allMethods: string[];
   methods: string[];
+
+  /**
+   * Build a complete HTTP/1.1 message (header block, optionally plus body)
+   * into a single contiguous Buffer. Used by the OutgoingMessage fast path
+   * in `lib/_http_outgoing.js`.
+   *
+   * @param firstLine Status/request line, e.g. `"HTTP/1.1 200 OK\r\n"`.
+   * @param headers Flat `[name, value, name, value, ...]` list, or null.
+   * @param body String/Uint8Array body, empty string for a complete
+   *   headers+terminator message, or null/undefined for headers-only
+   *   (`_storeHeader`; does not append the chunked `0\r\n\r\n`).
+   * @param bodyEncoding 0=buffer/none, 1=latin1, 2=utf8.
+   * @param flags Bitmask of BuildHttpMessageFlags.
+   * @param date Pre-formatted UTC date string (or empty).
+   * @param keepAliveSec Keep-Alive timeout in seconds.
+   * @param maxRequests Max requests per socket (0 = omit from Keep-Alive).
+   * @param knownLength Content-Length if already known, else -1.
+   * @param out Optional Float64Array(4) receiving out-params.
+   * @returns The on-wire message Buffer, or `undefined` on failure.
+   */
+  buildHttpMessage(
+    firstLine: string,
+    headers: readonly string[] | null | undefined,
+    body: string | InternalHttpParserBinding.Buffer | null | undefined,
+    bodyEncoding: InternalHttpParserBinding.BuildHttpMessageBodyEncoding | number,
+    flags: InternalHttpParserBinding.BuildHttpMessageFlags,
+    date: string,
+    keepAliveSec: number,
+    maxRequests: number,
+    knownLength: number,
+    out?: InternalHttpParserBinding.BuildHttpMessageOut,
+  ): InternalHttpParserBinding.Buffer | undefined;
 }


### PR DESCRIPTION
## Summary

Add a C++ `buildHttpMessage` helper used by the HTTP/1.1 outgoing path so the common cases avoid repeated JavaScript string concatenation and multi-write overhead:

- **`_storeHeader`**: builds the status/request line + header block natively (with JS fallback for special cases such as content-disposition latin1 / unique cookie joining).
- **`ServerResponse.end()` fast paths**:
  - Headers not yet rendered: full message (headers + body) built in C++ and written once.
  - After `writeHead()`: `tryFastFlushEnd` flushes the prebuilt header + body without the full `write_()` / extra empty-write path (this is the `benchmark/http/simple.js` case).
- Server-side native headers stay as **Buffers** until write time (no latin1 string copy on the hot path). ClientRequest still materializes a string for `_header` compatibility.
- Complex encodings (hex, utf16le, ...), trailers, and fake/standalone sockets keep the existing JS path.

Public API and on-the-wire format are unchanged.

## Benchmarks

Machine-local `out/Release` on the same host. Baseline measured before this change.

### `benchmark/http/simple.js` (primary)

```text
type=bytes len=4 chunks=1 c=50 chunkedEnc=0 duration=5
```

| | RPS |
|---|---|
| **Baseline** | ~**80,236** |
| **This PR** (5 runs, latest tip) | **120,087 / 122,461 / 116,360 / 122,196 / 123,654** |
| **Delta** | **~+45% to +54%** (typical ~**+50%** around 120–123k) |

Other `simple.js` variants (same tip):

| Config | RPS (3 runs) |
|---|---|
| `chunkedEnc=1` (TE: chunked) | 121k / 120k / 116k |
| `len=1024` content-length | 103k / 106k / 96k |

### Other microbenches

| Workload | RPS |
|---|---|
| `end-vs-write-end` `method=end` asc/64 c=50 duration=5 | ~104–129k (run-to-run variance) |
| `end-vs-write-end` `method=write` asc/64 c=50 duration=5 | ~106k |
| Custom keep-alive `res.end('ok')` only (50 clients, 3s) | ~47–49k |

Review feedback (document flags, no incidental C++ reformat, no `Buffer.concat`) is included; the common ASCII path still shows the large win vs baseline.

### Tests

Full `test/parallel/test-http*` suite: **751/751 passed** (pre-push on an earlier tip); targeted suite re-run after the latest speed-ups.

## Test plan

- [x] `tools/test.py test/parallel/test-http* --mode=release` (751 passed)
- [x] Targeted cases: write-head, non-utf8 content-disposition, chunked 204/304, CONNECT, client default headers, outgoing-end-types, hex/utf16le first-chunk encodings, standalone ServerResponse
- [x] `benchmark/http/simple.js` before/after (and after review + further speed-ups)
- [ ] CI on this PR