### PR TITLE
net: handle undefined parent in _unrefTimer and _destroy

### DIFF
--- a/lib/net.js
+++ b/lib/net.js
@@ -665,7 +665,9 @@ ObjectSetPrototypeOf(Socket, stream.Duplex);
 
 // Refresh existing timeouts.
 Socket.prototype._unrefTimer = function _unrefTimer() {
-  for (let s = this; s !== null; s = s._parent) {
+  // `_parent` may be null; we use a loose `!= null` check in case external
+  // code sets it to undefined.
+  for (let s = this; s != null; s = s._parent) {
     if (s[kTimeout])
       s[kTimeout].refresh();
   }
@@ -1026,7 +1028,9 @@ Socket.prototype._destroy = function(exception, cb) {
 
   this.connecting = false;
 
-  for (let s = this; s !== null; s = s._parent) {
+  // `_parent` may be null; we use a loose `!= null` check in case external
+  // code sets it to undefined.
+  for (let s = this; s != null; s = s._parent) {
     clearTimeout(s[kTimeout]);
   }
 

--- a/test/parallel/test-net-socket-unref-timer-parent-chain.js
+++ b/test/parallel/test-net-socket-unref-timer-parent-chain.js
@@ -1,0 +1,25 @@
+'use strict';
+const common = require('../common');
+
+// Walking the `_parent` chain must stop on a nullish link, not only strict
+// `null`. During connection teardown a socket's `_parent` can be left
+// `undefined`, which previously caused `_unrefTimer()` and `_destroy()` to read
+// a property off `undefined` and throw.
+// Refs: https://github.com/nodejs/node/issues/64490
+
+const assert = require('assert');
+const net = require('net');
+
+{
+  const socket = new net.Socket();
+  socket._parent = undefined;
+  socket._unrefTimer();
+}
+
+{
+  const socket = new net.Socket();
+  socket._parent = undefined;
+  socket.on('error', common.mustNotCall());
+  socket.destroy();
+  assert.strictEqual(socket.destroyed, true);
+}

--- a/test/parallel/test-net-unref-timer-parent-undefined.js
+++ b/test/parallel/test-net-unref-timer-parent-undefined.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const common = require('../common');
+
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+
+// A TLS socket whose `_parent` is left `undefined` during teardown must not
+// crash when reads land on it (`onStreamRead` -> `_unrefTimer`) or when it is
+// destroyed (`_destroy`). Both walk the `_parent` chain.
+// Refs: https://github.com/nodejs/node/issues/64490
+
+const options = {
+  key: fixtures.readKey('agent1-key.pem'),
+  cert: fixtures.readKey('agent1-cert.pem'),
+};
+
+const server = tls.createServer(options, common.mustCall((conn) => {
+  setTimeout(() => conn.write('x'), 50);
+}));
+
+server.listen(0, common.mustCall(() => {
+  const client = tls.connect({
+    port: server.address().port,
+    rejectUnauthorized: false,
+  }, common.mustCall(() => {
+    client._parent = undefined;
+  }));
+
+  client.on('data', common.mustCall(() => {
+    server.close();
+    client.destroy();
+  }));
+
+  client.on('error', common.mustNotCall());
+}));


### PR DESCRIPTION
The fix and approach are from #64491 by @Shivay-98; opening from a fresh branch to land it, since that PR stalled awaiting the requested changes (unrelated commit dropped, failing test addressed, `Signed-off-by` added).

`Socket.prototype._unrefTimer` and `Socket.prototype._destroy` both walk the socket `_parent` chain with a strict `!== null` check. When teardown leaves a socket's `_parent` as `undefined` (for example a TLS socket layered over another stream), the loop steps onto `undefined` and throws

```
TypeError: Cannot read properties of undefined (reading 'Symbol(timeout)')
    at TLSSocket._unrefTimer (node:net)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons)
```

from an uncaught I/O callback, crashing the process. Switching both loops to a nullish `!= null` check stops the walk on `undefined` as well.

The original PR fixed only `_unrefTimer`; its regression test also calls `destroy()`, which hits the same unpatched loop in `_destroy`, so that path is fixed and covered here too.

Fixes: https://github.com/nodejs/node/issues/64490
Refs: https://github.com/nodejs/node/pull/64491

##### Checklist
- [x] `make -j4 test` (UNIX) passes
- [x] tests and/or benchmarks are included
- [x] commit message follows [commit guidelines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines)