### PR TITLE
test: keep finalization before-exit ref alive

### DIFF
--- a/test/fixtures/process/before-exit.mjs
+++ b/test/fixtures/process/before-exit.mjs
@@ -1,7 +1,9 @@
 import { strictEqual } from 'assert'
 
+let obj
+
 function setup() {
-  const obj = { foo: 'bar' }
+  obj = { foo: 'bar' }
   process.finalization.registerBeforeExit(obj, shutdown)
 }
 
@@ -27,5 +29,6 @@ function shutdown(obj, event) {
 setup()
 
 process.on('exit', function () {
+  strictEqual(obj.foo, 'bar')
   strictEqual(shutdownCalled, true)
 })


### PR DESCRIPTION
This is a fixture within the `test-process-finalization` test, which flaked yesterday, and quite a bit recently: https://github.com/nodejs/reliability/issues?q=%22test-process-finalization%22. All the examples for the recent failures are from this fixture.

Exactly the same problem & fix as for the sibling `test/fixtures/process/close.mjs` fixture: https://github.com/nodejs/node/pull/64085. I have checked and AFAICT this is the last remaining example of the set, so hopefully this'll make test-process-finalization stable once and for all :crossed_fingers:

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
