### PR TITLE
test: fix flaky http2 maxOriginSetSize test

### DIFF
--- a/test/parallel/test-http2-origin-set-max-size.mjs
+++ b/test/parallel/test-http2-origin-set-max-size.mjs
@@ -22,10 +22,6 @@ const cert = fixtures.readKey('agent8-cert.pem', 'binary');
 const ca = fixtures.readKey('fake-startcom-root-cert.pem', 'binary');
 
 const server = createSecureServer({ key, cert });
-server.on('stream', (stream) => {
-  stream.respond();
-  stream.end('ok');
-});
 server.on('session', (session) => {
   let i = 0;
   const timer = setInterval(() => {
@@ -72,8 +68,6 @@ await new Promise((resolve) => {
   }));
   client.on('goaway', mustNotCall());
   client.on('close', resolve);
-
-  client.request().resume();
 });
 
 // Test non-default values
@@ -86,8 +80,6 @@ await Promise.all([-0, 9, 1.5].map((maxOriginSetSize) => new Promise((resolve) =
   }));
   client.on('goaway', mustNotCall());
   client.on('close', resolve);
-
-  client.request().resume();
 })));
 
 
@@ -103,8 +95,6 @@ await Promise.all([512, Infinity].map((maxOriginSetSize) => new Promise((resolve
   client.on('error', mustNotCall());
   client.on('goaway', mustNotCall());
   client.on('close', resolve);
-
-  client.request().resume();
 })));
 
 server.close();


### PR DESCRIPTION
A fix for a flake from today's list: https://github.com/nodejs/reliability/issues/1597.

Can't reproduce the flake locally directly, but I can with a small delay on the server stream response to simulate the very plausible IO delay on the response. Flake 100% reproduces with a setTimeout into the server stream handler at the top:

```js
server.on('stream', (stream) => {
  stream.on('error', () => {}); // We need errors handlers just for the repro
  setTimeout(() => { // Delay longer than the setInterval below
    try {
      stream.respond();
      stream.end('ok');
    } catch {}
  }, 100);
});
```

This fails every time, as in the flake example in https://github.com/nodejs/reliability/blob/main/reports/2026-07-10.md:

```
Error [ERR_HTTP2_TOO_MANY_ORIGINS]: The server sent more ORIGIN frames than the allowed number of -0
    at Http2Session.onOrigin (node:internal/http2/core:783:23)
Emitted 'error' event on ClientHttp2Stream instance at:
    at emitErrorNT (node:internal/streams/destroy:170:8)
    at emitErrorCloseNT (node:internal/streams/destroy:129:3)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  code: 'ERR_HTTP2_TOO_MANY_ORIGINS'
}
```

I'll do a stress test as well and see if I can confirm the fix directly.

Flake explanation:

* The server runs a 10ms interval on every session which sends 10 origins
* The test tries different <10 max origin limits, which will all fail
* The test also sends a request
* When the origins are rejected, the session is destroyed
* All open request streams will also be destroyed when the session is destroyed
* This creates a race:
  * If the request completes before the interval then the test passes (request finishes clean, session destroyed as expected)
  * If the request is still open when the interval fires and destroys the session, the request fails and emits an unhandled error => flake.

This PR fixes that by dropping the request (and server handler) completely from all tests here (the immediate flake, as well as the others). They aren't necessary - I think they exist because this was copied from test-http2-origin, which does actually use the request flow.

These tests though operate purely on just the session directly (server session handler triggers the interval, client session emits the error). The requests were ignored and the server handler did nothing. Dropping the requests completely simplifies the test and kills the race.

Would be good to get confirmation of that from @mcollina, since this was added as a security fix (https://github.com/nodejs-private/node-private/pull/855) which I can't see but I'm fairly confident.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
