### PR TITLE
doc: clarify tlsSocket.authorized on resumption

### DIFF
--- a/doc/api/tls.md
+++ b/doc/api/tls.md
@@ -1072,6 +1072,18 @@ added: v0.11.4
 This property is `true` if the peer certificate was signed by one of the CAs
 specified when creating the `tls.TLSSocket` instance, otherwise `false`.
 
+The peer certificate is only verified during a full TLS handshake. When a
+connection is established by resuming a previous session (see
+[Session Resumption][]), verification is not repeated. If the client
+presented a certificate in the original handshake, `authorized` and
+`authorizationError` carry the result stored with the session, including
+any verification error. On TLS 1.3, a client that sent no certificate at
+all can resume a session and report `authorized` as `true`, while
+[`tls.TLSSocket.getPeerCertificate()`][] returns an empty object. Servers
+that authorize clients manually with `rejectUnauthorized: false` should
+therefore also check [`tls.TLSSocket.isSessionReused()`][] and that a peer
+certificate is present.
+
 ### `tlsSocket.disableRenegotiation()`
 
 <!-- YAML
@@ -2580,6 +2592,7 @@ added: v0.11.3
 [`tls.TLSSocket.getProtocol()`]: #tlssocketgetprotocol
 [`tls.TLSSocket.getSession()`]: #tlssocketgetsession
 [`tls.TLSSocket.getTLSTicket()`]: #tlssocketgettlsticket
+[`tls.TLSSocket.isSessionReused()`]: #tlssocketissessionreused
 [`tls.TLSSocket.servername`]: #tlssocketservername
 [`tls.TLSSocket`]: #class-tlstlssocket
 [`tls.connect()`]: #tlsconnectoptions-callback


### PR DESCRIPTION
In #35317, @bnoordhuis diagnosed that session resumption cuts out the client-certificate exchange and invited exactly this change: "I do feel the documentation for `socket.authorized` should mention that caveat… I've added the `doc` label. Pull request welcome!" The `tlsSocket.authorized` section still describes only the full-handshake behavior.

Before writing the text I measured all six scenarios on current `main` (TLS 1.2/1.3 × trusted/untrusted/no client cert; deterministic, reproduced with two independent harnesses): when a certificate was presented in the original handshake, the verification result — including any error — is carried with the session on both protocol versions (`SSL_get_verify_result` reads the session-stored result; `deps/ncrypto/ncrypto.cc` `verifyPeerCertificate`). The one case that still flips is TLS 1.3 with no client certificate: the full handshake reports `authorized === false`, but a resumed connection reports `authorized === true` with `getPeerCertificate()` empty — the deliberate carve-out shared with PSK (`TLS1_3_VERSION && SSL_session_reused` → `X509_V_OK`, from #23188). The added paragraph states the carry-over rule, that exception, and the practical check for servers that authorize manually with `rejectUnauthorized: false`.

I used an AI assistant while researching and drafting this change; I've verified the behavior with live repros and against the source myself and take full responsibility for it.

Fixes: #35317
