### PR TITLE
zlib: accept ArrayBuffer dictionary in Zstd

### DIFF
--- a/doc/api/zlib.md
+++ b/doc/api/zlib.md
@@ -1099,6 +1099,10 @@ added:
   - v23.8.0
   - v22.15.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/64599
+    description: The `dictionary` option can be a `TypedArray`, `DataView`, or
+                 `ArrayBuffer`.
   - version: v26.5.0
     pr-url: https://github.com/nodejs/node/pull/64023
     description: The `rejectGarbageAfterEnd` option was added.
@@ -1115,8 +1119,8 @@ Each Zstd-based class takes an `options` object. All options are optional.
 * `maxOutputLength` {integer} Limits output size when using
   [convenience methods][]. **Default:** [`buffer.kMaxLength`][]
 * `info` {boolean} If `true`, returns an object with `buffer` and `engine`. **Default:** `false`
-* `dictionary` {Buffer} Optional dictionary used to
-  improve compression efficiency when compressing or decompressing data that
+* `dictionary` {Buffer|TypedArray|DataView|ArrayBuffer} Optional dictionary used
+  to improve compression efficiency when compressing or decompressing data that
   shares common patterns with the dictionary.
 * `rejectGarbageAfterEnd` {boolean} If `true`, decompression fails when
   input remains after the first complete compressed stream. **Default:** `false`

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -926,6 +926,15 @@ class Zstd extends ZlibBase {
       });
     }
 
+    let dictionary = opts?.dictionary;
+    if (dictionary !== undefined && !isArrayBufferView(dictionary)) {
+      if (isAnyArrayBuffer(dictionary)) {
+        dictionary = Buffer.from(dictionary);
+      } else {
+        dictionary = undefined;
+      }
+    }
+
     const handle = mode === ZSTD_COMPRESS ?
       new binding.ZstdCompress() : new binding.ZstdDecompress();
 
@@ -938,7 +947,7 @@ class Zstd extends ZlibBase {
       pledgedSrcSize,
       writeState,
       processCallback,
-      opts?.dictionary && isArrayBufferView(opts.dictionary) ? opts.dictionary : undefined,
+      dictionary,
     );
 
     super(opts, mode, handle, zstdDefaultOpts);

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -33,6 +33,7 @@ const {
   ObjectSetPrototypeOf,
   Symbol,
   Uint32Array,
+  Uint8Array,
 } = primordials;
 
 const {

--- a/lib/zlib.js
+++ b/lib/zlib.js
@@ -929,7 +929,7 @@ class Zstd extends ZlibBase {
     let dictionary = opts?.dictionary;
     if (dictionary !== undefined && !isArrayBufferView(dictionary)) {
       if (isAnyArrayBuffer(dictionary)) {
-        dictionary = Buffer.from(dictionary);
+        dictionary = new Uint8Array(dictionary);
       } else {
         dictionary = undefined;
       }

--- a/test/parallel/test-zlib-zstd-dictionary.js
+++ b/test/parallel/test-zlib-zstd-dictionary.js
@@ -24,3 +24,19 @@ zlib.zstdCompress(input, { dictionary }, common.mustSucceed((compressed) => {
     assert.strictEqual(decompressed.toString(), input.toString());
   }));
 }));
+
+const baseline = zlib.zstdCompressSync(input, { dictionary }).length;
+
+const arrayBuffer = dictionary.buffer.slice(
+  dictionary.byteOffset, dictionary.byteOffset + dictionary.byteLength);
+const uint8 = new Uint8Array(arrayBuffer);
+const dataView = new DataView(arrayBuffer);
+
+for (const dict of [arrayBuffer, uint8, dataView]) {
+  assert.strictEqual(zlib.zstdCompressSync(input, { dictionary: dict }).length,
+                     baseline);
+
+  const compressed = zlib.zstdCompressSync(input, { dictionary: dict });
+  const decompressed = zlib.zstdDecompressSync(compressed, { dictionary: dict });
+  assert.strictEqual(decompressed.toString(), input.toString());
+}


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64598

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
