### PR TITLE
permission: add unique warning codes

### DIFF
--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -682,20 +682,18 @@ function initializePermission() {
     ObjectFreeze(require('path'));
     const { has, drop } = require('internal/process/permission');
     const warnFlags = [
-      '--allow-addons',
-      '--allow-child-process',
-      '--allow-inspector',
-      '--allow-wasi',
-      '--allow-worker',
+      { flag: '--allow-addons', enabled: true, code: 'PERM0001' },
+      { flag: '--allow-child-process', enabled: true, code: 'PERM0002' },
+      { flag: '--allow-ffi', enabled: process.config.variables.node_use_ffi, code: 'PERM0003' },
+      { flag: '--allow-inspector', enabled: true, code: 'PERM0004' },
+      { flag: '--allow-wasi', enabled: true, code: 'PERM0005' },
+      { flag: '--allow-worker', enabled: true, code: 'PERM0006' },
     ];
-    if (process.config.variables.node_use_ffi) {
-      warnFlags.splice(2, 0, '--allow-ffi');
-    }
-    for (const flag of warnFlags) {
-      if (getOptionValue(flag)) {
+    for (const { flag, enabled, code } of warnFlags) {
+      if (enabled && getOptionValue(flag)) {
         process.emitWarning(
           `The flag ${flag} must be used with extreme caution. ` +
-        'It could invalidate the permission model.', 'SecurityWarning');
+        'It could invalidate the permission model.', 'SecurityWarning', code);
       }
     }
     const warnCommaFlags = [

--- a/test/parallel/test-permission-warning-flags.js
+++ b/test/parallel/test-permission-warning-flags.js
@@ -28,3 +28,17 @@ for (const flag of warnFlags) {
   assert.match(stderr.toString(), new RegExp(`\\[PERM\\d{4}\\] SecurityWarning: The flag ${RegExp.escape(flag)} must be used with extreme caution`));
   assert.strictEqual(status, 0);
 }
+
+const { status, stderr } = spawnSync(
+  process.execPath,
+  [
+    '--permission', '--allow-child-process', '--allow-wasi', '--disable-warning=PERM0002', '-e',
+    'setTimeout(() => {}, 1)',
+  ]
+);
+
+// Disabled warning does not appear
+assert.doesNotMatch(stderr.toString(), new RegExp(`The flag --allow-child-process must be used with extreme caution`));
+// But non-disabled warnings still appear
+assert.match(stderr.toString(), new RegExp(`The flag --allow-wasi must be used with extreme caution`));
+assert.strictEqual(status, 0);

--- a/test/parallel/test-permission-warning-flags.js
+++ b/test/parallel/test-permission-warning-flags.js
@@ -25,6 +25,6 @@ for (const flag of warnFlags) {
     ]
   );
 
-  assert.match(stderr.toString(), new RegExp(`SecurityWarning: The flag ${RegExp.escape(flag)} must be used with extreme caution`));
+  assert.match(stderr.toString(), new RegExp(`\\[PERM\\d{4}\\] SecurityWarning: The flag ${RegExp.escape(flag)} must be used with extreme caution`));
   assert.strictEqual(status, 0);
 }


### PR DESCRIPTION
Adds unique warning codes of the form `PERM0000` for all permissions-related `SecurityWarning`s, so that they can be individually (and minimally) silenced if required, e.g. `--disable-warning=PERM0002`. See https://github.com/nodejs/node/issues/59818#issuecomment-3269493586 for an example use-case.

There isn't much of an existing pattern for warning codes, except `DEP0000` for deprecations, so this follows that convention. There are currently 2 other places which generate `SecurityWarning`s which should perhaps be given unique codes as well (something for a separate PR I think)

Fixes: https://github.com/nodejs/node/issues/59818

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
