### PR TITLE
src: add SetAbortHandler

### DIFF
--- a/src/node.h
+++ b/src/node.h
@@ -844,6 +844,16 @@ NODE_EXTERN void SetProcessExitHandler(
     std::function<void(Environment*, int)>&& handler);
 NODE_EXTERN void DefaultProcessExitHandler(Environment* env, int exit_code);
 
+// Sets a process-global handler invoked when Node.js programmatically aborts
+// (the ABORT() macro: failed CHECK/DCHECK, UNREACHABLE(), node::Assert(), and
+// OnFatalError()). The handler may return, in which case Node.js still
+// terminates the process (via abort()/_exit), or it may terminate the
+// process itself. The default handler writes the native and JavaScript
+// backtraces to stderr. Passing nullptr restores the default handler. This is
+// process-global and may be invoked before any Isolate or Environment exists.
+using AbortHandler = void (*)();
+NODE_EXTERN void SetAbortHandler(AbortHandler handler);
+
 // This may return nullptr if context is not associated with a Node instance.
 NODE_EXTERN Environment* GetCurrentEnvironment(v8::Local<v8::Context> context);
 NODE_EXTERN IsolateData* GetEnvironmentIsolateData(Environment* env);

--- a/src/node.h
+++ b/src/node.h
@@ -844,14 +844,13 @@ NODE_EXTERN void SetProcessExitHandler(
     std::function<void(Environment*, int)>&& handler);
 NODE_EXTERN void DefaultProcessExitHandler(Environment* env, int exit_code);
 
-// Sets a process-global handler invoked when Node.js programmatically aborts
-// (the ABORT() macro: failed CHECK/DCHECK, UNREACHABLE(), node::Assert(), and
-// OnFatalError()). The handler may return, in which case Node.js still
-// terminates the process (via abort()/_exit), or it may terminate the
-// process itself. The default handler writes the native and JavaScript
-// backtraces to stderr. Passing nullptr restores the default handler. This is
+// Sets a process-global handler invoked when Node.js programmatically aborts. A
+// message describing the reason for the abort may or may not be passed as a
+// parameter to the handler. The handler should not return, but node will ensure
+// that the process exits after the handler is called regardless of whether or
+// not it returns. Passing nullptr restores the default handler. This is
 // process-global and may be invoked before any Isolate or Environment exists.
-using AbortHandler = void (*)();
+using AbortHandler = void (*)(const char* message);
 NODE_EXTERN void SetAbortHandler(AbortHandler handler);
 
 // This may return nullptr if context is not associated with a Node instance.

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -394,12 +394,16 @@ void AppendExceptionLine(Environment* env,
 }
 
 namespace {
-// Default handler: reproduces previous ABORT() output (native + JS backtrace to
-// stderr). Termination is NOT done here. The ABORT() macro backstops it.
-void DefaultAbortHandler() {
+// Default handler: Dumps native + JS backtraces to stderr and exits. This
+// indirectly calls backtrace so it can not be marked as [[noreturn]] (see the
+// comment on node::Assert() below). `message` is ignored because the
+// assertion/fatal-error message, if any, is already printed to stderr by the
+// caller (Assert()/OnFatalError()) before this handler runs.
+void DefaultAbortHandler(const char* /*message*/) {
   DumpNativeBacktrace(stderr);
   DumpJavaScriptBacktrace(stderr);
   fflush(stderr);
+  ABORT_NO_BACKTRACE();
 }
 // Constant-initialized, so this is valid from load time, safe even for a
 // CHECK() during early startup, before any SetAbortHandler call.
@@ -426,7 +430,7 @@ void Assert(const AssertionInfo& info) {
           info.message);
 
   fflush(stderr);
-  ABORT();
+  ABORT_WITH_MESSAGE(info.message);
 }
 
 enum class EnhanceFatalException { kEnhance, kDontEnhance };
@@ -604,7 +608,7 @@ static void ReportFatalException(Environment* env,
   }
 
   fflush(stderr);
-  ABORT();
+  ABORT_WITH_MESSAGE(message);
 }
 
 void OOMErrorHandler(const char* location, const v8::OOMDetails& details) {
@@ -640,7 +644,7 @@ void OOMErrorHandler(const char* location, const v8::OOMDetails& details) {
   }
 
   fflush(stderr);
-  ABORT();
+  ABORT_WITH_MESSAGE(message);
 }
 
 v8::ModifyCodeGenerationFromStringsResult ModifyCodeGenerationFromStrings(

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -393,6 +393,26 @@ void AppendExceptionLine(Environment* env,
             .FromMaybe(false));
 }
 
