### PR TITLE
src: avoid redundant DataPointer reallocations

### DIFF
--- a/deps/ncrypto/ncrypto.cc
+++ b/deps/ncrypto/ncrypto.cc
@@ -483,9 +483,12 @@ Buffer<void> DataPointer::release() {
 }
 
 DataPointer DataPointer::resize(size_t len) {
-  size_t actual_len = std::min(len_, len);
+  const size_t actual_len = std::min(len_, len);
+  if (actual_len == len_) return std::move(*this);
+
   auto buf = release();
-  if (actual_len == len_) return DataPointer(buf.data, actual_len);
+  if (actual_len == 0) return DataPointer(buf.data, actual_len);
+
   buf.data = OPENSSL_realloc(buf.data, actual_len);
   buf.len = actual_len;
   return DataPointer(buf);


### PR DESCRIPTION
`DataPointer::resize()` checked for an unchanged size only after `release()` had reset the stored length to zero. As a result, every non-empty resize called `OPENSSL_realloc()`, even when the allocation was already the right size.

Check for the no-op before releasing the buffer. This avoids an allocator call and, with BoringSSL, a new allocation, copy, cleanse, and free.

Keep the explicit zero-length path to preserve successful empty crypto outputs.