### PR TITLE
test: fix flaky http2 socket proxy destroy test

### DIFF
--- a/test/parallel/test-http2-socket-proxy-destroy.js
+++ b/test/parallel/test-http2-socket-proxy-destroy.js
@@ -5,6 +5,7 @@ if (!common.hasCrypto)
   common.skip('missing crypto');
 const assert = require('assert');
 const h2 = require('http2');
+const Countdown = require('../common/countdown');
 
 // Calling .destroy() on the socket proxy must not throw
 // (previously threw ERR_HTTP2_NO_SOCKET_MANIPULATION) and must
@@ -16,6 +17,8 @@ server.on('stream', common.mustCall(function(stream) {
   stream.respond();
   stream.end('ok');
 }, 2));
+
+const countdown = new Countdown(2, () => server.close());
 
 server.listen(0, common.mustCall(() => {
   const port = server.address().port;
@@ -33,6 +36,7 @@ server.listen(0, common.mustCall(() => {
         assert.strictEqual(client.socket, undefined);
         // Destroying again through a stale proxy reference must not throw.
         socket.destroy();
+        countdown.dec();
       }));
     }));
     client.on('error', common.mustNotCall());
@@ -51,7 +55,7 @@ server.listen(0, common.mustCall(() => {
       assert.strictEqual(err.message, 'boom');
     }));
     client.on('close', common.mustCall(() => {
-      server.close();
+      countdown.dec();
     }));
   }
 }));


### PR DESCRIPTION
Fix a flaky test (failing [yesterday](https://github.com/nodejs/reliability/blob/main/reports/2026-07-22.md)) introduced recently in https://github.com/nodejs/node/pull/64427.

This is effectively two tests running in parallel against a single server. The second test shuts down the server when it finishes, assuming that this means everything is done, but if the first test runs slowly it may not complete before that happens.

Adding a `setTimeout` manually around the first test block to simulate this recreates the same error as in CI.

Nice easy fix: use a `Countdown` to wait for both tests before closing the server, so there's no interdependency.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
