### PR TITLE
quic: fix coverage comment typo

### DIFF
--- a/lib/internal/quic/diagnostics.js
+++ b/lib/internal/quic/diagnostics.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// TODO(@jasnell) Temporarily ignoring c8 covrerage for this file while tests
+// TODO(@jasnell) Temporarily ignoring c8 coverage for this file while tests
 // are still being developed.
 /* c8 ignore start */
 

--- a/lib/internal/quic/quic.js
+++ b/lib/internal/quic/quic.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// TODO(@jasnell) Temporarily ignoring c8 covrerage for this file while tests
+// TODO(@jasnell) Temporarily ignoring c8 coverage for this file while tests
 // are still being developed.
 /* c8 ignore start */
 

--- a/lib/internal/quic/state.js
+++ b/lib/internal/quic/state.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// TODO(@jasnell) Temporarily ignoring c8 covrerage for this file while tests
+// TODO(@jasnell) Temporarily ignoring c8 coverage for this file while tests
 // are still being developed.
 /* c8 ignore start */
 

--- a/lib/internal/quic/stats.js
+++ b/lib/internal/quic/stats.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// TODO(@jasnell) Temporarily ignoring c8 covrerage for this file while tests
+// TODO(@jasnell) Temporarily ignoring c8 coverage for this file while tests
 // are still being developed.
 /* c8 ignore start */
 

--- a/lib/internal/quic/symbols.js
+++ b/lib/internal/quic/symbols.js
@@ -1,6 +1,6 @@
 'use strict';
 
-// TODO(@jasnell) Temporarily ignoring c8 covrerage for this file while tests
+// TODO(@jasnell) Temporarily ignoring c8 coverage for this file while tests
 // are still being developed.
 /* c8 ignore start */
 


### PR DESCRIPTION
Fix `covrerage` → `coverage` in the TODO comments for the QUIC modules.

```diff
- // TODO(@jasnell) Temporarily ignoring c8 covrerage for this file while tests
+ // TODO(@jasnell) Temporarily ignoring c8 coverage for this file while tests
```

The same typo appears in `diagnostics.js`, `quic.js`, `state.js`, `stats.js`, and `symbols.js`.
