### PR TITLE
http: emit aborted event on requests

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -2787,9 +2787,23 @@ deprecated:
   - v16.12.0
 -->
 
-> Stability: 0 - Deprecated. Listen for `'close'` event instead.
+> Stability: 0 - Deprecated. Use the `'close'` event on the response. If it was aborted `writableFinished` will be false.
 
-Emitted when the request has been aborted.
+Emitted when the request has been aborted, i.e. the underlying connection
+was terminated before the message (request or response) was fully
+received *and* before the message cycle completed (for a server request,
+before the corresponding response was finished).
+
+This event is only emitted if the message was not already fully
+processed. In particular, note that:
+
+* `'aborted'` is not emitted after the `'close'` event has already fired for
+  a message that completed normally.
+* Fully reading the body of an `http.IncomingMessage` (for example via
+  `req.resume()` or by piping/consuming it) does **not** by itself mean the
+  request/response cycle is done. On the server, a request can still be
+  aborted (its `'aborted'` event fired) after its body has been completely
+  read, as long as the corresponding response has not finished yet.
 
 ### Event: `'close'`
 
@@ -2803,6 +2817,18 @@ changes:
 -->
 
 Emitted when the request has been completed.
+
+More precisely, this event is emitted when this side of the HTTP message
+(headers and body) has finished being processed, either because it was
+fully read (`'end'` was emitted) or because the message stream was
+destroyed.
+
+`'close'` does **not** imply that the request/response cycle as a whole
+finished successfully, and it does **not** imply that the peer received a
+complete response. For example, on the server side `'close'` on the
+`request` object can fire as soon as the request body has been read, well
+before `response.end()` has been called or the response has actually been
+sent to the client.
 
 ### `message.aborted`
 
@@ -2830,6 +2856,7 @@ added: v0.3.0
 
 The `message.complete` property will be `true` if a complete HTTP message has
 been received and successfully parsed.
+
 
 This property is particularly useful as a means of determining if a client or
 server fully transmitted a message before a connection was terminated:

