### PR TITLE
stream: fix unhandled rejection for errored pipeTo writes

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1495,6 +1495,19 @@ function readableStreamFromIterable(iterable) {
   return stream;
 }
 
+// markPromiseAsHandled only silences unhandled-rejection if the promise is
+// still pending. writableStreamDefaultWriterWrite can return an already-
+// rejected promise when the destination has errored or closed; in that case
+// attach a real handler via setPromiseHandled.
+function markPipeToWritePromiseHandled(promise, dest) {
+  if (dest[kState].state === 'writable' &&
+      !writableStreamCloseQueuedOrInFlight(dest)) {
+    markPromiseAsHandled(promise);
+  } else {
+    setPromiseHandled(promise);
+  }
+}
+
 function readableStreamPipeTo(
   source,
   dest,
@@ -1668,7 +1681,7 @@ function readableStreamPipeTo(
         // Write the chunk - we're already in a separate microtask from enqueue
         // because we awaited the writer ready promise above.
         state.currentWrite = writableStreamDefaultWriterWrite(writer, chunk);
-        markPromiseAsHandled(state.currentWrite);
+        markPipeToWritePromiseHandled(state.currentWrite, dest);
 
         // Check backpressure after each write
         if (dest[kState].backpressure) {
@@ -1772,7 +1785,9 @@ class PipeToReadableStreamReadRequest {
     // "ReadableStreamPipeTo" step 15's "chunk steps".
     queueMicrotask(() => {
       this.state.currentWrite = writableStreamDefaultWriterWrite(this.writer, chunk);
-      markPromiseAsHandled(this.state.currentWrite);
+      markPipeToWritePromiseHandled(
+        this.state.currentWrite,
+        this.writer[kState].stream);
       this.promise.resolve(false);
     });
   }

--- a/test/parallel/test-whatwg-pipeto-transform-error.js
+++ b/test/parallel/test-whatwg-pipeto-transform-error.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const {
+  ReadableStream,
+  TransformStream,
+  WritableStream,
+} = require('stream/web');
+
+// A late write after the destination has errored returns an already-rejected
+// promise. That must not surface as an unhandled rejection when the pipeTo()
+// rejection is already handled.
+// Refs: https://github.com/nodejs/node/issues/64561
+
+process.on('unhandledRejection', common.mustNotCall());
+
+(async () => {
+  const source = new ReadableStream({
+    start(controller) {
+      controller.enqueue('a');
+      controller.enqueue('b');
+      controller.close();
+    },
+  });
+
+  const asyncPassThrough = new TransformStream({
+    async transform(chunk, controller) {
+      controller.enqueue(chunk);
+    },
+  });
+
+  const identity = new TransformStream();
+
+  const failingTransform = new TransformStream({
+    transform() {
+      throw new Error('boom');
+    },
+  });
+
+  await assert.rejects(
+    source
+      .pipeThrough(asyncPassThrough)
+      .pipeThrough(identity)
+      .pipeThrough(failingTransform)
+      .pipeTo(new WritableStream()),
+    { message: 'boom' },
+  );
+})().then(common.mustCall());


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

Fixes a v26.4.0 regression where `ReadableStream.pipeTo()` could crash the
process with an unhandled rejection even when the `pipeTo()` promise
rejection was already caught.

In #63572, per-chunk `setPromiseHandled()` was replaced with
`markPromiseAsHandled()`. That is safe for pending write promises, but when
a later chunk is written after the destination has already errored,
`writableStreamDefaultWriterWrite()` returns an already-rejected promise.
Marking that promise handled afterwards does not cancel V8's pending
unhandled-rejection notification.

This keeps `markPromiseAsHandled()` on the writable fast path and falls
back to `setPromiseHandled()` when the destination is no longer writable
(or close is queued/in flight).

No documentation changes; behavior is restored to match Node.js ≤ v26.3.1,
Deno, Bun, and browsers.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `make -j4 test` (UNIX) or `vcbuild test` (Windows) passes / CI will validate
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines)

Fixes: https://github.com/nodejs/node/issues/64561
Refs: https://github.com/nodejs/node/pull/63572