### PR TITLE
fs: support removing read-only files in rmSync on Windows

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -1745,6 +1745,41 @@ static void RMDir(const FunctionCallbackInfo<Value>& args) {
   }
 }
 
+#ifdef _WIN32
+static void ClearReadOnlyAttributeWHelper(const wchar_t* path) {
+  DWORD attrs = GetFileAttributesW(path);
+  if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_READONLY)) {
+    SetFileAttributesW(path, attrs & ~FILE_ATTRIBUTE_READONLY);
+  }
+}
+
+static void ClearReadOnlyAttributeW(const std::filesystem::path& path,
+                                    bool recursive) {
+  std::error_code ec;
+  auto file_status = std::filesystem::symlink_status(path, ec);
+  if (ec) return;
+
+  if (recursive &&
+      file_status.type() == std::filesystem::file_type::directory) {
+    for (const auto& entry : std::filesystem::recursive_directory_iterator(
+             path,
+             std::filesystem::directory_options::skip_permission_denied,
+             ec)) {
+      std::error_code entry_ec;
+      auto entry_status = entry.symlink_status(entry_ec);
+      if (entry_ec) continue;
+      if (entry_status.type() != std::filesystem::file_type::symlink) {
+        ClearReadOnlyAttributeWHelper(entry.path().c_str());
+      }
+    }
+  }
+
+  if (file_status.type() != std::filesystem::file_type::symlink) {
+    ClearReadOnlyAttributeWHelper(path.c_str());
+  }
+}
+#endif
+
 static void RmSync(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   Isolate* isolate = env->isolate();
@@ -1789,6 +1824,9 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
   };
 
   int i = 1;
+#ifdef _WIN32
+  bool cleared_readonly = false;
+#endif
 
   while (maxRetries >= 0) {
     if (recursive) {
@@ -1796,6 +1834,22 @@ static void RmSync(const FunctionCallbackInfo<Value>& args) {
     } else {
       std::filesystem::remove(file_path, error);
     }
+
+#ifdef _WIN32
+    // On Windows, libc++ does not clear the read-only attribute before
+    // removing a file (unlike MSVC STL which does). Attempt to clear it
+    // manually when we get EPERM (operation_not_permitted) so that read-only
+    // files can be deleted, matching the behavior of official Node.js builds.
+    if (error == std::errc::operation_not_permitted && !cleared_readonly) {
+      cleared_readonly = true;
+      ClearReadOnlyAttributeW(file_path, recursive);
+      if (recursive) {
+        std::filesystem::remove_all(file_path, error);
+      } else {
+        std::filesystem::remove(file_path, error);
+      }
+    }
+#endif  // _WIN32
 
     if (!error || error == std::errc::no_such_file_or_directory) {
       return;

--- a/test/parallel/test-fs-rm.js
+++ b/test/parallel/test-fs-rm.js
@@ -631,3 +631,30 @@ if (isGitPresent) {
     }
   }
 }
+
+{
+  // Test that rmSync can delete read-only files (and directories containing read-only files recursively)
+  const dirname = nextDirPath();
+  const filePath = path.join(dirname, 'readonly-file.txt');
+  const recursiveDir = path.join(dirname, 'subdir');
+  const recursiveFilePath = path.join(recursiveDir, 'readonly-nested.txt');
+
+  fs.mkdirSync(recursiveDir, { recursive: true });
+  fs.writeFileSync(filePath, 'hello');
+  fs.writeFileSync(recursiveFilePath, 'world');
+
+  // Make files read-only
+  fs.chmodSync(filePath, 0o444);
+  fs.chmodSync(recursiveFilePath, 0o444);
+
+  // rmSync without recursive option on a file
+  fs.rmSync(filePath);
+  assert.strictEqual(fs.existsSync(filePath), false);
+
+  // rmSync with recursive option on a directory containing a read-only file
+  fs.rmSync(recursiveDir, { recursive: true });
+  assert.strictEqual(fs.existsSync(recursiveDir), false);
+
+  // Clean up parent directory
+  fs.rmSync(dirname, { recursive: true, force: true });
+}


### PR DESCRIPTION
### Summary

Ensure `fs.rmSync` can delete read-only files and directories containing them on Windows when Node is built with clang `libc++` (e.g. inside Electron).

### Description

Since the migration to `std::filesystem::remove` and `std::filesystem::remove_all` on Windows, Node's `fs.rmSync` behaves differently depending on whether it was built with MSVC STL or clang `libc++`.

MSVC STL's implementation of `std::filesystem::remove` automatically clears the read-only attribute of a file before attempting to delete it. However, `libc++`'s implementation on Windows does not clear the read-only attribute, which causes the deletion to fail with `operation_not_permitted` (EPERM). This issue directly impacts downstream platforms like Electron that compile Node.js with `libc++` on Windows (see `electron/electron#52253`).

This commit introduces a Windows-specific helper `ClearReadOnlyAttributeW` in `src/node_file.cc` that is called if `operation_not_permitted` is encountered. It manually clears the `FILE_ATTRIBUTE_READONLY` attribute from the file (or recursively from files inside a directory) and retries the removal operation, bringing `libc++` builds to parity with MSVC STL builds.

### Verification

Added a new test in `test/parallel/test-fs-rm.js` that makes files read-only using `fs.chmodSync(file, 0o444)` (which sets the file attribute on Windows) and validates that `fs.rmSync` can delete them both directly and recursively as part of a directory.

Fixes: https://github.com/nodejs/node/issues/64374