### PR TITLE
src: fix out-of-bounds write when transcoding odd-length ucs2

### DIFF
--- a/src/node_i18n.cc
+++ b/src/node_i18n.cc
@@ -123,10 +123,13 @@ MaybeLocal<Object> ToBufferEndian(Environment* env, MaybeStackBuffer<T>* buf) {
 
 void CopySourceBuffer(MaybeStackBuffer<UChar>* dest,
                       const char* data,
-                      const size_t length,
                       const size_t length_in_chars) {
   dest->AllocateSufficientStorage(length_in_chars);
   char* dst = reinterpret_cast<char*>(**dest);
+  // The destination holds length_in_chars UChar units. Copy that many whole
+  // units and ignore a trailing odd byte; copying the raw byte length would
+  // write one byte past the buffer when the source length is not even.
+  const size_t length = length_in_chars * sizeof(UChar);
   memcpy(dst, data, length);
   if constexpr (IsBigEndian()) {
     CHECK(nbytes::SwapBytes16(dst, length));
@@ -199,7 +202,7 @@ MaybeLocal<Object> TranscodeFromUcs2(Environment* env,
   to.set_subst_chars(sub.c_str());
 
   const size_t length_in_chars = source_length / sizeof(UChar);
-  CopySourceBuffer(&sourcebuf, source, source_length, length_in_chars);
+  CopySourceBuffer(&sourcebuf, source, length_in_chars);
   MaybeStackBuffer<char> destbuf(length_in_chars);
   const uint32_t len = ucnv_fromUChars(to.conv(), *destbuf, length_in_chars,
                                        *sourcebuf, length_in_chars, status);

--- a/test/parallel/test-icu-transcode.js
+++ b/test/parallel/test-icu-transcode.js
@@ -88,3 +88,18 @@ assert.deepStrictEqual(
 {
   buffer.transcode(new buffer.Buffer.allocUnsafeSlow(1), 'utf16le', 'ucs2');
 }
+
+// An odd-length ucs2 source must only convert whole 2-byte code units and
+// leave the trailing byte untouched, without reading or writing past the
+// conversion buffer. Lengths are chosen to exercise both the on-stack and the
+// heap-allocated code paths.
+for (const len of [2049, 4099]) {
+  const src = Buffer.alloc(len, 0x61);
+  const wholeUnits = src.subarray(0, len - 1);
+  for (const to of ['latin1', 'ascii']) {
+    assert.deepStrictEqual(
+      buffer.transcode(src, 'utf16le', to),
+      buffer.transcode(wholeUnits, 'utf16le', to),
+      `ucs2->${to} odd length ${len}`);
+  }
+}


### PR DESCRIPTION
CopySourceBuffer sizes its destination for whole UChar units (source_length / sizeof(UChar)) but memcpy's the raw byte length, so Buffer.transcode() of an odd-length utf16le buffer into latin1/ascii writes one byte past the conversion buffer, on both the on-stack and the heap path. Copy only the whole code units so a trailing half byte is ignored; ucnv_fromUChars already consumes length_in_chars units, so the extra byte was never read back. Added an odd-length case to test-icu-transcode.js that trips ASAN on the current code.