+namespace {
+// Default handler: reproduces previous ABORT() output (native + JS backtrace to
+// stderr). Termination is NOT done here. The ABORT() macro backstops it.
+void DefaultAbortHandler() {
+  DumpNativeBacktrace(stderr);
+  DumpJavaScriptBacktrace(stderr);
+  fflush(stderr);
+}
+// Constant-initialized, so this is valid from load time, safe even for a CHECK()
+// during early startup, before any SetAbortHandler call.
+AbortHandler g_abort_handler = DefaultAbortHandler;
+}  // namespace
+
+void SetAbortHandler(AbortHandler handler) {
+  g_abort_handler = handler ? handler : DefaultAbortHandler;
+}
+AbortHandler GetAbortHandler() {
+  return g_abort_handler;
+}
+
 void Assert(const AssertionInfo& info) {
   std::string name = GetHumanReadableProcessName();
 

--- a/src/node_errors.cc
+++ b/src/node_errors.cc
@@ -401,8 +401,8 @@ void DefaultAbortHandler() {
   DumpJavaScriptBacktrace(stderr);
   fflush(stderr);
 }
-// Constant-initialized, so this is valid from load time, safe even for a CHECK()
-// during early startup, before any SetAbortHandler call.
+// Constant-initialized, so this is valid from load time, safe even for a
+// CHECK() during early startup, before any SetAbortHandler call.
 AbortHandler g_abort_handler = DefaultAbortHandler;
 }  // namespace
 

--- a/src/util.h
+++ b/src/util.h
@@ -143,9 +143,10 @@ AbortHandler GetAbortHandler();
 // correct backtracing.
 // `ABORT` must be a macro and not a [[noreturn]] function to make sure the
 // backtrace is correct.
-#define ABORT()                                                                \
+#define ABORT() ABORT_WITH_MESSAGE(nullptr)
+#define ABORT_WITH_MESSAGE(message)                                            \
   do {                                                                         \
-    node::GetAbortHandler()();                                                 \
+    node::GetAbortHandler()(message);                                          \
     ABORT_NO_BACKTRACE();                                                      \
   } while (0)
 

--- a/src/util.h
+++ b/src/util.h
@@ -126,6 +126,9 @@ void NODE_EXTERN_PRIVATE Assert(const AssertionInfo& info);
 void DumpNativeBacktrace(FILE* fp);
 void DumpJavaScriptBacktrace(FILE* fp);
 
+// Returns the currently installed abort handler which is never null.
+AbortHandler GetAbortHandler();
+
 // Windows 8+ does not like abort() in Release mode
 #ifdef _WIN32
 #define ABORT_NO_BACKTRACE() _exit(static_cast<int>(node::ExitCode::kAbort))
@@ -142,9 +145,7 @@ void DumpJavaScriptBacktrace(FILE* fp);
 // backtrace is correct.
 #define ABORT()                                                                \
   do {                                                                         \
-    node::DumpNativeBacktrace(stderr);                                         \
-    node::DumpJavaScriptBacktrace(stderr);                                     \
-    fflush(stderr);                                                            \
+    node::GetAbortHandler()();                                                 \
     ABORT_NO_BACKTRACE();                                                      \
   } while (0)
 

