### PR TITLE
deps: V8: cherry-pick 1158ae719749

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -42,7 +42,7 @@
 
     # Reset this number to 0 on major V8 upgrades.
     # Increment by one for each non-official patch applied to deps/v8.
-    'v8_embedder_string': '-node.25',
+    'v8_embedder_string': '-node.26',
 
     ##### V8 defaults for Node.js #####
 

--- a/deps/v8/src/wasm/jump-table-assembler.cc
+++ b/deps/v8/src/wasm/jump-table-assembler.cc
@@ -114,6 +114,10 @@ void JumpTableAssembler::EmitLazyCompileJumpSlot(uint32_t func_index,
 }
 
 bool JumpTableAssembler::EmitJumpSlot(Address target) {
+  intptr_t displacement = target - (pc_ + kJumpTableSlotEntryMarkerSize +
+                                    MacroAssembler::kIntraSegmentJmpInstrSize);
+  if (!is_int32(displacement)) return false;
+
 #ifdef V8_ENABLE_CET_IBT
   uint32_t endbr_insn = 0xfa1e0ff3;
   uint32_t nop = 0x00401f0f;
@@ -122,11 +126,7 @@ bool JumpTableAssembler::EmitJumpSlot(Address target) {
   emit<uint32_t>(nop, kRelaxedStore);
 #endif
 
-  intptr_t displacement =
-      target - (pc_ + MacroAssembler::kIntraSegmentJmpInstrSize);
-  if (!is_int32(displacement)) return false;
-
-  uint8_t inst[kJumpTableSlotSize] = {
+  uint8_t inst[8] = {
       0xe9, 0,    0,    0, 0,  // near_jmp displacement
       0xcc, 0xcc, 0xcc,        // int3 * 3
   };

--- a/deps/v8/src/wasm/jump-table-assembler.h
+++ b/deps/v8/src/wasm/jump-table-assembler.h
@@ -184,8 +184,10 @@ class V8_EXPORT_PRIVATE JumpTableAssembler {
 #if V8_TARGET_ARCH_X64
 #ifdef V8_ENABLE_CET_IBT
   static constexpr int kJumpTableSlotSize = 16;
+  static constexpr int kJumpTableSlotEntryMarkerSize = 8;
 #else  // V8_ENABLE_CET_IBT
   static constexpr int kJumpTableSlotSize = 8;
+  static constexpr int kJumpTableSlotEntryMarkerSize = 0;
 #endif
   static constexpr int kJumpTableLineSize = kJumpTableSlotSize;
   static constexpr int kFarJumpTableSlotSize = 16;


### PR DESCRIPTION
Lands cleanly, and is zero-impact for standard (non-CET) builds.

@VlkrS: are you in a position to test a V8_ENABLE_CET_IBT build?

Fixes: #64424