### PR TITLE
readline: improve performance

### DIFF
--- a/benchmark/readline/readline-createInterface.js
+++ b/benchmark/readline/readline-createInterface.js
@@ -1,0 +1,26 @@
+'use strict';
+const common = require('../common.js');
+const readline = require('readline');
+const { Readable, Writable } = require('stream');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  terminal: [0, 1],
+});
+
+function main({ n, terminal }) {
+  bench.start();
+  for (let i = 0; i < n; i++) {
+    const input = new Readable({ read() {} });
+    const output = new Writable({ write(chunk, encoding, callback) {
+      callback();
+    } });
+    const rl = readline.createInterface({
+      input,
+      output,
+      terminal: Boolean(terminal),
+    });
+    rl.close();
+  }
+  bench.end(n);
+}

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -17,7 +17,7 @@ const {
   MathMax,
   MathMaxApply,
   NumberIsFinite,
-  ObjectDefineProperty,
+  ObjectDefineProperties,
   ObjectSetPrototypeOf,
   RegExpPrototypeExec,
   SafeStringIterator,
@@ -172,6 +172,7 @@ function InterfaceConstructor(input, output, completer, terminal) {
   let crlfDelay;
   let prompt = '> ';
   let signal;
+  let historyOptions;
 
   if (input?.input) {
     // An options object was given
@@ -210,12 +211,15 @@ function InterfaceConstructor(input, output, completer, terminal) {
     crlfDelay = input.crlfDelay;
     input = input.input;
 
-    input.size = historySize;
-    input.history = history;
-    input.removeHistoryDuplicates = removeHistoryDuplicates;
+    historyOptions = {
+      __proto__: null,
+      size: historySize,
+      history,
+      removeHistoryDuplicates,
+    };
   }
 
-  this.setupHistoryManager(input);
+  this.setupHistoryManager(historyOptions ?? input);
 
   if (completer !== undefined && typeof completer !== 'function') {
     throw new ERR_INVALID_ARG_VALUE('completer', completer);
@@ -358,6 +362,30 @@ function InterfaceConstructor(input, output, completer, terminal) {
 ObjectSetPrototypeOf(InterfaceConstructor.prototype, EventEmitter.prototype);
 ObjectSetPrototypeOf(InterfaceConstructor, EventEmitter);
 
+// Shared descriptors for the history accessors defined on each instance.
+// Hoisted to avoid allocating fresh closures on every construction.
+const kHistoryAccessorDescriptors = {
+  __proto__: null,
+  history: {
+    __proto__: null, configurable: true, enumerable: true,
+    get() { return this.historyManager.history; },
+    set(newHistory) { return this.historyManager.history = newHistory; },
+  },
+  historyIndex: {
+    __proto__: null, configurable: true, enumerable: true,
+    get() { return this.historyManager.index; },
+    set(historyIndex) { return this.historyManager.index = historyIndex; },
+  },
+  historySize: {
+    __proto__: null, configurable: true, enumerable: true,
+    get() { return this.historyManager.size; },
+  },
+  isFlushing: {
+    __proto__: null, configurable: true, enumerable: true,
+    get() { return this.historyManager.isFlushing; },
+  },
+};
+
 class Interface extends InterfaceConstructor {
   get columns() {
     if (this.output?.columns) return this.output.columns;
@@ -388,27 +416,7 @@ class Interface extends InterfaceConstructor {
       this.historyManager.initialize(options.onHistoryFileLoaded);
     }
 
-    ObjectDefineProperty(this, 'history', {
-      __proto__: null, configurable: true, enumerable: true,
-      get() { return this.historyManager.history; },
-      set(newHistory) { return this.historyManager.history = newHistory; },
-    });
-
-    ObjectDefineProperty(this, 'historyIndex', {
-      __proto__: null, configurable: true, enumerable: true,
-      get() { return this.historyManager.index; },
-      set(historyIndex) { return this.historyManager.index = historyIndex; },
-    });
-
-    ObjectDefineProperty(this, 'historySize', {
-      __proto__: null, configurable: true, enumerable: true,
-      get() { return this.historyManager.size; },
-    });
-
-    ObjectDefineProperty(this, 'isFlushing', {
-      __proto__: null, configurable: true, enumerable: true,
-      get() { return this.historyManager.isFlushing; },
-    });
+    ObjectDefineProperties(this, kHistoryAccessorDescriptors);
   }
 
   [kSetRawMode](mode) {

--- a/lib/internal/readline/interface.js
+++ b/lib/internal/readline/interface.js
@@ -20,6 +20,7 @@ const {
   ObjectDefineProperties,
   ObjectSetPrototypeOf,
   RegExpPrototypeExec,
+  RegExpPrototypeSymbolSplit,
   SafeStringIterator,
   StringPrototypeCodePointAt,
   StringPrototypeEndsWith,
@@ -630,37 +631,44 @@ class Interface extends InterfaceConstructor {
       this[kSawReturnAt] = 0;
     }
 
-    // Run test() on the new string chunk, not on the entire line buffer.
-    let newPartContainsEnding = RegExpPrototypeExec(lineEnding, string);
-    if (newPartContainsEnding !== null) {
-      if (this[kLine_buffer]) {
-        string = this[kLine_buffer] + string;
-        this[kLine_buffer] = null;
-        lineEnding.lastIndex = 0; // Start the search from the beginning of the string.
-        newPartContainsEnding = RegExpPrototypeExec(lineEnding, string);
-      }
-      this[kSawReturnAt] = StringPrototypeEndsWith(string, '\r') ?
-        DateNow() :
-        0;
+    if (!string) {
+      return;
+    }
 
-      const indexes = [0, newPartContainsEnding.index, lineEnding.lastIndex];
-      let nextMatch;
-      while ((nextMatch = RegExpPrototypeExec(lineEnding, string)) !== null) {
-        ArrayPrototypePush(indexes, nextMatch.index, lineEnding.lastIndex);
-      }
-      const lastIndex = indexes.length - 1;
-      // Either '' or (conceivably) the unfinished portion of the next line
-      this[kLine_buffer] = StringPrototypeSlice(string, indexes[lastIndex]);
-      for (let i = 1; i < lastIndex; i += 2) {
-        this[kOnLine](StringPrototypeSlice(string, indexes[i - 1], indexes[i]));
-      }
-    } else if (string) {
-      // No newlines this time, save what we have for next time
+    // Split the new string chunk, not the entire line buffer: a single
+    // split pass avoids allocating a match object per line ending.
+    // When the chunk contains none of the rare line endings, a plain
+    // string split is much cheaper than the regular expression.
+    const lines =
+      StringPrototypeIncludes(string, '\r') ||
+      StringPrototypeIncludes(string, '\u2028') ||
+      StringPrototypeIncludes(string, '\u2029') ?
+        RegExpPrototypeSymbolSplit(lineEnding, string) :
+        StringPrototypeSplit(string, '\n');
+    const lastIndex = lines.length - 1;
+    if (lastIndex === 0) {
+      // No line endings this time, save what we have for next time.
       if (this[kLine_buffer]) {
         this[kLine_buffer] += string;
       } else {
         this[kLine_buffer] = string;
       }
+      return;
+    }
+
+    this[kSawReturnAt] = StringPrototypeEndsWith(string, '\r') ?
+      DateNow() :
+      0;
+
+    let first = lines[0];
+    if (this[kLine_buffer]) {
+      first = this[kLine_buffer] + first;
+    }
+    // Either '' or (conceivably) the unfinished portion of the next line
+    this[kLine_buffer] = lines[lastIndex];
+    this[kOnLine](first);
+    for (let i = 1; i < lastIndex; i++) {
+      this[kOnLine](lines[i]);
     }
   }
 

--- a/lib/readline.js
+++ b/lib/readline.js
@@ -115,7 +115,9 @@ function Interface(input, output, completer, terminal) {
   FunctionPrototypeCall(InterfaceConstructor, this,
                         input, output, completer, terminal);
 
-  if (process.env.TERM === 'dumb') {
+  // Reading process.env is expensive and _ttyWrite is only used in
+  // terminal mode, so only check for a dumb terminal when relevant.
+  if (this.terminal && process.env.TERM === 'dumb') {
     this._ttyWrite = FunctionPrototypeBind(_ttyWriteDumb, this);
   }
 }


### PR DESCRIPTION
Speed up `readline.createInterface()`, which is on the hot path of every CLI tool that reads lines from a stream.

A CPU profile of interface construction showed three avoidable costs:

1. `setupHistoryManager()` accounted for ~43% of construction self time: every instance ran four `ObjectDefineProperty` calls, allocating six fresh closures and four descriptor objects each time. The accessors (`history`, `historyIndex`, `historySize`, `isFlushing`) are now defined from a module-level shared descriptor map with a single `ObjectDefineProperties` call. They remain own, enumerable, configurable properties, so observable semantics are unchanged.
2. The constructor assigned `size`, `history` and `removeHistoryDuplicates` onto the user-provided input stream to forward them to the history manager. It now passes a plain options object instead, so the user's stream is no longer observably mutated and doesn't go through extra hidden-class transitions. The legacy positional-arguments path is unchanged.
3. The `Interface` wrapper unconditionally read `process.env.TERM` (which goes through the env interceptor) to bind the dumb-terminal `_ttyWrite`. The check is now gated on `this.terminal`, since `_ttyWrite` is never invoked when the interface is not in terminal mode.

Results with the new benchmark (30 runs, interleaved via `benchmark/compare.js`):

```
                                                         confidence improvement accuracy (*)   (**)  (***)
readline/readline-createInterface.js terminal=0 n=100000        ***     63.81 %       ±1.94% ±2.59% ±3.38%
readline/readline-createInterface.js terminal=1 n=100000        ***     38.05 %       ±1.90% ±2.53% ±3.31%
```

---

**Update:** a second commit speeds up line throughput as well. `[kNormalWrite]` ran a regular-expression `exec` loop that allocated a match object and two index entries per line, then sliced each line out in JS. It now does a single split pass, and uses a plain string split on `"\n"` when the chunk contains none of the rare line endings (`\r`, ` `, ` `), which takes V8's fast string-split path.

Results for `readline/readline-iterable.js` (20 runs, interleaved):

```
                                                   confidence improvement accuracy (*)    (**)   (***)
readline/readline-iterable.js type='new' n=10             ***      5.18 %       ±1.91%  ±2.57%  ±3.38%
readline/readline-iterable.js type='new' n=100              *     13.16 %      ±12.52% ±16.89% ±22.48%
readline/readline-iterable.js type='new' n=1000           ***     32.94 %      ±11.25% ±15.31% ±20.66%
readline/readline-iterable.js type='new' n=10000          ***     47.44 %       ±4.83%  ±6.53%  ±8.70%
readline/readline-iterable.js type='new' n=100000         ***     70.71 %       ±2.18%  ±2.94%  ±3.91%
readline/readline-iterable.js type='new' n=1000000        ***     80.62 %       ±1.51%  ±2.05%  ±2.75%
readline/readline-iterable.js type='old' n=10             ***      4.92 %       ±1.50%  ±2.01%  ±2.66%
readline/readline-iterable.js type='old' n=100                    -5.79 %      ±10.40% ±13.97% ±18.46%
readline/readline-iterable.js type='old' n=1000                    1.39 %       ±6.82%  ±9.14% ±12.03%
readline/readline-iterable.js type='old' n=10000          ***     18.40 %       ±3.62%  ±4.85%  ±6.38%
readline/readline-iterable.js type='old' n=100000         ***     26.02 %       ±2.91%  ±3.93%  ±5.21%
readline/readline-iterable.js type='old' n=1000000        ***     31.42 %       ±2.00%  ±2.67%  ±3.52%
```

Event-based consumption (`rl.on('line')`) goes from 8.1M to 13.3M lines/s (+65%) in a microbenchmark of 32-byte lines.
