### PR TITLE
stream: remove custom `CloneableDOMException` implementation

### DIFF
--- a/lib/internal/webstreams/transfer.js
+++ b/lib/internal/webstreams/transfer.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const {
-  ObjectDefineProperties,
   PromiseResolve,
   PromiseWithResolvers,
-  ReflectConstruct,
 } = primordials;
 
 const {
@@ -30,73 +28,6 @@ const {
 } = require('internal/webstreams/writablestream');
 
 const assert = require('internal/assert');
-
-const {
-  markTransferMode,
-  kClone,
-  kDeserialize,
-} = require('internal/worker/js_transferable');
-
-// This class is a bit of a hack. The Node.js implementation of
-// DOMException is not transferable/cloneable. This provides us
-// with a variant that is. Unfortunately, it means playing around
-// a bit with the message, name, and code properties and the
-// prototype. We can revisit this if DOMException is ever made
-// properly cloneable.
-class CloneableDOMException extends DOMException {
-  constructor(message, name) {
-    super(message, name);
-    markTransferMode(this, true, false);
-    this[kDeserialize]({
-      message: this.message,
-      name: this.name,
-      code: this.code,
-    });
-  }
-
-  [kClone]() {
-    return {
-      data: {
-        message: this.message,
-        name: this.name,
-        code: this.code,
-      },
-      deserializeInfo:
-        'internal/webstreams/transfer:InternalCloneableDOMException',
-    };
-  }
-
-  [kDeserialize]({ message, name, code }) {
-    ObjectDefineProperties(this, {
-      message: {
-        __proto__: null,
-        configurable: true,
-        enumerable: true,
-        get() { return message; },
-      },
-      name: {
-        __proto__: null,
-        configurable: true,
-        enumerable: true,
-        get() { return name; },
-      },
-      code: {
-        __proto__: null,
-        configurable: true,
-        enumerable: true,
-        get() { return code; },
-      },
-    });
-  }
-}
-
-function InternalCloneableDOMException() {
-  return ReflectConstruct(
-    CloneableDOMException,
-    [],
-    DOMException);
-}
-InternalCloneableDOMException[kDeserialize] = () => {};
 
 class CrossRealmTransformReadableSource {
   constructor(port, unref) {
@@ -132,7 +63,7 @@ class CrossRealmTransformReadableSource {
     };
 
     port.onmessageerror = () => {
-      const error = new CloneableDOMException(
+      const error = new DOMException(
         'Internal transferred ReadableStream error',
         'DataCloneError');
       port.postMessage({ type: 'error', value: error });
@@ -161,10 +92,6 @@ class CrossRealmTransformReadableSource {
     try {
       this[kState].port.postMessage({ type: 'error', value: reason });
     } catch (error) {
-      if (error instanceof DOMException) {
-        // eslint-disable-next-line no-ex-assign
-        error = new CloneableDOMException(error.message, error.name);
-      }
       this[kState].port.postMessage({ type: 'error', value: error });
       throw error;
     } finally {
@@ -206,7 +133,7 @@ class CrossRealmTransformWritableSink {
       }
     };
     port.onmessageerror = () => {
-      const error = new CloneableDOMException(
+      const error = new DOMException(
         'Internal transferred ReadableStream error',
         'DataCloneError');
       port.postMessage({ type: 'error', value: error });
@@ -240,10 +167,6 @@ class CrossRealmTransformWritableSink {
     try {
       this[kState].port.postMessage({ type: 'chunk', value: chunk });
     } catch (error) {
-      if (error instanceof DOMException) {
-        // eslint-disable-next-line no-ex-assign
-        error = new CloneableDOMException(error.message, error.name);
-      }
       this[kState].port.postMessage({ type: 'error', value: error });
       this[kState].port.close();
       throw error;
@@ -259,10 +182,6 @@ class CrossRealmTransformWritableSink {
     try {
       this[kState].port.postMessage({ type: 'error', value: reason });
     } catch (error) {
-      if (error instanceof DOMException) {
-        // eslint-disable-next-line no-ex-assign
-        error = new CloneableDOMException(error.message, error.name);
-      }
       this[kState].port.postMessage({ type: 'error', value: error });
       throw error;
     } finally {
@@ -308,6 +227,4 @@ module.exports = {
   newCrossRealmWritableSink,
   CrossRealmTransformWritableSink,
   CrossRealmTransformReadableSource,
-  CloneableDOMException,
-  InternalCloneableDOMException,
 };


### PR DESCRIPTION
As the comment says, it's more than time to revisit the hack now that `DOMException` has been clonable for a while