### PR TITLE
quic: serialize stream reset code as string

### DIFF
--- a/lib/internal/quic/state.js
+++ b/lib/internal/quic/state.js
@@ -926,7 +926,7 @@ class QuicStreamState {
       wantsHeaders,
       wantsTrailers,
       early,
-      resetCode,
+      resetCode: `${resetCode}`,
       writeDesiredSize,
       highWaterMark,
     };

--- a/test/parallel/test-quic-internal-endpoint-stats-state.mjs
+++ b/test/parallel/test-quic-internal-endpoint-stats-state.mjs
@@ -179,6 +179,7 @@ strictEqual(sessionState.maxDatagramSize, 0);
 strictEqual(sessionState.lastDatagramId, 0n);
 
 strictEqual(typeof streamState.toJSON(), 'object');
+strictEqual(JSON.parse(streamState.toString()).resetCode, '0');
 strictEqual(typeof sessionState.toJSON(), 'object');
 strictEqual(typeof inspect(streamState), 'string');
 strictEqual(typeof inspect(sessionState), 'string');


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

## Description

`QuicStreamState.toJSON()` returned `resetCode` as a `BigInt`.
`QuicStreamState.toString()` serializes that object with
`JSONStringify()`, so serializing a live stream state threw
`TypeError: Do not know how to serialize a BigInt`. Calling
`JSON.stringify()` on the state failed for the same reason.

Serialize `resetCode` as a string, matching the handling of other 64-bit
QUIC state values. Using a string also preserves values outside JavaScript's
safe integer range. This only changes the JSON representation; it does not
change QUIC stream reset processing or the stored reset code.

Add a regression assertion that serializes a stream state and verifies the
parsed `resetCode` value.
