### PR TITLE
dns: add tests for ENODATA states, fix failure on main

### DIFF
--- a/.github/workflows/test-internet.yml
+++ b/.github/workflows/test-internet.yml
@@ -10,9 +10,13 @@ on:
     paths:
       - .github/workflows/test-internet.yml
       - test/internet/**
+      - test/common/internet.js
       - internal/dns/**
       - lib/dns.js
+      - lib/internal/dns/**
       - lib/net.js
+      - src/cares_wrap.cc
+      - src/cares_wrap.h
   push:
     branches:
       - main
@@ -22,9 +26,13 @@ on:
     paths:
       - .github/workflows/test-internet.yml
       - test/internet/**
+      - test/common/internet.js
       - internal/dns/**
       - lib/dns.js
+      - lib/internal/dns/**
       - lib/net.js
+      - src/cares_wrap.cc
+      - src/cares_wrap.h
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/test/common/internet.js
+++ b/test/common/internet.js
@@ -46,6 +46,10 @@ const addresses = {
   DNS4_SERVER: '8.8.8.8',
   // An accessible IPv4 DNS server
   DNS6_SERVER: '2001:4860:4860::8888',
+  // A valid host with no records (except SOA)
+  NO_RECORD_HOST: 'void.example.com',
+  // A valid host with no TXT records, and a CNAME to a host with no TXT records
+  CNAME_TO_NO_TXT_HOST: 'www.microsoft.com',
 };
 
 for (const key of Object.keys(addresses)) {

--- a/test/internet/test-dns-txt-sigsegv.js
+++ b/test/internet/test-dns-txt-sigsegv.js
@@ -1,15 +1,17 @@
 'use strict';
 const common = require('../common');
+const { addresses } = require('../common/internet');
 const assert = require('assert');
 const dns = require('dns');
 const dnsPromises = dns.promises;
 
-(async function() {
-  const result = await dnsPromises.resolveTxt('www.microsoft.com');
-  assert.strictEqual(result.length, 0);
-})().then(common.mustCall());
+assert.rejects(
+  dnsPromises.resolveTxt(addresses.CNAME_TO_NO_TXT_HOST),
+  { code: 'ENODATA' },
+).then(common.mustCall());
 
-dns.resolveTxt('www.microsoft.com', common.mustCall((err, records) => {
-  assert.strictEqual(err, null);
-  assert.strictEqual(records.length, 0);
+dns.resolveTxt(addresses.CNAME_TO_NO_TXT_HOST, common.mustCall((err, records) => {
+  assert.ok(err instanceof Error);
+  assert.strictEqual(err.code, 'ENODATA');
+  assert.strictEqual(records, undefined);
 }));

--- a/test/internet/test-dns.js
+++ b/test/internet/test-dns.js
@@ -724,6 +724,67 @@ test(function test_resolve_failure(done) {
 });
 
 
+async function testEmptyRecords(method, done) {
+  await assert.rejects(
+    dnsPromises[method](addresses.NO_RECORD_HOST),
+    { code: 'ENODATA' },
+  );
+
+  const req = dns[method](addresses.NO_RECORD_HOST, common.mustCall((err, result) => {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(err.code, 'ENODATA');
+    assert.strictEqual(result, undefined);
+    done();
+  }));
+
+  checkWrap(req);
+}
+
+test(function test_empty_4_records(done) {
+  testEmptyRecords('resolve4', done);
+});
+
+test(function test_empty_6_records(done) {
+  testEmptyRecords('resolve6', done);
+});
+
+test(function test_empty_caa_records(done) {
+  testEmptyRecords('resolveCaa', done);
+});
+
+test(function test_empty_cname_records(done) {
+  testEmptyRecords('resolveCname', done);
+});
+
+test(function test_empty_mx_records(done) {
+  testEmptyRecords('resolveMx', done);
+});
+
+test(function test_empty_naptr_records(done) {
+  testEmptyRecords('resolveNaptr', done);
+});
+
+test(function test_empty_ns_records(done) {
+  testEmptyRecords('resolveNs', done);
+});
+
+test(function test_empty_ptr_records(done) {
+  testEmptyRecords('resolvePtr', done);
+});
+
+test(function test_empty_srv_records(done) {
+  testEmptyRecords('resolveSrv', done);
+});
+
+test(function test_empty_tlsa_records(done) {
+  testEmptyRecords('resolveTlsa', done);
+});
+
+test(function test_empty_txt_records(done) {
+  testEmptyRecords('resolveTxt', done);
+});
+
+
 let getaddrinfoCallbackCalled = false;
 
 console.log(`looking up ${addresses.INET4_HOST}..`);


### PR DESCRIPTION
This adds new tests to codify the existing behaviour of throwing ENODATA when there are no matching DNS records.

It also updates an existing test which was broken by https://github.com/nodejs/node/pull/64355 (see the failing pipeline here: https://github.com/nodejs/node/actions/workflows/test-internet.yml)

Previously requesting DNS records for a domain which has a CNAME to another domain, neither of which contain the requested type of record, would return an empty array. Since #64355, it will instead throw ENODATA. This is a user-facing change which should perhaps be considered semver-major. I've asked for input from the original author/reviewers [here](https://github.com/nodejs/node/pull/64355#issuecomment-5022083070).

The new tests in `test-dns.js` have been run against d6cd5c19cf22e6b2391aafa722f400677b68c7ad (the commit just before the breaking change) to confirm they represent the previous behaviour.

Finally, this updates the trigger for the relevant pipeline so that the internet tests will run if the cares_wrap.cc (and various other related files) are changed, which should reduce the chance of similar changes breaking main in the future.