### PR TITLE
build: extract temporal_capi crate directory name into gyp variable

### DIFF
--- a/deps/crates/crates.gyp
+++ b/deps/crates/crates.gyp
@@ -2,6 +2,7 @@
   'variables': {
     'cargo%': 'cargo',
     'cargo_vendor_dir': './vendor',
+    'temporal_capi_dir': 'temporal_capi',
     'cargo_rust_target%': '',
   },
   'conditions': [
@@ -120,7 +121,7 @@
       ],
       'direct_dependent_settings': {
         'include_dirs': [
-          '<(cargo_vendor_dir)/temporal_capi/bindings/cpp',
+          '<(cargo_vendor_dir)/<(temporal_capi_dir)/bindings/cpp',
         ],
       },
     },


### PR DESCRIPTION
This is a no-op for current builds, but will allow the crate updater (nodejs/node-core-utils#1117) to update the include path with the new crate location, as the crate directory names will include a version string.
