### PR TITLE
v8: avoid truncating cppgc heap statistics

### DIFF
--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -463,10 +463,10 @@ static MaybeLocal<Object> ConvertHeapStatsToJSObject(
         const cppgc::HeapStatistics::ObjectStatsEntry& object_stats =
             page_stats.object_statistics[k];
         MaybeLocal<Value> object_stats_values[] = {
-            Uint32::NewFromUnsigned(
-                isolate, static_cast<uint32_t>(object_stats.allocated_bytes)),
-            Uint32::NewFromUnsigned(
-                isolate, static_cast<uint32_t>(object_stats.object_count))};
+            Number::New(isolate,
+                        static_cast<double>(object_stats.allocated_bytes)),
+            Number::New(isolate,
+                        static_cast<double>(object_stats.object_count))};
         Local<Object> object_stats_object;
         if (!NewDictionaryInstanceNullProto(
                  context, object_stats_template, object_stats_values)
@@ -478,12 +478,11 @@ static MaybeLocal<Object> ConvertHeapStatsToJSObject(
 
       // Set page statistics
       MaybeLocal<Value> page_stats_values[] = {
-          Uint32::NewFromUnsigned(
-              isolate, static_cast<uint32_t>(page_stats.committed_size_bytes)),
-          Uint32::NewFromUnsigned(
-              isolate, static_cast<uint32_t>(page_stats.resident_size_bytes)),
-          Uint32::NewFromUnsigned(
-              isolate, static_cast<uint32_t>(page_stats.used_size_bytes)),
+          Number::New(isolate,
+                      static_cast<double>(page_stats.committed_size_bytes)),
+          Number::New(isolate,
+                      static_cast<double>(page_stats.resident_size_bytes)),
+          Number::New(isolate, static_cast<double>(page_stats.used_size_bytes)),
           Array::New(isolate,
                      object_statistics_array.data(),
                      object_statistics_array.size())};
@@ -521,15 +520,14 @@ static MaybeLocal<Object> ConvertHeapStatsToJSObject(
     }
     MaybeLocal<Value> space_stats_values[] = {
         name_value,
-        Uint32::NewFromUnsigned(
+        Number::New(
             isolate,
-            static_cast<uint32_t>(stats.space_stats[i].committed_size_bytes)),
-        Uint32::NewFromUnsigned(
+            static_cast<double>(stats.space_stats[i].committed_size_bytes)),
+        Number::New(
             isolate,
-            static_cast<uint32_t>(stats.space_stats[i].resident_size_bytes)),
-        Uint32::NewFromUnsigned(
-            isolate,
-            static_cast<uint32_t>(stats.space_stats[i].used_size_bytes)),
+            static_cast<double>(stats.space_stats[i].resident_size_bytes)),
+        Number::New(isolate,
+                    static_cast<double>(stats.space_stats[i].used_size_bytes)),
         Array::New(isolate,
                    page_statistics_array.data(),
                    page_statistics_array.size()),
@@ -550,12 +548,9 @@ static MaybeLocal<Object> ConvertHeapStatsToJSObject(
     return MaybeLocal<Object>();
   }
   MaybeLocal<Value> heap_statistics_values[] = {
-      Uint32::NewFromUnsigned(
-          isolate, static_cast<uint32_t>(stats.committed_size_bytes)),
-      Uint32::NewFromUnsigned(isolate,
-                              static_cast<uint32_t>(stats.resident_size_bytes)),
-      Uint32::NewFromUnsigned(isolate,
-                              static_cast<uint32_t>(stats.used_size_bytes)),
+      Number::New(isolate, static_cast<double>(stats.committed_size_bytes)),
+      Number::New(isolate, static_cast<double>(stats.resident_size_bytes)),
+      Number::New(isolate, static_cast<double>(stats.used_size_bytes)),
       Array::New(isolate,
                  space_statistics_array.data(),
                  space_statistics_array.size()),


### PR DESCRIPTION
Convert cppgc size_t counters directly to JavaScript Numbers instead of narrowing them to uint32_t.

This prevents v8.getCppHeapStatistics() values from wrapping when a cppgc heap statistic exceeds 4 GiB.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
