### PR TITLE
quic: fix infinite loop if STOP_SENDING received on a buffering stream

### DIFF
--- a/src/quic/application.cc
+++ b/src/quic/application.cc
@@ -410,6 +410,12 @@ class DefaultApplication final : public Session::Application {
 
   void ResumeStream(stream_id id) override { ScheduleStream(id); }
 
+  void StreamWriteShut(stream_id id) override {
+    if (auto stream = session().FindStream(id)) [[likely]] {
+      stream->Unschedule();
+    }
+  }
+
   void BlockStream(stream_id id) override {
     if (auto stream = session().FindStream(id)) [[likely]] {
       // Remove the stream from the send queue. It will be re-scheduled

--- a/test/parallel/test-quic-stream-stop-sending-buffered.mjs
+++ b/test/parallel/test-quic-stream-stop-sending-buffered.mjs
@@ -1,0 +1,49 @@
+// Flags: --experimental-quic --no-warnings
+
+// A peer STOP_SENDING must unschedule buffered outbound data.
+
+import { hasQuic, mustCall, skip } from '../common/index.mjs';
+import assert from 'node:assert';
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { connect, listen } = await import('../common/quic.mjs');
+
+const serverStreamReady = Promise.withResolvers();
+const clientBuffered = Promise.withResolvers();
+const serverReset = Promise.withResolvers();
+
+const serverEndpoint = await listen(mustCall((serverSession) => {
+  serverSession.onstream = mustCall(async (stream) => {
+    serverStreamReady.resolve();
+    await clientBuffered.promise;
+
+    const closed = assert.rejects(stream.closed, {
+      code: 'ERR_QUIC_APPLICATION_ERROR',
+    });
+    stream.stopSending(1n);
+    stream.writer.endSync();
+    await closed;
+    serverSession.close();
+    serverReset.resolve();
+  });
+}));
+
+const clientSession = await connect(serverEndpoint.address);
+await clientSession.opened;
+
+const stream = await clientSession.createBidirectionalStream();
+const clientClosed = stream.closed.catch(() => {});
+const writer = stream.writer;
+writer.writeSync(new Uint8Array([1]));
+await serverStreamReady.promise;
+
+writer.writeSync(new Uint8Array(64 * 1024));
+clientBuffered.resolve();
+
+await serverReset.promise;
+
+await Promise.all([clientClosed, clientSession.closed]);
+await serverEndpoint.close();


### PR DESCRIPTION
The HTTP/3 application implements `StreamWriteShut` to clean up streams after ngtcp2 reports NGTCP2_ERR_STREAM_SHUT_WR (generally when STOP_SENDING is received).

The default application does not. This meant it fell into a busy loop in ngtcp2 where it tried to send the data constantly in a loop forever, blocking the process. Test here reproduces this: the server accepts the stream but never reads, the client writes enough data to end up buffered, the server sends STOP_SENDING => 100% CPU never exits.

The default QUIC app now unschedules the stream when it's shut, which fixes the test.

This is largely independent of #64710. It fails with or without that change. In effect that PR changes the callback & frame-level behaviour around STOP_SENDING, while this one fixes a bug in the low-level writing behaviour for closed stream errors.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
