### PR TITLE
http: propagate highWaterMark to ClientRequest OutgoingMessage

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -51,6 +51,7 @@ const {
   kSkipPendingData,
 } = require('_http_common');
 const {
+  kHighWaterMark,
   kUniqueHeaders,
   parseUniqueHeadersOption,
   OutgoingMessage,
@@ -346,6 +347,14 @@ function ClientRequest(input, options, cb) {
     options = input || kEmptyObject;
   } else {
     options = ObjectAssign({ __proto__: null }, input, options);
+  }
+
+  // Propagate the user's highWaterMark to OutgoingMessage so that
+  // _writeRaw() uses the correct threshold for writes buffered before
+  // the socket connects (Path B).  Without this, the OutgoingMessage
+  // defaults to 64 KB regardless of what the caller requested.
+  if (options.highWaterMark != null) {
+    this[kHighWaterMark] = options.highWaterMark;
   }
 
   let agent = options.agent;

--- a/test/parallel/test-http-client-highwatermark.js
+++ b/test/parallel/test-http-client-highwatermark.js
@@ -1,0 +1,81 @@
+// Flags: --expose-internals
+'use strict';
+
+// Regression test: http.request({ highWaterMark }) must propagate the value
+// to OutgoingMessage's kHighWaterMark so that _writeRaw() Path B (buffering
+// before socket connects) uses the correct threshold.
+//
+// Without the fix:
+//   - write() returns the wrong boolean (compares against default 64KB)
+//   - On Node >= 24.16.0 (post #62936), this causes a deadlock when
+//     the user awaits 'drain' after write() incorrectly returns false.
+//
+// Fixes: https://github.com/nodejs/node/issues/64645
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const { kHighWaterMark } = require('_http_outgoing');
+const { getDefaultHighWaterMark } = require('internal/streams/state');
+
+const server = http.createServer(common.mustCall((req, res) => {
+  req.resume();
+  req.on('end', () => res.end('ok'));
+}, 3));
+
+server.listen(0, common.mustCall(() => {
+  const port = server.address().port;
+  let completed = 0;
+
+  function done() {
+    if (++completed === 3) server.close();
+  }
+
+  // Test 1: kHighWaterMark is set to user value on the ClientRequest.
+  {
+    const hwm = getDefaultHighWaterMark() * 2;
+    const req = http.request({ port, method: 'POST', highWaterMark: hwm });
+    assert.strictEqual(req[kHighWaterMark], hwm);
+    req.end();
+    req.on('response', (res) => { res.resume(); res.on('end', done); });
+  }
+
+  // Test 2: Large HWM — write below threshold returns true before socket connects.
+  {
+    const req = http.request({
+      port,
+      method: 'POST',
+      highWaterMark: 100_000,
+    }, common.mustCall((res) => {
+      res.resume();
+      res.on('end', done);
+    }));
+
+    // 64KB write in the same tick — socket not yet connected (Path B).
+    // With HWM=100KB, write() must return true.
+    const result = req.write(Buffer.alloc(64 * 1024));
+    assert.strictEqual(result, true);
+    req.end();
+  }
+
+  // Test 3: Small HWM — write above threshold returns false, drain fires.
+  {
+    const req = http.request({
+      port,
+      method: 'POST',
+      highWaterMark: 512,
+    }, common.mustCall((res) => {
+      res.resume();
+      res.on('end', done);
+    }));
+
+    // 2KB write in the same tick — exceeds HWM of 512 bytes.
+    const result = req.write(Buffer.alloc(2 * 1024));
+    assert.strictEqual(result, false);
+
+    // Drain must fire (no deadlock) so we can complete the request.
+    req.on('drain', common.mustCall(() => {
+      req.end();
+    }));
+  }
+}));


### PR DESCRIPTION
`http.request({ highWaterMark })` passes the value to the TCP socket via `createConnection()` but does not set it on the `OutgoingMessage`'s internal `kHighWaterMark`. `OutgoingMessage._writeRaw()` has two mutually exclusive write paths:

- **Path A** (socket connected): `conn.write()` — uses socket's HWM (correct)
- **Path B** (no socket yet): `outputSize < this[kHighWaterMark]` — uses OutgoingMessage's own default (64 KB) (incorrect)

Because the `OutgoingMessage` constructor already accepts `options.highWaterMark`, the fix is to set `kHighWaterMark` from the user's options after they are parsed in the `ClientRequest` constructor.

This resolves two symptoms:

1. `write()` returning the wrong boolean for pre-socket writes (the user's `highWaterMark` was silently ignored on all Node versions).
2. A deadlock on Node >= 24.16.0 where the incorrect `false` return sets `kNeedDrain`, but `drain` never fires because the socket was never backpressured (introduced by the stricter drain gate in #62936).

### Test results (compiled from source)

```
=== UNPATCHED Node v26.5.0 ===
FAIL: write() returned false (expected true)

=== PATCHED Node v27.0.0-pre (this PR) ===
PASS: write() returned true
test-http-client-highwatermark.js passes (exit 0)
test-http-server-options-highwatermark.js passes
test-http-outgoing-drain-writable-length.js passes
test-http-outgoing-end-cork.js passes
test-http-highwatermark.js passes
test-http-response-drain-cork.js passes
```

### Minimal reproduction

```bash
node -e "require('http').createServer((req,res)=>{req.resume();req.on('end',()=>res.end('ok'))}).listen(9001)"
```

```js
const http = require('http');
const req = http.request({ hostname: '127.0.0.1', port: 9001, method: 'POST', highWaterMark: 100_000 });
const ok = req.write(Buffer.alloc(64 * 1024));
console.log(`write() returned ${ok}, expected true (64KB < 100KB highWaterMark)`);
if (!ok) {
  setTimeout(() => { console.error('DEADLOCK: drain never fired'); process.exit(1); }, 3000);
  req.on('drain', () => { console.log('drain fired'); req.end(); });
} else {
  req.end();
  req.on('response', (res) => { res.resume(); res.on('end', () => process.exit(0)); });
}
```

| Node version | `write()` returns | Drain fires? | Outcome |
|---|---|---|---|
| v22.x | `false` (wrong) | Yes (old eager drain) | HWM ignored but no hang |
| v26.5.0 | `false` (wrong) | Never | DEADLOCK |
| This PR | `true` (correct) | N/A (no backpressure) | Works correctly |

Fixes: https://github.com/nodejs/node/issues/64645
Refs: https://github.com/nodejs/node/pull/62936