### PR TITLE
assert,util: fix TypeError on Maps with null keys

### DIFF
--- a/lib/internal/util/comparisons.js
+++ b/lib/internal/util/comparisons.js
@@ -837,10 +837,13 @@ function mapObjectEquiv(array, a, b, mode, memo) {
   let start = 0;
   let end = array.length - 1;
   const comparator = mode !== kLoose ? objectComparisonStart : innerDeepEqual;
-  const extraChecks = mode === kLoose || array.length !== a.size;
 
   for (const { 0: key1, 1: item1 } of a) {
-    if (extraChecks && (typeof key1 !== 'object' || key1 === null)) {
+    // Primitive and `null` keys can never match an object key collected in
+    // `array`, so resolve them directly against `b`. `null` is `typeof
+    // 'object'`, so without this it would reach the object comparator, which
+    // reads `key1.constructor` and throws a `TypeError`.
+    if (typeof key1 !== 'object' || key1 === null) {
       if (b.has(key1)) {
         if (mode !== kLoose || innerDeepEqual(item1, b.get(key1), mode, memo)) {
           continue;

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -421,6 +421,17 @@ test('es6 Maps and Sets', () => {
     new Map([[undefined, null], ['+000', 2n]]),
     new Map([[null, undefined], [false, '2']]),
   );
+  // A null key whose value is an object, alongside another object key and a
+  // matching map size, must not crash the unordered object-key matching (null
+  // is `typeof 'object'`). Refs: https://github.com/nodejs/node/issues/64433
+  assertNotDeepOrStrict(
+    new Map([[null, { v: 1 }], [{ a: 1 }, 1]]),
+    new Map([[{ b: 2 }, { v: 1 }], [{ a: 1 }, 1]])
+  );
+  assertDeepAndStrictEqual(
+    new Map([[null, { v: 1 }], [{ a: 1 }, 1]]),
+    new Map([[null, { v: 1 }], [{ a: 1 }, 1]])
+  );
   const xarray = ['x'];
   assertDeepAndStrictEqual(
     new Set([xarray, ['y']]),


### PR DESCRIPTION
Fixes #64433.

`assert.deepStrictEqual`, `assert.notDeepStrictEqual`, and `util.isDeepStrictEqual` throw a `TypeError` on Maps with a `null` key in a specific shape: one map has a `null` key with an object value, the other has an object key with a deeply-equal value but no `null` key, and both maps are the same size.

It comes from `mapObjectEquiv` in `lib/internal/util/comparisons.js`, which only resolved primitive and `null` keys directly against the other map when `array.length !== a.size`. When the sizes match, the `null` key skipped that and reached the object comparator, which reads `key.constructor` with no null guard (and `typeof null` is `'object'`). It only affects strict mode; loose already handled it and partial uses a different path.

The fix handles primitive and `null` keys unconditionally. I added a regression to `test-assert-deep.js` covering both the crashing case and the equal case.
