### PR TITLE
src: list scripts when `--run` has no command

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -2657,6 +2657,9 @@ forked processes, or clustered processes.
 <!-- YAML
 added: v22.0.0
 changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/64606
+    description: Passing `--run` without a command lists the available scripts.
   - version: v22.3.0
     pr-url: https://github.com/nodejs/node/pull/53032
     description: NODE_RUN_SCRIPT_NAME environment variable is added.
@@ -2672,6 +2675,15 @@ changes:
 
 This runs a specified command from a package.json's `"scripts"` object.
 If a missing `"command"` is provided, it will list the available scripts.
+
+Passing `--run` without a command lists the available scripts and exits
+with a non-zero exit code:
+
+```console
+$ node --run
+Available scripts are:
+  test: node --test
+```
 
 `--run` will traverse up to the root directory and finds a `package.json`
 file to run the command from.

--- a/doc/node.1
+++ b/doc/node.1
@@ -1318,6 +1318,13 @@ forked processes, or clustered processes.
 .It Fl -run
 This runs a specified command from a package.json's \fB"scripts"\fR object.
 If a missing \fB"command"\fR is provided, it will list the available scripts.
+Passing \fB--run\fR without a command lists the available scripts and exits
+with a non-zero exit code:
+.Bd -literal
+$ node --run
+Available scripts are:
+  test: node --test
+.Ed
 \fB--run\fR will traverse up to the root directory and finds a \fBpackage.json\fR
 file to run the command from.
 \fB--run\fR prepends \fB./node_modules/.bin\fR for each ancestor of

--- a/src/node.cc
+++ b/src/node.cc
@@ -1133,7 +1133,8 @@ InitializeOncePerProcessInternal(const std::vector<std::string>& args,
     }
   }
 
