### PR TITLE
quic: preserve session stats after close

### DIFF
--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -870,7 +870,7 @@ class QuicSessionStats {
   [kFinishClose]() {
     const view = TypedArrayPrototypeSubarray(this.#handle,
                                              this.#offset,
-                                             this.#offset + IDX_STATS_STREAM_COUNT);
+                                             this.#offset + IDX_STATS_SESSION_COUNT);
     this.#handle = new BigUint64Array(view);
     this.#offset = 0;
     this.#disconnected = true;

--- a/test/parallel/test-quic-session-stream-lifecycle.mjs
+++ b/test/parallel/test-quic-session-stream-lifecycle.mjs
@@ -90,6 +90,8 @@ clientSession.destroy();
 strictEqual(clientSession.destroyed, true);
 strictEqual(clientSession.endpoint, null);
 strictEqual(clientSession.stats.isConnected, false);
+strictEqual(typeof clientSession.stats.cwnd, 'bigint');
+strictEqual(typeof clientSession.stats.streamsIdleTimedOut, 'bigint');
 
 strictEqual(stream.destroyed, true);
 


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## Description

`QuicSessionStats[kFinishClose]()` used `IDX_STATS_STREAM_COUNT` when
snapshotting session statistics. Since stream stats contain fewer entries
than session stats, fields beginning with `cwnd` were omitted after a session
was destroyed and returned `undefined`.

Use `IDX_STATS_SESSION_COUNT` so the complete session stats slice is copied
before the native session releases its arena slot. Add regression assertions
for the first previously omitted field (`cwnd`) and the final session field
(`streamsIdleTimedOut`).

## Validation

- `make lint-js`
- `git diff --check origin/main...HEAD`
- `python3 tools/test.py --mode=release parallel/test-quic-session-stream-lifecycle`
  (passed on the same patch before rebasing onto current `main`; a post-rebase
  rebuild was blocked by local disk capacity)
