### PR TITLE
events: inline hybrid dispatch closures

### DIFF
--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -791,14 +791,6 @@ class EventTarget {
   }
 
   [kHybridDispatch](nodeValue, type, event) {
-    const createEvent = () => {
-      if (event === undefined) {
-        event = this[kCreateEvent](nodeValue, type);
-        event[kTarget] = this;
-        event[kIsBeingDispatched] = true;
-      }
-      return event;
-    };
     if (event !== undefined) {
       event[kTarget] = this;
       event[kIsBeingDispatched] = true;
@@ -844,7 +836,12 @@ class EventTarget {
         if (handler.isNodeStyleListener) {
           arg = nodeValue;
         } else {
-          arg = createEvent();
+          if (event === undefined) {
+            event = this[kCreateEvent](nodeValue, type);
+            event[kTarget] = this;
+            event[kIsBeingDispatched] = true;
+          }
+          arg = event;
         }
         const callback = handler.weak ?
           handler.callback.deref() : handler.callback;

--- a/lib/internal/event_target.js
+++ b/lib/internal/event_target.js
@@ -806,13 +806,8 @@ class EventTarget {
     let handler = root.next;
     let next;
 
-    const iterationCondition = () => {
-      if (handler === undefined) {
-        return false;
-      }
-      return root.resistStopPropagation || handler.passive || event?.[kStop] !== true;
-    };
-    while (iterationCondition()) {
+    while (handler !== undefined &&
+           (root.resistStopPropagation || handler.passive || event?.[kStop] !== true)) {
       // Cache the next item in case this iteration removes the current one
       next = handler.next;
 


### PR DESCRIPTION
**lib: inline createEvent hybrid dispatch closure**

Originally added in https://github.com/nodejs/node/commit/16b11cd2adaa5f60382a7f205f893f38a5061fff, it first
had three callers. Now there's only one branch requireing it.

**lib: inline iterationCondition hybrid dispatch closure**

While more readable, the removed closure overhead unlocks 10-20% in
eventtarget.js benchmark (30 runs).

