### PR TITLE
vfs: enforce readonly state on open handles

### DIFF
--- a/lib/internal/vfs/file_handle.js
+++ b/lib/internal/vfs/file_handle.js
@@ -19,6 +19,7 @@ const {
 } = require('internal/errors');
 const {
   createEBADF,
+  createEROFS,
 } = require('internal/vfs/errors');
 
 // Private symbols
@@ -365,6 +366,7 @@ class MemoryFileHandle extends VirtualFileHandle {
   #size;
   #entry;
   #getStats;
+  #isReadOnly;
 
   #checkClosed(syscall) {
     if (this.closed) {
@@ -379,13 +381,15 @@ class MemoryFileHandle extends VirtualFileHandle {
    * @param {Buffer} content The initial file content
    * @param {object} entry The entry object (for updating content)
    * @param {Function} getStats Function to get updated stats
+   * @param {Function} [isReadOnly] Returns the provider's read-only state
    */
-  constructor(path, flags, mode, content, entry, getStats) {
+  constructor(path, flags, mode, content, entry, getStats, isReadOnly) {
     super(path, flags, mode);
     this.#content = content;
     this.#size = content.length;
     this.#entry = entry;
     this.#getStats = getStats;
+    this.#isReadOnly = isReadOnly;
 
     // Handle different open modes
     if (flags === 'w' || flags === 'w+' ||
@@ -404,11 +408,16 @@ class MemoryFileHandle extends VirtualFileHandle {
   }
 
   /**
-   * Throws EBADF if the handle was not opened for writing.
+   * Throws EBADF if the handle was not opened for writing, or EROFS if the
+   * provider is read-only.
+   * @param {string} syscall The system call name
    */
-  #checkWritable() {
+  #checkWritable(syscall) {
     if (this.flags === 'r') {
-      throw createEBADF('write');
+      throw createEBADF(syscall);
+    }
+    if (this.#isReadOnly?.()) {
+      throw createEROFS(syscall, this.path);
     }
   }
 
@@ -513,7 +522,7 @@ class MemoryFileHandle extends VirtualFileHandle {
    */
   writeSync(buffer, offset, length, position) {
     this.#checkClosed('write');
-    this.#checkWritable();
+    this.#checkWritable('write');
 
     // In append mode, always write at the end
     const useCurrentPosition = isCurrentPosition(position);
@@ -612,7 +621,7 @@ class MemoryFileHandle extends VirtualFileHandle {
    */
   writeFileSync(data, options) {
     this.#checkClosed('write');
-    this.#checkWritable();
+    this.#checkWritable('write');
 
     const buffer = typeof data === 'string' ? Buffer.from(data, options?.encoding) : data;
 
@@ -681,7 +690,7 @@ class MemoryFileHandle extends VirtualFileHandle {
    */
   truncateSync(len = 0) {
     this.#checkClosed('ftruncate');
-    this.#checkWritable();
+    this.#checkWritable('ftruncate');
 
     if (len < this.#size) {
       // Zero out truncated region to avoid stale data

--- a/lib/internal/vfs/providers/memory.js
+++ b/lib/internal/vfs/providers/memory.js
@@ -543,7 +543,16 @@ class MemoryProvider extends VirtualProvider {
     }
 
     const getStats = (size) => this.#createStats(entry, size);
-    return new MemoryFileHandle(normalized, flags, mode ?? entry.mode, entry.content, entry, getStats);
+    const isReadOnly = () => this.readonly;
+    return new MemoryFileHandle(
+      normalized,
+      flags,
+      mode ?? entry.mode,
+      entry.content,
+      entry,
+      getStats,
+      isReadOnly,
+    );
   }
 
   async open(path, flags, mode) {

--- a/test/parallel/test-vfs-memory-provider.js
+++ b/test/parallel/test-vfs-memory-provider.js
@@ -583,6 +583,8 @@ const vfs = require('node:vfs');
   const myVfs = vfs.create();
   myVfs.writeFileSync('/file.txt', 'content');
   myVfs.mkdirSync('/dir', { recursive: true });
+  const fd = myVfs.openSync('/file.txt', 'r+');
+  const appendFd = myVfs.openSync('/file.txt', 'a');
 
   // Set to readonly
   myVfs.provider.setReadOnly();
@@ -629,12 +631,30 @@ const vfs = require('node:vfs');
   assert.throws(() => {
     myVfs.symlinkSync('/file.txt', '/link');
   }, { code: 'EROFS' });
+
+  // File descriptors opened before setReadOnly() must not bypass it.
+  assert.throws(() => {
+    myVfs.writeSync(fd, Buffer.from('new'), 0, 3, 0);
+  }, { code: 'EROFS' });
+
+  assert.throws(() => {
+    myVfs.ftruncateSync(fd, 0);
+  }, { code: 'EROFS' });
+
+  assert.throws(() => {
+    myVfs.writeSync(appendFd, Buffer.from('new'), 0, 3, null);
+  }, { code: 'EROFS' });
+
+  assert.strictEqual(myVfs.readFileSync('/file.txt', 'utf8'), 'content');
+  myVfs.closeSync(fd);
+  myVfs.closeSync(appendFd);
 }
 
 // Test async operations on readonly MemoryProvider
 (async () => {
   const myVfs = vfs.create();
   myVfs.writeFileSync('/readonly.txt', 'content');
+  const handle = await myVfs.provider.open('/readonly.txt', 'r+');
   myVfs.provider.setReadOnly();
 
   await assert.rejects(
@@ -661,4 +681,27 @@ const vfs = require('node:vfs');
     myVfs.promises.copyFile('/readonly.txt', '/copy.txt'),
     { code: 'EROFS' }
   );
+
+  await assert.rejects(
+    handle.write(Buffer.from('new'), 0, 3, 0),
+    { code: 'EROFS' }
+  );
+
+  await assert.rejects(
+    handle.writeFile('new'),
+    { code: 'EROFS' }
+  );
+
+  await assert.rejects(
+    handle.truncate(0),
+    { code: 'EROFS' }
+  );
+
+  await assert.rejects(
+    handle.writev([Buffer.from('n'), Buffer.from('ew')], 0),
+    { code: 'EROFS' }
+  );
+
+  assert.strictEqual(await handle.readFile('utf8'), 'content');
+  await handle.close();
 })().then(common.mustCall());


### PR DESCRIPTION
`MemoryProvider.setReadOnly()` prevented new writable handles from being opened,
but handles opened before the transition retained write access. This allowed
descriptor-based writes and truncation to bypass the provider's documented
read-only state.

Pass a live provider-state callback to `MemoryFileHandle` and check it at each
mutation primitive. This covers descriptor and direct-handle operations,
including delegated async, vector, and append-mode writes, while preserving
`EBADF` precedence for handles that were not opened for writing.

Regression tests cover:

- `writeSync()` and `ftruncateSync()` through pre-existing descriptors
- append-mode descriptors opened before `setReadOnly()`
- async handle `write()`, `writeFile()`, `truncate()`, and `writev()`
- unchanged file contents after rejected mutations

Validation:

- `python3 tools/test.py test/parallel/test-vfs-memory-provider.js test/parallel/test-vfs-memory-file-handle.js`
- JavaScript lint on the three changed files

Fixes: https://github.com/nodejs/node/issues/64401