--- a/lib/_http_incoming.js
+++ b/lib/_http_incoming.js
@@ -231,7 +231,11 @@ IncomingMessage.prototype._read = function _read() {
 // any messages, before ever calling this.  In that case, just skip
 // it, since something else is destroying this connection anyway.
 IncomingMessage.prototype._destroy = function _destroy(err, cb) {
-  if (!this.readableEnded || !this.complete) {
+  // `this.aborted` may already have been set to `true` by the caller
+  // (e.g. abortIncoming() in _http_server.js) to indicate that the
+  // connection went away while the request/response was still pending.
+  // Avoid clobbering that and emitting a duplicate 'aborted' event.
+  if (!this.aborted && (!this.readableEnded || !this.complete)) {
     this.aborted = true;
     this.emit('aborted');
   }

--- a/lib/_http_server.js
+++ b/lib/_http_server.js
@@ -909,6 +909,18 @@ function socketOnClose(socket, state) {
 function abortIncoming(incoming) {
   while (incoming.length) {
     const req = incoming.shift();
+    // Any request still sitting in `state.incoming` has not had its
+    // response finished yet (see resOnFinish(), which shift()s the
+    // request off this array once the response completes). If the
+    // underlying socket is going away while the request is still
+    // pending here, that unambiguously means the client (or the
+    // connection) went away before the request/response cycle could
+    // complete, i.e. the request was aborted - regardless of whether
+    // the request body itself had already been fully read.
+    if (!req.aborted) {
+      req.aborted = true;
+      req.emit('aborted');
+    }
     req.destroy(new ConnResetException('aborted'));
   }
 }

--- a/test/parallel/test-http-server-aborted-after-request-end.js
+++ b/test/parallel/test-http-server-aborted-after-request-end.js
@@ -1,0 +1,53 @@
+'use strict';
+
+// Regression test: the request object's 'aborted' event (and .aborted
+// property) must still be emitted/set when the client destroys the
+// connection, even if the request body had already been fully consumed
+// (i.e. the request stream already emitted 'end') before the response
+// finished. This complements test-http-server-aborted-while-reading-body.js,
+// which covers aborting *while* the body is still being read.
+// See https://github.com/nodejs/node/issues/40775.
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+let clientReq;
+const server = http.createServer(common.mustCall((req, res) => {
+  // Close the server once the request stream is torn down, regardless of
+  // whether 'aborted' fired. This is guaranteed to happen (unlike
+  // 'aborted', which is exactly what's under test here), so a regression
+  // makes this test fail fast via the mustCall() check below instead of
+  // hanging forever.
+  req.on('close', common.mustCall(() => {
+    server.close();
+  }));
+
+  req.on('aborted', common.mustCall(() => {
+    assert.strictEqual(req.aborted, true);
+  }));
+
+  req.on('end', common.mustCall(() => {
+    // At this point the request body has been fully read, but the
+    // response has not been sent yet. Destroying the client request
+    // now must still result in the server's 'aborted' event firing.
+    clientReq.destroy();
+  }));
+
+  req.resume();
+}));
+
+server.listen(0, common.mustCall(() => {
+  clientReq = http.request({
+    method: 'POST',
+    port: server.address().port,
+    headers: { connection: 'keep-alive' },
+  }, common.mustNotCall());
+
+  // Destroying the request may or may not surface an error on the client
+  // side depending on timing; only the server-side 'aborted' event
+  // (asserted above) is under test here.
+  clientReq.on('error', () => {});
+
+  clientReq.end();
+}));

--- a/test/parallel/test-http-server-aborted-while-reading-body.js
+++ b/test/parallel/test-http-server-aborted-while-reading-body.js
@@ -1,0 +1,55 @@
+'use strict';
+
+// Regression test: the request object's 'aborted' event (and .aborted
+// property) must be emitted when the client destroys the connection while
+// the server is still in the middle of reading the request body, i.e.
+// before 'end' has fired on the request stream. This is the "classic"
+// abort case and complements
+// test-http-server-aborted-after-request-end.js, which covers aborting
+// *after* the body has already been fully read.
+// See https://github.com/nodejs/node/issues/40775.
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+
+let clientReq;
+const server = http.createServer(common.mustCall((req, res) => {
+  // Close the server once the request stream is torn down, regardless of
+  // whether 'aborted' fired. This is guaranteed to happen (unlike
+  // 'aborted', which is exactly what's under test here), so a regression
+  // makes this test fail fast via the mustCall() check below instead of
+  // hanging forever.
+  req.on('close', common.mustCall(() => {
+    server.close();
+  }));
+
+  req.on('aborted', common.mustCall(() => {
+    assert.strictEqual(req.aborted, true);
+    assert.strictEqual(req.complete, false);
+  }));
+
+  req.on('data', common.mustCall(() => {
+    // Once the first chunk of the body has arrived, destroy the client
+    // connection before it finishes sending the rest of the body (and
+    // before the server ever calls res.end()/sends a response).
+    clientReq.destroy();
+  }));
+}));
+
+server.listen(0, common.mustCall(() => {
+  clientReq = http.request({
+    method: 'POST',
+    port: server.address().port,
+    headers: { connection: 'keep-alive' },
+  }, common.mustNotCall());
+
+  // Destroying the request may or may not surface an error on the client
+  // side depending on timing; only the server-side 'aborted' event
+  // (asserted above) is under test here.
+  clientReq.on('error', () => {});
+
+  // Write a chunk but never call end(), so the server never sees the body
+  // finish before the connection is destroyed.
+  clientReq.write('some data');
+}));


### PR DESCRIPTION
Currently the aborted event is never emitted on the request object. This merge request fixes that by ensuring the abort event is emitted on the request if the server hasn't finished reading the request or the response sending the response hasn't finished yet. It also improved the documentation to make it clear when close and abort events are emitted.

Fixes: https://github.com/nodejs/node/issues/46666

I would welcome reverting the deprecation from the req aborted event, but didn't do that here. IMO it's much nicer for devs to be able to listen for client aborts in a single place (the request object).

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
