### PR TITLE
stream: use RangeError for broadcast overflow

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -591,7 +591,7 @@ class BroadcastWriter {
 
     if (policy === 'strict') {
       if (this.#pendingWrites.length >= 1) {
-        throw new ERR_INVALID_STATE.TypeError(
+        throw new ERR_INVALID_STATE.RangeError(
           'Backpressure violation: too many pending writes. ' +
           'Await each write() call to respect backpressure.');
       }

--- a/test/parallel/test-stream-iter-broadcast-backpressure.js
+++ b/test/parallel/test-stream-iter-broadcast-backpressure.js
@@ -113,6 +113,28 @@ async function testBlockBackpressureContent() {
   assert.strictEqual(done.done, true);
 }
 
+async function testStrictBackpressureOverflow() {
+  const { writer } = broadcast({
+    budget: 16384,
+    backpressure: 'strict',
+  });
+
+  await writer.write(new Uint8Array(16384));
+  const pending = writer.write('b');
+
+  await assert.rejects(writer.write('c'), {
+    name: 'RangeError',
+    code: 'ERR_INVALID_STATE',
+  });
+
+  writer.fail();
+  await assert.rejects(pending, {
+    name: 'TypeError',
+    code: 'ERR_INVALID_STATE',
+    message: 'Invalid state: Failed',
+  });
+}
+
 // Writev async path
 async function testWritevAsync() {
   const { writer, broadcast: bc } = broadcast({ budget: 16384 });
@@ -141,6 +163,7 @@ Promise.all([
   testDropNewest(),
   testBlockBackpressure(),
   testBlockBackpressureContent(),
+  testStrictBackpressureOverflow(),
   testWritevAsync(),
   testEndSyncReturnValue(),
 ]).then(common.mustCall());


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64419

Broadcast writers using the `strict` backpressure policy currently reject
with `ERR_INVALID_STATE` as a `TypeError` when the pending writes queue
overflows.

This change uses `ERR_INVALID_STATE.RangeError`, matching the existing
push writer behavior, and adds regression coverage for the error type and code.