### PR TITLE
inspector: fix out-of-bounds read in ws frame decoding

### DIFF
--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -360,7 +360,11 @@ static ws_decode_result decode_frame_hybi17(const std::vector<char>& buffer,
   }
   size_t payload_length = static_cast<size_t>(payload_length64);
 
-  if (buffer.size() - kMaskingKeyWidthInBytes < payload_length)
+  // The masking key and the payload follow the header `it` already walked
+  // past, so they have to fit in what is left rather than in the whole buffer.
+  size_t remaining = static_cast<size_t>(buffer.end() - it);
+  if (remaining < kMaskingKeyWidthInBytes ||
+      remaining - kMaskingKeyWidthInBytes < payload_length)
     return FRAME_INCOMPLETE;
 
   std::vector<char>::const_iterator masking_key = it;

--- a/src/inspector_socket.cc
+++ b/src/inspector_socket.cc
@@ -363,8 +363,7 @@ static ws_decode_result decode_frame_hybi17(const std::vector<char>& buffer,
   // The masking key and the payload follow the header `it` already walked
   // past, so they have to fit in what is left rather than in the whole buffer.
   size_t remaining = static_cast<size_t>(buffer.end() - it);
-  if (remaining < kMaskingKeyWidthInBytes ||
-      remaining - kMaskingKeyWidthInBytes < payload_length)
+  if (remaining < kMaskingKeyWidthInBytes + payload_length)
     return FRAME_INCOMPLETE;
 
   std::vector<char>::const_iterator masking_key = it;

--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -409,6 +409,24 @@ TEST_F(InspectorSocketTest, ReadsAndWritesInspectorMessage) {
                          reinterpret_cast<uv_handle_t*>(&client_socket)));
 }
 
+TEST_F(InspectorSocketTest, WaitsForFrameBodyToArrive) {
+  do_write(const_cast<char*>(HANDSHAKE_REQ), sizeof(HANDSHAKE_REQ) - 1);
+  expect_handshake();
+
+  // A header announcing a masked five byte payload, with the masking key and
+  // the payload still on the wire. The frame has to be treated as incomplete
+  // until the remaining bytes show up.
+  const char FRAME_HEADER[] = {'\x81', '\x85'};
+  do_write(FRAME_HEADER, sizeof(FRAME_HEADER));
+
+  const char FRAME_BODY[] = {'\x01', '\x02', '\x03', '\x04',
+                             '\x69', '\x67', '\x6F', '\x68', '\x6E'};
+  do_write(FRAME_BODY, sizeof(FRAME_BODY));
+
+  const char CLIENT_MESSAGE[] = "hello";
+  delegate->ExpectData(CLIENT_MESSAGE, sizeof(CLIENT_MESSAGE) - 1);
+}
+
 TEST_F(InspectorSocketTest, BufferEdgeCases) {
   do_write(const_cast<char*>(HANDSHAKE_REQ), sizeof(HANDSHAKE_REQ) - 1);
   expect_handshake();

--- a/test/cctest/test_inspector_socket.cc
+++ b/test/cctest/test_inspector_socket.cc
@@ -419,6 +419,13 @@ TEST_F(InspectorSocketTest, WaitsForFrameBodyToArrive) {
   const char FRAME_HEADER[] = {'\x81', '\x85'};
   do_write(FRAME_HEADER, sizeof(FRAME_HEADER));
 
+  // Round trip through the server so the header is guaranteed to have been
+  // read on its own, instead of arriving together with the body below.
+  const char SERVER_MESSAGE[] = "ping";
+  const char SERVER_FRAME[] = {'\x81', '\x04', 'p', 'i', 'n', 'g'};
+  delegate->Write(SERVER_MESSAGE, sizeof(SERVER_MESSAGE) - 1);
+  expect_on_client(SERVER_FRAME, sizeof(SERVER_FRAME));
+
   const char FRAME_BODY[] = {'\x01', '\x02', '\x03', '\x04',
                              '\x69', '\x67', '\x6F', '\x68', '\x6E'};
   do_write(FRAME_BODY, sizeof(FRAME_BODY));


### PR DESCRIPTION
decode_frame_hybi17 checks the announced payload length against buffer.size(), but the payload is read from it + kMaskingKeyWidthInBytes, after the iterator has already walked past the two byte header and the extended length field. A client that sends only the two header bytes of a masked frame, 0x81 0xFD, underflows buffer.size() - kMaskingKeyWidthInBytes to SIZE_MAX, passes the check, and the unmasking loop reads 125 bytes past a two byte vector; the bytes it picks up go to OnWsFrame and back out to the peer. Measuring against what is left after the header fixes both that underflow and the header bytes the old check never accounted for.