### PR TITLE
test: prefer in-memory databases in sqlite tests

### DIFF
--- a/test/parallel/test-sqlite-data-types.js
+++ b/test/parallel/test-sqlite-data-types.js
@@ -1,22 +1,13 @@
 'use strict';
 const { skipIfSQLiteMissing } = require('../common');
 skipIfSQLiteMissing();
-const tmpdir = require('../common/tmpdir');
-const { join } = require('node:path');
 const { DatabaseSync } = require('node:sqlite');
 const { suite, test } = require('node:test');
-let cnt = 0;
-
-tmpdir.refresh();
-
-function nextDb() {
-  return join(tmpdir.path, `database-${cnt++}.db`);
-}
 
 suite('data binding and mapping', () => {
   test('supported data types', (t) => {
     const u8a = new TextEncoder().encode('a☃b☃c');
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE types(
@@ -83,7 +74,7 @@ suite('data binding and mapping', () => {
   });
 
   test('large strings are bound correctly', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, text TEXT) STRICT;'
@@ -118,7 +109,7 @@ suite('data binding and mapping', () => {
   });
 
   test('unsupported data types', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE types(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -153,7 +144,7 @@ suite('data binding and mapping', () => {
 
   test('throws when binding a BigInt that is too large', (t) => {
     const max = 9223372036854775807n; // Largest 64-bit signed integer value.
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE types(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -173,7 +164,7 @@ suite('data binding and mapping', () => {
   });
 
   test('statements are unbound on each call', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'

--- a/test/parallel/test-sqlite-named-parameters.js
+++ b/test/parallel/test-sqlite-named-parameters.js
@@ -1,21 +1,12 @@
 'use strict';
 const { skipIfSQLiteMissing } = require('../common');
 skipIfSQLiteMissing();
-const tmpdir = require('../common/tmpdir');
-const { join } = require('node:path');
 const { DatabaseSync } = require('node:sqlite');
 const { suite, test } = require('node:test');
-let cnt = 0;
-
-tmpdir.refresh();
-
-function nextDb() {
-  return join(tmpdir.path, `database-${cnt++}.db`);
-}
 
 suite('named parameters', () => {
   test('throws on unknown named parameters', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE types(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -32,7 +23,7 @@ suite('named parameters', () => {
   });
 
   test('bare named parameters are supported', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -47,7 +38,7 @@ suite('named parameters', () => {
   });
 
   test('duplicate bare named parameters are supported', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -62,7 +53,7 @@ suite('named parameters', () => {
   });
 
   test('bare named parameters throw on ambiguous names', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE types(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'

--- a/test/parallel/test-sqlite-statement-sync.js
+++ b/test/parallel/test-sqlite-statement-sync.js
@@ -2,17 +2,8 @@
 'use strict';
 const { skipIfSQLiteMissing } = require('../common');
 skipIfSQLiteMissing();
-const tmpdir = require('../common/tmpdir');
-const { join } = require('node:path');
 const { DatabaseSync, StatementSync } = require('node:sqlite');
 const { suite, test } = require('node:test');
-let cnt = 0;
-
-tmpdir.refresh();
-
-function nextDb() {
-  return join(tmpdir.path, `database-${cnt++}.db`);
-}
 
 suite('StatementSync() constructor', () => {
   test('StatementSync cannot be constructed directly', (t) => {
@@ -27,7 +18,7 @@ suite('StatementSync() constructor', () => {
 
 suite('StatementSync.prototype.get()', () => {
   test('executes a query and returns undefined on no results', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     let stmt = db.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
     t.assert.strictEqual(stmt.get(), undefined);
@@ -36,7 +27,7 @@ suite('StatementSync.prototype.get()', () => {
   });
 
   test('executes a query and returns the first result', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     let stmt = db.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
     t.assert.strictEqual(stmt.get(), undefined);
@@ -48,7 +39,7 @@ suite('StatementSync.prototype.get()', () => {
   });
 
   test('executes a query that returns special columns', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const stmt = db.prepare('SELECT 1 as __proto__, 2 as constructor, 3 as toString');
     t.assert.deepStrictEqual(stmt.get(), { __proto__: null, ['__proto__']: 1, constructor: 2, toString: 3 });
@@ -80,14 +71,14 @@ suite('StatementSync.prototype.get()', () => {
 
 suite('StatementSync.prototype.all()', () => {
   test('executes a query and returns an empty array on no results', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const stmt = db.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
     t.assert.deepStrictEqual(stmt.all(), []);
   });
 
   test('executes a query and returns all results', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     let stmt = db.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
     t.assert.deepStrictEqual(stmt.run(), { changes: 0, lastInsertRowid: 0 });
@@ -133,7 +124,7 @@ suite('StatementSync.prototype.all()', () => {
 
 suite('StatementSync.prototype.iterate()', () => {
   test('executes a query and returns an empty iterator on no results', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const stmt = db.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
     const iter = stmt.iterate();
@@ -143,7 +134,7 @@ suite('StatementSync.prototype.iterate()', () => {
   });
 
   test('executes a query and returns all results', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     let stmt = db.prepare('CREATE TABLE storage(key TEXT, val TEXT)');
     t.assert.deepStrictEqual(stmt.run(), { changes: 0, lastInsertRowid: 0 });
@@ -299,7 +290,7 @@ suite('StatementSync.prototype.iterate()', () => {
 
 suite('StatementSync.prototype.run()', () => {
   test('executes a query and returns change metadata', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE storage(key TEXT, val TEXT);
@@ -311,7 +302,7 @@ suite('StatementSync.prototype.run()', () => {
   });
 
   test('SQLite throws when trying to bind too many parameters', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -329,7 +320,7 @@ suite('StatementSync.prototype.run()', () => {
   });
 
   test('SQLite defaults to NULL for unbound parameters', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER NOT NULL) STRICT;'
@@ -366,7 +357,7 @@ suite('StatementSync.prototype.run()', () => {
   });
 
   test('SQLite defaults unbound ?NNN parameters', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER NOT NULL) STRICT;'
@@ -385,7 +376,7 @@ suite('StatementSync.prototype.run()', () => {
   });
 
   test('binds ?NNN params by position', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER NOT NULL) STRICT;'
@@ -398,7 +389,7 @@ suite('StatementSync.prototype.run()', () => {
 
 suite('StatementSync.prototype.sourceSQL', () => {
   test('equals input SQL', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE types(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -412,7 +403,7 @@ suite('StatementSync.prototype.sourceSQL', () => {
 
 suite('StatementSync.prototype.expandedSQL', () => {
   test('equals expanded SQL', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE types(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -431,7 +422,7 @@ suite('StatementSync.prototype.expandedSQL', () => {
 
 suite('StatementSync.prototype.setReadBigInts()', () => {
   test('BigInts support can be toggled', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;
@@ -464,7 +455,7 @@ suite('StatementSync.prototype.setReadBigInts()', () => {
   });
 
   test('throws when input is not a boolean', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE types(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -480,7 +471,7 @@ suite('StatementSync.prototype.setReadBigInts()', () => {
   });
 
   test('BigInt is required for reading large integers', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const bad = db.prepare(`SELECT ${Number.MAX_SAFE_INTEGER} + 1`);
     t.assert.throws(() => {
@@ -500,7 +491,7 @@ suite('StatementSync.prototype.setReadBigInts()', () => {
 
 suite('StatementSync.prototype.setReturnArrays()', () => {
   test('throws when input is not a boolean', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -518,7 +509,7 @@ suite('StatementSync.prototype.setReturnArrays()', () => {
 
 suite('StatementSync.prototype.get() with array output', () => {
   test('returns array row when setReturnArrays is true', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
@@ -538,7 +529,7 @@ suite('StatementSync.prototype.get() with array output', () => {
 
   test('returns array rows with BigInts when both flags are set', (t) => {
     const expected = [1n, 9007199254740992n];
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE big_data(id INTEGER, big_num INTEGER);
@@ -557,7 +548,7 @@ suite('StatementSync.prototype.get() with array output', () => {
 
 suite('StatementSync.prototype.all() with array output', () => {
   test('returns array rows when setReturnArrays is true', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
@@ -598,7 +589,7 @@ suite('StatementSync.prototype.all() with array output', () => {
       9,
       'text3',
     ];
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE wide_table(
@@ -623,7 +614,7 @@ suite('StatementSync.prototype.all() with array output', () => {
 
 suite('StatementSync.prototype.iterate() with array output', () => {
   test('iterates array rows when setReturnArrays is true', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
@@ -692,7 +683,7 @@ suite('StatementSync.prototype.iterate() with array output', () => {
 
 suite('StatementSync.prototype.setAllowBareNamedParameters()', () => {
   test('bare named parameter support can be toggled', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -718,7 +709,7 @@ suite('StatementSync.prototype.setAllowBareNamedParameters()', () => {
   });
 
   test('throws when input is not a boolean', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -736,7 +727,7 @@ suite('StatementSync.prototype.setAllowBareNamedParameters()', () => {
 
 suite('options.readBigInts', () => {
   test('BigInts are returned when input is true', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;
@@ -749,7 +740,7 @@ suite('options.readBigInts', () => {
   });
 
   test('numbers are returned when input is false', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;
@@ -762,7 +753,7 @@ suite('options.readBigInts', () => {
   });
 
   test('throws when input is not a boolean', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -777,7 +768,7 @@ suite('options.readBigInts', () => {
   });
 
   test('setReadBigInts can override prepare option', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;
@@ -794,7 +785,7 @@ suite('options.readBigInts', () => {
 
 suite('options.returnArrays', () => {
   test('arrays are returned when input is true', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
@@ -810,7 +801,7 @@ suite('options.returnArrays', () => {
   });
 
   test('objects are returned when input is false', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
@@ -826,7 +817,7 @@ suite('options.returnArrays', () => {
   });
 
   test('throws when input is not a boolean', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;'
@@ -841,7 +832,7 @@ suite('options.returnArrays', () => {
   });
 
   test('setReturnArrays can override prepare option', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
@@ -859,7 +850,7 @@ suite('options.returnArrays', () => {
   });
 
   test('all() returns arrays when input is true', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
@@ -879,7 +870,7 @@ suite('options.returnArrays', () => {
   });
 
   test('iterate() returns arrays when input is true', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(key INTEGER PRIMARY KEY, val TEXT) STRICT;
@@ -901,7 +892,7 @@ suite('options.returnArrays', () => {
 
 suite('options.allowBareNamedParameters', () => {
   test('bare named parameters are allowed when input is true', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -918,7 +909,7 @@ suite('options.allowBareNamedParameters', () => {
   });
 
   test('bare named parameters throw when input is false', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -937,7 +928,7 @@ suite('options.allowBareNamedParameters', () => {
   });
 
   test('throws when input is not a boolean', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'
@@ -955,7 +946,7 @@ suite('options.allowBareNamedParameters', () => {
   });
 
   test('setAllowBareNamedParameters can override prepare option', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(
       'CREATE TABLE data(key INTEGER PRIMARY KEY, val INTEGER) STRICT;'

--- a/test/parallel/test-sqlite-transactions.js
+++ b/test/parallel/test-sqlite-transactions.js
@@ -1,21 +1,12 @@
 'use strict';
 const { skipIfSQLiteMissing } = require('../common');
 skipIfSQLiteMissing();
-const tmpdir = require('../common/tmpdir');
-const { join } = require('node:path');
 const { DatabaseSync } = require('node:sqlite');
 const { suite, test } = require('node:test');
-let cnt = 0;
-
-tmpdir.refresh();
-
-function nextDb() {
-  return join(tmpdir.path, `database-${cnt++}.db`);
-}
 
 suite('manual transactions', () => {
   test('a transaction is committed', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(
@@ -42,7 +33,7 @@ suite('manual transactions', () => {
   });
 
   test('a transaction is rolled back', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     const setup = db.exec(`
       CREATE TABLE data(

--- a/test/parallel/test-sqlite-typed-array-and-data-view.js
+++ b/test/parallel/test-sqlite-typed-array-and-data-view.js
@@ -1,17 +1,8 @@
 'use strict';
 const { skipIfSQLiteMissing } = require('../common');
 skipIfSQLiteMissing();
-const tmpdir = require('../common/tmpdir');
-const { join } = require('node:path');
 const { DatabaseSync } = require('node:sqlite');
 const { suite, test } = require('node:test');
-let cnt = 0;
-
-tmpdir.refresh();
-
-function nextDb() {
-  return join(tmpdir.path, `database-${cnt++}.db`);
-}
 
 const arrayBuffer = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]).buffer;
 const TypedArrays = [
@@ -32,7 +23,7 @@ const TypedArrays = [
 suite('StatementSync with TypedArray/DataView', () => {
   for (const [displayName, TypedArray] of TypedArrays) {
     test(displayName, (t) => {
-      const db = new DatabaseSync(nextDb());
+      const db = new DatabaseSync(':memory:');
       t.after(() => { db.close(); });
       db.exec('CREATE TABLE test (data BLOB)');
       // insert

--- a/test/parallel/test-sqlite.js
+++ b/test/parallel/test-sqlite.js
@@ -36,7 +36,7 @@ suite('accessing the node:sqlite module', () => {
 });
 
 test('ERR_SQLITE_ERROR is thrown for errors originating from SQLite', (t) => {
-  const db = new DatabaseSync(nextDb());
+  const db = new DatabaseSync(':memory:');
   t.after(() => { db.close(); });
   const setup = db.exec(`
     CREATE TABLE test(
@@ -86,6 +86,7 @@ test('sqlite constants are defined', (t) => {
 });
 
 test('PRAGMAs are supported', (t) => {
+  // WAL journal mode requires an on-disk database.
   const db = new DatabaseSync(nextDb());
   t.after(() => { db.close(); });
   t.assert.deepStrictEqual(
@@ -218,7 +219,7 @@ suite('SQL APIs enabled at build time', () => {
   });
 
   test('dbstat is enabled', (t) => {
-    const db = new DatabaseSync(nextDb());
+    const db = new DatabaseSync(':memory:');
     t.after(() => { db.close(); });
     db.exec(`
       CREATE TABLE t1 (key INTEGER PRIMARY KEY);


### PR DESCRIPTION
Refs #64665. Converts the SQLite tests that only exercise SQL behavior (transactions, data types, typed-array/data-view binding) from temporary file databases to `:memory:`, which is faster and drops the `nextDb()` temp-file bookkeeping.

Tests that verify on-disk behavior (timeout, database-sync) intentionally keep using files. This is a focused first pass; the mixed-usage files (named-parameters, statement-sync) could follow.

Refs: https://github.com/nodejs/node/issues/64665

cc @araujogui, let me know if this is what you had in mind, happy to extend it to the remaining files.
