### PR TITLE
fs: preserve negative utimes timestamps

### DIFF
--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -4,7 +4,6 @@ const {
   ArrayIsArray,
   BigInt,
   Date,
-  DateNow,
   DatePrototypeGetTime,
   ErrorCaptureStackTrace,
   FunctionPrototypeCall,
@@ -786,9 +785,6 @@ function toUnixTimestamp(time, name = 'time') {
     return +time;
   }
   if (NumberIsFinite(time)) {
-    if (time < 0) {
-      return DateNow() / 1000;
-    }
     return time;
   }
   if (isDate(time)) {

--- a/test/parallel/test-fs-utimes.js
+++ b/test/parallel/test-fs-utimes.js
@@ -46,7 +46,7 @@ function stat_resource(resource, statSync = fs.statSync) {
 }
 
 function check_mtime(resource, mtime, statSync) {
-  mtime = fs._toUnixTimestamp(mtime);
+  mtime = getExpectedMtime(mtime);
   const stats = stat_resource(resource, statSync);
   const real_mtime = fs._toUnixTimestamp(stats.mtime);
   return mtime - real_mtime;
@@ -64,14 +64,17 @@ function expect_ok(syscall, resource, err, atime, mtime, statSync) {
   assert(
     // Check up to single-second precision.
     // Sub-second precision is OS and fs dependent.
-    !err && (mtime_diff < 2) || err && err.code === 'ENOSYS',
+    !err && (Math.abs(mtime_diff) < 2) || err && err.code === 'ENOSYS',
     `FAILED: expect_ok ${util.inspect(arguments)}
      check_mtime: ${mtime_diff}`
   );
 }
 
 function getExpectedMtime(mtime) {
-  // Negative numeric timestamps are normalized to "now" at call time.
+  // Keep negative numeric timestamps so the test catches normalization to now.
+  if (typeof mtime === 'number' && mtime < 0) {
+    return mtime;
+  }
   return fs._toUnixTimestamp(mtime);
 }
 


### PR DESCRIPTION
`toUnixTimestamp()` converted negative numbers to the current time, while negative strings and Dates were handled correctly.

Keep numeric timestamps unchanged and add coverage for negative values.

Fixes: #64597