### PR TITLE
doc: replace large tables in crypto.md and webcrypto.md with lists

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -73,38 +73,48 @@ try {
 
 ## Asymmetric key types
 
-The following table lists the asymmetric key types recognized by the
-[`KeyObject`][] API and the export/import formats supported for each key type.
+The following lists group the asymmetric key types recognized by the
+[`KeyObject`][] API by the complete set of formats supported for importing and
+exporting each type.
 
-| Key Type                           | Description        | OID                     | `'pem'` | `'der'` | `'jwk'` | `'raw-public'` | `'raw-private'` | `'raw-seed'` |
-| ---------------------------------- | ------------------ | ----------------------- | ------- | ------- | ------- | -------------- | --------------- | ------------ |
-| `'dh'`                             | Diffie-Hellman     | 1.2.840.113549.1.3.1    | ✔       | ✔       |         |                |                 |              |
-| `'dsa'`                            | DSA                | 1.2.840.10040.4.1       | ✔       | ✔       |         |                |                 |              |
-| `'ec'`                             | Elliptic curve     | 1.2.840.10045.2.1       | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'ed25519'`                        | Ed25519            | 1.3.101.112             | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'ed448'`                          | Ed448              | 1.3.101.113             | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'ml-dsa-44'`[^openssl35]          | ML-DSA-44          | 2.16.840.1.101.3.4.3.17 | ✔       | ✔       | ✔       | ✔              |                 | ✔            |
-| `'ml-dsa-65'`[^openssl35]          | ML-DSA-65          | 2.16.840.1.101.3.4.3.18 | ✔       | ✔       | ✔       | ✔              |                 | ✔            |
-| `'ml-dsa-87'`[^openssl35]          | ML-DSA-87          | 2.16.840.1.101.3.4.3.19 | ✔       | ✔       | ✔       | ✔              |                 | ✔            |
-| `'ml-kem-512'`[^openssl35]         | ML-KEM-512         | 2.16.840.1.101.3.4.4.1  | ✔       | ✔       | ✔       | ✔              |                 | ✔            |
-| `'ml-kem-768'`[^openssl35]         | ML-KEM-768         | 2.16.840.1.101.3.4.4.2  | ✔       | ✔       | ✔       | ✔              |                 | ✔            |
-| `'ml-kem-1024'`[^openssl35]        | ML-KEM-1024        | 2.16.840.1.101.3.4.4.3  | ✔       | ✔       | ✔       | ✔              |                 | ✔            |
-| `'rsa-pss'`                        | RSA PSS            | 1.2.840.113549.1.1.10   | ✔       | ✔       |         |                |                 |              |
-| `'rsa'`                            | RSA                | 1.2.840.113549.1.1.1    | ✔       | ✔       | ✔       |                |                 |              |
-| `'slh-dsa-sha2-128f'`[^openssl35]  | SLH-DSA-SHA2-128f  | 2.16.840.1.101.3.4.3.21 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-sha2-128s'`[^openssl35]  | SLH-DSA-SHA2-128s  | 2.16.840.1.101.3.4.3.20 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-sha2-192f'`[^openssl35]  | SLH-DSA-SHA2-192f  | 2.16.840.1.101.3.4.3.23 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-sha2-192s'`[^openssl35]  | SLH-DSA-SHA2-192s  | 2.16.840.1.101.3.4.3.22 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-sha2-256f'`[^openssl35]  | SLH-DSA-SHA2-256f  | 2.16.840.1.101.3.4.3.25 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-sha2-256s'`[^openssl35]  | SLH-DSA-SHA2-256s  | 2.16.840.1.101.3.4.3.24 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-shake-128f'`[^openssl35] | SLH-DSA-SHAKE-128f | 2.16.840.1.101.3.4.3.27 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-shake-128s'`[^openssl35] | SLH-DSA-SHAKE-128s | 2.16.840.1.101.3.4.3.26 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-shake-192f'`[^openssl35] | SLH-DSA-SHAKE-192f | 2.16.840.1.101.3.4.3.29 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-shake-192s'`[^openssl35] | SLH-DSA-SHAKE-192s | 2.16.840.1.101.3.4.3.28 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-shake-256f'`[^openssl35] | SLH-DSA-SHAKE-256f | 2.16.840.1.101.3.4.3.31 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'slh-dsa-shake-256s'`[^openssl35] | SLH-DSA-SHAKE-256s | 2.16.840.1.101.3.4.3.30 | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'x25519'`                         | X25519             | 1.3.101.110             | ✔       | ✔       | ✔       | ✔              | ✔               |              |
-| `'x448'`                           | X448               | 1.3.101.111             | ✔       | ✔       | ✔       | ✔              | ✔               |              |
+**Formats:** `'pem'`, `'der'`
+
+* **`'dh'` (Diffie-Hellman)** — OID `1.2.840.113549.1.3.1`
+* **`'dsa'`** — OID `1.2.840.10040.4.1`
+* **`'rsa-pss'`** — OID `1.2.840.113549.1.1.10`
+
+**Formats:** `'pem'`, `'der'`, `'jwk'`
+
+* **`'rsa'`** — OID `1.2.840.113549.1.1.1`
+
+**Formats:** `'pem'`, `'der'`, `'jwk'`, `'raw-public'`, `'raw-private'`
+
+* **`'ec'` (Elliptic curve)** — OID `1.2.840.10045.2.1`
+* **`'ed25519'`** — OID `1.3.101.112`
+* **`'ed448'`** — OID `1.3.101.113`
+* **`'slh-dsa-sha2-128f'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.21`
+* **`'slh-dsa-sha2-128s'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.20`
+* **`'slh-dsa-sha2-192f'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.23`
+* **`'slh-dsa-sha2-192s'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.22`
+* **`'slh-dsa-sha2-256f'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.25`
+* **`'slh-dsa-sha2-256s'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.24`
+* **`'slh-dsa-shake-128f'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.27`
+* **`'slh-dsa-shake-128s'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.26`
+* **`'slh-dsa-shake-192f'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.29`
+* **`'slh-dsa-shake-192s'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.28`
+* **`'slh-dsa-shake-256f'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.31`
+* **`'slh-dsa-shake-256s'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.30`
+* **`'x25519'`** — OID `1.3.101.110`
+* **`'x448'`** — OID `1.3.101.111`
+
+**Formats:** `'pem'`, `'der'`, `'jwk'`, `'raw-public'`, `'raw-seed'`
+
+* **`'ml-dsa-44'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.17`
+* **`'ml-dsa-65'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.18`
+* **`'ml-dsa-87'`[^openssl35]** — OID `2.16.840.1.101.3.4.3.19`
+* **`'ml-kem-512'`[^openssl35]** — OID `2.16.840.1.101.3.4.4.1`
+* **`'ml-kem-768'`[^openssl35]** — OID `2.16.840.1.101.3.4.4.2`
+* **`'ml-kem-1024'`[^openssl35]** — OID `2.16.840.1.101.3.4.4.3`
 
 ### Key formats
 

--- a/doc/api/webcrypto.md
+++ b/doc/api/webcrypto.md
@@ -513,101 +513,81 @@ const decrypted = new TextDecoder().decode(await crypto.subtle.decrypt(
 ));
 ```
 
-## Algorithm matrix
+## Algorithm support
 
-The following tables detail the algorithms supported by the Node.js Web
+The following sections detail the algorithms supported by the Node.js Web
 Crypto API implementation and the APIs supported for each:
 
 ### Key Management APIs
 
-| Algorithm                            | [`subtle.generateKey()`][] | [`subtle.exportKey()`][] | [`subtle.importKey()`][] | [`subtle.getPublicKey()`][] |
-| ------------------------------------ | -------------------------- | ------------------------ | ------------------------ | --------------------------- |
-| `'AES-CBC'`                          | ✔                          | ✔                        | ✔                        |                             |
-| `'AES-CTR'`                          | ✔                          | ✔                        | ✔                        |                             |
-| `'AES-GCM'`                          | ✔                          | ✔                        | ✔                        |                             |
-| `'AES-KW'`                           | ✔                          | ✔                        | ✔                        |                             |
-| `'AES-OCB'`                          | ✔                          | ✔                        | ✔                        |                             |
-| `'Argon2d'`                          |                            |                          | ✔                        |                             |
-| `'Argon2i'`                          |                            |                          | ✔                        |                             |
-| `'Argon2id'`                         |                            |                          | ✔                        |                             |
-| `'ChaCha20-Poly1305'`[^modern-algos] | ✔                          | ✔                        | ✔                        |                             |
-| `'ECDH'`                             | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'ECDSA'`                            | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'Ed25519'`                          | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'Ed448'`[^secure-curves]            | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'HKDF'`                             |                            |                          | ✔                        |                             |
-| `'HMAC'`                             | ✔                          | ✔                        | ✔                        |                             |
-| `'KMAC128'`[^modern-algos]           | ✔                          | ✔                        | ✔                        |                             |
-| `'KMAC256'`[^modern-algos]           | ✔                          | ✔                        | ✔                        |                             |
-| `'ML-DSA-44'`[^modern-algos]         | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'ML-DSA-65'`[^modern-algos]         | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'ML-DSA-87'`[^modern-algos]         | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'ML-KEM-512'`[^modern-algos]        | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'ML-KEM-768'`[^modern-algos]        | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'ML-KEM-1024'`[^modern-algos]       | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'PBKDF2'`                           |                            |                          | ✔                        |                             |
-| `'RSA-OAEP'`                         | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'RSA-PSS'`                          | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'RSASSA-PKCS1-v1_5'`                | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'X25519'`                           | ✔                          | ✔                        | ✔                        | ✔                           |
-| `'X448'`[^secure-curves]             | ✔                          | ✔                        | ✔                        | ✔                           |
+* [`subtle.generateKey()`][], [`subtle.exportKey()`][], and
+  [`subtle.importKey()`][] support `'AES-CBC'`, `'AES-CTR'`, `'AES-GCM'`,
+  `'AES-KW'`, `'AES-OCB'`, `'ChaCha20-Poly1305'`[^modern-algos], `'HMAC'`,
+  `'KMAC128'`[^modern-algos], and `'KMAC256'`[^modern-algos].
+* [`subtle.importKey()`][] supports `'Argon2d'`, `'Argon2i'`, `'Argon2id'`,
+  `'HKDF'`, and `'PBKDF2'`.
+* [`subtle.generateKey()`][], [`subtle.exportKey()`][],
+  [`subtle.importKey()`][], and [`subtle.getPublicKey()`][] support `'ECDH'`,
+  `'ECDSA'`, `'Ed25519'`, `'Ed448'`[^secure-curves],
+  `'ML-DSA-44'`[^modern-algos], `'ML-DSA-65'`[^modern-algos],
+  `'ML-DSA-87'`[^modern-algos], `'ML-KEM-512'`[^modern-algos],
+  `'ML-KEM-768'`[^modern-algos], `'ML-KEM-1024'`[^modern-algos], `'RSA-OAEP'`,
+  `'RSA-PSS'`, `'RSASSA-PKCS1-v1_5'`, `'X25519'`, and
+  `'X448'`[^secure-curves].
 
 ### Crypto Operation APIs
 
-**Column Legend:**
+* [`subtle.encrypt()`][] and [`subtle.decrypt()`][] support `'AES-CBC'`,
+  `'AES-CTR'`, `'AES-GCM'`, `'AES-OCB'`,
+  `'ChaCha20-Poly1305'`[^modern-algos], and `'RSA-OAEP'`.
+* [`subtle.sign()`][] and [`subtle.verify()`][] support `'ECDSA'`, `'Ed25519'`,
+  `'Ed448'`[^secure-curves], `'HMAC'`, `'KMAC128'`[^modern-algos],
+  `'KMAC256'`[^modern-algos], `'ML-DSA-44'`[^modern-algos],
+  `'ML-DSA-65'`[^modern-algos], `'ML-DSA-87'`[^modern-algos], `'RSA-PSS'`, and
+  `'RSASSA-PKCS1-v1_5'`.
+* [`subtle.deriveBits()`][] and [`subtle.deriveKey()`][] support `'Argon2d'`,
+  `'Argon2i'`, `'Argon2id'`, `'ECDH'`, `'HKDF'`, `'PBKDF2'`, `'X25519'`, and
+  `'X448'`[^secure-curves].
+* [`subtle.wrapKey()`][] and [`subtle.unwrapKey()`][] support `'AES-CBC'`,
+  `'AES-CTR'`, `'AES-GCM'`, `'AES-KW'`, `'AES-OCB'`,
+  `'ChaCha20-Poly1305'`[^modern-algos], and `'RSA-OAEP'`.
+* [`subtle.encapsulateBits()`][], [`subtle.decapsulateBits()`][],
+  [`subtle.encapsulateKey()`][], and [`subtle.decapsulateKey()`][] support
+  `'ML-KEM-512'`[^modern-algos], `'ML-KEM-768'`[^modern-algos], and
+  `'ML-KEM-1024'`[^modern-algos].
+* [`subtle.digest()`][] supports `'cSHAKE128'`[^modern-algos],
+  `'cSHAKE256'`[^modern-algos], `'KT128'`[^modern-algos],
+  `'KT256'`[^modern-algos], `'SHA-1'`, `'SHA-256'`, `'SHA-384'`, `'SHA-512'`,
+  `'SHA3-256'`[^modern-algos], `'SHA3-384'`[^modern-algos],
+  `'SHA3-512'`[^modern-algos], `'TurboSHAKE128'`[^modern-algos], and
+  `'TurboSHAKE256'`[^modern-algos].
 
-* **Encryption**: [`subtle.encrypt()`][] / [`subtle.decrypt()`][]
-* **Signatures and MAC**: [`subtle.sign()`][] / [`subtle.verify()`][]
-* **Key or Bits Derivation**: [`subtle.deriveBits()`][] / [`subtle.deriveKey()`][]
-* **Key Wrapping**: [`subtle.wrapKey()`][] / [`subtle.unwrapKey()`][]
-* **Key Encapsulation**: [`subtle.encapsulateBits()`][] / [`subtle.decapsulateBits()`][] /
-  [`subtle.encapsulateKey()`][] / [`subtle.decapsulateKey()`][]
-* **Digest**: [`subtle.digest()`][]
+### Key Formats
 
-| Algorithm                            | Encryption | Signatures and MAC | Key or Bits Derivation | Key Wrapping | Key Encapsulation | Digest |
-| ------------------------------------ | ---------- | ------------------ | ---------------------- | ------------ | ----------------- | ------ |
-| `'AES-CBC'`                          | ✔          |                    |                        | ✔            |                   |        |
-| `'AES-CTR'`                          | ✔          |                    |                        | ✔            |                   |        |
-| `'AES-GCM'`                          | ✔          |                    |                        | ✔            |                   |        |
-| `'AES-KW'`                           |            |                    |                        | ✔            |                   |        |
-| `'AES-OCB'`                          | ✔          |                    |                        | ✔            |                   |        |
-| `'Argon2d'`                          |            |                    | ✔                      |              |                   |        |
-| `'Argon2i'`                          |            |                    | ✔                      |              |                   |        |
-| `'Argon2id'`                         |            |                    | ✔                      |              |                   |        |
-| `'ChaCha20-Poly1305'`[^modern-algos] | ✔          |                    |                        | ✔            |                   |        |
-| `'cSHAKE128'`[^modern-algos]         |            |                    |                        |              |                   | ✔      |
-| `'cSHAKE256'`[^modern-algos]         |            |                    |                        |              |                   | ✔      |
-| `'ECDH'`                             |            |                    | ✔                      |              |                   |        |
-| `'ECDSA'`                            |            | ✔                  |                        |              |                   |        |
-| `'Ed25519'`                          |            | ✔                  |                        |              |                   |        |
-| `'Ed448'`[^secure-curves]            |            | ✔                  |                        |              |                   |        |
-| `'HKDF'`                             |            |                    | ✔                      |              |                   |        |
-| `'HMAC'`                             |            | ✔                  |                        |              |                   |        |
-| `'KMAC128'`[^modern-algos]           |            | ✔                  |                        |              |                   |        |
-| `'KMAC256'`[^modern-algos]           |            | ✔                  |                        |              |                   |        |
-| `'KT128'`[^modern-algos]             |            |                    |                        |              |                   | ✔      |
-| `'KT256'`[^modern-algos]             |            |                    |                        |              |                   | ✔      |
-| `'ML-DSA-44'`[^modern-algos]         |            | ✔                  |                        |              |                   |        |
-| `'ML-DSA-65'`[^modern-algos]         |            | ✔                  |                        |              |                   |        |
-| `'ML-DSA-87'`[^modern-algos]         |            | ✔                  |                        |              |                   |        |
-| `'ML-KEM-512'`[^modern-algos]        |            |                    |                        |              | ✔                 |        |
-| `'ML-KEM-768'`[^modern-algos]        |            |                    |                        |              | ✔                 |        |
-| `'ML-KEM-1024'`[^modern-algos]       |            |                    |                        |              | ✔                 |        |
-| `'PBKDF2'`                           |            |                    | ✔                      |              |                   |        |
-| `'RSA-OAEP'`                         | ✔          |                    |                        | ✔            |                   |        |
-| `'RSA-PSS'`                          |            | ✔                  |                        |              |                   |        |
-| `'RSASSA-PKCS1-v1_5'`                |            | ✔                  |                        |              |                   |        |
-| `'SHA-1'`                            |            |                    |                        |              |                   | ✔      |
-| `'SHA-256'`                          |            |                    |                        |              |                   | ✔      |
-| `'SHA-384'`                          |            |                    |                        |              |                   | ✔      |
-| `'SHA-512'`                          |            |                    |                        |              |                   | ✔      |
-| `'SHA3-256'`[^modern-algos]          |            |                    |                        |              |                   | ✔      |
-| `'SHA3-384'`[^modern-algos]          |            |                    |                        |              |                   | ✔      |
-| `'SHA3-512'`[^modern-algos]          |            |                    |                        |              |                   | ✔      |
-| `'TurboSHAKE128'`[^modern-algos]     |            |                    |                        |              |                   | ✔      |
-| `'TurboSHAKE256'`[^modern-algos]     |            |                    |                        |              |                   | ✔      |
-| `'X25519'`                           |            |                    | ✔                      |              |                   |        |
-| `'X448'`[^secure-curves]             |            |                    | ✔                      |              |                   |        |
+The following list describes the formats supported by [`subtle.importKey()`][]
+and [`subtle.exportKey()`][].
+
+* **`'AES-CBC'`, `'AES-CTR'`, `'AES-GCM'`, `'AES-KW'`, and `'HMAC'`** can
+  be imported and exported using `'jwk'`, `'raw'`, and
+  `'raw-secret'`[^modern-algos].
+* **`'AES-OCB'`[^modern-algos], `'ChaCha20-Poly1305'`[^modern-algos],
+  `'KMAC128'`[^modern-algos], and `'KMAC256'`[^modern-algos]** can be imported
+  and exported using `'jwk'` and `'raw-secret'`[^modern-algos].
+* **`'Argon2d'`[^modern-algos], `'Argon2i'`[^modern-algos], and
+  `'Argon2id'`[^modern-algos]** can be imported using
+  `'raw-secret'`[^modern-algos]; export is not supported.
+* **`'ECDH'`, `'ECDSA'`, `'Ed25519'`, `'Ed448'`[^secure-curves], `'X25519'`,
+  and `'X448'`[^secure-curves]** can be imported and exported using `'spki'`,
+  `'pkcs8'`, `'jwk'`, `'raw'`, and `'raw-public'`[^modern-algos].
+* **`'HKDF'` and `'PBKDF2'`** can be imported using `'raw'` and
+  `'raw-secret'`[^modern-algos]; export is not supported.
+* **`'ML-DSA-44'`[^modern-algos], `'ML-DSA-65'`[^modern-algos],
+  `'ML-DSA-87'`[^modern-algos], `'ML-KEM-512'`[^modern-algos],
+  `'ML-KEM-768'`[^modern-algos], and `'ML-KEM-1024'`[^modern-algos]** can be
+  imported and exported using `'spki'`, `'pkcs8'`, `'jwk'`,
+  `'raw-public'`[^modern-algos], and `'raw-seed'`[^modern-algos].
+* **`'RSA-OAEP'`, `'RSA-PSS'`, and `'RSASSA-PKCS1-v1_5'`** can be imported
+  and exported using `'spki'`, `'pkcs8'`, and `'jwk'`.
 
 ## Class: `Crypto`
 
@@ -731,48 +711,8 @@ The possible usages are:
 * `'unwrapKey'` - Enable using the key with [`subtle.unwrapKey()`][]
 
 Valid key usages depend on the key algorithm (identified by
-`cryptokey.algorithm.name`).
-
-**Column Legend:**
-
-* **Encryption**: [`subtle.encrypt()`][] / [`subtle.decrypt()`][]
-* **Signatures and MAC**: [`subtle.sign()`][] / [`subtle.verify()`][]
-* **Key or Bits Derivation**: [`subtle.deriveBits()`][] / [`subtle.deriveKey()`][]
-* **Key Wrapping**: [`subtle.wrapKey()`][] / [`subtle.unwrapKey()`][]
-* **Key Encapsulation**: [`subtle.encapsulateBits()`][] / [`subtle.decapsulateBits()`][] /
-  [`subtle.encapsulateKey()`][] / [`subtle.decapsulateKey()`][]
-
-| Supported Key Algorithm              | Encryption | Signatures and MAC | Key or Bits Derivation | Key Wrapping | Key Encapsulation |
-| ------------------------------------ | ---------- | ------------------ | ---------------------- | ------------ | ----------------- |
-| `'AES-CBC'`                          | ✔          |                    |                        | ✔            |                   |
-| `'AES-CTR'`                          | ✔          |                    |                        | ✔            |                   |
-| `'AES-GCM'`                          | ✔          |                    |                        | ✔            |                   |
-| `'AES-KW'`                           |            |                    |                        | ✔            |                   |
-| `'AES-OCB'`                          | ✔          |                    |                        | ✔            |                   |
-| `'Argon2d'`                          |            |                    | ✔                      |              |                   |
-| `'Argon2i'`                          |            |                    | ✔                      |              |                   |
-| `'Argon2id'`                         |            |                    | ✔                      |              |                   |
-| `'ChaCha20-Poly1305'`[^modern-algos] | ✔          |                    |                        | ✔            |                   |
-| `'ECDH'`                             |            |                    | ✔                      |              |                   |
-| `'ECDSA'`                            |            | ✔                  |                        |              |                   |
-| `'Ed25519'`                          |            | ✔                  |                        |              |                   |
-| `'Ed448'`[^secure-curves]            |            | ✔                  |                        |              |                   |
-| `'HKDF'`                             |            |                    | ✔                      |              |                   |
-| `'HMAC'`                             |            | ✔                  |                        |              |                   |
-| `'KMAC128'`[^modern-algos]           |            | ✔                  |                        |              |                   |
-| `'KMAC256'`[^modern-algos]           |            | ✔                  |                        |              |                   |
-| `'ML-DSA-44'`[^modern-algos]         |            | ✔                  |                        |              |                   |
-| `'ML-DSA-65'`[^modern-algos]         |            | ✔                  |                        |              |                   |
-| `'ML-DSA-87'`[^modern-algos]         |            | ✔                  |                        |              |                   |
-| `'ML-KEM-512'`[^modern-algos]        |            |                    |                        |              | ✔                 |
-| `'ML-KEM-768'`[^modern-algos]        |            |                    |                        |              | ✔                 |
-| `'ML-KEM-1024'`[^modern-algos]       |            |                    |                        |              | ✔                 |
-| `'PBKDF2'`                           |            |                    | ✔                      |              |                   |
-| `'RSA-OAEP'`                         | ✔          |                    |                        | ✔            |                   |
-| `'RSA-PSS'`                          |            | ✔                  |                        |              |                   |
-| `'RSASSA-PKCS1-v1_5'`                |            | ✔                  |                        |              |                   |
-| `'X25519'`                           |            |                    | ✔                      |              |                   |
-| `'X448'`[^secure-curves]             |            |                    | ✔                      |              |                   |
+`cryptokey.algorithm.name`). See [Crypto operation APIs][] for the operations
+supported by each key algorithm.
 
 ## Class: `CryptoKeyPair`
 
