### PR TITLE
zlib: reject truncated zstd input

### DIFF
--- a/src/node_zlib.cc
+++ b/src/node_zlib.cc
@@ -358,6 +358,7 @@ class ZstdDecompressContext final : public ZstdContext {
   // Streaming-related, should be available for all compression libraries:
   void Close();
   void DoThreadPoolWork();
+  CompressionError GetErrorInfo() const;
   CompressionError ResetStream();
 
   // Zstd specific:
@@ -375,6 +376,7 @@ class ZstdDecompressContext final : public ZstdContext {
 
  private:
   DeleteFnPtr<ZSTD_DCtx, ZstdDecompressContext::FreeZstd> dctx_;
+  bool frame_complete_ = false;
 };
 
 class CompressionStreamMemoryOwner {
@@ -1717,6 +1719,8 @@ void ZstdDecompressContext::Close() {
 
 CompressionError ZstdDecompressContext::Init(uint64_t pledged_src_size,
                                              std::string_view dictionary) {
+  frame_complete_ = false;
+
 #ifdef NODE_BUNDLED_ZSTD
   ZSTD_customMem custom_mem = {
       CompressionStreamMemoryOwner::AllocForBrotli,
@@ -1752,12 +1756,37 @@ CompressionError ZstdDecompressContext::ResetStream() {
 }
 
 void ZstdDecompressContext::DoThreadPoolWork() {
+  // The JavaScript processing loop retries with an empty input buffer when the
+  // previous call filled the output buffer. Avoid interpreting that retry as
+  // the beginning of a new, incomplete frame.
+  if (frame_complete_ && input_.size == 0) {
+    return;
+  }
+
   size_t const ret = ZSTD_decompressStream(dctx_.get(), &output_, &input_);
   if (ZSTD_isError(ret)) {
+    frame_complete_ = false;
     error_ = ZSTD_getErrorCode(ret);
     error_code_string_ = ZstdStrerror(error_);
     error_string_ = ZSTD_getErrorString(error_);
+  } else {
+    frame_complete_ = ret == 0;
   }
+}
+
+CompressionError ZstdDecompressContext::GetErrorInfo() const {
+  CompressionError error = ZstdContext::GetErrorInfo();
+  if (error.IsError()) {
+    return error;
+  }
+
+  if (flush_ == ZSTD_e_end && !frame_complete_ && input_.pos == input_.size &&
+      output_.pos < output_.size) {
+    return CompressionError(
+        "unexpected end of file", "Z_BUF_ERROR", Z_BUF_ERROR);
+  }
+
+  return {};
 }
 
 template <typename Stream>

--- a/test/parallel/test-zlib-truncated.js
+++ b/test/parallel/test-zlib-truncated.js
@@ -22,6 +22,12 @@ const errMessage = /unexpected end of file/;
   { comp: 'gzip', decomp: 'unzip', decompSync: 'unzipSync' },
   { comp: 'deflate', decomp: 'inflate', decompSync: 'inflateSync' },
   { comp: 'deflateRaw', decomp: 'inflateRaw', decompSync: 'inflateRawSync' },
+  {
+    comp: 'zstdCompress',
+    decomp: 'zstdDecompress',
+    decompSync: 'zstdDecompressSync',
+    partialFlush: zlib.constants.ZSTD_e_flush,
+  },
 ].forEach(function(methods) {
   zlib[methods.comp](inputString, common.mustSucceed((compressed) => {
     const truncated = compressed.slice(0, compressed.length / 2);
@@ -46,16 +52,59 @@ const errMessage = /unexpected end of file/;
       assert.match(err.message, errMessage);
     }));
 
-    const syncFlushOpt = { finishFlush: zlib.constants.Z_SYNC_FLUSH };
+    const partialFlushOpt = {
+      finishFlush: methods.partialFlush ?? zlib.constants.Z_SYNC_FLUSH,
+    };
 
-    // Sync truncated input test, finishFlush = Z_SYNC_FLUSH
-    const result = toUTF8(zlib[methods.decompSync](truncated, syncFlushOpt));
+    // Sync truncated input test with a non-finalizing finish flush.
+    const result = toUTF8(zlib[methods.decompSync](truncated, partialFlushOpt));
     assert.strictEqual(result, inputString.slice(0, result.length));
 
-    // Async truncated input test, finishFlush = Z_SYNC_FLUSH
-    zlib[methods.decomp](truncated, syncFlushOpt, common.mustSucceed((decompressed) => {
+    // Async truncated input test with a non-finalizing finish flush.
+    zlib[methods.decomp](truncated, partialFlushOpt, common.mustSucceed((decompressed) => {
       const result = toUTF8(decompressed);
       assert.strictEqual(result, inputString.slice(0, result.length));
     }));
   }));
 });
+
+// A non-zero return from ZSTD_decompressStream() can also mean that the
+// output buffer is full. Make sure that is drained before treating the return
+// value as truncated input.
+{
+  const input = Buffer.alloc(zlib.constants.Z_DEFAULT_CHUNK * 2, 0x61);
+  const compressed = zlib.zstdCompressSync(input);
+  const decompressed = zlib.zstdDecompressSync(compressed, {
+    chunkSize: zlib.constants.Z_MIN_CHUNK,
+  });
+  assert.deepStrictEqual(decompressed, input);
+}
+
+// Ending a stream after a previous write completed a frame must not be
+// mistaken for an empty, truncated frame.
+{
+  const input = Buffer.from(inputString);
+  const compressed = zlib.zstdCompressSync(input);
+  const decompressor = zlib.createZstdDecompress();
+  const output = [];
+
+  decompressor.on('data', (chunk) => output.push(chunk));
+  decompressor.on('end', common.mustCall(() => {
+    assert.deepStrictEqual(Buffer.concat(output), input);
+  }));
+  decompressor.write(compressed, common.mustCall(() => decompressor.end()));
+}
+
+// Conversely, ending after a previous write supplied only part of a frame
+// must report that the frame is incomplete.
+{
+  const compressed = zlib.zstdCompressSync(inputString);
+  const truncated = compressed.subarray(0, compressed.length / 2);
+  const decompressor = zlib.createZstdDecompress();
+
+  decompressor.on('error', common.mustCall((error) => {
+    assert.match(error.message, errMessage);
+  }));
+  decompressor.write(truncated, common.mustCall(() => decompressor.end()));
+  decompressor.resume();
+}


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fixes: #64592