### PR TITLE
src: fix comment typos

### DIFF
--- a/src/node_builtins.cc
+++ b/src/node_builtins.cc
@@ -562,7 +562,7 @@ bool BuiltinLoader::CompileAllBuiltinsAndCopyCodeCache(
       std::unordered_set(eager_builtins.begin(), eager_builtins.end());
 
   for (const auto& id : ids) {
-    // Eagerly compile primordials/boostrap/main scripts during code cache
+    // Eagerly compile primordials/bootstrap/main scripts during code cache
     // generation.
     if (id.starts_with(primordial_prefix) || id.starts_with(bootstrap_prefix) ||
         id.starts_with(main_prefix)) {

--- a/src/node_builtins.h
+++ b/src/node_builtins.h
@@ -207,7 +207,7 @@ class NODE_EXTERN_PRIVATE BuiltinLoader {
 
   const UnionBytes config_;
 
-  // If any bulitins should be eagerly compiled i.e. with inner functions
+  // If any builtins should be eagerly compiled i.e. with inner functions
   // compiled too, either use should_eager_compile_ to compile all builtins
   // eagerly, or use to_eager_compile_ to compile specific builtins eagerly.
   // Currently we set should_eager_compile_ to true when compiling primordials,

--- a/src/node_platform.cc
+++ b/src/node_platform.cc
@@ -597,9 +597,9 @@ void NodePlatform::DrainTasks(Isolate* isolate) {
     // However, not blocking on the worker tasks at all can lead to loss of some
     // critical user-blocking worker tasks e.g. wasm async compilation tasks,
     // which should block the main thread until they are completed, as the
-    // documentation suggets. As a compromise, we currently only block on
+    // documentation suggests. As a compromise, we currently only block on
     // user-blocking tasks to reduce the chance of deadlocks while making sure
-    // that criticl user-blocking tasks are not lost.
+    // that critical user-blocking tasks are not lost.
     worker_thread_task_runner_->BlockingDrain();
   } while (per_isolate->FlushForegroundTasksInternal());
 }

--- a/src/quic/streams.cc
+++ b/src/quic/streams.cc
@@ -1262,7 +1262,7 @@ void Stream::NotifyStreamOpened(stream_id id) {
           headers->flags);
     }
   }
-  // If the stream is not a local undirectional stream and is_readable is
+  // If the stream is not a local unidirectional stream and is_readable is
   // false, then we should shutdown the streams readable side now.
   if (!is_local_unidirectional() && !is_readable()) {
     NotifyReadableEnded(pending_close_read_code_);


### PR DESCRIPTION
Fix typos in source comments.

```diff
- // Eagerly compile primordials/boostrap/main scripts during code cache
+ // Eagerly compile primordials/bootstrap/main scripts during code cache

- // If any bulitins should be eagerly compiled i.e. with inner functions
+ // If any builtins should be eagerly compiled i.e. with inner functions

- // documentation suggets. As a compromise, we currently only block on
+ // documentation suggests. As a compromise, we currently only block on

- // that criticl user-blocking tasks are not lost.
+ // that critical user-blocking tasks are not lost.

- // If the stream is not a local undirectional stream and is_readable is
+ // If the stream is not a local unidirectional stream and is_readable is
```

This supersedes #64488, which was closed after an unrelated macOS
`test-debugger-exec` timeout. This PR is based on the current `main` branch.
