### PR TITLE
doc: fix spelling in devcontainer guide

### DIFF
--- a/doc/contributing/using-devcontainer.md
+++ b/doc/contributing/using-devcontainer.md
@@ -2,7 +2,7 @@
 
 Node.js publishes a [nightly image on DockerHub](https://hub.docker.com/r/nodejs/devcontainer) for
 [Dev Containers](https://containers.dev/) that can be used to spin up a
-development container that comes with pre-installed build dependencies and pre-genreated build cache.
+development container that comes with pre-installed build dependencies and pre-generated build cache.
 
 When you need to test a few changes in the main branch and do not need
 to change the V8 headers (which is rare), using the nightly image will allow you to compile your


### PR DESCRIPTION
Fixes a typo in `doc/contributing/using-devcontainer.md`.

```diff
- pre-genreated build cache.
+ pre-generated build cache.
```

This is a documentation-only change.