### PR TITLE
sqlite: fix use-after-free in Exec() and ApplyChangeset()

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -1584,6 +1584,13 @@ void DatabaseSync::Exec(const FunctionCallbackInfo<Value>& args) {
     return;
   }
 
+  // Keep the database alive during sqlite3_exec(), which may call
+  // user-defined SQLite functions that trigger JavaScript callbacks.
+  // If the JavaScript callback drops all references to the database,
+  // the DatabaseSync could otherwise be garbage-collected while the
+  // SQLite callback is still executing, causing a use-after-free.
+  BaseObjectPtr<DatabaseSync> guard(db);
+
   Utf8Value sql(env->isolate(), args[0].As<String>());
   int r = sqlite3_exec(db->connection_, *sql, nullptr, nullptr, nullptr);
   CHECK_ERROR_OR_THROW(env->isolate(), db, r, SQLITE_OK, void());
@@ -2357,6 +2364,13 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
       };
     }
   }
+
+  // Keep the database alive during sqlite3changeset_apply(), which may
+  // call conflict or filter callbacks that trigger JavaScript execution.
+  // If the JavaScript callback drops all references to the database,
+  // the DatabaseSync could otherwise be garbage-collected while the
+  // callback is still executing, causing a use-after-free.
+  BaseObjectPtr<DatabaseSync> guard(db);
 
   ArrayBufferViewContents<uint8_t> buf(args[0]);
   int r = sqlite3changeset_apply(


### PR DESCRIPTION
When `sqlite3_exec()` or `sqlite3changeset_apply()` call JavaScript
callbacks (user-defined functions, conflict handlers, or filter
callbacks), the `DatabaseSync` object could be garbage-collected
if the JavaScript code drops all references to it. Both methods
only held a raw `DatabaseSync*` pointer on the C++ stack, which
V8 GC does not track.

Add a `BaseObjectPtr<DatabaseSync>` guard that keeps the database
alive for the duration of these SQLite API calls, preventing a
use-after-free when the JavaScript callback triggers GC.