### PR TITLE
doc: update security release prepare command

### DIFF
--- a/doc/contributing/releases.md
+++ b/doc/contributing/releases.md
@@ -377,14 +377,20 @@ git checkout -b v1.2.3-proposal upstream/v1.x-staging
 You can also run:
 
 ```bash
-git node release -S --prepare --security=../vulnerabilities.json --filterLabel vX.x
+git node release -S --prepare --security=../security-release
 ```
+
+The `--security` flag takes the path to your clone of the `security-release`
+repository (or directly to a `vulnerabilities.json` file). The reports and
+dependency updates to cherry-pick are selected automatically from each entry's
+`affectedVersions` mapping for the release line you are on, and the matching
+`CVE-ID` trailers are added from the same file.
 
 Example:
 
 ```bash
 git checkout v20.x
-git node release -S --prepare --security=../vulnerabilities.json --filterLabel v20.x
+git node release -S --prepare --security=../security-release
 ```
 
 to automate the remaining steps until step 6 or you can perform it manually
@@ -392,7 +398,7 @@ following the below steps. For semver-minors, you can pass the new version
 explicitly with `--newVersion` arg:
 
 ```bash
-git node release -S --prepare --security=../vulnerabilities.json --filterLabel v20.x --newVersion 20.20.0
+git node release -S --prepare --security=../security-release --newVersion 20.20.0
 ```
 
 <details>


### PR DESCRIPTION
Updates the security release preparation docs to match the new `git node release --prepare --security` behaviour.

`--security` now takes the path to `vulnerabilities.json` (or the security-release repository root), and the reports and dependency updates to cherry-pick — together with their CVE-ID trailers — are selected automatically from each entry's `affectedVersions` mapping for the release line being prepared. The `--filterLabel` flag is therefore no longer needed and has been removed from the examples.

See nodejs/node-core-utils#1124.