### PR TITLE
doc: note --env-file is not applied to --run

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2706,6 +2706,9 @@ The following environment variables are set when running a script with `--run`:
 * `NODE_RUN_PACKAGE_JSON_PATH`: The path to the `package.json` that is being
   processed.
 
+Environment variables loaded from a file with [`--env-file`][] are not applied
+to the command executed by `--run`.
+
 ### `--secure-heap-min=n`
 
 <!-- YAML


### PR DESCRIPTION
Fixes #62988.

Documents under `--run` that variables loaded with `--env-file` are not applied to the command it executes. Per the discussion on the issue this behavior is intended, so this just documents it.
