### PR TITLE
test_runner: display coverage errors in dot reporter

### DIFF
--- a/lib/internal/test_runner/reporter/dot.js
+++ b/lib/internal/test_runner/reporter/dot.js
@@ -10,6 +10,7 @@ module.exports = async function* dot(source) {
   let count = 0;
   let columns = getLineLength();
   const failedTests = [];
+  const diagnosticErrors = [];
   for await (const { type, data } of source) {
     if (type === 'test:pass') {
       yield `${colors.green}.${colors.reset}`;
@@ -17,6 +18,9 @@ module.exports = async function* dot(source) {
     if (type === 'test:fail') {
       yield `${colors.red}X${colors.reset}`;
       ArrayPrototypePush(failedTests, data);
+    }
+    if (type === 'test:diagnostic' && data.level === 'error') {
+      ArrayPrototypePush(diagnosticErrors, data.message);
     }
     if ((type === 'test:fail' || type === 'test:pass') && ++count === columns) {
       yield '\n';
@@ -31,6 +35,12 @@ module.exports = async function* dot(source) {
     yield `\n${colors.red}Failed tests:${colors.white}\n\n`;
     for (const test of failedTests) {
       yield formatTestReport('test:fail', test);
+    }
+  }
+  if (diagnosticErrors.length > 0) {
+    yield `\n${colors.red}Diagnostic errors:${colors.white}\n\n`;
+    for (const msg of diagnosticErrors) {
+      yield `${msg}\n`;
     }
   }
 };

--- a/test/fixtures/test-runner/output/dot_reporter_coverage.js
+++ b/test/fixtures/test-runner/output/dot_reporter_coverage.js
@@ -1,0 +1,18 @@
+'use strict';
+require('../../../common');
+const fixtures = require('../../../common/fixtures');
+const spawn = require('node:child_process').spawn;
+
+spawn(
+  process.execPath,
+  [
+    '--no-warnings',
+    '--test-reporter', 'dot',
+    '--experimental-test-coverage',
+    '--test-coverage-lines=100',
+    '--test-coverage-branches=100',
+    '--test-coverage-functions=100',
+    fixtures.path('test-runner/output/output.js'),
+  ],
+  { stdio: 'inherit' },
+);

--- a/test/fixtures/test-runner/output/dot_reporter_coverage.snapshot
+++ b/test/fixtures/test-runner/output/dot_reporter_coverage.snapshot
@@ -1,0 +1,168 @@
+........XX...X..XXX.
+X.....XXX...........
+.X.........X...XXX.X
+X.....XXXXXXX...XXXX
+X
+
+Failed tests:
+
+⚠ sync fail todo (*ms) # TODO
+  Error: thrown from sync fail todo
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:42:9)
+      at <node-internal-frames>
+⚠ sync fail todo with message (*ms) # this is a failing todo
+  Error: thrown from sync fail todo with message
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:47:9)
+      at <node-internal-frames>
+✖ sync throw fail (*ms)
+  Error: thrown from sync throw fail
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:63:9)
+      at <node-internal-frames>
+✖ async throw fail (*ms)
+  Error: thrown from async throw fail
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:75:9)
+      at <node-internal-frames>
+﹣ async skip fail (*ms) # SKIP
+  Error: thrown from async throw fail
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:80:9)
+      at <node-internal-frames>
+✖ async assertion fail (*ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be strictly equal:
+
+  true !== false
+
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:85:10)
+      at <node-internal-frames>
+      at <node-internal-frames> {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: true,
+    expected: false,
+    operator: 'strictEqual',
+    diff: 'simple'
+  }
+✖ reject fail (*ms)
+  Error: rejected from reject fail
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:93:25)
+      at <node-internal-frames>
+✖ +sync throw fail (*ms)
+  Error: thrown from subtest sync throw fail
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:127:11)
+      at <node-internal-frames>
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:125:11)
+      at <node-internal-frames>
+✖ subtest sync throw fail (*ms)
+  '1 subtest failed'
+✖ sync throw non-error fail (*ms)
+  Symbol(thrown symbol from sync throw non-error fail)
+✖ sync skip option is false fail (*ms)
+  Error: this should be executed
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:212:9)
+      at <node-internal-frames>
+✖ callback fail (*ms)
+  Error: callback failure
+      at Immediate.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:245:10)
+      at <node-internal-frames>
+✖ callback also returns a Promise (*ms)
+  'passed a callback but also returned a Promise'
+✖ callback throw (*ms)
+  Error: thrown from callback throw
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:267:9)
+      at <node-internal-frames>
+✖ callback called twice (*ms)
+  'callback invoked multiple times'
+✖ callback called twice in future tick (*ms)
+  Error [ERR_TEST_FAILURE]: callback invoked multiple times
+      at Immediate.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:283:5) {
+    code: 'ERR_TEST_FAILURE',
+    failureType: 'multipleCallbackInvocations',
+    cause: 'callback invoked multiple times'
+  }
+✖ callback async throw (*ms)
+  Error: thrown from callback async throw
+      at Immediate.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:289:11)
+      at <node-internal-frames>
+✖ custom inspect symbol fail (*ms)
+  customized
+✖ custom inspect symbol that throws fail (*ms)
+  { foo: 1, Symbol(nodejs.util.inspect.custom): [Function: [nodejs.util.inspect.custom]] }
+✖ sync throw fails at first (*ms)
+  Error: thrown from subtest sync throw fails at first
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:335:11)
+      at <node-internal-frames>
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:334:11)
+      at <node-internal-frames>
+✖ sync throw fails at second (*ms)
+  Error: thrown from subtest sync throw fails at second
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:338:11)
+      at <node-internal-frames>
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:337:11)
+      at <node-internal-frames>
+✖ subtest sync throw fails (*ms)
+  '2 subtests failed'
+✖ timed out async test (*ms)
+  'test timed out after *ms'
+✖ timed out callback test (*ms)
+  'test timed out after *ms'
+✖ rejected thenable (*ms)
+  'custom error'
+✖ unfinished test with uncaughtException (*ms)
+  Error: foo
+      at Timeout._onTimeout (<project-root>/test/fixtures/test-runner/output/output.js:393:30)
+      at <node-internal-frames>
+✖ unfinished test with unhandledRejection (*ms)
+  Error: bar
+      at Timeout._onTimeout (<project-root>/test/fixtures/test-runner/output/output.js:399:37)
+      at <node-internal-frames>
+✖ assertion errors display actual and expected properly (*ms)
+  AssertionError [ERR_ASSERTION]: Expected values to be loosely deep-equal:
+
+  {
+    bar: 1,
+    baz: {
+      date: 1970-01-01T00:00:00.000Z,
+      null: null,
+      number: 1,
+      string: 'Hello',
+      undefined: undefined
+    },
+    boo: [
+      1
+    ],
+    foo: 1
+  }
+
+  should loosely deep-equal
+
+  {
+    baz: {
+      date: 1970-01-01T00:00:00.000Z,
+      null: null,
+      number: 1,
+      string: 'Hello',
+      undefined: undefined
+    },
+    boo: [
+      1
+    ],
+    circular: <ref *1> {
+      bar: 2,
+      c: [Circular *1]
+    }
+  }
+      at TestContext.<anonymous> (<project-root>/test/fixtures/test-runner/output/output.js:425:12) {
+    generatedMessage: true,
+    code: 'ERR_ASSERTION',
+    actual: [Object],
+    expected: [Object],
+    operator: 'deepEqual',
+    diff: 'simple'
+  }
+✖ invalid subtest fail (*ms)
+  'test could not be created because its parent finished'
+
+Diagnostic errors:
+
+Error: *% line coverage does not meet threshold of 100.00%.
+Error: *% branch coverage does not meet threshold of 100.00%.
+Error: *% function coverage does not meet threshold of 100.00%.

