### PR TITLE
permission: do not throw on denied access in audit mode

### DIFF
--- a/src/permission/permission.h
+++ b/src/permission/permission.h
@@ -37,9 +37,11 @@ namespace permission {
     const auto resource__ = (resource);                                        \
     if (!env__->permission()->is_granted(env__, perm__, resource__))           \
         [[unlikely]] {                                                         \
-      node::permission::Permission::ThrowAccessDenied(                         \
-          env__, perm__, resource__);                                          \
-      if (!env__->permission()->warning_only()) return __VA_ARGS__;            \
+      if (!env__->permission()->warning_only()) {                              \
+        node::permission::Permission::ThrowAccessDenied(                       \
+            env__, perm__, resource__);                                        \
+        return __VA_ARGS__;                                                    \
+      }                                                                        \
     }                                                                          \
   } while (0)
 
@@ -51,9 +53,11 @@ namespace permission {
     const auto resource__ = (resource);                                        \
     if (!env__->permission()->is_granted(env__, perm__, resource__))           \
         [[unlikely]] {                                                         \
-      node::permission::Permission::AsyncThrowAccessDenied(                    \
-          env__, (wrap), perm__, resource__);                                  \
-      if (!env__->permission()->warning_only()) return __VA_ARGS__;            \
+      if (!env__->permission()->warning_only()) {                              \
+        node::permission::Permission::AsyncThrowAccessDenied(                 \
+            env__, (wrap), perm__, resource__);                               \
+        return __VA_ARGS__;                                                    \
+      }                                                                        \
     }                                                                          \
   } while (0)
 

--- a/test/parallel/test-permission-audit-fs-does-not-deny.js
+++ b/test/parallel/test-permission-audit-fs-does-not-deny.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const common = require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { isMainThread } = require('node:worker_threads');
+const { test } = require('node:test');
+const fs = require('node:fs');
+
+if (!isMainThread) {
+  common.skip('This test only works on a main thread');
+}
+
+const restrictedFile = tmpdir.resolve('restricted.txt');
+
+const childScript = `
+  const dc = require('node:diagnostics_channel');
+  const msgs = [];
+  dc.subscribe('node:permission-model:fs', (m) => msgs.push({
+    permission: m.permission,
+    resource: m.resource,
+  }));
+  try {
+    require('node:fs').readFileSync(${JSON.stringify(restrictedFile)});
+    console.log('NO_THROW');
+  } catch (e) {
+    console.log('THREW ' + e.code);
+  }
+  console.log('AUDIT ' + JSON.stringify(msgs));
+`;
+
+test('permission-audit logs fs denial without throwing', () => {
+  tmpdir.refresh();
+  fs.writeFileSync(restrictedFile, 'x');
+
+  // Audit mode: should NOT throw, SHOULD publish the channel message.
+  {
+    const { stdout, stderr, status } = spawnSync(
+      process.execPath,
+      ['--permission-audit', '-e', childScript],
+      { encoding: 'utf8' },
+    );
+    assert.strictEqual(status, 0, stderr);
+    const lines = stdout.split('\n');
+    assert.ok(lines.includes('NO_THROW'), stdout);
+    const auditLine = lines.find((l) => l.startsWith('AUDIT'));
+    assert.ok(auditLine, stdout);
+    const msgs = JSON.parse(auditLine.replace('AUDIT ', ''));
+    assert.ok(
+      msgs.some((m) =>
+        m.permission === 'FileSystemRead' &&
+        String(m.resource).endsWith('restricted.txt')),
+      JSON.stringify(msgs));
+  }
+
+  // Enforce mode (--permission): SHOULD throw ERR_ACCESS_DENIED (the child
+  // script catches it, so the process exits 0 while logging THREW ...).
+  {
+    const { stdout, stderr, status } = spawnSync(
+      process.execPath,
+      ['--permission', '-e', childScript],
+      { encoding: 'utf8' },
+    );
+    assert.strictEqual(status, 0, stderr);
+    const lines = stdout.split('\n');
+    assert.ok(lines.some((l) => l.startsWith('THREW ERR_ACCESS_DENIED')), stdout);
+    assert.ok(!lines.includes('NO_THROW'), stdout);
+  }
+});


### PR DESCRIPTION
## Summary

`--permission-audit` is intended to be an observe-only mode: it publishes
denial events to the `node:permission-model:*` diagnostics channels *without*
blocking the operation. Only `--permission` (enforce mode) should throw
`ERR_ACCESS_DENIED`.

The two C++ macros that gate every denied call site
(`THROW_IF_INSUFFICIENT_PERMISSIONS` for sync paths,
`ASYNC_THROW_IF_INSUFFICIENT_PERMISSIONS` for async paths) in
`src/permission/permission.h` were structured as:

```cpp
Permission::ThrowAccessDenied(env__, perm__, resource__);   // runs ALWAYS
if (!warning_only()) return __VA_ARGS__;                     // only return is guarded
```

`ThrowAccessDenied` raises the V8 exception **unconditionally** — before the
`warning_only()` check. So in `--permission-audit` mode (where
`warning_only_=true`, set in `src/env.cc`) the exception is still thrown,
defeating the audit-only purpose of the flag. The diagnostics message is
published correctly (that happens inside `Permission::is_scope_granted`), but
then the API call wrongly throws instead of continuing.

This moves the throw/reject inside the `!warning_only()` branch for both macros.
In audit mode, the diagnostics-channel message is published and execution
continues; in enforce mode (`--permission`), behavior is unchanged.

## Repro

```bash
echo hello > /tmp/aa.txt
cat > t.js <<'EOF'
const dc = require("node:diagnostics_channel");
dc.subscribe("node:permission-model:fs", (msg) => { console.log("LISTENED", msg); });
eval('require("fs").readFileSync("/tmp/aa.txt")');
EOF

node --permission-audit t.js   # before: LISTENED then ERR_ACCESS_DENIED throw
                               # after:  LISTENED only, exit 0
node --permission t.js         # unchanged: LISTENED then ERR_ACCESS_DENIED throw
```

## Affected scopes

Every permission scope, both sync and async call sites — fs read/write, net,
child_process, worker, addon, ffi, inspector, wasi.

Refs: https://github.com/nodejs/node/commit/9ddd1a9c27c253f46d587a8c906ccd83417b4606