### PR TITLE
doc: fix typo in embedding.md

### DIFF
--- a/doc/api/embedding.md
+++ b/doc/api/embedding.md
@@ -115,7 +115,7 @@ int RunNodeInstance(MultiIsolatePlatform* platform,
                     const std::vector<std::string>& exec_args) {
   int exit_code = 0;
 
-  // Setup up a libuv event loop, v8::Isolate, and Node.js Environment.
+  // Set up a libuv event loop, v8::Isolate, and Node.js Environment.
   std::vector<std::string> errors;
   std::unique_ptr<CommonEnvironmentSetup> setup =
       CommonEnvironmentSetup::Create(platform, &errors, args, exec_args);


### PR DESCRIPTION
Fixes a typo: `Setup up` → `Set up` in `doc/api/embedding.md` (the C++ embedder API example).

```diff
-  // Setup up a libuv event loop, v8::Isolate, and Node.js Environment.
+  // Set up a libuv event loop, v8::Isolate, and Node.js Environment.
```

`Set up` is the correct verb form (`setup` is the noun/adjective form), and it also matches the existing wording a few lines above: "In order to set up a `v8::Isolate`".