@@ -1181,30 +1121,7 @@ When `format` is `'jwk'` and the export is successful, the returned promise
 will be resolved with a JavaScript object conforming to the [JSON Web Key][]
 specification.
 
-| Supported Key Algorithm              | `'spki'` | `'pkcs8'` | `'jwk'` | `'raw'` | `'raw-secret'` | `'raw-public'` | `'raw-seed'` |
-| ------------------------------------ | -------- | --------- | ------- | ------- | -------------- | -------------- | ------------ |
-| `'AES-CBC'`                          |          |           | ✔       | ✔       | ✔              |                |              |
-| `'AES-CTR'`                          |          |           | ✔       | ✔       | ✔              |                |              |
-| `'AES-GCM'`                          |          |           | ✔       | ✔       | ✔              |                |              |
-| `'AES-KW'`                           |          |           | ✔       | ✔       | ✔              |                |              |
-| `'AES-OCB'`[^modern-algos]           |          |           | ✔       |         | ✔              |                |              |
-| `'ChaCha20-Poly1305'`[^modern-algos] |          |           | ✔       |         | ✔              |                |              |
-| `'ECDH'`                             | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'ECDSA'`                            | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'Ed25519'`                          | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'Ed448'`[^secure-curves]            | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'HMAC'`                             |          |           | ✔       | ✔       | ✔              |                |              |
-| `'KMAC128'`[^modern-algos]           |          |           | ✔       |         | ✔              |                |              |
-| `'KMAC256'`[^modern-algos]           |          |           | ✔       |         | ✔              |                |              |
-| `'ML-DSA-44'`[^modern-algos]         | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-DSA-65'`[^modern-algos]         | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-DSA-87'`[^modern-algos]         | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-KEM-512'`[^modern-algos]        | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-KEM-768'`[^modern-algos]        | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-KEM-1024'`[^modern-algos]       | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'RSA-OAEP'`                         | ✔        | ✔         | ✔       |         |                |                |              |
-| `'RSA-PSS'`                          | ✔        | ✔         | ✔       |         |                |                |              |
-| `'RSASSA-PKCS1-v1_5'`                | ✔        | ✔         | ✔       |         |                |                |              |
+See [Key formats][] for the formats supported by each algorithm.
 
 ### `subtle.getPublicKey(key, keyUsages)`
 
