### PR TITLE
doc: fix execFile/execFileSync shell option docs

### DIFF
--- a/doc/api/child_process.md
+++ b/doc/api/child_process.md
@@ -373,7 +373,7 @@ changes:
     normally be created on Windows systems. **Default:** `false`.
   * `windowsVerbatimArguments` {boolean} No quoting or escaping of arguments is
     done on Windows. Ignored on Unix. **Default:** `false`.
-  * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
+  * `shell` {boolean|string} If `true`, runs `file` inside of a shell. Uses
     `'/bin/sh'` on Unix, and `process.env.ComSpec` on Windows. A different
     shell can be specified as a string. See [Shell requirements][] and
     [Default Windows shell][]. **Default:** `false` (no shell).
@@ -390,7 +390,7 @@ except that it does not spawn a shell by default. Rather, the specified
 executable `file` is spawned directly as a new process making it slightly more
 efficient than [`child_process.exec()`][].
 
-The same options as [`child_process.exec()`][] are supported. Since a shell is
+The same options as [`child_process.exec()`][] are supported. If a shell is
 not spawned, behaviors such as I/O redirection and file globbing are not
 supported.
 
@@ -1175,7 +1175,7 @@ changes:
     **Default:** `'buffer'`.
   * `windowsHide` {boolean} Hide the subprocess console window that would
     normally be created on Windows systems. **Default:** `false`.
-  * `shell` {boolean|string} If `true`, runs `command` inside of a shell. Uses
+  * `shell` {boolean|string} If `true`, runs `file` inside of a shell. Uses
     `'/bin/sh'` on Unix, and `process.env.ComSpec` on Windows. A different
     shell can be specified as a string. See [Shell requirements][] and
     [Default Windows shell][]. **Default:** `false` (no shell).


### PR DESCRIPTION
This fixes a few small inaccuracies in the `child_process` docs, all pointed out in #32524.

The `shell` option for `execFile()` and `execFileSync()` says it runs `command` inside a shell, but those functions take a `file` argument, not `command`. The wording was copied from `exec()`/`spawn()`, where `command` is correct.

The note under `execFile()` also reads "Since a shell is not spawned, behaviors such as I/O redirection and file globbing are not supported", which contradicts the line right before it saying the same options as `exec()` (including `shell`) are supported. Changing "Since" to "If" makes it only apply when there's no shell.

I left the exec-vs-execFile "difference" wording (also mentioned in the issue) alone, since it isn't wrong as written and looked more like a judgment call for a maintainer.