-  if (!per_process::cli_options->run.empty()) {
+  // A bare `--run` (empty value) lists the available scripts; a value runs it.
+  if (per_process::cli_options->has_run) {
     auto positional_args = task_runner::GetPositionalArgs(args);
     result->early_return_ = true;
     task_runner::RunTask(

--- a/src/node_options-inl.h
+++ b/src/node_options-inl.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <ranges>
+#include <type_traits>
 #include "node_options.h"
 #include "util.h"
 
@@ -453,18 +454,21 @@ void OptionsParser<Options>::Parse(
 
     std::string value;
     if (info.type != kBoolean && info.type != kNoOp && info.type != kV8Option) {
+      // `--run` may be passed without a script name to list available scripts,
+      // so an omitted value is not an error and must not swallow a later flag.
+      const bool optional_value = name == "--run";
       if (equals_index != std::string::npos) {
         value = arg.substr(equals_index + 1);
-        if (value.empty()) {
+        if (value.empty() && !optional_value) {
+          missing_argument();
+          break;
+        }
+      } else if (args.empty() || (optional_value && args.first()[0] == '-')) {
+        if (!optional_value) {
           missing_argument();
           break;
         }
       } else {
-        if (args.empty()) {
-          missing_argument();
-          break;
-        }
-
         value = args.pop_first();
 
         if (!value.empty() && value[0] == '-') {
@@ -511,6 +515,12 @@ void OptionsParser<Options>::Parse(
         break;
       default:
         UNREACHABLE();
+    }
+
+    // Record that `--run` was seen so an empty value can be distinguished from
+    // the option being absent. Guarded so it only compiles for the owning type.
+    if constexpr (std::is_same_v<Options, PerProcessOptions>) {
+      if (name == "--run") options->has_run = true;
     }
   }
   options->CheckOptions(errors, orig_args);

--- a/src/node_options.h
+++ b/src/node_options.h
@@ -355,6 +355,9 @@ class PerProcessOptions : public Options {
   bool print_version = false;
   std::string experimental_sea_config;
   std::string run;
+  // Tracks whether `--run` was passed, since an empty `run` is ambiguous
+  // between "not passed" and "passed without a script name" (lists scripts).
+  bool has_run = false;
 
   std::string build_sea;
 #ifdef NODE_HAVE_I18N_SUPPORT

--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -249,6 +249,27 @@ FindPackageJson(const std::filesystem::path& cwd) {
   return {{package_json_path, raw_content, path_env_var}};
 }
 
+// Prints every "name: command" pair in the scripts object to the given stream.
+static void PrintScripts(FILE* out,
+                         simdjson::ondemand::object& scripts_object) {
+  // Reset the object to iterate from the beginning, in case it was read before.
+  scripts_object.reset();
+  simdjson::ondemand::value value;
+  for (auto field : scripts_object) {
+    std::string_view key_str;
+    std::string_view value_str;
+    if (!field.unescaped_key().get(key_str) && !field.value().get(value) &&
+        !value.get_string().get(value_str)) {
+      fprintf(out,
+              "  %.*s: %.*s\n",
+              static_cast<int>(key_str.size()),
+              key_str.data(),
+              static_cast<int>(value_str.size()),
+              value_str.data());
+    }
+  }
+}
+
 void RunTask(const std::shared_ptr<InitializationResultImpl>& result,
              std::string_view command_id,
              const std::vector<std::string_view>& positional_args) {
@@ -300,6 +321,16 @@ void RunTask(const std::shared_ptr<InitializationResultImpl>& result,
     return;
   }
 
+  // With no command (e.g. bare `node --run`), list the available scripts but
+  // exit non-zero so a script invoking `node --run $CMD` with an unset
+  // variable still fails, as it did before bare `--run` was allowed.
+  if (command_id.empty()) {
+    fprintf(stderr, "Available scripts are:\n");
+    PrintScripts(stderr, scripts_object);
+    result->exit_code_ = ExitCode::kInvalidCommandLineArgument;
+    return;
+  }
+
   // If the command_id is not found in the scripts object, throw an error.
   std::string_view command;
   if (auto command_error =
@@ -317,23 +348,7 @@ void RunTask(const std::shared_ptr<InitializationResultImpl>& result,
               command_id.data(),
               path.string().c_str());
       fprintf(stderr, "Available scripts are:\n");
-
-      // Reset the object to iterate over it again
-      scripts_object.reset();
-      simdjson::ondemand::value value;
-      for (auto field : scripts_object) {
-        std::string_view key_str;
-        std::string_view value_str;
-        if (!field.unescaped_key().get(key_str) && !field.value().get(value) &&
-            !value.get_string().get(value_str)) {
-          fprintf(stderr,
-                  "  %.*s: %.*s\n",
-                  static_cast<int>(key_str.size()),
-                  key_str.data(),
-                  static_cast<int>(value_str.size()),
-                  value_str.data());
-        }
-      }
+      PrintScripts(stderr, scripts_object);
     }
     result->exit_code_ = ExitCode::kGenericUserError;
     return;

--- a/test/message/node_run_list.js
+++ b/test/message/node_run_list.js
@@ -1,0 +1,14 @@
+'use strict';
+
+require('../common');
+const assert = require('node:assert/strict');
+const childProcess = require('node:child_process');
+const fixtures = require('../common/fixtures');
+
+const child = childProcess.spawnSync(
+  process.execPath,
+  [ '--no-warnings', '--run'],
+  { cwd: fixtures.path('run-script'), encoding: 'utf8' },
+);
+assert.strictEqual(child.status, 9);
+console.log(child.stderr);

--- a/test/message/node_run_list.out
+++ b/test/message/node_run_list.out
@@ -1,0 +1,14 @@
+Available scripts are:
+  test: echo "Error: no test specified" && exit 1
+  ada: ada
+  ada-windows: ada.bat
+  positional-args: positional-args
+  positional-args-windows: positional-args.bat
+  custom-env: custom-env
+  custom-env-windows: custom-env.bat
+  path-env: path-env
+  path-env-windows: path-env.bat
+  special-env-variables: special-env-variables
+  special-env-variables-windows: special-env-variables.bat
+  pwd: pwd
+  pwd-windows: cd

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -222,4 +222,39 @@ describe('node --run [command]', () => {
     assert.strictEqual(child.stdout, '');
     assert.strictEqual(child.code, 1);
   });
+
+  it('lists available scripts when no command is given', async () => {
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run'],
+      { cwd: fixtures.path('run-script') },
+    );
+    assert.match(child.stderr, /Available scripts are:/);
+    assert.match(child.stderr, /test: echo "Error: no test specified" && exit 1/);
+    assert.strictEqual(child.stdout, '');
+    assert.strictEqual(child.code, 9);
+  });
+
+  it('does not consume a following flag as the script name', async () => {
+    // `--run` followed by a flag lists scripts rather than treating the flag
+    // as a script name.
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run', '--no-warnings'],
+      { cwd: fixtures.path('run-script') },
+    );
+    assert.match(child.stderr, /Available scripts are:/);
+    assert.strictEqual(child.code, 9);
+  });
+
+  it('errors when listing scripts without a package.json', async () => {
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run'],
+      { cwd: __dirname },
+    );
+    assert.match(child.stderr, /Can't find package\.json/);
+    assert.strictEqual(child.stdout, '');
+    assert.strictEqual(child.code, 1);
+  });
 });


### PR DESCRIPTION
This extends the behaviour when you run `node --run <unknown script>` that prints a list of available scripts, to now print available scripts when you simply run `node --run`, to mimic the behaviour of `npm run`, etc.

```console
$ node --run
Available scripts are:
  test: node --test
  build: node build.js
```

Previously, `node --run` with no command errored with `--run requires an argument`.

This is my first contribution to Node.js so while I've tried to read and follow everything, please let me know if I'm missing anything!

Fixes: #64870