### PR TITLE
doc: fix dnsPromises.lookup verbatim default

### DIFF
--- a/doc/api/dns.md
+++ b/doc/api/dns.md
@@ -1113,8 +1113,7 @@ changes:
     IPv4 addresses are placed before IPv6 addresses.
     This option will be deprecated in favor of `order`. When both are specified,
     `order` has higher precedence. New code should only use `order`.
-    **Default:** currently `false` (addresses are reordered) but this is
-    expected to change in the not too distant future. Default value is
+    **Default:** `true` (addresses are not reordered). Default value is
     configurable using [`dns.setDefaultResultOrder()`][] or
     [`--dns-result-order`][].
 


### PR DESCRIPTION
The `verbatim` option for `dnsPromises.lookup()` documents its default as `false` (addresses reordered), but that's stale. The default flipped to `true` in v17 (#39987), same as the callback `dns.lookup()`.

You can see it contradicts itself already: the `order` bullet right above says `verbatim` (addresses are not reordered) by default, and the `dns.lookup()` section documents the same `verbatim` option as `true`. Source confirms it too — both paths start from `DNS_ORDER_VERBATIM` (`lib/dns.js`, `lib/internal/dns/promises.js`), with the global default set to `'verbatim'` in `lib/internal/dns/utils.js`.

This just updates the `dnsPromises.lookup()` bullet to match. Docs only.
