### PR TITLE
meta: lower stale to 3 months

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,13 +9,13 @@ on:
 env:
   CLOSE_MESSAGE: >
     This {0} has been automatically closed after 30 days of inactivity
-    following its stale status (no activity for a total of 240 days).
+    following its stale status (no activity for a total of 120 days).
 
     If this is still relevant, feel free to reopen it or leave a comment
     with additional details so we can continue the discussion.
 
   WARN_MESSAGE: >
-    This {0} has been marked as stale due to 210 days of inactivity.
+    This {0} has been marked as stale due to 90 days of inactivity.
 
     It will be automatically closed in 30 days if no further activity occurs.
     If this is still relevant, please leave a comment or update it to keep it open.
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.3.0
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          days-before-stale: 210
+          days-before-stale: 90
           days-before-close: 30
           stale-issue-label: stale
           exempt-issue-labels: never-stale, confirmed-bug


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/pull/62105/changes#r3182288004
Ref: https://openjs-foundation.slack.com/archives/C019Y2T6STH/p1784126065845719

Lowers the stale bot from 210 days to 90 days (closing at 120 days), per the above suggestions.

**Note**: On July 27, 2026, the Stalebot will close a "wave" of stale PRs due to it's limit being increased on June 27, 2026. This PR shouldn't land _around_ the same time to avoid noise, it should either land several days before or several days after.