### PR TITLE
tls: fix authorized state on no-cert TLS1.3 client cert resumption

### DIFF
--- a/lib/internal/tls/wrap.js
+++ b/lib/internal/tls/wrap.js
@@ -1323,6 +1323,13 @@ function onServerSocketSecure() {
 
       if (this._rejectUnauthorized)
         this.destroy();
+    } else if (!this._handle.getPeerX509Certificate()) {
+      // Ncrypto reports X509_V_OK for TLS 1.3 resumption without a peer
+      // certificate, as it uses PSKs. Require one to authorize the socket.
+      this.authorizationError = 'UNABLE_TO_GET_ISSUER_CERT';
+
+      if (this._rejectUnauthorized)
+        this.destroy();
     } else {
       this.authorized = true;
     }

--- a/test/parallel/test-tls-client-cert-resumption.js
+++ b/test/parallel/test-tls-client-cert-resumption.js
@@ -100,7 +100,8 @@ async function testResumption(version, name) {
     else
       assert.strictEqual(peer.subject.CN, peerCN, where);
 
-    socket.resume();
+    // N.b. BoringSSL only sends a ticket after a write:
+    socket.end('.');
   }, 2));
 
   server.listen(0);
@@ -142,7 +143,7 @@ async function testRejectResumedWithoutCert() {
   lenient.on('secureConnection', common.mustCall((socket) => {
     assert.strictEqual(socket.authorized, false);
     assert.strictEqual(socket.authorizationError, 'UNABLE_TO_GET_ISSUER_CERT');
-    socket.resume();
+    socket.end('.');
   }));
 
   const strict = tls.createServer({ ...options, rejectUnauthorized: true });

--- a/test/parallel/test-tls-client-cert-resumption.js
+++ b/test/parallel/test-tls-client-cert-resumption.js
@@ -1,0 +1,198 @@
+'use strict';
+const common = require('../common');
+if (!common.hasCrypto)
+  common.skip('missing crypto');
+
+// Server-side client-certificate authorization must survive TLS session
+// resumption. On a resumed handshake the client does not re-send its
+// certificate, so the server has to report the same authorization state it
+// derived from the original full handshake:
+//
+//   - a trusted certificate stays authorized,
+//   - an untrusted certificate stays unauthorized with its verification error,
+//   - a missing certificate stays unauthorized (UNABLE_TO_GET_ISSUER_CERT).
+//
+// The missing-certificate case is special on TLS 1.3: ncrypto reports X509_V_OK
+// for the resumed PSK handshake even though no certificate was presented, so
+// the absence has to be detected explicitly (see onServerSocketSecure() in
+// lib/internal/tls/wrap.js). The final case checks that such a certificate-less
+// resumed session is rejected outright when rejectUnauthorized is set.
+
+const assert = require('assert');
+const crypto = require('crypto');
+const tls = require('tls');
+const fixtures = require('../common/fixtures');
+const { once } = require('events');
+
+const ca = fixtures.readKey('ca1-cert.pem');
+const serverCert = {
+  key: fixtures.readKey('agent2-key.pem'),
+  cert: fixtures.readKey('agent2-cert.pem'),
+};
+
+// Client certificate variants, keyed by the peer state they produce.
+const CLIENTS = {
+  trusted: {                                          // Signed by ca1
+    creds: {
+      key: fixtures.readKey('agent1-key.pem'),
+      cert: fixtures.readKey('agent1-cert.pem'),
+    },
+    authorized: true,
+    authorizationError: null,
+    peerCN: 'agent1',
+  },
+  untrusted: {                                        // Signed by ca2, not trusted
+    creds: {
+      key: fixtures.readKey('agent3-key.pem'),
+      cert: fixtures.readKey('agent3-cert.pem'),
+    },
+    authorized: false,
+    authorizationError: 'UNABLE_TO_VERIFY_LEAF_SIGNATURE',
+    peerCN: 'agent3',
+  },
+  missing: {                                          // No client certificate
+    creds: {},
+    authorized: false,
+    authorizationError: 'UNABLE_TO_GET_ISSUER_CERT',
+    peerCN: undefined,
+  },
+};
+
+async function handshake(options, captureSession) {
+  const socket = tls.connect(options);
+  const sessionPromise = captureSession ?
+    once(socket, 'session').then(([session]) => session) : null;
+
+  socket.resume();
+  await once(socket, 'secureConnect');
+
+  const closePromise = once(socket, 'close');
+  const session = sessionPromise ? await sessionPromise : undefined;
+  socket.end();
+  await closePromise;
+  return session;
+}
+
+// Test a single resumption configuration and expected result:
+async function testResumption(version, name) {
+  const { creds, authorized, authorizationError, peerCN } = CLIENTS[name];
+
+  let connections = 0;
+  const server = tls.createServer({
+    ...serverCert,
+    ca,
+    requestCert: true,
+    rejectUnauthorized: false,
+    minVersion: version,
+    maxVersion: version,
+  }, common.mustCall((socket) => {
+    // 2nd conn must resume:
+    const resumed = connections++ === 1;
+    const where = `${version} ${name} ${resumed ? 'resumed' : 'new'}`;
+    assert.strictEqual(socket.isSessionReused(), resumed, where);
+
+    // Both conns must report same expected auth state:
+    assert.strictEqual(socket.authorized, authorized, where);
+    assert.strictEqual(socket.authorizationError, authorizationError, where);
+    const peer = socket.getPeerCertificate();
+    if (peerCN === undefined)
+      assert.deepStrictEqual(peer, {}, where);
+    else
+      assert.strictEqual(peer.subject.CN, peerCN, where);
+
+    socket.resume();
+  }, 2));
+
+  server.listen(0);
+  await once(server, 'listening');
+
+  const options = {
+    port: server.address().port,
+    host: '127.0.0.1',
+    checkServerIdentity: () => undefined,
+    rejectUnauthorized: false,
+    minVersion: version,
+    maxVersion: version,
+    ...creds,
+  };
+
+  try {
+    const session = await handshake(options, true);
+    assert(session);
+    await handshake({ ...options, session });
+  } finally {
+    server.close();
+    await once(server, 'close');
+  }
+}
+
+// Test the special case of resumption from rejectUnauthorized:false to
+// rejectUnauthorized:true, which must be rejected even though the original
+// session worked initially.
+async function testRejectResumedWithoutCert() {
+  const options = {
+    ...serverCert,
+    ca,
+    requestCert: true,
+    minVersion: 'TLSv1.3',
+    maxVersion: 'TLSv1.3',
+    ticketKeys: crypto.randomBytes(48),
+  };
+  const lenient = tls.createServer({ ...options, rejectUnauthorized: false });
+  lenient.on('secureConnection', common.mustCall((socket) => {
+    assert.strictEqual(socket.authorized, false);
+    assert.strictEqual(socket.authorizationError, 'UNABLE_TO_GET_ISSUER_CERT');
+    socket.resume();
+  }));
+
+  const strict = tls.createServer({ ...options, rejectUnauthorized: true });
+  strict.on('secureConnection', common.mustNotCall());
+
+  const clientOptions = (port) => ({
+    port,
+    host: '127.0.0.1',
+    rejectUnauthorized: false,
+    checkServerIdentity: () => undefined,
+    minVersion: 'TLSv1.3',
+    maxVersion: 'TLSv1.3',
+  });
+
+  lenient.listen(0);
+  await once(lenient, 'listening');
+  const session = await handshake(clientOptions(lenient.address().port), true);
+  assert(session);
+  lenient.close();
+  await once(lenient, 'close');
+
+  strict.listen(0);
+  await once(strict, 'listening');
+
+  const resumed = tls.connect({ ...clientOptions(strict.address().port), session });
+  resumed.on('error', () => {});  // May observe the server's reset.
+  resumed.resume();
+
+  // The client completes the resumed handshake (it has the server's Finished)
+  // before the server's reset can arrive, so this asserts the strict server
+  // actually resumed rather than falling back to a rejected full handshake.
+  await once(resumed, 'secureConnect');
+  assert.strictEqual(resumed.isSessionReused(), true);
+
+  // Then the socket is destroyed during 'secure', which surfaces as a reset
+  // rather than a handshake failure.
+  const [err] = await once(strict, 'tlsClientError');
+  assert.strictEqual(err.code, 'ECONNRESET');
+
+  resumed.destroy();
+  strict.close();
+  await once(strict, 'close');
+}
+
+(async function() {
+  // Run the full matrix of configurations:
+  for (const version of ['TLSv1.2', 'TLSv1.3'])
+    for (const name of Object.keys(CLIENTS))
+      await testResumption(version, name);
+
+  // Validate the rejectUnauth:false->true case
+  await testRejectResumedWithoutCert();
+})().then(common.mustCall());


### PR DESCRIPTION
Previously if you used TLS 1.3 and the server requested a client cert, but the client didn't send one, and you used `rejectUnauthorized: false` (e.g. to manually verify state with some extra conditions) then the initial session would report `authorized=false`, but resuming the session later would report `authorized=true`.

This doesn't match TLS 1.2 behaviour (which correctly preserves authorization state & errors across resumption). It's not inevitable and it wasn't intentional - this is an artifact of our internal logic for handling PSKs in TLS 1.3 inside ncrypto ([here](https://github.com/nodejs/node/blob/2deb0a1b0f542c4b7fedc16dda1149c65e546f0d/deps/ncrypto/ncrypto.cc#L4100-L4106)) that wasn't properly validated on this side.

We now correctly report the authorization state and/or error from the original connection in all cases. This also adds a matrix test that fully checks the invariant over all combinations of TLS 1.2/1.3 + valid-cert/invalid-cert/no-cert: authorized state after resume should always match the initial state.

Fixes #35317 - note there is some debate in there (cc @bnoordhuis) but I think there's confusion in some of the descriptions and it's actually just a clear bug.

See also #64584 which was opened just now, to simply document the current state.

This PR is either a fix for the current state (in which case we could close #64584) or a semver-major change (in which case we can keep the document PR for now, and merge this to clean that up to change the behaviour as a major bump). Opinions from @nodejs/crypto would be helpful. This is arguably a security fix but it has been directly described in public in that issue as intended behaviour for nearly 6 years.

The scope is limited to `rejectUnauthorized: false` cases, which does imply a degree of taking your own responsibility for validation - but even if you enable that option we still shouldn't lie to you unnecessarily, as we do today.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
