### PR TITLE
events: avoid retaining removed event names

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -86,6 +86,7 @@ const { addAbortListener } = require('internal/events/abort_listener');
 
 const kCapture = Symbol('kCapture');
 const kErrorMonitor = Symbol('events.errorMonitor');
+const kShapeMode = Symbol('shapeMode');
 const kEmitting = Symbol('events.emitting');
 const kMaxEventTargetListeners = Symbol('events.maxEventTargetListeners');
 const kMaxEventTargetListenersWarned =
@@ -334,6 +335,9 @@ EventEmitter.init = function(opts) {
       this._events === ObjectGetPrototypeOf(this)._events) {
     this._events = { __proto__: null };
     this._eventsCount = 0;
+    this[kShapeMode] = false;
+  } else {
+    this[kShapeMode] = true;
   }
 
   this._maxListeners ||= undefined;
@@ -687,12 +691,13 @@ EventEmitter.prototype.removeListener =
       if (list === listener || list.listener === listener) {
         this._eventsCount -= 1;
 
-        // Leave the key in place with an `undefined` value: repeatedly
-        // adding and removing a listener for the same event this way keeps
-        // the `events` object in the same shape and avoids both a `delete`
-        // (which would put the object into dictionary mode) and allocating
-        // a fresh object when the last listener is removed.
-        events[type] = undefined;
+        if (this[kShapeMode]) {
+          events[type] = undefined;
+        } else if (this._eventsCount === 0) {
+          this._events = { __proto__: null };
+        } else {
+          delete events[type];
+        }
 
         if (events.removeListener !== undefined)
           this.emit('removeListener', type, list.listener || listener);
@@ -752,6 +757,7 @@ EventEmitter.prototype.removeAllListeners =
           else
             delete events[type];
         }
+        this[kShapeMode] = false;
         return this;
       }
 
@@ -764,6 +770,7 @@ EventEmitter.prototype.removeAllListeners =
         this.removeAllListeners('removeListener');
         this._events = { __proto__: null };
         this._eventsCount = 0;
+        this[kShapeMode] = false;
         return this;
       }
 

--- a/test/parallel/test-event-emitter-remove-listeners.js
+++ b/test/parallel/test-event-emitter-remove-listeners.js
@@ -146,6 +146,19 @@ function listener2() {}
 
 {
   const ee = new EventEmitter();
+  ee.on('persistent', listener1);
+
+  for (let i = 0; i < 100; i++) {
+    const eventName = `event-${i}`;
+    ee.on(eventName, listener2);
+    ee.removeListener(eventName, listener2);
+  }
+
+  assert.deepStrictEqual(Reflect.ownKeys(ee._events), ['persistent']);
+}
+
+{
+  const ee = new EventEmitter();
   const listener = () => {};
   ee._events = undefined;
   const e = ee.removeListener('foo', listener);


### PR DESCRIPTION
Follow-up to https://github.com/nodejs/node/pull/64373.

That change retained removed listener keys with an `undefined` value for all `EventEmitter` instances. With unstructured event names, `_events` would therefore grow without bound.

This restores shape mode so preallocated emitters can retain their fixed keys while ordinary emitters delete dynamic keys or reset the events object. It also adds a regression test that adds and removes 100 unique event names and verifies they are not retained.
