### PR TITLE
stream: abort pending single-source merge reads

### DIFF
--- a/lib/internal/streams/iter/consumers.js
+++ b/lib/internal/streams/iter/consumers.js
@@ -426,8 +426,10 @@ function merge(...args) {
       if (normalized.length === 0) return;
 
       if (normalized.length === 1) {
-        for await (const batch of normalized[0]) {
-          signal?.throwIfAborted();
+        const source = signal !== undefined && isAsyncIterable(sources[0]) ?
+          from(yieldAbortable(sources[0], signal)) :
+          yieldAbortable(normalized[0], signal);
+        for await (const batch of source) {
           yield batch;
         }
         return;

--- a/lib/internal/streams/iter/utils.js
+++ b/lib/internal/streams/iter/utils.js
@@ -133,6 +133,9 @@ function yieldAbortable(source, signal) {
         if (!completed && typeof iterator.return === 'function') {
           const result = iterator.return();
           if (aborted) {
+            // PromiseResolve(result) can reject if result is a thenable that
+            // rejects, so mark it as handled even though the abort takes
+            // precedence over the result of iterator.return().
             markPromiseAsHandled(PromiseResolve(result));
           } else {
             await result;

--- a/lib/internal/streams/iter/utils.js
+++ b/lib/internal/streams/iter/utils.js
@@ -133,7 +133,7 @@ function yieldAbortable(source, signal) {
         if (!completed && typeof iterator.return === 'function') {
           const result = iterator.return();
           if (aborted) {
-            markPromiseAsHandled(result);
+            markPromiseAsHandled(PromiseResolve(result));
           } else {
             await result;
           }

--- a/test/parallel/test-stream-iter-consumers-merge.js
+++ b/test/parallel/test-stream-iter-consumers-merge.js
@@ -179,6 +179,7 @@ async function testMergeSignalDuringPendingSingleSourceRead() {
       return this;
     },
     next() {
+      // Intentionally never settle to verify that aborting interrupts a pending read.
       return new Promise(() => {});
     },
     return() {

--- a/test/parallel/test-stream-iter-consumers-merge.js
+++ b/test/parallel/test-stream-iter-consumers-merge.js
@@ -170,6 +170,36 @@ async function testMergeSignalDuringPendingMultiSourceRead() {
   await assert.rejects(next, { name: 'AbortError' });
 }
 
+async function testMergeSignalDuringPendingSingleSourceRead() {
+  const ac = new AbortController();
+  let returned = false;
+  const source = {
+    __proto__: null,
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+    next() {
+      return new Promise(() => {});
+    },
+    return() {
+      returned = true;
+      return { __proto__: null, done: true };
+    },
+  };
+
+  const iter = merge(source, {
+    __proto__: null,
+    signal: ac.signal,
+  })[Symbol.asyncIterator]();
+
+  const next = iter.next();
+  await new Promise(setImmediate);
+  ac.abort();
+
+  await assert.rejects(next, { name: 'AbortError' });
+  assert.strictEqual(returned, true);
+}
+
 async function testMergeDoesNotDrainSourcesWhileIdle() {
   function source(n) {
     return {
@@ -332,6 +362,7 @@ Promise.all([
   testMergeConsumerBreak(),
   testMergeSignalMidIteration(),
   testMergeSignalDuringPendingMultiSourceRead(),
+  testMergeSignalDuringPendingSingleSourceRead(),
   testMergeDoesNotDrainSourcesWhileIdle(),
   testMergeStringSources(),
   testMergeObjectLikeSources(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64444

The single-source `merge()` path uses a plain `for await` loop, so aborting
during a pending read neither rejects `next()` nor closes the source iterator.

Make the single-source path abort-aware before normalization so cancellation
reaches the active source iterator. Also allow the shared abort cleanup helper
to handle iterators whose `return()` method returns a synchronous iterator
result.