### PR TITLE
doc: fix typos in documentation

### DIFF
--- a/doc/api/deprecations.md
+++ b/doc/api/deprecations.md
@@ -4564,7 +4564,7 @@ The `module.register()` API provides off-thread async hooks for customizing ES m
 the `module.registerHooks()` API provides similar hooks that are synchronous, in-thread, and
 work for all types of modules.
 Supporting async hooks has proven to be complex, involving worker threads orchestration, and there are issues
-that have proven unresolveable. See [caveats of asynchronous customization hooks][]. Please migrate to
+that have proven unresolvable. See [caveats of asynchronous customization hooks][]. Please migrate to
 `module.registerHooks()` as soon as possible as `module.register()` will be
 removed in a future version of Node.js.
 

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -3441,7 +3441,7 @@ import 'package-name'; // supported
 added: v22.6.0
 -->
 
-Type stripping is not supported for files descendent of a `node_modules` directory.
+Type stripping is not supported for files descendant of a `node_modules` directory.
 
 <a id="ERR_UNSUPPORTED_RESOLVE_REQUEST"></a>
 

--- a/doc/api/n-api.md
+++ b/doc/api/n-api.md
@@ -4329,7 +4329,7 @@ napi_status napi_strict_equals(napi_env env,
 Returns `napi_ok` if the API succeeded.
 
 This API represents the invocation of the Strict Equality algorithm as
-defined in [Section IsStrctEqual][] of the ECMAScript Language Specification.
+defined in [Section IsStrictlyEqual][] of the ECMAScript Language Specification.
 
 ### `napi_detach_arraybuffer`
 
@@ -4636,7 +4636,7 @@ They can be one or more of the following bit flags:
   opposed to an instance property, which is the default. This is used only by
   [`napi_define_class`][]. It is ignored by `napi_define_properties`.
 * `napi_default_method`: Like a method in a JS class, the property is
-  configurable and writeable, but not enumerable.
+  configurable and writable, but not enumerable.
 * `napi_default_jsproperty`: Like a property set via assignment in JavaScript,
   the property is writable, enumerable, and configurable.
 
@@ -6986,7 +6986,7 @@ the add-on's file name during loading.
 [Section DefineOwnProperty]: https://tc39.es/ecma262/#sec-ordinary-object-internal-methods-and-internal-slots-defineownproperty-p-desc
 [Section Function objects]: https://tc39.es/ecma262/#sec-function-objects
 [Section IsArray]: https://tc39.es/ecma262/#sec-isarray
-[Section IsStrctEqual]: https://tc39.es/ecma262/#sec-strict-equality-comparison
+[Section IsStrictlyEqual]: https://tc39.es/ecma262/#sec-strict-equality-comparison
 [Section Promise objects]: https://tc39.es/ecma262/#sec-promise-objects
 [Section SharedArrayBuffer objects]: https://tc39.es/ecma262/#sec-sharedarraybuffer-objects
 [Section ToBoolean]: https://tc39.es/ecma262/#sec-toboolean

--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3552,7 +3552,7 @@ changes:
 * `stream` {Stream|ReadableStream|WritableStream} A stream to attach a signal
   to.
 
-Attaches an AbortSignal to a readable or writeable stream. This lets code
+Attaches an AbortSignal to a readable or writable stream. This lets code
 control stream destruction using an `AbortController`.
 
 Calling `abort` on the `AbortController` corresponding to the passed
@@ -3844,7 +3844,7 @@ const myWritable = new Writable({
 
 Calling `abort` on the `AbortController` corresponding to the passed
 `AbortSignal` will behave the same way as calling `.destroy(new AbortError())`
-on the writeable stream.
+on the writable stream.
 
 ```js
 const { Writable } = require('node:stream');

--- a/doc/contributing/advocacy-ambassador-program.md
+++ b/doc/contributing/advocacy-ambassador-program.md
@@ -196,7 +196,7 @@ Some of the things to highlight include:
   time we all have other responsibilities that affect how much time we have
   available to do so.
 * People are volunteering their time to review your PRs and answer questions in
-  the issues you open. Be mindfull of your asks for their time and acknowledge
+  the issues you open. Be mindful of your asks for their time and acknowledge
   the gift of their time. Too many issues/PRs in a short period of time may
   overwhelm maintainers leading to less progress versus more, try to pace your
   issues and PRs so that you don't have too many open at the same time. The

--- a/doc/contributing/issues.md
+++ b/doc/contributing/issues.md
@@ -60,7 +60,7 @@ activities, such as applying labels and closing/reopening/assigning issues.
 For more information on the roles and permissions, see ["Permission levels for
 repositories owned by an organization"](https://docs.github.com/en/github/setting-up-and-managing-organizations-and-teams/repository-permission-levels-for-an-organization#permission-levels-for-repositories-owned-by-an-organization).
 
-When triagging issues and PRs:
+When triaging issues and PRs:
 
 * Show patience and empathy, especially to first-time contributors.
 * Show no patience towards spam or troll, close the issue without interacting with it and

--- a/doc/contributing/maintaining/maintaining-dependencies.md
+++ b/doc/contributing/maintaining/maintaining-dependencies.md
@@ -167,7 +167,7 @@ dependencies.
 
 The container provides a durable copy of the versions of the tools
 used for a specific build which are under the control of the Node.js
-project. In addition, the tools and verions are documented through metadata
+project. In addition, the tools and versions are documented through metadata
 within the container in the `/home/node/metadata directory`.
 
 The available tools can be found by looking at the current version of the

--- a/src/crypto/README.md
+++ b/src/crypto/README.md
@@ -4,7 +4,7 @@ Welcome. You've found your way to the Node.js native crypto subsystem.
 
 Do not be afraid.
 
-While crypto may be a dark, mysterious, and forboding subject; and while
+While crypto may be a dark, mysterious, and foreboding subject; and while
 this directory may be filled with many `*.h` and `*.cc` files, finding
 your way around is not too difficult. And I can promise you that a Gru
 will not jump out of the shadows and eat you (well, "promise" may be a


### PR DESCRIPTION
This fixes a handful of small typos I noticed while reading through the docs.

`doc/api/deprecations.md` and `doc/api/errors.md`:

```diff
- that have proven unresolveable.
+ that have proven unresolvable.

- Type stripping is not supported for files descendent of a `node_modules` directory.
+ Type stripping is not supported for files descendant of a `node_modules` directory.
```

`doc/api/n-api.md` had a misspelling in the reference to the ECMAScript
[`IsStrictlyEqual`](https://tc39.es/ecma262/#sec-strict-equality-comparison)
operation. Renamed the reference label as well.

```diff
- defined in [Section IsStrctEqual][] of the ECMAScript Language Specification.
+ defined in [Section IsStrictlyEqual][] of the ECMAScript Language Specification.
```

Also changed `writeable` to `writable` in the N-API and stream docs. This is
consistent with `napi_writable`, `Writable`, and `WritableStream`.

```diff
- configurable and writeable, but not enumerable.
+ configurable and writable, but not enumerable.

- Attaches an AbortSignal to a readable or writeable stream.
+ Attaches an AbortSignal to a readable or writable stream.

- on the writeable stream.
+ on the writable stream.
```

The remaining changes are straightforward spelling fixes:

```diff
- Be mindfull of your asks for their time
+ Be mindful of your asks for their time

- When triagging issues and PRs:
+ When triaging issues and PRs:

- the tools and verions are documented through metadata
+ the tools and versions are documented through metadata

- a dark, mysterious, and forboding subject
+ a dark, mysterious, and foreboding subject
```
