### PR TITLE
crypto: use user-facing error for output encoding changes

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -848,6 +848,9 @@ added: v0.1.94
   If `outputEncoding` is specified, a string is
   returned. If an `outputEncoding` is not provided, a [`Buffer`][] is returned.
 
+If an output encoding was specified in a previous call to
+[`cipher.update()`][], `outputEncoding` must use the same encoding.
+
 Once the `cipher.final()` method has been called, the `Cipheriv` object can no
 longer be used to encrypt data. Attempts to call `cipher.final()` more than
 once will result in an error being thrown.
@@ -940,6 +943,8 @@ The `outputEncoding` specifies the output format of the enciphered
 data. If the `outputEncoding`
 is specified, a string using the specified encoding is returned. If no
 `outputEncoding` is provided, a [`Buffer`][] is returned.
+When `outputEncoding` is specified, it must use the same encoding as previous
+calls to `cipher.update()`.
 
 The `cipher.update()` method can be called multiple times with new data until
 [`cipher.final()`][] is called. Calling `cipher.update()` after
@@ -1158,6 +1163,9 @@ added: v0.1.94
   If `outputEncoding` is specified, a string is
   returned. If an `outputEncoding` is not provided, a [`Buffer`][] is returned.
 
+If an output encoding was specified in a previous call to
+[`decipher.update()`][], `outputEncoding` must use the same encoding.
+
 Once the `decipher.final()` method has been called, the `Decipheriv` object can
 no longer be used to decrypt data. Attempts to call `decipher.final()` more
 than once will result in an error being thrown.
@@ -1290,6 +1298,8 @@ The `outputEncoding` specifies the output format of the enciphered
 data. If the `outputEncoding`
 is specified, a string using the specified encoding is returned. If no
 `outputEncoding` is provided, a [`Buffer`][] is returned.
+When `outputEncoding` is specified, it must use the same encoding as previous
+calls to `decipher.update()`.
 
 The `decipher.update()` method can be called multiple times with new data until
 [`decipher.final()`][] is called. Calling `decipher.update()` after

--- a/lib/internal/crypto/cipher.js
+++ b/lib/internal/crypto/cipher.js
@@ -54,8 +54,6 @@ const {
   isArrayBufferView,
 } = require('internal/util/types');
 
-const assert = require('internal/assert');
-
 const LazyTransform = require('internal/streams/lazy_transform');
 
 const { normalizeEncoding, kEmptyObject } = require('internal/util');
@@ -98,7 +96,11 @@ function getDecoder(decoder, encoding) {
     if (normalizedEncoding === undefined) {
       throw new ERR_UNKNOWN_ENCODING(encoding);
     }
-    assert.fail('Cannot change encoding');
+    throw new ERR_INVALID_ARG_VALUE(
+      'outputEncoding',
+      encoding,
+      `cannot be changed from '${decoder.encoding}'`,
+    );
   }
   return decoder;
 }

--- a/test/parallel/test-crypto-encoding-validation-error.js
+++ b/test/parallel/test-crypto-encoding-validation-error.js
@@ -12,13 +12,19 @@ const createCipher = () => {
   return createCipheriv('aes-256-cbc', randomBytes(32), randomBytes(16));
 };
 
+const encodingChangeError = {
+  code: 'ERR_INVALID_ARG_VALUE',
+  name: 'TypeError',
+  message: /cannot be changed from 'utf8'/,
+};
+
 {
   const cipher = createCipher();
   cipher.update('test', 'utf-8', 'utf-8');
 
   assert.throws(
     () => cipher.update('666f6f', 'hex', 'hex'),
-    { message: /Cannot change encoding/ }
+    encodingChangeError
   );
 }
 
@@ -28,7 +34,7 @@ const createCipher = () => {
 
   assert.throws(
     () => cipher.final('hex'),
-    { message: /Cannot change encoding/ }
+    encodingChangeError
   );
 }
 


### PR DESCRIPTION
Fixes: #64689


<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
