### PR TITLE
tools: fix shared-lib build on V8 cache miss

### DIFF
--- a/.github/workflows/build-shared.yml
+++ b/.github/workflows/build-shared.yml
@@ -39,6 +39,7 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: tarballs
+          merge-multiple: true
 
       - name: Extract tarball
         shell: bash


### PR DESCRIPTION
Fixes the `Test Shared libraries` workflow failing on a V8 cache miss for fork PRs (#64554).

The first `download-artifact` step in `build-shared.yml` doesn't name an artifact, so on a cache miss it pulls in the libv8 NAR alongside the tarball. With multiple artifacts, each lands in its own directory, so `tar xzf tarballs/*.tar.gz` ends up matching a directory and fails. Setting `merge-multiple: true` flattens them back into `tarballs`, matching the single-artifact layout the extract step expects. The NAR is still downloaded separately by name for the V8 step.

Fixes: https://github.com/nodejs/node/issues/64554
