### PR TITLE
repl: add block-based history navigation

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -395,6 +395,19 @@ function myWriter(output) {
 }
 ```
 
+### Block-based history navigation
+
+<!-- YAML
+added: REPLACEME
+-->
+
+When recalling a multiline entry from history, the Up and Down arrow
+keys navigate between history entries as whole blocks rather than
+moving the cursor line-by-line within the recalled entry. Up/Down
+always jump directly to the previous/next history entry, making it
+easy to recall multiline functions and code blocks with a single
+keypress — matching the behavior of Ctrl+P and Ctrl+N.
+
 ## Class: `REPLServer`
 
 <!-- YAML

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -149,6 +149,8 @@ const {
   kMultilinePrompt,
   kAddNewLineOnTTY,
   kLastCommandErrored,
+  kHistoryPrev,
+  kHistoryNext,
 } = require('internal/readline/interface');
 
 const parentModule = module;
@@ -702,7 +704,19 @@ class REPLServer extends Interface {
         }
         clearPreview(key);
         if (!reverseSearch(d, key)) {
-          ttyWrite(d, key);
+          // Up/Down navigate history in blocks rather than moving
+          // line-by-line within a recalled multiline entry, making
+          // arrow-key navigation behave like Ctrl-P / Ctrl-N.
+          // See: https://github.com/nodejs/node/issues/48146
+          if (key.name === 'up' || key.name === 'down') {
+            if (key.name === 'up') {
+              self[kHistoryPrev]();
+            } else {
+              self[kHistoryNext]();
+            }
+          } else {
+            ttyWrite(d, key);
+          }
           const showCompletionPreview = key.name !== 'escape';
           showPreview(showCompletionPreview);
         }


### PR DESCRIPTION
## Description

When recalling a multiline entry from history, the Up and Down arrow
keys now navigate between history entries as whole blocks rather than
moving line-by-line within a recalled entry.

Previously, recalling a multiline function from history and pressing
Up would move the cursor within that entry's lines before advancing
to the previous history entry. With this change, Up/Down always jump
directly to the previous/next history entry, matching the behavior
of Ctrl-P/Ctrl-N.

### Example

```
> function add(a, b) {
...   return a + b;
... }
undefined
> // press Up arrow once — jumps to the full 'function add' block, not just last line
```

Fixes: https://github.com/nodejs/node/issues/48146