--- a/src/util.h
+++ b/src/util.h
@@ -143,7 +143,7 @@ AbortHandler GetAbortHandler();
 // correct backtracing.
 // `ABORT` must be a macro and not a [[noreturn]] function to make sure the
 // backtrace is correct.
-#define ABORT() ABORT_WITH_MESSAGE(nullptr)
+#define ABORT() ABORT_WITH_MESSAGE(__FILE__ ":" STRINGIFY(__LINE__))
 #define ABORT_WITH_MESSAGE(message)                                            \
   do {                                                                         \
     node::GetAbortHandler()(message);                                          \

--- a/test/abort/test-addon-abort-handler.js
+++ b/test/abort/test-addon-abort-handler.js
@@ -1,0 +1,4 @@
+'use strict';
+require('../common');
+process.env.ALLOW_CRASHES = true;
+require('../addons/abort-handler/test');

--- a/test/abort/test-addon-abort-handler.js
+++ b/test/abort/test-addon-abort-handler.js
@@ -1,4 +1,0 @@
-'use strict';
-require('../common');
-process.env.ALLOW_CRASHES = true;
-require('../addons/abort-handler/test');

--- a/test/addons/abort-handler/binding.cc
+++ b/test/addons/abort-handler/binding.cc
@@ -3,7 +3,7 @@
 #include <cstdio>
 
 namespace {
-void TestAbortHandler() {
+void TestAbortHandler(const char* /*message*/) {
   fputs("CUSTOM_ABORT_HANDLER_RAN\n", stderr);
   fflush(stderr);
 }

--- a/test/addons/abort-handler/binding.cc
+++ b/test/addons/abort-handler/binding.cc
@@ -1,0 +1,18 @@
+#include <node.h>
+#include <v8.h>
+#include <cstdio>
+
+namespace {
+void TestAbortHandler() {
+  fputs("CUSTOM_ABORT_HANDLER_RAN\n", stderr);
+  fflush(stderr);
+}
+
+void InstallAbortHandler(const v8::FunctionCallbackInfo<v8::Value>&) {
+  node::SetAbortHandler(TestAbortHandler);
+}
+}  // namespace
+
+NODE_MODULE_INIT() {
+  NODE_SET_METHOD(exports, "installAbortHandler", InstallAbortHandler);
+}

--- a/test/addons/abort-handler/binding.gyp
+++ b/test/addons/abort-handler/binding.gyp
@@ -1,0 +1,9 @@
+{
+  'targets': [
+    {
+      'target_name': 'binding',
+      'sources': [ 'binding.cc' ],
+      'includes': ['../common.gypi'],
+    }
+  ]
+}

--- a/test/addons/abort-handler/test.js
+++ b/test/addons/abort-handler/test.js
@@ -3,7 +3,7 @@ const common = require('../../common');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const { spawnSync } = require('child_process');
+const { exec } = require('child_process');
 
 const bindingPath = path.resolve(
   __dirname, 'build', common.buildType, 'binding.node');
@@ -18,26 +18,28 @@ if (process.argv[2] === 'child') {
   return;
 }
 
-// We do not want to generate core files / actually crash the process when
-// running this test as a regular addon test. It is also required as an
-// abort test with ALLOW_CRASHES set (see ../../abort/test-addon-abort-handler.js).
-if (!process.env.ALLOW_CRASHES)
-  common.skip('test needs ALLOW_CRASHES to spawn a crashing child');
-
-const result = spawnSync(process.execPath, [__filename, 'child']);
-
-const stderr = result.stderr.toString();
-assert.ok(
-  stderr.includes('CUSTOM_ABORT_HANDLER_RAN'),
-  `Expected custom abort handler marker in stderr, got:\n${stderr}`);
-assert.ok(
-  !stderr.includes('Native stack trace'),
-  `Expected the custom handler to replace the default dump, got:\n${stderr}`);
-
-if (common.isWindows) {
-  assert.strictEqual(result.status, 134);
-  assert.strictEqual(result.signal, null);
-} else {
-  assert.strictEqual(result.status, null);
-  assert.strictEqual(result.signal, 'SIGABRT');
+const escapedArgs =
+  common.escapePOSIXShell`"${process.execPath}" "${__filename}" child`;
+if (!common.isWindows) {
+  // Do not create core files, as it can take a lot of disk space on
+  // continuous testing and developers' machines.
+  escapedArgs[0] = 'ulimit -c 0 && ' + escapedArgs[0];
 }
+
+exec(...escapedArgs, common.mustCall((err, stdout, stderr) => {
+  assert.ok(
+    stderr.includes('CUSTOM_ABORT_HANDLER_RAN'),
+    `Expected custom abort handler marker in stderr, got:\n${stderr}`);
+  assert.ok(
+    !stderr.includes('Native stack trace'),
+    `Expected the custom handler to replace the default dump, got:\n${stderr}`);
+
+  // The child aborts. Whether that surfaces as the SIGABRT signal or as exit
+  // code 134 depends on shell wrapping: the `ulimit -c 0 && ...` prefix makes
+  // /bin/sh wait on (rather than exec-replace itself with) the node grandchild,
+  // so sh reports the aborted grandchild as a normal exit with code 134.
+  // common.nodeProcessAborted() accepts both forms.
+  assert.ok(
+    err && common.nodeProcessAborted(err.code, err.signal),
+    `Expected the child to abort, got code=${err?.code} signal=${err?.signal}`);
+}));

--- a/test/addons/abort-handler/test.js
+++ b/test/addons/abort-handler/test.js
@@ -1,0 +1,43 @@
+'use strict';
+const common = require('../../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const bindingPath = path.resolve(
+  __dirname, 'build', common.buildType, 'binding.node');
+
+if (!fs.existsSync(bindingPath))
+  common.skip('binding not built yet');
+
+if (process.argv[2] === 'child') {
+  const binding = require(bindingPath);
+  binding.installAbortHandler();
+  process.abort();
+  return;
+}
+
+// We do not want to generate core files / actually crash the process when
+// running this test as a regular addon test. It is also required as an
+// abort test with ALLOW_CRASHES set (see ../../abort/test-addon-abort-handler.js).
+if (!process.env.ALLOW_CRASHES)
+  common.skip('test needs ALLOW_CRASHES to spawn a crashing child');
+
+const result = spawnSync(process.execPath, [__filename, 'child']);
+
+const stderr = result.stderr.toString();
+assert.ok(
+  stderr.includes('CUSTOM_ABORT_HANDLER_RAN'),
+  `Expected custom abort handler marker in stderr, got:\n${stderr}`);
+assert.ok(
+  !stderr.includes('Native stack trace'),
+  `Expected the custom handler to replace the default dump, got:\n${stderr}`);
+
+if (common.isWindows) {
+  assert.strictEqual(result.status, 134);
+  assert.strictEqual(result.signal, null);
+} else {
+  assert.strictEqual(result.status, null);
+  assert.strictEqual(result.signal, 'SIGABRT');
+}

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -1201,3 +1201,43 @@ TEST_F(EnvironmentTest, LoadEnvironmentWithCallbackWithESModule) {
   printf("Frame: %s\n", *frame_str);
   EXPECT_EQ(frame_str.ToString(), "    at embedded:esm.mjs:3:15");
 }
+
+namespace {
+void CustomAbortHandlerForContractTest() {}
+
+bool abort_handler_dispatch_flag = false;
+void AbortHandlerThatSetsDispatchFlag() {
+  abort_handler_dispatch_flag = true;
+}
+}  // namespace
+
+TEST(AbortHandlerTest, DefaultIsNonNullAndSetAbortHandlerRoundTrips) {
+  node::AbortHandler old = node::GetAbortHandler();
+
+  // There should always be a non-null default handler installed.
+  EXPECT_NE(node::GetAbortHandler(), nullptr);
+
+  node::SetAbortHandler(CustomAbortHandlerForContractTest);
+  EXPECT_EQ(node::GetAbortHandler(), CustomAbortHandlerForContractTest);
+
+  node::SetAbortHandler(nullptr);
+  EXPECT_NE(node::GetAbortHandler(), nullptr);
+  EXPECT_NE(node::GetAbortHandler(), CustomAbortHandlerForContractTest);
+
+  node::SetAbortHandler(old);
+}
+
+TEST(AbortHandlerTest, InstalledHandlerIsInvokedWhenCalled) {
+  node::AbortHandler old = node::GetAbortHandler();
+  abort_handler_dispatch_flag = false;
+
+  node::SetAbortHandler(AbortHandlerThatSetsDispatchFlag);
+  node::AbortHandler h = node::GetAbortHandler();
+  // Fail cleanly (instead of crashing on a null call) if the handler wasn't
+  // actually installed.
+  ASSERT_NE(h, nullptr);
+  h();
+  EXPECT_TRUE(abort_handler_dispatch_flag);
+
+  node::SetAbortHandler(old);
+}

--- a/test/cctest/test_environment.cc
+++ b/test/cctest/test_environment.cc
@@ -1203,11 +1203,13 @@ TEST_F(EnvironmentTest, LoadEnvironmentWithCallbackWithESModule) {
 }
 
 namespace {
-void CustomAbortHandlerForContractTest() {}
+void CustomAbortHandlerForContractTest(const char* message) {}
 
 bool abort_handler_dispatch_flag = false;
-void AbortHandlerThatSetsDispatchFlag() {
+const char* abort_handler_received_message = nullptr;
+void AbortHandlerThatSetsDispatchFlag(const char* message) {
   abort_handler_dispatch_flag = true;
+  abort_handler_received_message = message;
 }
 }  // namespace
 
@@ -1230,14 +1232,20 @@ TEST(AbortHandlerTest, DefaultIsNonNullAndSetAbortHandlerRoundTrips) {
 TEST(AbortHandlerTest, InstalledHandlerIsInvokedWhenCalled) {
   node::AbortHandler old = node::GetAbortHandler();
   abort_handler_dispatch_flag = false;
+  abort_handler_received_message = nullptr;
 
   node::SetAbortHandler(AbortHandlerThatSetsDispatchFlag);
   node::AbortHandler h = node::GetAbortHandler();
   // Fail cleanly (instead of crashing on a null call) if the handler wasn't
   // actually installed.
   ASSERT_NE(h, nullptr);
-  h();
+
+  // Dispatch through the public GetAbortHandler() accessor directly (not via
+  // the ABORT() macro, so nothing terminates), and verify the message is
+  // passed through unchanged.
+  node::GetAbortHandler()("some-test-message");
   EXPECT_TRUE(abort_handler_dispatch_flag);
+  EXPECT_STREQ(abort_handler_received_message, "some-test-message");
 
   node::SetAbortHandler(old);
 }


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

This adds `SetAbortHandler`, which allows embedders to specify custom behavior in situations where `ABORT()` is called.  The current behavior of `ABORT()` is to stream both the native and JS backtraces to `stderr` and exit  with platform specific behavior.  Some embedders may want to change this behavior, such as changing where the backtrace is provided. Embedders can also use the handler to exit with their own behavior, but node will still guarantee an exit if the provided abort handler returns.

A `DefaultAbortHandler` is used to ensure existing behavior does not change unless an abort handler is explicitly provided. The only difference with this design is an additional stack frame in the backtrace for the abort handler, but this behavior was never guaranteed. 

A new `ABORT_WITH_MESSAGE` macro is also added for cases where a message can be passed describing the reason for the abort. This new macro replaces existing calls to `ABORT` in various error handlers in `node_errors.cc` where a message is already available. This message is then propagated to the abort handler, but no changes are made to the default abort handler. That behavior does not change here.