--- a/test/test-runner/test-output-dot-reporter-coverage.mjs
+++ b/test/test-runner/test-output-dot-reporter-coverage.mjs
@@ -1,0 +1,10 @@
+// Test that dot reporter output with coverage includes diagnostic errors
+import '../common/index.mjs';
+import * as fixtures from '../common/fixtures.mjs';
+import { spawnAndAssert, specTransform, ensureCwdIsProjectRoot } from '../common/assertSnapshot.js';
+
+ensureCwdIsProjectRoot();
+await spawnAndAssert(
+  fixtures.path('test-runner/output/dot_reporter_coverage.js'),
+  specTransform,
+);


### PR DESCRIPTION
When using the dot reporter with `--experimental-test-coverage` and
coverage thresholds, if a threshold is not met, the dot reporter
outputs only dots (`.`) with no error message. The process exits with
code 1 but gives no indication of what went wrong.

This happens because the dot reporter does not handle
`test:diagnostic` events with `error` level, which are emitted when
coverage thresholds are not satisfied.

## Changes

- Added handling for `test:diagnostic` events with `level === 'error'`
- Collected error messages are displayed after the dot output,
  similar to how failed tests are displayed

## Before

```bash
$ node --test --experimental-test-coverage --test-reporter=dot \
  --test-coverage-lines=100 test.js
.

$ echo $?
1           # failed but no error shown
```

## After

```bash
$ node --test --experimental-test-coverage --test-reporter=dot \
  --test-coverage-lines=100 test.js
.

Diagnostic errors:

Error: 85.00% line coverage does not meet threshold of 100.00%.
$ echo $?
1
```

Fixes: https://github.com/nodejs/node/issues/60884

