### PR TITLE
repl: add ImportExpression to disallow list of speculative evaluation

### DIFF
--- a/lib/internal/repl/completion.js
+++ b/lib/internal/repl/completion.js
@@ -629,6 +629,7 @@ function findExpressionCompleteTarget(code) {
     ForInStatement: disallow,
     ForOfStatement: disallow,
     CallExpression: disallow,
+    ImportExpression: disallow,
     AssignmentExpression: disallow,
     UpdateExpression: disallow,
   });

--- a/test/parallel/test-repl-tab-complete.js
+++ b/test/parallel/test-repl-tab-complete.js
@@ -562,4 +562,14 @@ describe('REPL tab completion (core functionality)', () => {
 
     replServer.close();
   });
+
+  it('does not evaluate dynamic imports for completion', () => {
+    const { replServer } = startNewREPLServer({
+      eval: common.mustNotCall(),
+    });
+
+    replServer.complete('import("").', getNoResultsFunction());
+
+    replServer.close();
+  });
 });


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes: #64523 

REPL speculative completeions were allowing `ImportExpression` to be
egarly evaluated, which caused the REPL to try importing invalid modules
which would cause the REPL to get stuck in a loop of trying to import
the module and failing causing it to lock up. This commit makes it so
that `ImportExpression` are disallowed from being evaluated in that case.