@@ -1345,39 +1262,7 @@ representation of the key material.
 
 If importing KDF algorithm keys, `extractable` must be `false`.
 
-The algorithms currently supported include:
-
-| Supported Key Algorithm              | `'spki'` | `'pkcs8'` | `'jwk'` | `'raw'` | `'raw-secret'` | `'raw-public'` | `'raw-seed'` |
-| ------------------------------------ | -------- | --------- | ------- | ------- | -------------- | -------------- | ------------ |
-| `'AES-CBC'`                          |          |           | ✔       | ✔       | ✔              |                |              |
-| `'AES-CTR'`                          |          |           | ✔       | ✔       | ✔              |                |              |
-| `'AES-GCM'`                          |          |           | ✔       | ✔       | ✔              |                |              |
-| `'AES-KW'`                           |          |           | ✔       | ✔       | ✔              |                |              |
-| `'AES-OCB'`[^modern-algos]           |          |           | ✔       |         | ✔              |                |              |
-| `'Argon2d'`[^modern-algos]           |          |           |         |         | ✔              |                |              |
-| `'Argon2i'`[^modern-algos]           |          |           |         |         | ✔              |                |              |
-| `'Argon2id'`[^modern-algos]          |          |           |         |         | ✔              |                |              |
-| `'ChaCha20-Poly1305'`[^modern-algos] |          |           | ✔       |         | ✔              |                |              |
-| `'ECDH'`                             | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'ECDSA'`                            | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'Ed25519'`                          | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'Ed448'`[^secure-curves]            | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'HKDF'`                             |          |           |         | ✔       | ✔              |                |              |
-| `'HMAC'`                             |          |           | ✔       | ✔       | ✔              |                |              |
-| `'KMAC128'`[^modern-algos]           |          |           | ✔       |         | ✔              |                |              |
-| `'KMAC256'`[^modern-algos]           |          |           | ✔       |         | ✔              |                |              |
-| `'ML-DSA-44'`[^modern-algos]         | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-DSA-65'`[^modern-algos]         | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-DSA-87'`[^modern-algos]         | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-KEM-512'`[^modern-algos]        | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-KEM-768'`[^modern-algos]        | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'ML-KEM-1024'`[^modern-algos]       | ✔        | ✔         | ✔       |         |                | ✔              | ✔            |
-| `'PBKDF2'`                           |          |           |         | ✔       | ✔              |                |              |
-| `'RSA-OAEP'`                         | ✔        | ✔         | ✔       |         |                |                |              |
-| `'RSA-PSS'`                          | ✔        | ✔         | ✔       |         |                |                |              |
-| `'RSASSA-PKCS1-v1_5'`                | ✔        | ✔         | ✔       |         |                |                |              |
-| `'X25519'`                           | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
-| `'X448'`[^secure-curves]             | ✔        | ✔         | ✔       | ✔       |                | ✔              |              |
+See [Key formats][] for the algorithms and formats currently supported.
 
 ### `subtle.sign(algorithm, key, data)`
 
@@ -2832,7 +2717,9 @@ added:
 [^openssl35]: Requires OpenSSL >= 3.5
 
 [Checking for runtime algorithm support]: #checking-for-runtime-algorithm-support
+[Crypto operation APIs]: #crypto-operation-apis
 [JSON Web Key]: https://tools.ietf.org/html/rfc7517
+[Key formats]: #key-formats
 [Key usages]: #cryptokeyusages
 [Modern Algorithms in the Web Cryptography API]: #modern-algorithms-in-the-web-cryptography-api
 [RFC 4122]: https://www.rfc-editor.org/rfc/rfc4122.txt


### PR DESCRIPTION
Because the current tables aren't compatible with the (subjective opinion trigger warning ⚠️ ) overly narrow main content section of the doc redesign.