### PR TITLE
stream: skip null output from stateful transforms

### DIFF
--- a/lib/internal/streams/iter/pull.js
+++ b/lib/internal/streams/iter/pull.js
@@ -503,6 +503,7 @@ function* withFlushSync(source) {
 function* applyStatefulSyncTransform(source, transform) {
   const output = transform(withFlushSync(source));
   for (const item of output) {
+    if (item === null) continue;
     const batch = [];
     for (const chunk of flattenTransformYieldSync(item)) {
       ArrayPrototypePush(batch, chunk);
@@ -642,6 +643,7 @@ async function* withFlushAsync(source) {
 async function* applyStatefulAsyncTransform(source, transform, options) {
   const output = transform(withFlushAsync(source), options);
   for await (const item of output) {
+    if (item === null) continue;
     // Fast path: item is already a Uint8Array[] batch (e.g. compression transforms)
     if (isUint8ArrayBatch(item)) {
       if (item.length > 0) {

--- a/test/parallel/test-stream-iter-transform-output.js
+++ b/test/parallel/test-stream-iter-transform-output.js
@@ -142,6 +142,28 @@ async function testStatefulSyncTransformYieldsString() {
   assert.deepStrictEqual(data, new TextEncoder().encode('world'));
 }
 
+// Stateful async transform yields null (no output)
+async function testStatefulTransformYieldsNull() {
+  const tx = {
+    async *transform() {
+      yield null;
+    },
+  };
+  const data = await bytes(pull(from('x'), tx));
+  assert.deepStrictEqual(data, new Uint8Array());
+}
+
+// Stateful sync transform yields null (no output)
+async function testStatefulSyncTransformYieldsNull() {
+  const tx = {
+    *transform() {
+      yield null;
+    },
+  };
+  const data = bytesSync(pullSync(fromSync('x'), tx));
+  assert.deepStrictEqual(data, new Uint8Array());
+}
+
 // Flush returns single Uint8Array (not batch)
 async function testFlushReturnsSingleUint8Array() {
   const tx = (chunks) => {
@@ -217,6 +239,8 @@ Promise.all([
   testStatefulTransformYieldsString(),
   testStatefulTransformYieldsArrayBuffer(),
   testStatefulSyncTransformYieldsString(),
+  testStatefulTransformYieldsNull(),
+  testStatefulSyncTransformYieldsNull(),
   testFlushReturnsSingleUint8Array(),
   testFlushReturnsString(),
   testSyncFlushReturnsSingleUint8Array(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64461

Stateful transforms currently pass `null` output to the flattening
helpers, causing `ERR_INVALID_ARG_TYPE`. Transform output
normalization defines `null` as no output.

Skip `null` before flattening stateful transform output in both the
sync and async paths.