### PR TITLE
vfs: make lchown update symlink metadata

### DIFF
--- a/doc/api/vfs.md
+++ b/doc/api/vfs.md
@@ -156,6 +156,7 @@ signatures as their [`node:fs`][] counterparts:
 * `linkSync(existingPath, newPath)`
 * `chmodSync(path, mode)`
 * `chownSync(path, uid, gid)`
+* `lchownSync(path, uid, gid)`
 * `utimesSync(path, atime, mtime)`
 * `lutimesSync(path, atime, mtime)`
 * `mkdtempSync(prefix)`

--- a/lib/internal/vfs/file_system.js
+++ b/lib/internal/vfs/file_system.js
@@ -506,6 +506,11 @@ class VirtualFileSystem {
     this[kProvider].chownSync(providerPath, uid, gid);
   }
 
+  lchownSync(filePath, uid, gid) {
+    const providerPath = this.#toProviderPath(filePath);
+    this[kProvider].lchownSync(providerPath, uid, gid);
+  }
+
   utimesSync(filePath, atime, mtime) {
     const providerPath = this.#toProviderPath(filePath);
     this[kProvider].utimesSync(providerPath, atime, mtime);
@@ -1234,7 +1239,7 @@ class VirtualFileSystem {
 
       async lchown(filePath, uid, gid) {
         const providerPath = toProviderPath(filePath);
-        provider.chownSync(providerPath, uid, gid);
+        provider.lchownSync(providerPath, uid, gid);
       },
 
       async utimes(filePath, atime, mtime) {

--- a/lib/internal/vfs/provider.js
+++ b/lib/internal/vfs/provider.js
@@ -235,6 +235,18 @@ class VirtualProvider {
     throw new ERR_METHOD_NOT_IMPLEMENTED('renameSync');
   }
 
+  /**
+   * Changes ownership of a path without following the final symbolic link.
+   * Providers with symlink support should override this.
+   * @param {string} path The path
+   * @param {number} uid The user id
+   * @param {number} gid The group id
+   * @returns {void}
+   */
+  lchownSync(path, uid, gid) {
+    return this.chownSync(path, uid, gid);
+  }
+
   // === DEFAULT IMPLEMENTATIONS (built on primitives) ===
 
   /**

--- a/lib/internal/vfs/providers/memory.js
+++ b/lib/internal/vfs/providers/memory.js
@@ -971,6 +971,13 @@ class MemoryProvider extends VirtualProvider {
     entry.ctime = DateNow();
   }
 
+  lchownSync(path, uid, gid) {
+    const entry = this.#getEntry(path, 'chown', false);
+    if (uid >= 0) entry.uid = uid;
+    if (gid >= 0) entry.gid = gid;
+    entry.ctime = DateNow();
+  }
+
   utimesSync(path, atime, mtime) {
     const entry = this.#getEntry(path, 'utime', true);
     entry.atime = toMs(atime);

--- a/lib/internal/vfs/setup.js
+++ b/lib/internal/vfs/setup.js
@@ -343,7 +343,7 @@ function createVfsHandlers() {
       vfsOpVoid(path, (vfs, n) => vfs.symlinkSync(target, n, type)),
     chmodSync: (path, mode) => vfsOpVoid(path, (vfs, n) => vfs.chmodSync(n, mode)),
     chownSync: (path, uid, gid) => vfsOpVoid(path, (vfs, n) => vfs.chownSync(n, uid, gid)),
-    lchownSync: (path, uid, gid) => vfsOpVoid(path, (vfs, n) => vfs.chownSync(n, uid, gid)),
+    lchownSync: (path, uid, gid) => vfsOpVoid(path, (vfs, n) => vfs.lchownSync(n, uid, gid)),
     utimesSync: (path, atime, mtime) =>
       vfsOpVoid(path, (vfs, n) => vfs.utimesSync(n, atime, mtime)),
     lutimesSync: (path, atime, mtime) =>

--- a/test/parallel/test-vfs-lchown-symlink.js
+++ b/test/parallel/test-vfs-lchown-symlink.js
@@ -1,0 +1,48 @@
+// Flags: --experimental-vfs
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const fsp = require('fs/promises');
+const path = require('path');
+const vfs = require('node:vfs');
+
+const mountPoint = path.resolve('/tmp/vfs-lchown-' + process.pid);
+const myVfs = vfs.create();
+myVfs.writeFileSync('/sync-target.txt', 'target');
+myVfs.symlinkSync('/sync-target.txt', '/sync-link.txt');
+myVfs.writeFileSync('/async-target.txt', 'target');
+myVfs.symlinkSync('/async-target.txt', '/async-link.txt');
+myVfs.writeFileSync('/promise-target.txt', 'target');
+myVfs.symlinkSync('/promise-target.txt', '/promise-link.txt');
+myVfs.mount(mountPoint);
+
+function assertOwnership(filePath, uid, gid) {
+  const stats = fs.lstatSync(path.join(mountPoint, filePath));
+  assert.strictEqual(stats.uid, uid);
+  assert.strictEqual(stats.gid, gid);
+}
+
+(async () => {
+  try {
+    fs.lchownSync(path.join(mountPoint, 'sync-link.txt'), 123, 456);
+    assertOwnership('/sync-target.txt', 0, 0);
+    assertOwnership('/sync-link.txt', 123, 456);
+
+    await new Promise((resolve, reject) => {
+      fs.lchown(path.join(mountPoint, 'async-link.txt'), 234, 567, (err) => {
+        if (err) reject(err);
+        else resolve();
+      });
+    });
+    assertOwnership('/async-target.txt', 0, 0);
+    assertOwnership('/async-link.txt', 234, 567);
+
+    await fsp.lchown(path.join(mountPoint, 'promise-link.txt'), 345, 678);
+    assertOwnership('/promise-target.txt', 0, 0);
+    assertOwnership('/promise-link.txt', 345, 678);
+  } finally {
+    myVfs.unmount();
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64572

This PR fixes VFS `lchown()` handling so ownership changes apply
to the symbolic link itself instead of following the link and modifying
its target.

It routes synchronous and asynchronous `lchown` operations through
dedicated VFS and provider handling, adds memory-provider support
that does not follow the final symlink, and preserves fallback behavior
for providers that do not override `lchownSync()`.

---

Assisted-by: openai:gpt-5.5