### PR TITLE
doc: clarify rules for adding new built-in modules

### DIFF
--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -445,7 +445,7 @@ Treat commits that introduce new core modules with extra care.
 
 New modules must only be added with the `node:` prefix, as `semver-minor`.
 
-When adding a "sub-module", e.g. a promise varient of an existing API (e.g.
+When adding a "sub-module", e.g. a promise variant of an existing API (e.g.
 `node:inspector/promises`) that is available without the `node:` prefix, making
 the sub-module available without the prefix is possible behind a runtime flag,
 or as a `semver-major` change.

--- a/doc/contributing/collaborator-guide.md
+++ b/doc/contributing/collaborator-guide.md
@@ -443,10 +443,12 @@ metadata. Raise a pull request like any other change.
 
 Treat commits that introduce new core modules with extra care.
 
-New modules must only be added with the `node:` prefix.
+New modules must only be added with the `node:` prefix, as `semver-minor`.
 
-When adding promises to an existing API, add `/promises`
-(`inspector/promises`, etc.). Apply the `semver-major` label to the addition.
+When adding a "sub-module", e.g. a promise varient of an existing API (e.g.
+`node:inspector/promises`) that is available without the `node:` prefix, making
+the sub-module available without the prefix is possible behind a runtime flag,
+or as a `semver-major` change.
 
 If the new module name is free in npm, register
 a placeholder in the module registry as soon as possible. Link to the pull


### PR DESCRIPTION
We've added the `node:` prefix requirement to avoid the semver-major requirement for new modules (well I don't remember if it was the intent, but it's definitely the consequence of it). In https://github.com/nodejs/node/pull/62066#issuecomment-4170651048, @jasnell marked the PR introducing `node:stream/iter` as https://github.com/nodejs/node/labels/semver-major, but I'd argue that it doesn't make sense to treat as semver-major a new ~prefixed~ module ~(i.e. it cannot shadow a user package)~ that's behind a runtime flag anyways. EDIT: it's not actually prefix-only, `require('stream/iter') === require(node:stream/iter')` – but still, because it's opt-in I think my point still stands.

In the case of `node:stream/iter`, not backporting it is blocking a number of backports on Node.js 24, which cascades into creating more conflicts on unrelated backports, which is a big maintenance burden