### PR TITLE
ffi: preserve uint8 semantics for bool fast calls

### DIFF
--- a/doc/contributing/ffi-fast-api-internals.md
+++ b/doc/contributing/ffi-fast-api-internals.md
@@ -200,7 +200,6 @@ surface. It models the ABI categories that the generated trampoline knows how to
 marshal directly:
 
 * `kVoid`
-* `kBool`
 * signed and unsigned 8-bit, 16-bit, 32-bit, and 64-bit integers
 * `kFloat32`
 * `kFloat64`
@@ -208,7 +207,8 @@ marshal directly:
 * `kBuffer`
 
 Public aliases are normalized in `FastScalarTypeFromName()` and
-`FastArgTypeFromName()`.
+`FastArgTypeFromName()`. In particular, `bool` is normalized to `kUint8` to
+match its documented 8-bit unsigned integer semantics.
 
 `pointer`, `ptr`, `string`, `str`, `buffer`, and `arraybuffer` all represent
 pointer-sized native values at the target ABI boundary. They differ in how

--- a/src/ffi/fast.cc
+++ b/src/ffi/fast.cc
@@ -37,7 +37,7 @@ bool FastScalarTypeFromName(std::string_view type, FastFFIType* out) {
   if (type == "void") {
     *out = FastFFIType::kVoid;
   } else if (type == "bool") {
-    *out = FastFFIType::kBool;
+    *out = FastFFIType::kUint8;
   } else if (IsTypeName(type, {"i8", "int8"})) {
     *out = FastFFIType::kInt8;
   } else if (IsTypeName(type, {"u8", "uint8"})) {
@@ -96,8 +96,6 @@ CTypeInfo::Type ToV8Type(FastFFIType type, bool is_return) {
   switch (type) {
     case FastFFIType::kVoid:
       return CTypeInfo::Type::kVoid;
-    case FastFFIType::kBool:
-      return CTypeInfo::Type::kBool;
     case FastFFIType::kUint8:
       return CTypeInfo::Type::kUint32;
     case FastFFIType::kInt8:

--- a/src/ffi/fast.h
+++ b/src/ffi/fast.h
@@ -17,7 +17,6 @@ struct FFIFunction;
 
 enum class FastFFIType : uint8_t {
   kVoid,
-  kBool,
   kInt8,
   kUint8,
   kInt16,

--- a/src/ffi/platforms/arm64.cc
+++ b/src/ffi/platforms/arm64.cc
@@ -136,7 +136,6 @@ uint32_t UxthW(unsigned reg) {
 // to the ABI width expected by the native target before the final call.
 bool EmitNarrow(uint32_t** cursor, FastFFIType type, unsigned reg) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kUint8:
       *(*cursor)++ = UxtbW(reg);
       return true;

--- a/src/ffi/platforms/loong64.cc
+++ b/src/ffi/platforms/loong64.cc
@@ -19,7 +19,6 @@ bool IsFloatType(FastFFIType type) {
 
 bool IsNarrowType(FastFFIType type) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kInt8:
     case FastFFIType::kUint8:
     case FastFFIType::kInt16:

--- a/src/ffi/platforms/ppc64.cc
+++ b/src/ffi/platforms/ppc64.cc
@@ -23,7 +23,6 @@ bool IsFloatType(FastFFIType type) {
 
 bool IsNarrowType(FastFFIType type) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kInt8:
     case FastFFIType::kUint8:
     case FastFFIType::kInt16:

--- a/src/ffi/platforms/riscv64.cc
+++ b/src/ffi/platforms/riscv64.cc
@@ -19,7 +19,6 @@ bool IsFloatType(FastFFIType type) {
 
 bool IsNarrowType(FastFFIType type) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kInt8:
     case FastFFIType::kUint8:
     case FastFFIType::kInt16:

--- a/src/ffi/platforms/s390x.cc
+++ b/src/ffi/platforms/s390x.cc
@@ -19,7 +19,6 @@ bool IsFloatType(FastFFIType type) {
 
 bool IsNarrowType(FastFFIType type) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kInt8:
     case FastFFIType::kUint8:
     case FastFFIType::kInt16:

--- a/src/ffi/platforms/x64.cc
+++ b/src/ffi/platforms/x64.cc
@@ -232,7 +232,6 @@ void EmitNarrowInstruction(uint8_t** cursor, uint8_t opcode, unsigned reg) {
 // consumes the declared low 8/16 bits.
 bool EmitNarrowReturn(uint8_t** cursor, FastFFIType type, unsigned reg) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kUint8:
       EmitNarrowInstruction(cursor, 0xb6, reg);
       return true;
@@ -252,7 +251,6 @@ bool EmitNarrowReturn(uint8_t** cursor, FastFFIType type, unsigned reg) {
 
 bool NeedsNarrow(FastFFIType type) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kUint8:
     case FastFFIType::kInt8:
     case FastFFIType::kUint16:
@@ -655,7 +653,6 @@ void EmitNarrowInstruction(uint8_t** cursor, uint8_t opcode, unsigned reg) {
 
 bool EmitNarrowReturn(uint8_t** cursor, FastFFIType type, unsigned reg) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kUint8:
       EmitNarrowInstruction(cursor, 0xb6, reg);
       return true;
@@ -675,7 +672,6 @@ bool EmitNarrowReturn(uint8_t** cursor, FastFFIType type, unsigned reg) {
 
 bool NeedsNarrow(FastFFIType type) {
   switch (type) {
-    case FastFFIType::kBool:
     case FastFFIType::kUint8:
     case FastFFIType::kInt8:
     case FastFFIType::kUint16:

--- a/test/ffi/test-ffi-calls.js
+++ b/test/ffi/test-ffi-calls.js
@@ -1,4 +1,4 @@
-// Flags: --experimental-ffi --expose-gc
+// Flags: --experimental-ffi --expose-gc --allow-natives-syntax
 'use strict';
 const common = require('../common');
 common.skipIfFFIMissing();
@@ -62,8 +62,16 @@ test('ffi bool signatures use uint8 values', () => {
       arguments: ['bool', 'bool'],
       return: 'bool',
     });
-    assert.strictEqual(boolAdder(1, 0), 1);
-    assert.throws(() => boolAdder(true, false), /Argument 0 must be a uint8/);
+    function callBoolAdder(a, b) {
+      return boolAdder(a, b);
+    }
+
+    eval('%PrepareFunctionForOptimization(callBoolAdder)');
+    assert.strictEqual(callBoolAdder(1, 0), 1);
+    eval('%OptimizeFunctionOnNextCall(callBoolAdder)');
+    assert.strictEqual(callBoolAdder(1, 0), 1);
+    assert.throws(
+      () => callBoolAdder(true, false), /Argument 0 must be a uint8/);
   } finally {
     lib.close();
   }


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64526

`node:ffi` documents `bool` as an 8-bit unsigned integer, but the Fast
API path mapped it to V8's Boolean type. As a result, behavior changed
after JIT optimization:

- return values changed from numbers to JavaScript Booleans;
- `true` and `false` became accepted as arguments.

This change normalizes `bool` to the existing `kUint8` Fast FFI type and
removes the now-unused `kBool` type. The regression test forces V8
optimization and verifies that numeric return values and argument
validation remain consistent.

---

Assisted-by: openai:gpt-5.6-sol