### PR TITLE
url: handle unparsable serialized URLs in setters

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -443,8 +443,12 @@ void BindingData::Update(const FunctionCallbackInfo<Value>& args) {
   Utf8Value new_value(isolate, args[2].As<String>());
 
   std::string_view new_value_view = new_value.ToStringView();
+  // A serialized URL is not always reparsable: the IDNA encoder can emit a
+  // host label that the decoder rejects. Fail the update instead of crashing.
   auto out = ada::parse<ada::url_aggregator>(input.ToStringView());
-  CHECK(out);
+  if (!out) {
+    return args.GetReturnValue().Set(false);
+  }
 
   bool result{true};
 

--- a/test/parallel/test-whatwg-url-custom-setters.js
+++ b/test/parallel/test-whatwg-url-custom-setters.js
@@ -39,6 +39,32 @@ const additionalTestCases =
   }
 }
 
+// The parser can produce a serialization it rejects when parsing it back: a
+// Unicode host encodes to an `xn--xn--` label that the punycode decoder turns
+// down. Setters reparse `href`, so the failure must not take the process down.
+// Implementations backed by ICU accept that label, and ada does too as of
+// https://github.com/ada-url/idna/pull/72, so this URL round-trips once that
+// lands here and the setters below apply as usual.
+test(function() {
+  const url = new URL('http:\u{1F600}xn-');
+  const setters = {
+    hostname: 'example.com',
+    host: 'example.com:8080',
+    protocol: 'https:',
+    pathname: '/path',
+    search: '?search',
+    hash: '#hash',
+    port: '8080',
+    username: 'username',
+    password: 'password',
+  };
+
+  for (const [property, value] of Object.entries(setters)) {
+    url[property] = value;
+    assert_equals(typeof url.href, 'string', `Setting ${property} does not crash`);
+  }
+}, 'URL: setting properties with an unparsable serialized URL');
+
 {
   const url = new URL('http://example.com/');
   const obj = {


### PR DESCRIPTION
URL updates reparse the stored serialized URL. Return failure when that parse does not succeed so property setters leave the URL unchanged.

Add coverage for URL values that are accepted initially but whose serialized form cannot be parsed again.