### PR TITLE
test: ensure assertions are reached on all tests

### DIFF
--- a/test/common/fixtures.mjs
+++ b/test/common/fixtures.mjs
@@ -1,5 +1,6 @@
 import fixtures from './fixtures.js';
 
+// eslint-disable-next-line no-restricted-syntax
 const {
   fixturesDir,
   path,

--- a/test/eslint.config_partial.mjs
+++ b/test/eslint.config_partial.mjs
@@ -117,6 +117,10 @@ export default [
           selector: 'CallExpression:matches([callee.type="Identifier"][callee.name="assert"], [callee.type="MemberExpression"][callee.object.type="Identifier"][callee.object.name="assert"][callee.property.type="Identifier"][callee.property.name="ok"])[arguments.0.type="UnaryExpression"][arguments.0.operator="!"][arguments.0.argument.type="CallExpression"][arguments.0.argument.callee.type="MemberExpression"][arguments.0.argument.callee.object.regex][arguments.0.argument.callee.property.name="test"]',
           message: 'Use assert.doesNotMatch instead',
         },
+        {
+          selector: 'VariableDeclarator[init.type="Identifier"][init.name=/^(assert|fixtures)$/]',
+          message: 'Do not destructure or rename `assert` nor `fixtures`',
+        },
         ...((fixturesSpecifier) => [
           {
             selector: `ImportDeclaration[source.value=${fixturesSpecifier.toString().replace('(\\.js)?', '\\.mjs')}]:not(${[

--- a/test/parallel/test-assert-deep.js
+++ b/test/parallel/test-assert-deep.js
@@ -4,7 +4,6 @@ const { mustCall, hasCrypto } = require('../common');
 const assert = require('assert');
 const util = require('util');
 const { test } = require('node:test');
-const { AssertionError } = assert;
 const defaultMsgStart = 'Expected values to be strictly deep-equal:\n';
 const defaultMsgStartFull = `${defaultMsgStart}+ actual - expected`;
 
@@ -688,11 +687,11 @@ test('Handle sparse arrays', () => {
   const b = new Array(3);
   a[2] = true;
   b[1] = true;
-  assertNotDeepOrStrict(a, b, AssertionError, { partial: 'pass' });
+  assertNotDeepOrStrict(a, b, assert.AssertionError, { partial: 'pass' });
   b[2] = true;
   assertNotDeepOrStrict(a, b);
   a[0] = true;
-  assertNotDeepOrStrict(a, b, AssertionError, { partial: 'pass' });
+  assertNotDeepOrStrict(a, b, assert.AssertionError, { partial: 'pass' });
 });
 
 test('Handle sets and maps with mixed keys', () => {
@@ -715,7 +714,7 @@ test('Handle different error messages', () => {
   assertNotDeepOrStrict(err1, new Error('foo2'), assert.AssertionError);
   assertNotDeepOrStrict(err1, new TypeError('foo1'), assert.AssertionError);
   assertDeepAndStrictEqual(err1, new Error('foo1'));
-  assertNotDeepOrStrict(err1, {}, AssertionError);
+  assertNotDeepOrStrict(err1, {}, assert.AssertionError);
 });
 
 test('Handle NaN', () => {
@@ -811,18 +810,18 @@ test('Additional tests', () => {
   assertDeepAndStrictEqual(new Date(2000, 3, 14), new Date(2000, 3, 14));
 
   assert.throws(() => { assert.deepEqual(new Date(), new Date(2000, 3, 14)); },
-                AssertionError,
+                assert.AssertionError,
                 'deepEqual(new Date(), new Date(2000, 3, 14))');
 
   assert.throws(
     () => { assert.notDeepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14)); },
-    AssertionError,
+    assert.AssertionError,
     'notDeepEqual(new Date(2000, 3, 14), new Date(2000, 3, 14))'
   );
 
   assert.throws(
     () => { assert.notDeepEqual('a'.repeat(1024), 'a'.repeat(1024)); },
-    AssertionError,
+    assert.AssertionError,
     'notDeepEqual("a".repeat(1024), "a".repeat(1024))'
   );
 
@@ -861,7 +860,7 @@ test('Additional tests', () => {
   assert.deepEqual(4, '4');
   assert.deepEqual(true, 1);
   assert.throws(() => assert.deepEqual(4, '5'),
-                AssertionError,
+                assert.AssertionError,
                 'deepEqual( 4, \'5\')');
 });
 
@@ -870,7 +869,7 @@ test('Having the same number of owned properties && the same set of keys', () =>
   assert.deepEqual({ a: 4, b: '2' }, { a: 4, b: '2' });
   assert.deepEqual([4], ['4']);
   assert.throws(
-    () => assert.deepEqual({ a: 4 }, { a: 4, b: true }), AssertionError);
+    () => assert.deepEqual({ a: 4 }, { a: 4, b: true }), assert.AssertionError);
   assert.notDeepEqual(['a'], { 0: 'a' });
   assert.deepEqual({ a: 4, b: '1' }, { b: '1', a: 4 });
   const a1 = [1, 2, 3];
@@ -880,7 +879,7 @@ test('Having the same number of owned properties && the same set of keys', () =>
   a2.b = true;
   a2.a = 'test';
   assert.throws(() => assert.deepEqual(Object.keys(a1), Object.keys(a2)),
-                AssertionError);
+                assert.AssertionError);
   assertDeepAndStrictEqual(a1, a2);
 });
 
@@ -946,7 +945,7 @@ test('Additional tests', () => {
 
   assert.throws(
     () => assert.deepStrictEqual(new Date(), new Date(2000, 3, 14)),
-    AssertionError,
+    assert.AssertionError,
     'deepStrictEqual(new Date(), new Date(2000, 3, 14))'
   );
 
@@ -1059,7 +1058,7 @@ test('Additional tests', () => {
 
   assert.throws(
     () => assert.deepStrictEqual([0, 1, 2, 'a', 'b'], [0, 1, 2, 'b', 'a']),
-    AssertionError);
+    assert.AssertionError);
 });
 
 test('Having the same number of owned properties && the same set of keys', () => {
@@ -1105,7 +1104,7 @@ test('Prototype check', () => {
   const obj1 = new Constructor1('Ryan', 'Dahl');
   let obj2 = new Constructor2('Ryan', 'Dahl');
 
-  assert.throws(() => assert.deepStrictEqual(obj1, obj2), AssertionError);
+  assert.throws(() => assert.deepStrictEqual(obj1, obj2), assert.AssertionError);
 
   Constructor2.prototype = Constructor1.prototype;
   obj2 = new Constructor2('Ryan', 'Dahl');
@@ -1262,7 +1261,7 @@ test('Verify that changed tags will still check for the error message', () => {
   err[Symbol.toStringTag] = 'Foobar';
   const err2 = new Error('bar');
   err2[Symbol.toStringTag] = 'Foobar';
-  assertNotDeepOrStrict(err, err2, AssertionError);
+  assertNotDeepOrStrict(err, err2, assert.AssertionError);
 });
 
 test('Check for non-native errors', () => {
@@ -1281,8 +1280,8 @@ test('Check for non-native errors', () => {
 test('Check for Errors with cause property', () => {
   const e1 = new Error('err', { cause: new Error('cause e1') });
   const e2 = new Error('err', { cause: new Error('cause e2') });
-  assertNotDeepOrStrict(e1, e2, AssertionError);
-  assertNotDeepOrStrict(e1, new Error('err'), AssertionError);
+  assertNotDeepOrStrict(e1, e2, assert.AssertionError);
+  assertNotDeepOrStrict(e1, new Error('err'), assert.AssertionError);
   assertDeepAndStrictEqual(e1, new Error('err', { cause: new Error('cause e1') }));
 });
 
@@ -1294,8 +1293,8 @@ test('Check for AggregateError', () => {
   const e3 = new AggregateError([e1duplicate, e2], 'Aggregate Error');
   const e3duplicate = new AggregateError([e1, e2], 'Aggregate Error');
   const e4 = new AggregateError([e1], 'Aggregate Error');
-  assertNotDeepOrStrict(e1, e3, AssertionError);
-  assertNotDeepOrStrict(e3, e4, AssertionError);
+  assertNotDeepOrStrict(e1, e3, assert.AssertionError);
+  assertNotDeepOrStrict(e3, e4, assert.AssertionError);
   assertDeepAndStrictEqual(e3, e3duplicate);
 });
 

--- a/test/parallel/test-dtls-alpn.mjs
+++ b/test/parallel/test-dtls-alpn.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const serverCert = readKey('agent1-cert.pem');
-const serverKey = readKey('agent1-key.pem');
-const ca = readKey('ca1-cert.pem');
+const serverCert = fixtures.readKey('agent1-cert.pem');
+const serverKey = fixtures.readKey('agent1-key.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const serverAlpnChecked = Promise.withResolvers();
 
@@ -29,7 +26,7 @@ const endpoint = listen(mustCall(async (session) => {
   session.onmessage = () => {};
   await session.opened;
   // Server should see the negotiated ALPN protocol.
-  strictEqual(session.alpnProtocol, 'coap');
+  assert.strictEqual(session.alpnProtocol, 'coap');
   serverAlpnChecked.resolve();
 }), {
   cert: serverCert.toString(),
@@ -48,7 +45,7 @@ const session = connect('127.0.0.1', endpoint.address.port, {
 await session.opened;
 
 // Client should see the negotiated protocol.
-strictEqual(session.alpnProtocol, 'coap');
+assert.strictEqual(session.alpnProtocol, 'coap');
 
 await serverAlpnChecked.promise;
 

--- a/test/parallel/test-dtls-async-dispose.mjs
+++ b/test/parallel/test-dtls-async-dispose.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const serverCert = readKey('agent1-cert.pem');
-const serverKey = readKey('agent1-key.pem');
-const ca = readKey('ca1-cert.pem');
+const serverCert = fixtures.readKey('agent1-cert.pem');
+const serverKey = fixtures.readKey('agent1-key.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const endpoint = listen(mustCall((session) => {
   session.onmessage = mustNotCall();
@@ -40,8 +37,8 @@ const session = connect('127.0.0.1', endpoint.address.port, {
 await session.opened;
 
 // Test that Symbol.asyncDispose exists.
-strictEqual(typeof session[Symbol.asyncDispose], 'function');
-strictEqual(typeof endpoint[Symbol.asyncDispose], 'function');
+assert.strictEqual(typeof session[Symbol.asyncDispose], 'function');
+assert.strictEqual(typeof endpoint[Symbol.asyncDispose], 'function');
 
 // Dispose the session.
 await session[Symbol.asyncDispose]();

--- a/test/parallel/test-dtls-basic.mjs
+++ b/test/parallel/test-dtls-basic.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual, match } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const serverCert = readKey('agent1-cert.pem');
-const serverKey = readKey('agent1-key.pem');
-const ca = readKey('ca1-cert.pem');
+const serverCert = fixtures.readKey('agent1-cert.pem');
+const serverKey = fixtures.readKey('agent1-key.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const serverReceivedData = Promise.withResolvers();
 const clientReceivedData = Promise.withResolvers();
@@ -32,7 +29,7 @@ let clientHandshakeDone = false;
 // Start server.
 const endpoint = listen(mustCall((session) => {
   session.onmessage = mustCall((data) => {
-    strictEqual(data.toString(), 'hello from client');
+    assert.strictEqual(data.toString(), 'hello from client');
     serverReceivedData.resolve();
 
     // Send response back to client.
@@ -40,8 +37,8 @@ const endpoint = listen(mustCall((session) => {
   });
 
   session.onhandshake = mustCall((protocol) => {
-    ok(protocol);
-    match(protocol, /DTLS/i);
+    assert.ok(protocol);
+    assert.match(protocol, /DTLS/i);
     serverHandshakeDone = true;
   });
 }), {
@@ -52,8 +49,8 @@ const endpoint = listen(mustCall((session) => {
 });
 
 const serverAddress = endpoint.address;
-ok(serverAddress);
-ok(serverAddress.port > 0);
+assert.ok(serverAddress);
+assert.ok(serverAddress.port > 0);
 
 // Connect client.
 const clientSession = connect('127.0.0.1', serverAddress.port, {
@@ -62,18 +59,18 @@ const clientSession = connect('127.0.0.1', serverAddress.port, {
 });
 
 clientSession.onmessage = mustCall((data) => {
-  strictEqual(data.toString(), 'hello from server');
+  assert.strictEqual(data.toString(), 'hello from server');
   clientReceivedData.resolve();
 });
 
 clientSession.onhandshake = mustCall((protocol) => {
-  ok(protocol);
+  assert.ok(protocol);
   clientHandshakeDone = true;
 });
 
 // Wait for handshake.
 const { protocol } = await clientSession.opened;
-match(protocol, /DTLS/i);
+assert.match(protocol, /DTLS/i);
 
 // Send data.
 clientSession.send('hello from client');
@@ -82,8 +79,8 @@ clientSession.send('hello from client');
 await Promise.all([serverReceivedData.promise, clientReceivedData.promise]);
 
 // Verify handshakes completed.
-ok(clientHandshakeDone);
-ok(serverHandshakeDone);
+assert.ok(clientHandshakeDone);
+assert.ok(serverHandshakeDone);
 
 // Clean up.
 await clientSession.close();

--- a/test/parallel/test-dtls-close.mjs
+++ b/test/parallel/test-dtls-close.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, throws } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const serverCert = readKey('agent1-cert.pem');
-const serverKey = readKey('agent1-key.pem');
-const ca = readKey('ca1-cert.pem');
+const serverCert = fixtures.readKey('agent1-cert.pem');
+const serverKey = fixtures.readKey('agent1-key.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
 
 // Test 1: Graceful close from client side.
 {
@@ -48,7 +45,7 @@ const ca = readKey('ca1-cert.pem');
 
   // Graceful close.
   const closedPromise = session.close();
-  ok(closedPromise instanceof Promise);
+  assert.ok(closedPromise instanceof Promise);
   await closedPromise;
 
   // Wait for server to see the close.
@@ -80,7 +77,7 @@ const ca = readKey('ca1-cert.pem');
   session.destroy();
 
   // After destroy, send should fail.
-  throws(() => {
+  assert.throws(() => {
     session.send('should fail');
   }, /destroyed/i);
 

--- a/test/parallel/test-dtls-multiple-clients.mjs
+++ b/test/parallel/test-dtls-multiple-clients.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const serverCert = readKey('agent1-cert.pem');
-const serverKey = readKey('agent1-key.pem');
-const ca = readKey('ca1-cert.pem');
+const serverCert = fixtures.readKey('agent1-cert.pem');
+const serverKey = fixtures.readKey('agent1-key.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const NUM_CLIENTS = 3;
 let sessionsAccepted = 0;
@@ -57,7 +54,7 @@ for (let i = 0; i < NUM_CLIENTS; i++) {
   });
 
   session.onmessage = mustCall((data) => {
-    strictEqual(data.toString(), `echo:client${i}`);
+    assert.strictEqual(data.toString(), `echo:client${i}`);
     received.resolve();
   });
 

--- a/test/parallel/test-dtls-options.mjs
+++ b/test/parallel/test-dtls-options.mjs
@@ -5,8 +5,6 @@
 import { hasCrypto, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { throws } = assert;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -18,36 +16,36 @@ if (!process.features.dtls) {
 const { listen, connect } = await import('node:dtls');
 
 // Test: listen() requires a callback.
-throws(() => {
+assert.throws(() => {
   listen(undefined, { cert: 'x', key: 'y', port: 0 });
 }, { code: 'ERR_INVALID_ARG_TYPE' });
 
 // Test: listen() requires cert.
-throws(() => {
+assert.throws(() => {
   listen(mustNotCall(), { key: 'y', port: 0 });
 }, { code: 'ERR_MISSING_ARGS' });
 
 // Test: listen() requires key.
-throws(() => {
+assert.throws(() => {
   listen(mustNotCall(), { cert: 'x', port: 0 });
 }, { code: 'ERR_MISSING_ARGS' });
 
 // Test: listen() requires port.
-throws(() => {
+assert.throws(() => {
   listen(mustNotCall(), { cert: 'x', key: 'y' });
 }, { code: 'ERR_MISSING_ARGS' });
 
 // Test: connect() requires valid host.
-throws(() => {
+assert.throws(() => {
   connect(123, 4433);
 }, { code: 'ERR_INVALID_ARG_TYPE' });
 
 // Test: connect() requires valid port.
-throws(() => {
+assert.throws(() => {
   connect('localhost', 'invalid');
 }, { code: 'ERR_INVALID_ARG_TYPE' });
 
 // Test: connect() rejects out-of-range port.
-throws(() => {
+assert.throws(() => {
   connect('localhost', 99999);
 }, { code: 'ERR_OUT_OF_RANGE' });

--- a/test/parallel/test-dtls-session-properties.mjs
+++ b/test/parallel/test-dtls-session-properties.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual, match } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const serverCert = readKey('agent1-cert.pem');
-const serverKey = readKey('agent1-key.pem');
-const ca = readKey('ca1-cert.pem');
+const serverCert = fixtures.readKey('agent1-cert.pem');
+const serverKey = fixtures.readKey('agent1-key.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const endpoint = listen(mustCall((session) => {
   session.onmessage = mustNotCall();
@@ -40,25 +37,25 @@ const session = connect('127.0.0.1', endpoint.address.port, {
 await session.opened;
 
 // Protocol should be DTLSv1.2.
-match(session.protocol, /DTLS/i);
+assert.match(session.protocol, /DTLS/i);
 
 // Cipher should be an object with name, standardName, version.
 const cipher = session.cipher;
-strictEqual(typeof cipher?.name, 'string');
-strictEqual(typeof cipher?.standardName, 'string');
-strictEqual(typeof cipher?.version, 'string');
+assert.strictEqual(typeof cipher?.name, 'string');
+assert.strictEqual(typeof cipher?.standardName, 'string');
+assert.strictEqual(typeof cipher?.version, 'string');
 
 // Remote address should be defined.
 const addr = session.remoteAddress;
-ok(addr);
+assert.ok(addr);
 
 // Peer certificate should be available (PEM string).
 const peerCert = session.peerCertificate;
-ok(peerCert);
-ok(peerCert.includes('BEGIN CERTIFICATE'));
+assert.ok(peerCert);
+assert.ok(peerCert.includes('BEGIN CERTIFICATE'));
 
 // State should reflect open connection.
-ok(session.state);
+assert.ok(session.state);
 
 await session.close();
 await endpoint.close();

--- a/test/parallel/test-dtls-stats.mjs
+++ b/test/parallel/test-dtls-stats.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual, notStrictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const serverCert = readKey('agent1-cert.pem');
-const serverKey = readKey('agent1-key.pem');
-const ca = readKey('ca1-cert.pem');
+const serverCert = fixtures.readKey('agent1-cert.pem');
+const serverKey = fixtures.readKey('agent1-key.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const serverReceivedData = Promise.withResolvers();
 const clientReceivedData = Promise.withResolvers();
@@ -33,7 +30,7 @@ const endpoint = listen(mustCall((session) => {
   serverSession = session;
 
   session.onmessage = mustCall((data) => {
-    strictEqual(data.toString(), 'hello from client');
+    assert.strictEqual(data.toString(), 'hello from client');
     session.send('hello from server');
     serverReceivedData.resolve();
   });
@@ -49,13 +46,13 @@ const endpoint = listen(mustCall((session) => {
 // --- Endpoint stats should be available immediately ---
 
 const epStats = endpoint.stats;
-ok(epStats, 'endpoint.stats should be defined');
-ok(epStats.isConnected, 'stats should be connected');
-ok(epStats.createdAt > 0n, 'createdAt should be set');
-strictEqual(epStats.destroyedAt, 0n);
-strictEqual(epStats.clientSessions, 0n);
-strictEqual(epStats.serverSessions, 0n);
-strictEqual(epStats.serverBusyCount, 0n);
+assert.ok(epStats, 'endpoint.stats should be defined');
+assert.ok(epStats.isConnected, 'stats should be connected');
+assert.ok(epStats.createdAt > 0n, 'createdAt should be set');
+assert.strictEqual(epStats.destroyedAt, 0n);
+assert.strictEqual(epStats.clientSessions, 0n);
+assert.strictEqual(epStats.serverSessions, 0n);
+assert.strictEqual(epStats.serverBusyCount, 0n);
 
 // Connect client.
 const clientSession = connect('127.0.0.1', endpoint.address.port, {
@@ -64,7 +61,7 @@ const clientSession = connect('127.0.0.1', endpoint.address.port, {
 });
 
 clientSession.onmessage = mustCall((data) => {
-  strictEqual(data.toString(), 'hello from server');
+  assert.strictEqual(data.toString(), 'hello from server');
   clientReceivedData.resolve();
 });
 
@@ -76,14 +73,14 @@ await clientSession.opened;
 // --- Client session stats after handshake ---
 
 const csStats = clientSession.stats;
-ok(csStats, 'session.stats should be defined');
-ok(csStats.isConnected, 'session stats should be connected');
-ok(csStats.createdAt > 0n, 'createdAt should be set');
-ok(csStats.handshakeCompletedAt > 0n, 'handshake timestamp should be set');
-ok(csStats.handshakeCompletedAt >= csStats.createdAt,
-   'handshake should complete after creation');
-strictEqual(csStats.closingAt, 0n);
-strictEqual(csStats.destroyedAt, 0n);
+assert.ok(csStats, 'session.stats should be defined');
+assert.ok(csStats.isConnected, 'session stats should be connected');
+assert.ok(csStats.createdAt > 0n, 'createdAt should be set');
+assert.ok(csStats.handshakeCompletedAt > 0n, 'handshake timestamp should be set');
+assert.ok(csStats.handshakeCompletedAt >= csStats.createdAt,
+          'handshake should complete after creation');
+assert.strictEqual(csStats.closingAt, 0n);
+assert.strictEqual(csStats.destroyedAt, 0n);
 
 // Record bytes before sending application data.
 const csBytesSentBefore = csStats.bytesSent;
@@ -97,58 +94,58 @@ await Promise.all([serverReceivedData.promise, clientReceivedData.promise]);
 
 // --- Client session stats after data exchange ---
 
-ok(csStats.bytesSent > csBytesSentBefore,
-   'bytesSent should increase after send');
-ok(csStats.messagesSent > csMessagesSentBefore,
-   'messagesSent should increase after send');
-ok(csStats.bytesReceived > 0n, 'bytesReceived should be non-zero');
-ok(csStats.messagesReceived > 0n, 'messagesReceived should be non-zero');
+assert.ok(csStats.bytesSent > csBytesSentBefore,
+          'bytesSent should increase after send');
+assert.ok(csStats.messagesSent > csMessagesSentBefore,
+          'messagesSent should increase after send');
+assert.ok(csStats.bytesReceived > 0n, 'bytesReceived should be non-zero');
+assert.ok(csStats.messagesReceived > 0n, 'messagesReceived should be non-zero');
 
 // --- Server session stats after data exchange ---
 
-ok(serverSession, 'server session should exist');
+assert.ok(serverSession, 'server session should exist');
 const ssStats = serverSession.stats;
-ok(ssStats.bytesReceived > 0n, 'server bytesReceived should be non-zero');
-ok(ssStats.messagesReceived > 0n, 'server messagesReceived should be non-zero');
-ok(ssStats.bytesSent > 0n, 'server bytesSent should be non-zero');
-ok(ssStats.messagesSent > 0n, 'server messagesSent should be non-zero');
-ok(ssStats.handshakeCompletedAt > 0n, 'server handshake timestamp should be set');
+assert.ok(ssStats.bytesReceived > 0n, 'server bytesReceived should be non-zero');
+assert.ok(ssStats.messagesReceived > 0n, 'server messagesReceived should be non-zero');
+assert.ok(ssStats.bytesSent > 0n, 'server bytesSent should be non-zero');
+assert.ok(ssStats.messagesSent > 0n, 'server messagesSent should be non-zero');
+assert.ok(ssStats.handshakeCompletedAt > 0n, 'server handshake timestamp should be set');
 
 // --- Endpoint stats after data exchange ---
 
-ok(epStats.bytesReceived > 0n, 'endpoint bytesReceived should be non-zero');
-ok(epStats.bytesSent > 0n, 'endpoint bytesSent should be non-zero');
-ok(epStats.packetsReceived > 0n, 'endpoint packetsReceived should be non-zero');
-ok(epStats.packetsSent > 0n, 'endpoint packetsSent should be non-zero');
-strictEqual(epStats.serverSessions, 1n);
+assert.ok(epStats.bytesReceived > 0n, 'endpoint bytesReceived should be non-zero');
+assert.ok(epStats.bytesSent > 0n, 'endpoint bytesSent should be non-zero');
+assert.ok(epStats.packetsReceived > 0n, 'endpoint packetsReceived should be non-zero');
+assert.ok(epStats.packetsSent > 0n, 'endpoint packetsSent should be non-zero');
+assert.strictEqual(epStats.serverSessions, 1n);
 
 // The client's own endpoint should track the client session.
 const clientEpStats = clientSession.endpoint.stats;
-strictEqual(clientEpStats.clientSessions, 1n);
-ok(clientEpStats.bytesSent > 0n);
-ok(clientEpStats.bytesReceived > 0n);
+assert.strictEqual(clientEpStats.clientSessions, 1n);
+assert.ok(clientEpStats.bytesSent > 0n);
+assert.ok(clientEpStats.bytesReceived > 0n);
 
 // --- toJSON / toString ---
 
 const epJson = epStats.toJSON();
-ok(epJson);
-strictEqual(typeof epJson.bytesReceived, 'string');
-strictEqual(typeof epJson.bytesSent, 'string');
-strictEqual(typeof epJson.connected, 'boolean');
+assert.ok(epJson);
+assert.strictEqual(typeof epJson.bytesReceived, 'string');
+assert.strictEqual(typeof epJson.bytesSent, 'string');
+assert.strictEqual(typeof epJson.connected, 'boolean');
 
 const ssJson = csStats.toJSON();
-ok(ssJson);
-strictEqual(typeof ssJson.handshakeCompletedAt, 'string');
-strictEqual(typeof ssJson.messagesReceived, 'string');
+assert.ok(ssJson);
+assert.strictEqual(typeof ssJson.handshakeCompletedAt, 'string');
+assert.strictEqual(typeof ssJson.messagesReceived, 'string');
 
 const epStr = epStats.toString();
-ok(typeof epStr === 'string');
-ok(epStr.includes('bytesReceived'));
+assert.ok(typeof epStr === 'string');
+assert.ok(epStr.includes('bytesReceived'));
 
 // Clean up.
 await clientSession.close();
 
 // After close, session closing timestamp should be set.
-notStrictEqual(csStats.closingAt, 0n);
+assert.notStrictEqual(csStats.closingAt, 0n);
 
 await endpoint.close();

--- a/test/parallel/test-quic-address-validation.mjs
+++ b/test/parallel/test-quic-address-validation.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,15 +16,15 @@ if (!hasQuic) {
 const { listen, connect, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const endpoint = new QuicEndpoint({ validateAddress: true });
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const info = await serverSession.opened;
   // The handshake should complete despite the Retry flow.
-  strictEqual(info.protocol, 'quic-test');
+  assert.strictEqual(info.protocol, 'quic-test');
   serverSession.close();
 }), {
   endpoint,
@@ -42,7 +39,7 @@ const clientSession = await connect(serverEndpoint.address, {
 });
 
 const info = await clientSession.opened;
-strictEqual(info.protocol, 'quic-test');
+assert.strictEqual(info.protocol, 'quic-test');
 
 // The serverEndpoint must be closed after we wait for the clientSession to close.
 await clientSession.closed;

--- a/test/parallel/test-quic-alpn-h3.mjs
+++ b/test/parallel/test-quic-alpn-h3.mjs
@@ -4,9 +4,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, notStrictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -14,8 +11,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // Test h3 ALPN negotiation with Http3ApplicationImpl.
 // Both server and client use the default ALPN (h3).
@@ -24,14 +21,14 @@ const serverOpened = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const info = await serverSession.opened;
-  strictEqual(info.protocol, 'h3');
+  assert.strictEqual(info.protocol, 'h3');
   serverOpened.resolve();
   serverSession.close();
 }), {
   sni: { '*': { keys: [key], certs: [cert] } },
 });
 
-notStrictEqual(serverEndpoint.address, undefined);
+assert.notStrictEqual(serverEndpoint.address, undefined);
 
 const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
@@ -40,7 +37,7 @@ const clientSession = await connect(serverEndpoint.address, {
 
 async function checkClient() {
   const info = await clientSession.opened;
-  strictEqual(info.protocol, 'h3');
+  assert.strictEqual(info.protocol, 'h3');
 }
 
 await Promise.all([serverOpened.promise, checkClient()]);

--- a/test/parallel/test-quic-alpn-mismatch.mjs
+++ b/test/parallel/test-quic-alpn-mismatch.mjs
@@ -8,10 +8,8 @@
 // 0x100 | <tls_alert>. For `no_application_protocol` (alert 120 / 0x78) this
 // is 0x178 == 376.
 
-import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
+import { hasQuic, skip, mustNotCall, expectsError } from '../common/index.mjs';
 import assert from 'node:assert';
-
-const { rejects, strictEqual, match } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -25,11 +23,6 @@ const expected = {
   message: /no application protocol/
 };
 
-const onerror = mustCall((err) => {
-  strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
-  strictEqual(err.errorCode, 376n);
-  match(err.message, /no application protocol/);
-});
 const transportParams = { maxIdleTimeout: 1 };
 
 // The handshake fails so the session is never surfaced to JS
@@ -43,12 +36,12 @@ const serverEndpoint = await listen(
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'nonexistent-protocol',
   transportParams,
-  onerror,
+  onerror: expectsError(expected),
 });
 
-await rejects(clientSession.opened, expected);
+await assert.rejects(clientSession.opened, expected);
 
 // The handshake should fail — opened may reject or never resolve.
 // The session should close with an error.
-await rejects(clientSession.closed, expected);
+await assert.rejects(clientSession.closed, expected);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-alpn.mjs
+++ b/test/parallel/test-quic-alpn.mjs
@@ -4,9 +4,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { notStrictEqual, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -14,8 +11,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // Server offers multiple ALPNs. Client requests one that the server supports.
 // Verify the negotiated protocol matches on both sides.
@@ -25,7 +22,7 @@ const serverOpened = Promise.withResolvers();
 async function checkSession(session) {
   const info = await session.opened;
   // The client should negotiate proto-b (the only protocol it requested)
-  strictEqual(info.protocol, 'proto-b');
+  assert.strictEqual(info.protocol, 'proto-b');
 }
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
@@ -36,7 +33,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   alpn: ['proto-a', 'proto-b', 'proto-c'],
 });
 
-notStrictEqual(serverEndpoint.address, undefined);
+assert.notStrictEqual(serverEndpoint.address, undefined);
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'proto-b',

--- a/test/parallel/test-quic-blocklist.mjs
+++ b/test/parallel/test-quic-blocklist.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import net from 'node:net';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -34,18 +32,18 @@ const { listen, connect } = await import('../common/quic.mjs');
     handshakeTimeout: 500,
     verifyPeer: 'manual',
     onerror: mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+      assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
     }),
   });
 
   // The session should fail — the server never sees the packet.
-  await rejects(clientSession.opened, {
+  await assert.rejects(clientSession.opened, {
     code: 'ERR_QUIC_TRANSPORT_ERROR',
   });
 
   // Verify the stat counter.
-  ok(serverEndpoint.stats.packetsBlocked > 0n,
-     'packetsBlocked should be non-zero');
+  assert.ok(serverEndpoint.stats.packetsBlocked > 0n,
+            'packetsBlocked should be non-zero');
 
   await serverEndpoint.close();
 }
@@ -72,8 +70,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   await clientSession.opened;
   await clientSession.close();
 
-  strictEqual(serverEndpoint.stats.packetsBlocked, 0n,
-              'No packets should be blocked for allowed address');
+  assert.strictEqual(serverEndpoint.stats.packetsBlocked, 0n); // No packets should be blocked for allowed address
 
   await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-callback-error-onblocked.mjs
+++ b/test/parallel/test-quic-callback-error-onblocked.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -42,5 +40,5 @@ stream.onblocked = mustCall(() => {
 stream.setBody(new Uint8Array(4096));
 
 // The stream's closed promise should reject with the error from the throw.
-await rejects(stream.closed, testError);
+await assert.rejects(stream.closed, testError);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-ondatagram.mjs
+++ b/test/parallel/test-quic-callback-error-ondatagram.mjs
@@ -6,8 +6,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,7 +18,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   // The session is destroyed by the ondatagram throw. The closed promise
   // rejects with testError. Verify that and signal completion.
-  await rejects(serverSession.closed, testError);
+  await assert.rejects(serverSession.closed, testError);
   serverDone.resolve();
 }), {
   transportParams: { maxDatagramFrameSize: 1200 },
@@ -28,7 +26,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
     throw testError;
   },
   onerror: mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   }),
 });
 

--- a/test/parallel/test-quic-callback-error-ondatagramstatus.mjs
+++ b/test/parallel/test-quic-callback-error-ondatagramstatus.mjs
@@ -6,8 +6,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,7 +26,7 @@ const clientSession = await connect(serverEndpoint.address, {
     throw testError;
   },
   onerror: mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   }),
 });
 await clientSession.opened;
@@ -37,5 +35,5 @@ await clientSession.opened;
 await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
 
 // The session's closed should reject with the error from the throw.
-await rejects(clientSession.closed, testError);
+await assert.rejects(clientSession.closed, testError);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onerror-option.mjs
+++ b/test/parallel/test-quic-callback-error-onerror-option.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,12 +24,12 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 const clientSession = await connect(serverEndpoint.address, {
   transportParams,
   onerror: mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   }),
 });
 await clientSession.opened;
 
 clientSession.destroy(testError);
 
-await rejects(clientSession.closed, testError);
+await assert.rejects(clientSession.closed, testError);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onerror-validation.mjs
+++ b/test/parallel/test-quic-callback-error-onerror-validation.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -22,19 +20,19 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   await serverSession.opened;
 
   // Session onerror validation: non-functions throw.
-  throws(() => { serverSession.onerror = 'not a function'; }, errorCheck);
-  throws(() => { serverSession.onerror = 42; }, errorCheck);
-  throws(() => { serverSession.onerror = null; }, errorCheck);
+  assert.throws(() => { serverSession.onerror = 'not a function'; }, errorCheck);
+  assert.throws(() => { serverSession.onerror = 42; }, errorCheck);
+  assert.throws(() => { serverSession.onerror = null; }, errorCheck);
 
   // Setting to a function works.
   const fn = () => {};
   serverSession.onerror = fn;
   // The getter returns the bound version, not the original.
-  strictEqual(typeof serverSession.onerror, 'function');
+  assert.strictEqual(typeof serverSession.onerror, 'function');
 
   // Setting to undefined clears it.
   serverSession.onerror = undefined;
-  strictEqual(serverSession.onerror, undefined);
+  assert.strictEqual(serverSession.onerror, undefined);
 
   serverSession.close();
 }));
@@ -47,17 +45,17 @@ const stream = await clientSession.createBidirectionalStream({
   body: new TextEncoder().encode('x'),
 });
 
-throws(() => { stream.onerror = 'not a function'; }, errorCheck);
-throws(() => { stream.onerror = 42; }, errorCheck);
-throws(() => { stream.onerror = null; }, errorCheck);
+assert.throws(() => { stream.onerror = 'not a function'; }, errorCheck);
+assert.throws(() => { stream.onerror = 42; }, errorCheck);
+assert.throws(() => { stream.onerror = null; }, errorCheck);
 
 // Setting to a function works.
 stream.onerror = () => {};
-strictEqual(typeof stream.onerror, 'function');
+assert.strictEqual(typeof stream.onerror, 'function');
 
 // Setting to undefined clears it.
 stream.onerror = undefined;
-strictEqual(stream.onerror, undefined);
+assert.strictEqual(stream.onerror, undefined);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onerror.mjs
+++ b/test/parallel/test-quic-callback-error-onerror.mjs
@@ -10,8 +10,6 @@ import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -22,8 +20,8 @@ const { listen, connect } = await import('../common/quic.mjs');
 // It should fire once for the first client session (destroyed with error)
 // and not for the second (destroyed without error).
 dc.subscribe('quic.session.error', mustCall((msg) => {
-  ok(msg.session, 'session.error should include session');
-  ok(msg.error, 'session.error should include error');
+  assert.ok(msg.session, 'session.error should include session');
+  assert.ok(msg.error, 'session.error should include error');
 }));
 
 const transportParams = { maxIdleTimeout: 1 };
@@ -44,17 +42,17 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   let onerrorCalled = false;
   clientSession.onerror = mustCall((err) => {
     // Receives the original error.
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
     onerrorCalled = true;
   });
 
   clientSession.destroy(testError);
 
   // Onerror was called synchronously during destroy.
-  strictEqual(onerrorCalled, true);
+  assert.strictEqual(onerrorCalled, true);
 
   // Closed rejects with the original error.
-  await rejects(clientSession.closed, testError);
+  await assert.rejects(clientSession.closed, testError);
 }
 
 // Second client: destroy WITHOUT error — onerror should NOT fire.

--- a/test/parallel/test-quic-callback-error-onnewtoken.mjs
+++ b/test/parallel/test-quic-callback-error-onnewtoken.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,13 +28,13 @@ const clientSession = await connect(serverEndpoint.address, {
     throw testError;
   },
   onerror: mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   }),
 });
 
 await clientSession.opened;
 
 // The session's closed should reject with the error from the throw.
-await rejects(clientSession.closed, testError);
+await assert.rejects(clientSession.closed, testError);
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onpathvalidation.mjs
+++ b/test/parallel/test-quic-callback-error-onpathvalidation.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,7 +23,7 @@ const preferredEndpoint = await listen(mustNotCall(), {});
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   // The server session closes with a transport error when the
   // client is destroyed by the throw. That's expected.
-  await rejects(serverSession.closed, {
+  await assert.rejects(serverSession.closed, {
     code: 'ERR_QUIC_TRANSPORT_ERROR',
   });
 }), {
@@ -42,13 +40,13 @@ const clientSession = await connect(serverEndpoint.address, {
   },
   onerror: mustCall((err) => {
     // The error from the throw should be delivered here.
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   }),
 });
 await clientSession.opened;
 
 // The session's closed should reject with the thrown error.
-await rejects(clientSession.closed, testError);
+await assert.rejects(clientSession.closed, testError);
 
 await serverEndpoint.close();
 await preferredEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onreset.mjs
+++ b/test/parallel/test-quic-callback-error-onreset.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,7 +24,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     // The stream's onerror should fire with the throw from onreset.
     stream.onerror = mustCall((err) => {
-      strictEqual(err, testError);
+      assert.strictEqual(err, testError);
     });
 
     stream.onreset = () => {
@@ -36,7 +34,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     serverReady.resolve();
 
     // Stream closed rejects because the onreset throw destroyed it.
-    await rejects(stream.closed, testError);
+    await assert.rejects(stream.closed, testError);
     serverStreamDone.resolve();
   });
 }));

--- a/test/parallel/test-quic-callback-error-onsessionticket.mjs
+++ b/test/parallel/test-quic-callback-error-onsessionticket.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -29,13 +27,13 @@ const clientSession = await connect(serverEndpoint.address, {
     throw testError;
   },
   onerror: mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   }),
 });
 
 await clientSession.opened;
 
 // The session's closed should reject with the error from the throw.
-await rejects(clientSession.closed, testError);
+await assert.rejects(clientSession.closed, testError);
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-onstream-async.mjs
+++ b/test/parallel/test-quic-callback-error-onstream-async.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,7 +18,7 @@ const testError = new Error('async onstream rejection');
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   serverSession.onerror = mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   });
 
   serverSession.onstream = async () => {
@@ -28,7 +26,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   };
 
   // Session closed rejects with the error from the async rejection.
-  await rejects(serverSession.closed, testError);
+  await assert.rejects(serverSession.closed, testError);
 }), { transportParams: { maxIdleTimeout: 1 } });
 
 const clientSession = await connect(serverEndpoint.address, {

--- a/test/parallel/test-quic-callback-error-onstream.mjs
+++ b/test/parallel/test-quic-callback-error-onstream.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -22,7 +20,7 @@ const testError = new Error('sync onstream throw');
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   serverSession.onerror = mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   });
 
   serverSession.onstream = () => {
@@ -30,7 +28,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   };
 
   // The session's closed rejects with the error from destroy().
-  await rejects(serverSession.closed, testError);
+  await assert.rejects(serverSession.closed, testError);
 }), { transportParams: { maxIdleTimeout: 1 } });
 
 const clientSession = await connect(serverEndpoint.address, {

--- a/test/parallel/test-quic-callback-error-stream-onerror.mjs
+++ b/test/parallel/test-quic-callback-error-stream-onerror.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -43,17 +41,17 @@ await clientSession.opened;
   let onerrorCalled = false;
   stream.onerror = mustCall((err) => {
     // Receives the original error.
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
     onerrorCalled = true;
   });
 
   stream.destroy(testError);
 
   // The onerror was called synchronously during destroy.
-  strictEqual(onerrorCalled, true);
+  assert.strictEqual(onerrorCalled, true);
 
   // The stream.closed rejects with the original error.
-  await rejects(stream.closed, testError);
+  await assert.rejects(stream.closed, testError);
 }
 
 // The stream.onerror not called when destroy() has no error.

--- a/test/parallel/test-quic-callback-error-suppressed-async.mjs
+++ b/test/parallel/test-quic-callback-error-suppressed-async.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,11 +22,11 @@ const transportParams = { maxIdleTimeout: 1 };
 // The SuppressedError is thrown via process.nextTick after the
 // onerror promise rejects, so it appears as an uncaught exception.
 process.on('uncaughtException', mustCall((err) => {
-  ok(err instanceof SuppressedError);
+  assert.ok(err instanceof SuppressedError);
   // .error is the onerror rejection reason
-  strictEqual(err.error, onerrorRejection);
+  assert.strictEqual(err.error, onerrorRejection);
   // .suppressed is the original error that triggered destroy
-  strictEqual(err.suppressed, originalError);
+  assert.strictEqual(err.suppressed, originalError);
 }));
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
@@ -48,6 +46,6 @@ clientSession.onerror = mustCall(async () => {
 clientSession.destroy(originalError);
 
 // Closed rejects with the original error (not the SuppressedError).
-await rejects(clientSession.closed, originalError);
+await assert.rejects(clientSession.closed, originalError);
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-callback-error-suppressed.mjs
+++ b/test/parallel/test-quic-callback-error-suppressed.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,11 +24,11 @@ const transportParams = { maxIdleTimeout: 1 };
 // The SuppressedError is thrown via process.nextTick, so it appears
 // as an uncaught exception.
 process.on('uncaughtException', mustCall((err) => {
-  ok(err instanceof SuppressedError);
+  assert.ok(err instanceof SuppressedError);
   // .error is the onerror failure
-  strictEqual(err.error, onerrorError);
+  assert.strictEqual(err.error, onerrorError);
   // .suppressed is the original error that triggered destroy
-  strictEqual(err.suppressed, originalError);
+  assert.strictEqual(err.suppressed, originalError);
 }));
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
@@ -49,5 +47,5 @@ clientSession.onerror = mustCall(() => {
 clientSession.destroy(originalError);
 
 // Closed rejects with the original error (not the SuppressedError).
-await rejects(clientSession.closed, originalError);
+await assert.rejects(clientSession.closed, originalError);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-cc-algorithm.mjs
+++ b/test/parallel/test-quic-cc-algorithm.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,7 +24,7 @@ for (const cc of ['reno', 'cubic', 'bbr']) {
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const data = await bytes(stream);
-      strictEqual(data.byteLength, payloadLength);
+      assert.strictEqual(data.byteLength, payloadLength);
       stream.writer.endSync();
       await stream.closed;
       serverSession.close();
@@ -45,7 +43,7 @@ for (const cc of ['reno', 'cubic', 'bbr']) {
   await Promise.all([stream.closed, serverDone.promise]);
 
   // Verify the session stats show congestion control was active.
-  ok(clientSession.stats.cwnd > 0n, `${cc}: cwnd should be > 0`);
+  assert.ok(clientSession.stats.cwnd > 0n, `${cc}: cwnd should be > 0`);
 
   await clientSession.closed;
   await serverEndpoint.close();

--- a/test/parallel/test-quic-connection-concurrent.mjs
+++ b/test/parallel/test-quic-connection-concurrent.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -45,7 +43,7 @@ for (let i = 0; i < numClients; i++) {
       body: encoder.encode(message),
     });
     const received = await bytes(stream);
-    strictEqual(new TextDecoder().decode(received), message);
+    assert.strictEqual(new TextDecoder().decode(received), message);
     await stream.closed;
     cs.close();
     await cs.closed;

--- a/test/parallel/test-quic-connection-limits.mjs
+++ b/test/parallel/test-quic-connection-limits.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { rejects, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,19 +16,19 @@ if (!hasQuic) {
 const { listen, connect, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // Create endpoint with maxConnectionsTotal = 1.
 const endpoint = new QuicEndpoint({ maxConnectionsTotal: 1 });
 
 // Verify the limits are readable and mutable.
-strictEqual(endpoint.maxConnectionsTotal, 1);
+assert.strictEqual(endpoint.maxConnectionsTotal, 1);
 // The default maxConnectionsPerHost is 100 — a non-zero default that
 // prevents a single host from exhausting server resources.
-strictEqual(endpoint.maxConnectionsPerHost, 100);
+assert.strictEqual(endpoint.maxConnectionsPerHost, 100);
 endpoint.maxConnectionsPerHost = 50;
-strictEqual(endpoint.maxConnectionsPerHost, 50);
+assert.strictEqual(endpoint.maxConnectionsPerHost, 50);
 endpoint.maxConnectionsPerHost = 0;
 
 let sessionCount = 0;
@@ -60,21 +57,21 @@ const cs2 = await connect(serverEndpoint.address, {
   verifyPeer: 'manual',
   transportParams: { maxIdleTimeout: 1 },
   onerror: mustCall((err) => {
-    strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+    assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
   }),
 });
 
 await Promise.all([
-  rejects(cs2.opened, {
+  assert.rejects(cs2.opened, {
     code: 'ERR_QUIC_TRANSPORT_ERROR',
   }),
-  rejects(cs2.closed, {
+  assert.rejects(cs2.closed, {
     code: 'ERR_QUIC_TRANSPORT_ERROR',
   }),
 ]);
 
 // Only 1 session should have been accepted by the server.
-strictEqual(sessionCount, 1);
+assert.strictEqual(sessionCount, 1);
 
 await cs1.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram-abandoned.mjs
+++ b/test/parallel/test-quic-datagram-abandoned.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall, mustCallAtLeast } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { notStrictEqual, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -32,7 +30,7 @@ const clientSession = await connect(serverEndpoint.address, {
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagramstatus: mustCallAtLeast((id, status) => {
     if (status === 'abandoned') {
-      strictEqual(id, ids[0]);
+      assert.strictEqual(id, ids[0]);
       abandoned = true;
     }
     // We'll likely only get status for one other datagram.
@@ -49,13 +47,13 @@ ids[0] = await clientSession.sendDatagram(new Uint8Array([1]));
 ids[1] = await clientSession.sendDatagram(new Uint8Array([2]));
 ids[2] = await clientSession.sendDatagram(new Uint8Array([3]));
 
-notStrictEqual(ids[0], 0n);
-notStrictEqual(ids[1], 0n);
-notStrictEqual(ids[2], 0n);
+assert.notStrictEqual(ids[0], 0n);
+assert.notStrictEqual(ids[1], 0n);
+assert.notStrictEqual(ids[2], 0n);
 
 // The abandoned status fires synchronously during sendDatagram when the
 // queue overflows. It should already be set
-strictEqual(abandoned, true);
+assert.strictEqual(abandoned, true);
 
 await Promise.all([
   serverSession.close(),

--- a/test/parallel/test-quic-datagram-drop-newest.mjs
+++ b/test/parallel/test-quic-datagram-drop-newest.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const allReceived = Promise.withResolvers();
 const allStatusReceived = Promise.withResolvers();
@@ -39,9 +36,9 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagram: mustCall(function(data, early) {
     // We should only receive datagrams 1 and 2
-    strictEqual(data.length, 1);
-    ok(data[0] === 0 || data[0] === 1);
-    ok(!early);
+    assert.strictEqual(data.length, 1);
+    assert.ok(data[0] === 0 || data[0] === 1);
+    assert.ok(!early);
     if (++serverCounter === 2) allReceived.resolve();
   }, 2),
 });
@@ -76,8 +73,8 @@ for (let i = 0; i < 5; i++) {
 await Promise.all([allReceived.promise, allStatusReceived.promise]);
 
 // 3 abandoned (datagrams 1, 2, 3) and 2 acknowledged (datagrams 4, 5).
-strictEqual(clientAbandonCounter, 3);
-strictEqual(clientAckCounter, 2);
+assert.strictEqual(clientAbandonCounter, 3);
+assert.strictEqual(clientAckCounter, 2);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram-drop-oldest.mjs
+++ b/test/parallel/test-quic-datagram-drop-oldest.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const allReceived = Promise.withResolvers();
 const allStatusReceived = Promise.withResolvers();
@@ -39,9 +36,9 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   ondatagram: mustCall(function(data, early) {
     // With drop-oldest, the queue keeps the newest. After 5 sends with
     // queue size 2, only datagrams 4 and 5 (values 3 and 4) remain.
-    strictEqual(data.length, 1);
-    ok(data[0] === 3 || data[0] === 4);
-    ok(!early);
+    assert.strictEqual(data.length, 1);
+    assert.ok(data[0] === 3 || data[0] === 4);
+    assert.ok(!early);
     if (++serverCounter === 2) allReceived.resolve();
   }, 2),
 });
@@ -77,8 +74,8 @@ for (let i = 0; i < 5; i++) {
 await Promise.all([allReceived.promise, allStatusReceived.promise]);
 
 // 3 abandoned (datagrams 1, 2, 3) and 2 acknowledged (datagrams 4, 5).
-strictEqual(clientAbandonCounter, 3);
-strictEqual(clientAckCounter, 2);
+assert.strictEqual(clientAbandonCounter, 3);
+assert.strictEqual(clientAckCounter, 2);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram-echo.mjs
+++ b/test/parallel/test-quic-datagram-echo.mjs
@@ -10,9 +10,6 @@ import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 const { setTimeout } = await import('node:timers/promises');
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,8 +17,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const serverGot = Promise.withResolvers();
 const clientGot = Promise.withResolvers();
@@ -39,8 +36,8 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   // The sendDatagram call happens inside ondatagram (ngtcp2 callback
   // scope). The datagram is queued and flushed by SendPendingData.
   ondatagram: mustCall((data, early, session) => {
-    ok(data instanceof Uint8Array);
-    ok(!early);
+    assert.ok(data instanceof Uint8Array);
+    assert.ok(!early);
     session.sendDatagram(data);
     serverGot.resolve();
   }),
@@ -52,11 +49,11 @@ const clientSession = await connect(serverEndpoint.address, {
   transportParams: { maxDatagramFrameSize: 10 },
   // Client receives datagram from server.
   ondatagram: mustCall(function(data) {
-    ok(data instanceof Uint8Array);
-    strictEqual(data.byteLength, 3);
-    strictEqual(data[0], 10);
-    strictEqual(data[1], 20);
-    strictEqual(data[2], 30);
+    assert.ok(data instanceof Uint8Array);
+    assert.strictEqual(data.byteLength, 3);
+    assert.strictEqual(data[0], 10);
+    assert.strictEqual(data[1], 20);
+    assert.strictEqual(data[2], 30);
     clientGot.resolve();
   }),
 });

--- a/test/parallel/test-quic-datagram-edge-cases.mjs
+++ b/test/parallel/test-quic-datagram-edge-cases.mjs
@@ -9,8 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
 
-const { strictEqual, notStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -32,11 +30,11 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   // Zero-length ArrayBufferView
   const zeroId = await clientSession.sendDatagram(new Uint8Array(0));
-  strictEqual(zeroId, 0n);
+  assert.strictEqual(zeroId, 0n);
 
   // Zero-length string
   const emptyStringId = await clientSession.sendDatagram('');
-  strictEqual(emptyStringId, 0n);
+  assert.strictEqual(emptyStringId, 0n);
 
   await clientSession.close();
   await serverEndpoint.close();
@@ -57,11 +55,11 @@ const { listen, connect } = await import('../common/quic.mjs');
   await clientSession.opened;
 
   // maxDatagramSize reflects the peer's (server's) transport param.
-  strictEqual(clientSession.maxDatagramSize, 0);
+  assert.strictEqual(clientSession.maxDatagramSize, 0);
 
   // Sending returns 0n immediately — datagram not sent.
   const id = await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
-  strictEqual(id, 0n);
+  assert.strictEqual(id, 0n);
 
   await clientSession.close();
   await serverEndpoint.close();
@@ -86,7 +84,7 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   // Send a datagram even though the server has no ondatagram handler.
   const id = await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
-  notStrictEqual(id, 0n);
+  assert.notStrictEqual(id, 0n);
 
   await clientSession.closed;
   await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram-frame-size-validation.mjs
+++ b/test/parallel/test-quic-datagram-frame-size-validation.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ if (!hasQuic) {
 const { listen } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const alpn = ['quic-test'];
 
@@ -40,7 +37,7 @@ const invalid = [
 
 for (const maxDatagramFrameSize of invalid) {
   const transportParams = { maxDatagramFrameSize };
-  await rejects(
+  await assert.rejects(
     listen(mustNotCall(), { sni, alpn, transportParams }),
     { code: 'ERR_INVALID_ARG_VALUE' },
     `listen should reject maxDatagramFrameSize: ${maxDatagramFrameSize}`,

--- a/test/parallel/test-quic-datagram-multiple.mjs
+++ b/test/parallel/test-quic-datagram-multiple.mjs
@@ -11,9 +11,6 @@ import { hasQuic, skip, mustCall, mustCallAtLeast } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -22,8 +19,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const numDatagrams = 5;
 let serverDatagramCount = 0;
@@ -48,7 +45,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   alpn: ['quic-test'],
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagram: mustCallAtLeast((data) => {
-    ok(data instanceof Uint8Array);
+    assert.ok(data instanceof Uint8Array);
     serverDatagramCount++;
     gotSomeDg.resolve();
   }),
@@ -79,7 +76,7 @@ for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-v
 await stream.closed;
 
 // At least some datagrams should have arrived.
-ok(serverDatagramCount > 0, 'Server should have received at least one datagram');
+assert.ok(serverDatagramCount > 0, 'Server should have received at least one datagram');
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram-no-detach.mjs
+++ b/test/parallel/test-quic-datagram-no-detach.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, deepStrictEqual, notStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -40,21 +38,19 @@ await clientSession.opened;
 const source = new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8]);
 
 const firstId = await clientSession.sendDatagram(source);
-notStrictEqual(firstId, 0n);
-strictEqual(source.buffer.detached, false,
-            'source ArrayBuffer must not be detached after sendDatagram');
+assert.notStrictEqual(firstId, 0n);
+assert.strictEqual(source.buffer.detached, false); // source ArrayBuffer must not be detached after sendDatagram
 
 const secondId = await clientSession.sendDatagram(source);
-notStrictEqual(secondId, 0n);
-strictEqual(source.buffer.detached, false,
-            'source ArrayBuffer must remain live after second sendDatagram');
+assert.notStrictEqual(secondId, 0n);
+assert.strictEqual(source.buffer.detached, false); // source ArrayBuffer must remain live after second sendDatagram
 
 // Mutating the source after the previous sendDatagram returned must
 // not affect what the peer ultimately receives — the bytes have
 // already been copied into the QUIC layer's internal buffer.
 source[0] = 99;
 const thirdId = await clientSession.sendDatagram(source);
-notStrictEqual(thirdId, 0n);
+assert.notStrictEqual(thirdId, 0n);
 
 await allReceived.promise;
 
@@ -66,7 +62,7 @@ const expected = [
   Buffer.from([1, 2, 3, 4, 5, 6, 7, 8]).toString('hex'),
   Buffer.from([99, 2, 3, 4, 5, 6, 7, 8]).toString('hex'),
 ].sort();
-deepStrictEqual(sorted, expected);
+assert.deepStrictEqual(sorted, expected);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram-size-limits.mjs
+++ b/test/parallel/test-quic-datagram-size-limits.mjs
@@ -15,8 +15,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual, notStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -32,7 +30,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 }), {
   transportParams: { maxDatagramFrameSize: 200 },
   ondatagram: mustCall((data) => {
-    ok(data instanceof Uint8Array);
+    assert.ok(data instanceof Uint8Array);
     serverGot.resolve();
   }),
 });
@@ -46,19 +44,19 @@ const maxSize = clientSession.maxDatagramSize;
 
 // maxDatagramSize should be less than maxDatagramFrameSize due to
 // the DATAGRAM frame overhead (1 byte type + varint length encoding).
-ok(maxSize > 0);
-ok(maxSize < 200);
+assert.ok(maxSize > 0);
+assert.ok(maxSize < 200);
 
 // DGRAM-03 / DGIMP-10: Datagram too large — returns 0n.
 const oversized = new Uint8Array(maxSize + 1);
 const tooLargeId = await clientSession.sendDatagram(oversized);
-strictEqual(tooLargeId, 0n);
+assert.strictEqual(tooLargeId, 0n);
 
 // Datagram at exactly maxDatagramSize — accepted and delivered.
 const exactMax = new Uint8Array(maxSize);
 exactMax[0] = 42;
 const exactId = await clientSession.sendDatagram(exactMax);
-notStrictEqual(exactId, 0n);
+assert.notStrictEqual(exactId, 0n);
 
 await Promise.all([serverGot.promise, clientSession.closed]);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram-sources.mjs
+++ b/test/parallel/test-quic-datagram-sources.mjs
@@ -11,8 +11,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual, notStrictEqual, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -42,16 +40,16 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   // Send hex-encoded string — '48656c6c6f' is 'Hello' in hex.
   const hexId = await clientSession.sendDatagram('48656c6c6f', 'hex');
-  notStrictEqual(hexId, 0n);
+  assert.notStrictEqual(hexId, 0n);
 
   // Send base64-encoded string — 'V29ybGQ=' is 'World' in base64.
   const b64Id = await clientSession.sendDatagram('V29ybGQ=', 'base64');
-  notStrictEqual(b64Id, 0n);
+  assert.notStrictEqual(b64Id, 0n);
 
   await allReceived.promise;
 
-  deepStrictEqual(received[0], Buffer.from('Hello'));
-  deepStrictEqual(received[1], Buffer.from('World'));
+  assert.deepStrictEqual(received[0], Buffer.from('Hello'));
+  assert.deepStrictEqual(received[1], Buffer.from('World'));
 
   await clientSession.closed;
   await serverEndpoint.close();
@@ -67,7 +65,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   }), {
     transportParams: { maxDatagramFrameSize: 1200 },
     ondatagram: mustCall((data) => {
-      deepStrictEqual(Buffer.from(data), Buffer.from([42]));
+      assert.deepStrictEqual(Buffer.from(data), Buffer.from([42]));
       serverGot.resolve();
     }),
   });
@@ -81,7 +79,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   const promiseId = await clientSession.sendDatagram(
     Promise.resolve(new Uint8Array([42])),
   );
-  notStrictEqual(promiseId, 0n);
+  assert.notStrictEqual(promiseId, 0n);
 
   await Promise.all([serverGot.promise, clientSession.closed]);
   await serverEndpoint.close();
@@ -113,7 +111,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   });
 
   const id = await clientSession.sendDatagram(slowPromise);
-  strictEqual(id, 0n);
+  assert.strictEqual(id, 0n);
 
   await serverEndpoint.close();
 }
@@ -128,7 +126,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   }), {
     transportParams: { maxDatagramFrameSize: 1200 },
     ondatagram: mustCall((data) => {
-      deepStrictEqual(Buffer.from(data), Buffer.from([10, 20, 30]));
+      assert.deepStrictEqual(Buffer.from(data), Buffer.from([10, 20, 30]));
       serverGot.resolve();
     }),
   });
@@ -146,10 +144,10 @@ const { listen, connect } = await import('../common/quic.mjs');
   view[2] = 30;
 
   const id = await clientSession.sendDatagram(view);
-  notStrictEqual(id, 0n);
+  assert.notStrictEqual(id, 0n);
 
   // The SharedArrayBuffer should still be usable (copied, not transferred).
-  strictEqual(view[0], 10);
+  assert.strictEqual(view[0], 10);
 
   await Promise.all([serverGot.promise, clientSession.closed]);
   await serverEndpoint.close();
@@ -166,7 +164,7 @@ const { listen, connect } = await import('../common/quic.mjs');
     transportParams: { maxDatagramFrameSize: 1200 },
     ondatagram: mustCall((data) => {
       // The received data should match the slice content.
-      deepStrictEqual(Buffer.from(data), Buffer.from('hello'));
+      assert.deepStrictEqual(Buffer.from(data), Buffer.from('hello'));
       serverGot.resolve();
     }),
   });
@@ -180,7 +178,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   // ArrayBuffer is larger and the view has a non-zero offset.
   const pooledBuf = Buffer.from('hello');
   const id = await clientSession.sendDatagram(pooledBuf);
-  notStrictEqual(id, 0n);
+  assert.notStrictEqual(id, 0n);
 
   await Promise.all([serverGot.promise, clientSession.closed]);
   await serverEndpoint.close();
@@ -196,7 +194,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   }), {
     transportParams: { maxDatagramFrameSize: 1200 },
     ondatagram: mustCall((data) => {
-      deepStrictEqual(Buffer.from(data), Buffer.from([0xCA, 0xFE]));
+      assert.deepStrictEqual(Buffer.from(data), Buffer.from([0xCA, 0xFE]));
       serverGot.resolve();
     }),
   });
@@ -213,7 +211,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   // DataView over bytes [2, 3] of the buffer.
   const dv = new DataView(ab, 2, 2);
   const id = await clientSession.sendDatagram(dv);
-  notStrictEqual(id, 0n);
+  assert.notStrictEqual(id, 0n);
 
   await Promise.all([serverGot.promise, clientSession.closed]);
   await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram-status.mjs
+++ b/test/parallel/test-quic-datagram-status.mjs
@@ -9,9 +9,6 @@ import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 const { setTimeout } = await import('node:timers/promises');
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const serverGot = Promise.withResolvers();
 const statusReceived = Promise.withResolvers();
@@ -48,9 +45,9 @@ const clientSession = await connect(serverEndpoint.address, {
   verifyPeer: 'manual',
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagramstatus: mustCall((id, status) => {
-    strictEqual(typeof id, 'bigint');
-    strictEqual(typeof status, 'string');
-    ok(
+    assert.strictEqual(typeof id, 'bigint');
+    assert.strictEqual(typeof status, 'string');
+    assert.ok(
       status === 'acknowledged' || status === 'lost' || status === 'abandoned',
       `status should be 'acknowledged', 'lost', or 'abandoned', got '${status}'`,
     );
@@ -68,9 +65,9 @@ const id = await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
 await Promise.all([serverGot.promise, statusReceived.promise]);
 
 // The status callback should have been called with the same ID.
-strictEqual(statusId, id);
+assert.strictEqual(statusId, id);
 // On localhost the datagram should be acknowledged, not lost.
-strictEqual(statusValue, 'acknowledged');
+assert.strictEqual(statusValue, 'acknowledged');
 
 await clientSession.closed;
 

--- a/test/parallel/test-quic-datagram-utf8.mjs
+++ b/test/parallel/test-quic-datagram-utf8.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, deepStrictEqual, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,9 +25,9 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 }), {
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagram: mustCall((data) => {
-    ok(data instanceof Uint8Array);
+    assert.ok(data instanceof Uint8Array);
     // Verify the received bytes match the UTF-8 encoding.
-    deepStrictEqual(Buffer.from(data), expected);
+    assert.deepStrictEqual(Buffer.from(data), expected);
     serverGot.resolve();
   }),
 });
@@ -40,7 +38,7 @@ const clientSession = await connect(serverEndpoint.address, {
 await clientSession.opened;
 
 const id = await clientSession.sendDatagram(message);
-strictEqual(id, 1n);
+assert.strictEqual(id, 1n);
 
 await Promise.all([serverGot.promise, clientSession.closed]);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-datagram.mjs
+++ b/test/parallel/test-quic-datagram.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -18,8 +15,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const serverGot = Promise.withResolvers();
 
@@ -27,8 +24,8 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   await serverSession.opened;
   // maxDatagramSize reflects peer's max payload (frame size
   // minus DATAGRAM frame overhead of type byte + varint length).
-  ok(serverSession.maxDatagramSize > 0);
-  ok(serverSession.maxDatagramSize < 1200);
+  assert.ok(serverSession.maxDatagramSize > 0);
+  assert.ok(serverSession.maxDatagramSize < 1200);
   // Wait for the datagram before closing.
   await serverGot.promise;
   await serverSession.close();
@@ -37,8 +34,8 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   alpn: ['quic-test'],
   transportParams: { maxDatagramFrameSize: 1200 },
   ondatagram: mustCall((data) => {
-    ok(data instanceof Uint8Array);
-    strictEqual(data.byteLength, 3);
+    assert.ok(data instanceof Uint8Array);
+    assert.strictEqual(data.byteLength, 3);
     serverGot.resolve();
   }),
 });
@@ -52,8 +49,8 @@ const clientSession = await connect(serverEndpoint.address, {
 await clientSession.opened;
 
 // Client maxDatagramSize reflects actual payload max.
-ok(clientSession.maxDatagramSize > 0);
-ok(clientSession.maxDatagramSize < 1200);
+assert.ok(clientSession.maxDatagramSize > 0);
+assert.ok(clientSession.maxDatagramSize < 1200);
 
 // Client sends datagram.
 const id = await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));

--- a/test/parallel/test-quic-default-stream-limits.mjs
+++ b/test/parallel/test-quic-default-stream-limits.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,7 +18,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const info = await serverSession.opened;
 
   // The handshake info should be available.
-  ok(info, 'handshake info should be available');
+  assert.ok(info, 'handshake info should be available');
 
   await serverSession.closed;
 }));
@@ -31,25 +29,25 @@ const clientSession = await connect(serverEndpoint.address, {
 const info = await clientSession.opened;
 
 // Verify the handshake completed and we can inspect the session.
-ok(info, 'handshake info should be available');
+assert.ok(info, 'handshake info should be available');
 
 // Check that the session has reasonable default stream limits by
 // verifying we can create at least one bidirectional and one
 // unidirectional stream.
 const bidiStream = await clientSession.createBidirectionalStream();
-ok(bidiStream, 'should be able to create a bidi stream');
+assert.ok(bidiStream, 'should be able to create a bidi stream');
 bidiStream.destroy();
 
 const uniStream = await clientSession.createUnidirectionalStream();
-ok(uniStream, 'should be able to create a uni stream');
+assert.ok(uniStream, 'should be able to create a uni stream');
 uniStream.destroy();
 
 // Check the endpoint's maxConnectionsPerHost and maxConnectionsTotal
 // defaults are either 0 (unlimited) or a reasonable positive number.
 const maxPerHost = serverEndpoint.maxConnectionsPerHost;
 const maxTotal = serverEndpoint.maxConnectionsTotal;
-ok(maxPerHost >= 0, 'maxConnectionsPerHost should be non-negative');
-ok(maxTotal >= 0, 'maxConnectionsTotal should be non-negative');
+assert.ok(maxPerHost >= 0, 'maxConnectionsPerHost should be non-negative');
+assert.ok(maxTotal >= 0, 'maxConnectionsTotal should be non-negative');
 
 await clientSession.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-diagnostics-channel-busy.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-busy.mjs
@@ -8,9 +8,6 @@ import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -18,14 +15,14 @@ if (!hasQuic) {
 const { listen, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 let busyChangeCount = 0;
 dc.subscribe('quic.endpoint.busy.change', mustCall((msg) => {
   busyChangeCount++;
-  ok(msg.endpoint);
-  strictEqual(typeof msg.busy, 'boolean');
+  assert.ok(msg.endpoint);
+  assert.strictEqual(typeof msg.busy, 'boolean');
 }, 2));
 
 const endpoint = new QuicEndpoint();
@@ -39,6 +36,6 @@ const serverEndpoint = await listen(mustNotCall(), {
 endpoint.busy = true;
 endpoint.busy = false;
 
-strictEqual(busyChangeCount, 2);
+assert.strictEqual(busyChangeCount, 2);
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-diagnostics-channel-datagram-status.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-datagram-status.mjs
@@ -7,8 +7,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,9 +17,9 @@ const statusDone = Promise.withResolvers();
 
 // quic.session.receive.datagram.status fires with status.
 dc.subscribe('quic.session.receive.datagram.status', mustCall((msg) => {
-  ok(msg.session);
-  ok(msg.id);
-  strictEqual(msg?.status, 'acknowledged');
+  assert.ok(msg.session);
+  assert.ok(msg.id);
+  assert.strictEqual(msg?.status, 'acknowledged');
   statusDone.resolve();
 }));
 

--- a/test/parallel/test-quic-diagnostics-channel-datagram.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-datagram.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,15 +18,15 @@ const serverGot = Promise.withResolvers();
 
 // quic.session.send.datagram fires on send.
 dc.subscribe('quic.session.send.datagram', mustCall((msg) => {
-  ok(msg.session);
-  ok(msg.id);
-  ok(msg.length > 0);
+  assert.ok(msg.session);
+  assert.ok(msg.id);
+  assert.ok(msg.length > 0);
 }));
 
 // quic.session.receive.datagram fires on receipt.
 dc.subscribe('quic.session.receive.datagram', mustCall((msg) => {
-  ok(msg.session);
-  ok(msg.length > 0);
+  assert.ok(msg.session);
+  assert.ok(msg.length > 0);
 }));
 
 const serverEndpoint = await listen(async (serverSession) => {

--- a/test/parallel/test-quic-diagnostics-channel-error.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-error.mjs
@@ -9,10 +9,6 @@ import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { readKey } = fixtures;
-
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,14 +16,14 @@ if (!hasQuic) {
 const { listen } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const alpn = ['quic-test'];
 
 dc.subscribe('quic.endpoint.error', mustCall((msg) => {
-  ok(msg.endpoint);
-  ok(msg.error);
+  assert.ok(msg.endpoint);
+  assert.ok(msg.error);
 }));
 
 // Create first endpoint to occupy a port.
@@ -42,8 +38,8 @@ const ep2 = await listen(mustNotCall(), {
 });
 
 // ep2 is destroyed due to bind failure.
-strictEqual(ep2.destroyed, true);
-await rejects(ep2.closed, {
+assert.strictEqual(ep2.destroyed, true);
+await assert.rejects(ep2.closed, {
   code: 'ERR_QUIC_ENDPOINT_CLOSED',
   message: /Bind failure/,
 });

--- a/test/parallel/test-quic-diagnostics-channel-path.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-path.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,15 +18,15 @@ const clientChannelFired = Promise.withResolvers();
 
 // Subscribe to the path validation diagnostics channel.
 // Verify the client-side event fires with the correct properties.
-dc.subscribe('quic.session.path.validation', (msg) => {
-  ok(msg.session, 'message should have session');
-  ok(msg.result, 'message should have result');
-  ok(msg.newLocalAddress, 'message should have newLocalAddress');
-  ok(msg.newRemoteAddress, 'message should have newRemoteAddress');
+dc.subscribe('quic.session.path.validation', mustCall((msg) => {
+  assert.ok(msg.session, 'message should have session');
+  assert.ok(msg.result, 'message should have result');
+  assert.ok(msg.newLocalAddress, 'message should have newLocalAddress');
+  assert.ok(msg.newRemoteAddress, 'message should have newRemoteAddress');
   if (msg.preferredAddress === true) {
     clientChannelFired.resolve();
   }
-});
+}));
 
 const preferredEndpoint = await listen(mustNotCall(), {
   onpathvalidation() {},

--- a/test/parallel/test-quic-diagnostics-channel-session.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-session.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,15 +18,15 @@ const { listen, connect } = await import('../common/quic.mjs');
 let handshakeCount = 0;
 dc.subscribe('quic.session.handshake', mustCall((msg) => {
   handshakeCount++;
-  ok(msg.session);
+  assert.ok(msg.session);
   // The handshake info should include standard TLS fields.
-  strictEqual(typeof msg.protocol, 'string');
-  strictEqual(typeof msg.servername, 'string');
+  assert.strictEqual(typeof msg.protocol, 'string');
+  assert.strictEqual(typeof msg.servername, 'string');
 }, 2));
 
 // quic.session.update.key fires on key update.
 dc.subscribe('quic.session.update.key', mustCall((msg) => {
-  ok(msg.session);
+  assert.ok(msg.session);
 }));
 
 const serverEndpoint = await listen(async (serverSession) => {
@@ -46,4 +44,4 @@ await clientSession.closed;
 await serverEndpoint.close();
 
 // Both client and server handshakes should have fired.
-strictEqual(handshakeCount, 2);
+assert.strictEqual(handshakeCount, 2);

--- a/test/parallel/test-quic-diagnostics-channel-stream.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-stream.mjs
@@ -10,8 +10,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,23 +21,23 @@ const encoder = new TextEncoder();
 
 // Fires when the client creates a stream.
 dc.subscribe('quic.session.open.stream', mustCall((msg) => {
-  ok(msg.stream);
-  ok(msg.session);
-  strictEqual(msg.direction, 'bidi', 'open.stream direction should be bidi');
+  assert.ok(msg.stream);
+  assert.ok(msg.session);
+  assert.strictEqual(msg.direction, 'bidi'); // open.stream direction should be bidi
 }));
 
 // Fires when the server receives a stream.
 dc.subscribe('quic.session.received.stream', mustCall((msg) => {
-  ok(msg.stream);
-  ok(msg.session);
-  strictEqual(msg.direction, 'bidi', 'received.stream direction should be bidi');
+  assert.ok(msg.stream);
+  assert.ok(msg.session);
+  assert.strictEqual(msg.direction, 'bidi'); // received.stream direction should be bidi
 }));
 
 // Fires when a stream is destroyed.
 dc.subscribe('quic.stream.closed', mustCall((msg) => {
-  ok(msg.stream);
-  ok(msg.session);
-  ok(msg.stats, 'stream.closed should include stats');
+  assert.ok(msg.stream);
+  assert.ok(msg.session);
+  assert.ok(msg.stats, 'stream.closed should include stats');
 }, 2));
 
 const serverDone = Promise.withResolvers();

--- a/test/parallel/test-quic-diagnostics-channel-token.mjs
+++ b/test/parallel/test-quic-diagnostics-channel-token.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,17 +24,17 @@ function checkDone() {
 
 // quic.session.ticket fires when session ticket received.
 dc.subscribe('quic.session.ticket', mustCall((msg) => {
-  ok(msg.session);
-  ok(msg.ticket);
+  assert.ok(msg.session);
+  assert.ok(msg.ticket);
   ticketFired = true;
   checkDone();
 }));
 
 // quic.session.new.token fires when NEW_TOKEN received.
 dc.subscribe('quic.session.new.token', mustCall((msg) => {
-  ok(msg.session);
-  ok(msg.token);
-  ok(msg.address);
+  assert.ok(msg.session);
+  assert.ok(msg.token);
+  assert.ok(msg.address);
   tokenFired = true;
   checkDone();
 }));
@@ -46,8 +44,8 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 }));
 
 const clientSession = await connect(serverEndpoint.address, {
-  onsessionticket: mustCall((ticket) => { ok(ticket); }),
-  onnewtoken: mustCall((token) => { ok(token); }),
+  onsessionticket: mustCall((ticket) => { assert.ok(ticket); }),
+  onnewtoken: mustCall((token) => { assert.ok(token); }),
 });
 await Promise.all([clientSession.opened, allDone.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-diagnostics-channel.mjs
+++ b/test/parallel/test-quic-diagnostics-channel.mjs
@@ -14,8 +14,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,47 +25,47 @@ const events = [];
 // endpoint.created fires for both server and client endpoints.
 dc.subscribe('quic.endpoint.created', mustCall((msg) => {
   events.push('endpoint.created');
-  ok(msg.endpoint);
+  assert.ok(msg.endpoint);
 }, 2));
 
 // endpoint.listen fires once (server only).
 dc.subscribe('quic.endpoint.listen', mustCall((msg) => {
   events.push('endpoint.listen');
-  ok(msg.endpoint);
+  assert.ok(msg.endpoint);
 }));
 
 // endpoint.closing fires once (server endpoint closes).
 dc.subscribe('quic.endpoint.closing', mustCall((msg) => {
   events.push('endpoint.closing');
-  ok(msg.endpoint);
+  assert.ok(msg.endpoint);
 }));
 
 // endpoint.closed fires once (server endpoint closed).
 dc.subscribe('quic.endpoint.closed', mustCall((msg) => {
   events.push('endpoint.closed');
-  ok(msg.endpoint);
-  ok(msg.stats, 'endpoint.closed should include stats');
+  assert.ok(msg.endpoint);
+  assert.ok(msg.stats, 'endpoint.closed should include stats');
 }));
 
 // endpoint.connect fires before a client session is created.
 dc.subscribe('quic.endpoint.connect', mustCall((msg) => {
   events.push('endpoint.connect');
-  ok(msg.endpoint);
-  ok(msg.address);
-  ok(msg.options);
+  assert.ok(msg.endpoint);
+  assert.ok(msg.address);
+  assert.ok(msg.options);
 }));
 
 // session.created.client fires for the client session.
 dc.subscribe('quic.session.created.client', mustCall((msg) => {
   events.push('session.created.client');
-  ok(msg.session);
+  assert.ok(msg.session);
 }));
 
 // session.created.server fires for the server session.
 dc.subscribe('quic.session.created.server', mustCall((msg) => {
   events.push('session.created.server');
-  ok(msg.session);
-  ok(msg.address, 'server session should include remote address');
+  assert.ok(msg.session);
+  assert.ok(msg.address, 'server session should include remote address');
 }));
 
 // session.closing fires when session.close() is called.
@@ -75,14 +73,14 @@ dc.subscribe('quic.session.created.server', mustCall((msg) => {
 // The client session closes via CONNECTION_CLOSE without going through close().
 dc.subscribe('quic.session.closing', mustCall((msg) => {
   events.push('session.closing');
-  ok(msg.session);
+  assert.ok(msg.session);
 }));
 
 // session.closed fires when session is fully closed.
 dc.subscribe('quic.session.closed', mustCall((msg) => {
   events.push('session.closed');
-  ok(msg.session);
-  ok(msg.stats, 'session.closed should include stats');
+  assert.ok(msg.session);
+  assert.ok(msg.stats, 'session.closed should include stats');
 }, 2));
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
@@ -97,10 +95,10 @@ await Promise.all([clientSession.opened, clientSession.closed]);
 await serverEndpoint.close();
 
 // Verify key events occurred.
-ok(events.includes('endpoint.created'), 'missing endpoint.created');
-ok(events.includes('endpoint.listen'), 'missing endpoint.listen');
-ok(events.includes('endpoint.connect'), 'missing endpoint.connect');
-ok(events.includes('session.created.client'), 'missing session.created.client');
-ok(events.includes('session.created.server'), 'missing session.created.server');
-ok(events.includes('endpoint.closing'), 'missing endpoint.closing');
-ok(events.includes('endpoint.closed'), 'missing endpoint.closed');
+assert.ok(events.includes('endpoint.created'), 'missing endpoint.created');
+assert.ok(events.includes('endpoint.listen'), 'missing endpoint.listen');
+assert.ok(events.includes('endpoint.connect'), 'missing endpoint.connect');
+assert.ok(events.includes('session.created.client'), 'missing session.created.client');
+assert.ok(events.includes('session.created.server'), 'missing session.created.server');
+assert.ok(events.includes('endpoint.closing'), 'missing endpoint.closing');
+assert.ok(events.includes('endpoint.closed'), 'missing endpoint.closed');

--- a/test/parallel/test-quic-draining-period.mjs
+++ b/test/parallel/test-quic-draining-period.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -36,7 +34,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   // With 3x PTO on localhost (~1-4ms RTT), the draining period should
   // be well under 1 second. The idle timeout is 10 seconds. If the
   // draining period fix is working, elapsed should be much less than 10s.
-  ok(elapsed < 2000, `Expected draining to complete in < 2s, took ${elapsed}ms`);
+  assert.ok(elapsed < 2000, `Expected draining to complete in < 2s, took ${elapsed}ms`);
 
   await serverEndpoint.close();
 }
@@ -58,7 +56,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   const elapsed = Date.now() - start;
 
   // 10x PTO is still very short on localhost. Should complete promptly.
-  ok(elapsed < 2000, `Expected draining to complete in < 2s, took ${elapsed}ms`);
+  assert.ok(elapsed < 2000, `Expected draining to complete in < 2s, took ${elapsed}ms`);
 
   await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-edge-closing-ops.mjs
+++ b/test/parallel/test-quic-edge-closing-ops.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,18 +28,18 @@ await clientSession.opened;
 clientSession.close();
 
 // Creating a stream on a closing session rejects.
-await rejects(
+await assert.rejects(
   clientSession.createBidirectionalStream(),
   { code: 'ERR_INVALID_STATE' },
 );
 
-await rejects(
+await assert.rejects(
   clientSession.createUnidirectionalStream(),
   { code: 'ERR_INVALID_STATE' },
 );
 
 // sendDatagram on a closing session throws.
-await rejects(
+await assert.rejects(
   clientSession.sendDatagram(new Uint8Array([1, 2, 3])),
   { code: 'ERR_INVALID_STATE' },
 );

--- a/test/parallel/test-quic-edge-destroyed-ops.mjs
+++ b/test/parallel/test-quic-edge-destroyed-ops.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,7 +24,7 @@ const stream = await clientSession.createBidirectionalStream();
 
 // Destroy the stream, then try operations on it.
 stream.destroy();
-strictEqual(stream.destroyed, true);
+assert.strictEqual(stream.destroyed, true);
 
 // Operations on destroyed stream should not throw.
 stream.destroy();  // Idempotent.
@@ -34,20 +32,20 @@ stream.writer.endSync();  // No-op on destroyed.
 
 // Destroy the session, then try operations on it.
 clientSession.destroy();
-strictEqual(clientSession.destroyed, true);
+assert.strictEqual(clientSession.destroyed, true);
 
 // Properties should return null/undefined gracefully.
-strictEqual(clientSession.endpoint, null);
-strictEqual(clientSession.path, undefined);
-strictEqual(clientSession.certificate, undefined);
-strictEqual(clientSession.peerCertificate, undefined);
-strictEqual(clientSession.ephemeralKeyInfo, undefined);
+assert.strictEqual(clientSession.endpoint, null);
+assert.strictEqual(clientSession.path, undefined);
+assert.strictEqual(clientSession.certificate, undefined);
+assert.strictEqual(clientSession.peerCertificate, undefined);
+assert.strictEqual(clientSession.ephemeralKeyInfo, undefined);
 
 // destroy() again is idempotent.
 clientSession.destroy();
 
 // sendDatagram on destroyed session throws ERR_INVALID_STATE.
-await rejects(
+await assert.rejects(
   clientSession.sendDatagram(new Uint8Array([1])),
   { code: 'ERR_INVALID_STATE' },
 );

--- a/test/parallel/test-quic-edge-endpoint-destroy-active.mjs
+++ b/test/parallel/test-quic-edge-endpoint-destroy-active.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -43,8 +41,8 @@ await stream.closed;
 // Close the endpoint while the server session is still active
 // (the session is open but the stream is done).
 serverEndpoint.close();
-strictEqual(serverEndpoint.closing, true);
-strictEqual(serverEndpoint.destroyed, false);
+assert.strictEqual(serverEndpoint.closing, true);
+assert.strictEqual(serverEndpoint.destroyed, false);
 
 // The endpoint is waiting for the server session. Close the
 // client session to trigger the server session to close.
@@ -52,4 +50,4 @@ await clientSession.close();
 
 // The server session should close from the CONNECTION_CLOSE.
 await Promise.all([serverDone.promise, serverEndpoint.closed]);
-strictEqual(serverEndpoint.destroyed, true);
+assert.strictEqual(serverEndpoint.destroyed, true);

--- a/test/parallel/test-quic-edge-idempotent.mjs
+++ b/test/parallel/test-quic-edge-idempotent.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -37,17 +35,17 @@ await stream.closed;
 // Double close() on session — both return the same promise.
 const p1 = clientSession.close();
 const p2 = clientSession.close();
-strictEqual(p1, p2);
+assert.strictEqual(p1, p2);
 await clientSession.closed;
 
 // Double destroy() — second call is no-op.
 clientSession.destroy();
-strictEqual(clientSession.destroyed, true);
+assert.strictEqual(clientSession.destroyed, true);
 clientSession.destroy();  // Should not throw.
-strictEqual(clientSession.destroyed, true);
+assert.strictEqual(clientSession.destroyed, true);
 
 // Double close() on endpoint.
 const ep1 = serverEndpoint.close();
 const ep2 = serverEndpoint.close();
-strictEqual(ep1, ep2);
+assert.strictEqual(ep1, ep2);
 await serverEndpoint.closed;

--- a/test/parallel/test-quic-edge-session-destroy-immediate.mjs
+++ b/test/parallel/test-quic-edge-session-destroy-immediate.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,7 +26,7 @@ const clientSession = await connect(serverEndpoint.address, {
 // Destroy immediately without waiting for opened.
 clientSession.destroy();
 
-strictEqual(clientSession.destroyed, true);
+assert.strictEqual(clientSession.destroyed, true);
 
 // Opened may reject (session destroyed before handshake completed)
 // or resolve if handshake completed fast enough.

--- a/test/parallel/test-quic-enable-early-data.mjs
+++ b/test/parallel/test-quic-enable-early-data.mjs
@@ -4,9 +4,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { rejects, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -14,11 +11,11 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // enableEarlyData must be a boolean
-await rejects(connect({ port: 1234 }, {
+await assert.rejects(connect({ port: 1234 }, {
   alpn: 'quic-test',
   enableEarlyData: 'yes',
 }), {
@@ -50,8 +47,8 @@ const clientSession = await connect(serverEndpoint.address, {
   enableEarlyData: false,
 });
 clientSession.opened.then(mustCall((info) => {
-  strictEqual(info.earlyDataAttempted, false);
-  strictEqual(info.earlyDataAccepted, false);
+  assert.strictEqual(info.earlyDataAttempted, false);
+  assert.strictEqual(info.earlyDataAccepted, false);
   clientOpened.resolve();
 }));
 

--- a/test/parallel/test-quic-endpoint-async-dispose.mjs
+++ b/test/parallel/test-quic-endpoint-async-dispose.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,13 +25,13 @@ const clientSession = await connect(serverEndpoint.address);
 await clientSession.opened;
 
 // session[Symbol.asyncDispose] closes the session.
-strictEqual(typeof clientSession[Symbol.asyncDispose], 'function');
+assert.strictEqual(typeof clientSession[Symbol.asyncDispose], 'function');
 await clientSession[Symbol.asyncDispose]();
-strictEqual(clientSession.destroyed, true);
+assert.strictEqual(clientSession.destroyed, true);
 
 await serverDone.promise;
 
 // endpoint[Symbol.asyncDispose] closes the endpoint.
-strictEqual(typeof serverEndpoint[Symbol.asyncDispose], 'function');
+assert.strictEqual(typeof serverEndpoint[Symbol.asyncDispose], 'function');
 await serverEndpoint[Symbol.asyncDispose]();
-strictEqual(serverEndpoint.destroyed, true);
+assert.strictEqual(serverEndpoint.destroyed, true);

--- a/test/parallel/test-quic-endpoint-bind-failure.mjs
+++ b/test/parallel/test-quic-endpoint-bind-failure.mjs
@@ -11,9 +11,6 @@ import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, ok, rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -21,15 +18,15 @@ if (!hasQuic) {
 const { listen } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const alpn = ['quic-test'];
 
 // Bind first endpoint to get an assigned port.
 const ep1 = await listen(mustNotCall(), { sni, alpn });
 const { port } = ep1.address;
-ok(port > 0);
+assert.ok(port > 0);
 
 // Attempt to listen on the same port — should fail with bind error.
 // listen() returns an endpoint that is immediately destroyed.
@@ -38,10 +35,10 @@ const ep2 = await listen(mustNotCall(), {
   alpn,
   endpoint: { address: `127.0.0.1:${port}` },
 });
-strictEqual(ep2.destroyed, true);
+assert.strictEqual(ep2.destroyed, true);
 
 // The bind failure surfaces as a rejected closed promise.
-await rejects(ep2.closed, {
+await assert.rejects(ep2.closed, {
   code: 'ERR_QUIC_ENDPOINT_CLOSED',
   message: /Bind failure/,
 });

--- a/test/parallel/test-quic-endpoint-bind.mjs
+++ b/test/parallel/test-quic-endpoint-bind.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, ok } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -18,8 +15,8 @@ if (!hasQuic) {
 const { listen, connect, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // Binding to a specific port.
 {
@@ -38,10 +35,10 @@ const cert = readKey('agent1-cert.pem');
 
   // The address should reflect what we bound to.
   const addr = serverEndpoint.address;
-  strictEqual(addr.address, '127.0.0.1');
-  strictEqual(addr.family, 'ipv4');
-  strictEqual(typeof addr.port, 'number');
-  ok(addr.port > 0, 'port should be assigned');
+  assert.strictEqual(addr.address, '127.0.0.1');
+  assert.strictEqual(addr.family, 'ipv4');
+  assert.strictEqual(typeof addr.port, 'number');
+  assert.ok(addr.port > 0, 'port should be assigned');
 
   // Verify a client can connect to the bound address.
   const clientSession = await connect(serverEndpoint.address, {

--- a/test/parallel/test-quic-endpoint-busy.mjs
+++ b/test/parallel/test-quic-endpoint-busy.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { rejects, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -18,8 +15,8 @@ if (!hasQuic) {
 const { listen, connect, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const endpoint = new QuicEndpoint();
 
@@ -42,9 +39,9 @@ const cs1 = await connect(serverEndpoint.address, {
 await cs1.opened;
 
 // Set the endpoint busy.
-strictEqual(endpoint.busy, false);
+assert.strictEqual(endpoint.busy, false);
 endpoint.busy = true;
-strictEqual(endpoint.busy, true);
+assert.strictEqual(endpoint.busy, true);
 
 // Second connection while busy — server rejects.
 const cs2 = await connect(serverEndpoint.address, {
@@ -52,21 +49,21 @@ const cs2 = await connect(serverEndpoint.address, {
   verifyPeer: 'manual',
   transportParams: { maxIdleTimeout: 1 },
   onerror: mustCall((err) => {
-    strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+    assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
   }),
 });
 
-await rejects(cs2.opened, {
+await assert.rejects(cs2.opened, {
   code: 'ERR_QUIC_TRANSPORT_ERROR',
 });
 
-await rejects(cs2.closed, {
+await assert.rejects(cs2.closed, {
   code: 'ERR_QUIC_TRANSPORT_ERROR',
 });
 
 // Unset busy.
 endpoint.busy = false;
-strictEqual(endpoint.busy, false);
+assert.strictEqual(endpoint.busy, false);
 
 // Clean up.
 await cs1.close();

--- a/test/parallel/test-quic-endpoint-close-destroy.mjs
+++ b/test/parallel/test-quic-endpoint-close-destroy.mjs
@@ -10,8 +10,6 @@ import assert from 'node:assert';
 const { setTimeout } = await import('node:timers/promises');
 const { bytes } = await import('stream/iter');
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -37,13 +35,13 @@ const encoder = new TextEncoder();
     await serverSession.opened;
 
     // Before close, closing is false.
-    strictEqual(serverEndpoint.closing, false);
+    assert.strictEqual(serverEndpoint.closing, false);
 
     // Initiate endpoint close — it should wait for this session.
     serverEndpoint.close();
 
     // After close() is called, closing is true.
-    strictEqual(serverEndpoint.closing, true);
+    assert.strictEqual(serverEndpoint.closing, true);
 
     // The endpoint's closed promise should NOT resolve yet — session is open.
     let endpointClosed = false;
@@ -51,7 +49,7 @@ const encoder = new TextEncoder();
 
     // Give a tick to confirm endpoint hasn't closed yet.
     await setTimeout(100);
-    strictEqual(endpointClosed, false);
+    assert.strictEqual(endpointClosed, false);
 
     // Wait for the stream to complete, then close the session.
     await streamDone.promise;
@@ -75,5 +73,5 @@ const encoder = new TextEncoder();
                      stream.closed,
                      serverEndpoint.closed]);
 
-  strictEqual(serverEndpoint.destroyed, true);
+  assert.strictEqual(serverEndpoint.destroyed, true);
 }

--- a/test/parallel/test-quic-endpoint-destroy-after-close.mjs
+++ b/test/parallel/test-quic-endpoint-destroy-after-close.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -52,7 +50,7 @@ const closingPromise = serverEndpoint.close();
 // With the fix, the error is still recorded and surfaces on
 // `endpoint.closed`. Without the fix, it'd be silently dropped.
 const destroyError = new Error('destroy after close');
-const closedAssertion = rejects(serverEndpoint.closed, destroyError);
+const closedAssertion = assert.rejects(serverEndpoint.closed, destroyError);
 
 serverEndpoint.destroy(destroyError);
 
@@ -60,7 +58,7 @@ await closedAssertion;
 
 // `endpoint.close()` returns the same promise as `endpoint.closed`, so
 // it should reject with the same error as well.
-await rejects(closingPromise, destroyError);
+await assert.rejects(closingPromise, destroyError);
 
 await serverDone.promise;
 clientSession.destroy();

--- a/test/parallel/test-quic-endpoint-destroy-cascade-close-frame.mjs
+++ b/test/parallel/test-quic-endpoint-destroy-cascade-close-frame.mjs
@@ -22,8 +22,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -69,9 +67,9 @@ await serverHandshake.promise;
 // (rejects with the transport error decoded from the CONNECTION_CLOSE
 // frame) ends up as an unhandled rejection in the brief window before
 // this test gets back to awaiting them.
-const serverClosedAssertion = rejects(serverEndpoint.closed, serverError);
-const clientClosedAssertion = rejects(clientSession.closed, mustCall((err) => {
-  strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+const serverClosedAssertion = assert.rejects(serverEndpoint.closed, serverError);
+const clientClosedAssertion = assert.rejects(clientSession.closed, mustCall((err) => {
+  assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
   return true;
 }));
 

--- a/test/parallel/test-quic-endpoint-idle-timeout.mjs
+++ b/test/parallel/test-quic-endpoint-idle-timeout.mjs
@@ -10,8 +10,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -36,14 +34,14 @@ const { listen, connect } = await import('../common/quic.mjs');
   await client.opened;
 
   // Endpoint is alive while the session is active.
-  ok(!clientEndpoint.destroyed, 'endpoint should be alive');
+  assert.ok(!clientEndpoint.destroyed, 'endpoint should be alive');
 
   await client.close();
 
   // The endpoint's UDP handle is unref'd when all sessions close,
   // so it won't block process exit. Explicitly close it for cleanup.
   await clientEndpoint.close();
-  ok(clientEndpoint.destroyed, 'endpoint should be destroyed after close');
+  assert.ok(clientEndpoint.destroyed, 'endpoint should be destroyed after close');
 
   await serverEndpoint.close();
 }
@@ -65,15 +63,15 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   // The endpoint should NOT be immediately destroyed — idle timer
   // is running.
-  ok(!clientEndpoint.destroyed,
-     'endpoint should still be alive during idle timeout');
+  assert.ok(!clientEndpoint.destroyed,
+            'endpoint should still be alive during idle timeout');
 
   // Wait for the idle timeout to fire (1 second + margin).
   // Use a ref'd timer to keep the event loop alive while the
   // unref'd idle timer runs.
   await setTimeout(2000);
-  ok(clientEndpoint.destroyed,
-     'endpoint should be destroyed after idle timeout');
+  assert.ok(clientEndpoint.destroyed,
+            'endpoint should be destroyed after idle timeout');
 
   await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-endpoint-onsession-throws.mjs
+++ b/test/parallel/test-quic-endpoint-onsession-throws.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -35,7 +33,7 @@ const transportParams = { maxIdleTimeout: 1 };
   // a handler attached. The throw inside `onsession` is delivered
   // synchronously from the C++ -> JS callback, so the rejection can
   // arrive on the very next microtask after `connect()` returns.
-  const closedAssertion = rejects(serverEndpoint.closed, sessionError);
+  const closedAssertion = assert.rejects(serverEndpoint.closed, sessionError);
 
   const clientSession = await connect(serverEndpoint.address, {
     transportParams,
@@ -49,7 +47,7 @@ const transportParams = { maxIdleTimeout: 1 };
   // robust to network-dropped close packets and stops the event loop
   // from waiting on the client's idle timer to expire.
   clientSession.destroy();
-  await rejects(serverEndpoint.close(), sessionError);
+  await assert.rejects(serverEndpoint.close(), sessionError);
 }
 
 // -------------------------------------------------------------------
@@ -63,7 +61,7 @@ const transportParams = { maxIdleTimeout: 1 };
     throw sessionError;
   }), { transportParams, onerror() {} });
 
-  const closedAssertion = rejects(serverEndpoint.closed, sessionError);
+  const closedAssertion = assert.rejects(serverEndpoint.closed, sessionError);
 
   const clientSession = await connect(serverEndpoint.address, {
     transportParams,
@@ -72,5 +70,5 @@ const transportParams = { maxIdleTimeout: 1 };
   await closedAssertion;
 
   clientSession.destroy();
-  await rejects(serverEndpoint.close(), sessionError);
+  await assert.rejects(serverEndpoint.close(), sessionError);
 }

--- a/test/parallel/test-quic-endpoint-reuse.mjs
+++ b/test/parallel/test-quic-endpoint-reuse.mjs
@@ -12,8 +12,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, notStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -36,8 +34,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   // findSuitableEndpoint returns the first available non-listening
   // non-closing endpoint. After client1 is created, its endpoint
   // is available for client2.
-  strictEqual(client1.endpoint, client2.endpoint,
-              'client sessions should share an endpoint');
+  assert.strictEqual(client1.endpoint, client2.endpoint); // Client sessions should share an endpoint
 
   await client1.close();
   await client2.close();
@@ -60,8 +57,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   });
   await client2.opened;
 
-  notStrictEqual(client1.endpoint, client2.endpoint,
-                 'client sessions should have separate endpoints');
+  assert.notStrictEqual(client1.endpoint, client2.endpoint); // Client sessions should have separate endpoints
 
   await client1.close();
   await client2.close();
@@ -81,8 +77,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   // the server endpoint is in the registry. Self-connect is excluded
   // because the client's DCID associations would collide with the
   // server's session routing on the same endpoint.
-  notStrictEqual(client.endpoint, serverEndpoint,
-                 'client should not reuse the server endpoint');
+  assert.notStrictEqual(client.endpoint, serverEndpoint); // Client should not reuse the server endpoint
 
   await client.close();
   await serverEndpoint.close();

--- a/test/parallel/test-quic-endpoint-state-transitions.mjs
+++ b/test/parallel/test-quic-endpoint-state-transitions.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ if (!hasQuic) {
 const { listen, connect, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 {
   const endpoint = new QuicEndpoint();
@@ -36,9 +33,9 @@ const cert = readKey('agent1-cert.pem');
   });
 
   // After listen, the endpoint should be listening.
-  strictEqual(serverEndpoint.listening, true);
-  strictEqual(serverEndpoint.closing, false);
-  strictEqual(serverEndpoint.destroyed, false);
+  assert.strictEqual(serverEndpoint.listening, true);
+  assert.strictEqual(serverEndpoint.closing, false);
+  assert.strictEqual(serverEndpoint.destroyed, false);
 
   const cs = await connect(serverEndpoint.address, {
     alpn: 'quic-test',
@@ -50,10 +47,10 @@ const cert = readKey('agent1-cert.pem');
   // After close(), closing transitions to true. The endpoint is still
   // "listening" in the sense that it holds the socket, but closing is true.
   serverEndpoint.close();
-  strictEqual(serverEndpoint.closing, true);
+  assert.strictEqual(serverEndpoint.closing, true);
 
   await serverEndpoint.closed;
-  strictEqual(serverEndpoint.destroyed, true);
+  assert.strictEqual(serverEndpoint.destroyed, true);
 }
 
 // Binding to 0.0.0.0.
@@ -72,8 +69,8 @@ const cert = readKey('agent1-cert.pem');
   });
 
   const addr = serverEndpoint.address;
-  strictEqual(addr.address, '0.0.0.0');
-  ok(addr.port > 0);
+  assert.strictEqual(addr.address, '0.0.0.0');
+  assert.ok(addr.port > 0);
 
   // Connect via 127.0.0.1 since 0.0.0.0 listens on all interfaces.
   const cs = await connect(`127.0.0.1:${addr.port}`, {

--- a/test/parallel/test-quic-error-class.mjs
+++ b/test/parallel/test-quic-error-class.mjs
@@ -14,8 +14,6 @@
 import { hasQuic, skip } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, throws, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,63 +21,63 @@ if (!hasQuic) {
 const { QuicError } = await import('node:quic');
 
 // Sanity: QuicError is a function (class) and extends Error.
-strictEqual(typeof QuicError, 'function');
-ok(new QuicError('msg', { errorCode: 0n }) instanceof Error);
+assert.strictEqual(typeof QuicError, 'function');
+assert.ok(new QuicError('msg', { errorCode: 0n }) instanceof Error);
 
 // Required arguments.
 // `message` must be a string -> validateString throws ERR_INVALID_ARG_TYPE.
-throws(() => new QuicError(), { code: 'ERR_INVALID_ARG_TYPE' });
+assert.throws(() => new QuicError(), { code: 'ERR_INVALID_ARG_TYPE' });
 // `options` defaults to an empty object, so `errorCode` is missing.
-throws(() => new QuicError('msg'), { code: 'ERR_MISSING_ARGS' });
+assert.throws(() => new QuicError('msg'), { code: 'ERR_MISSING_ARGS' });
 // Explicit non-object options -> validateObject throws ERR_INVALID_ARG_TYPE.
-throws(() => new QuicError('msg', null), { code: 'ERR_INVALID_ARG_TYPE' });
+assert.throws(() => new QuicError('msg', null), { code: 'ERR_INVALID_ARG_TYPE' });
 // Empty options -> errorCode missing -> ERR_MISSING_ARGS.
-throws(() => new QuicError('msg', {}), { code: 'ERR_MISSING_ARGS' });
+assert.throws(() => new QuicError('msg', {}), { code: 'ERR_MISSING_ARGS' });
 
 // `message` must be a string.
-throws(() => new QuicError(42, { errorCode: 0n }), {
+assert.throws(() => new QuicError(42, { errorCode: 0n }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 
 // `errorCode` must be bigint or number.
-throws(() => new QuicError('msg', { errorCode: 'oops' }), {
+assert.throws(() => new QuicError('msg', { errorCode: 'oops' }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-throws(() => new QuicError('msg', { errorCode: true }), {
+assert.throws(() => new QuicError('msg', { errorCode: true }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 // `null` is preserved by destructuring (only `undefined` triggers the
 // default), so it flows through to the type check rather than the
 // missing-args check.
-throws(() => new QuicError('msg', { errorCode: null }), {
+assert.throws(() => new QuicError('msg', { errorCode: null }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 
 // `errorCode` range checks.
-throws(() => new QuicError('msg', { errorCode: -1 }), {
+assert.throws(() => new QuicError('msg', { errorCode: -1 }), {
   code: 'ERR_OUT_OF_RANGE',
 });
-throws(() => new QuicError('msg', { errorCode: -1n }), {
+assert.throws(() => new QuicError('msg', { errorCode: -1n }), {
   code: 'ERR_OUT_OF_RANGE',
 });
 // 2**62 is the first invalid value (max varint is 2**62 - 1).
-throws(() => new QuicError('msg', { errorCode: 1n << 62n }), {
+assert.throws(() => new QuicError('msg', { errorCode: 1n << 62n }), {
   code: 'ERR_OUT_OF_RANGE',
 });
 
 // `type` validation.
-throws(() => new QuicError('msg', { errorCode: 0n, type: 'bogus' }), {
+assert.throws(() => new QuicError('msg', { errorCode: 0n, type: 'bogus' }), {
   code: 'ERR_INVALID_ARG_VALUE',
 });
-throws(() => new QuicError('msg', { errorCode: 0n, type: 42 }), {
+assert.throws(() => new QuicError('msg', { errorCode: 0n, type: 42 }), {
   code: 'ERR_INVALID_ARG_VALUE',
 });
 
 // `code` (Node.js error code) must be a string when supplied.
-throws(() => new QuicError('msg', { errorCode: 0n, code: 42 }), {
+assert.throws(() => new QuicError('msg', { errorCode: 0n, code: 42 }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-throws(() => new QuicError('msg', { errorCode: 0n, code: null }), {
+assert.throws(() => new QuicError('msg', { errorCode: 0n, code: null }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 
@@ -88,32 +86,32 @@ throws(() => new QuicError('msg', { errorCode: 0n, code: null }), {
 // 1. Bigint errorCode, default type, default Node code.
 {
   const err = new QuicError('something broke', { errorCode: 0x42n });
-  strictEqual(err.message, 'something broke');
-  strictEqual(err.code, 'ERR_QUIC_STREAM_ABORTED');
-  strictEqual(err.errorCode, 0x42n);
-  strictEqual(err.type, 'application');
-  ok(err instanceof Error);
-  ok(err instanceof QuicError);
+  assert.strictEqual(err.message, 'something broke');
+  assert.strictEqual(err.code, 'ERR_QUIC_STREAM_ABORTED');
+  assert.strictEqual(err.errorCode, 0x42n);
+  assert.strictEqual(err.type, 'application');
+  assert.ok(err instanceof Error);
+  assert.ok(err instanceof QuicError);
 }
 
 // 2. Number errorCode, coerced to bigint.
 {
   const err = new QuicError('numeric code', { errorCode: 5 });
-  strictEqual(err.errorCode, 5n);
-  strictEqual(typeof err.errorCode, 'bigint');
+  assert.strictEqual(err.errorCode, 5n);
+  assert.strictEqual(typeof err.errorCode, 'bigint');
 }
 
 // 3. Boundary: 0n is allowed.
 {
   const err = new QuicError('zero', { errorCode: 0n });
-  strictEqual(err.errorCode, 0n);
+  assert.strictEqual(err.errorCode, 0n);
 }
 
 // 4. Boundary: 2**62 - 1 is allowed (largest valid 62-bit varint).
 {
   const max = (1n << 62n) - 1n;
   const err = new QuicError('max', { errorCode: max });
-  strictEqual(err.errorCode, max);
+  assert.strictEqual(err.errorCode, max);
 }
 
 // 5. Explicit type='transport'.
@@ -122,7 +120,7 @@ throws(() => new QuicError('msg', { errorCode: 0n, code: null }), {
     errorCode: 0x1n,
     type: 'transport',
   });
-  strictEqual(err.type, 'transport');
+  assert.strictEqual(err.type, 'transport');
 }
 
 // 6. Explicit type='application' (default).
@@ -131,7 +129,7 @@ throws(() => new QuicError('msg', { errorCode: 0n, code: null }), {
     errorCode: 0x102n,
     type: 'application',
   });
-  strictEqual(err.type, 'application');
+  assert.strictEqual(err.type, 'application');
 }
 
 // 7. Custom Node.js error code string via options.code.
@@ -140,8 +138,8 @@ throws(() => new QuicError('msg', { errorCode: 0n, code: null }), {
     errorCode: 0x10cn,
     code: 'ERR_CUSTOM_QUIC_FAILURE',
   });
-  strictEqual(err.code, 'ERR_CUSTOM_QUIC_FAILURE');
-  strictEqual(err.errorCode, 0x10cn);
+  assert.strictEqual(err.code, 'ERR_CUSTOM_QUIC_FAILURE');
+  assert.strictEqual(err.errorCode, 0x10cn);
 }
 
 // 8. Properties are read-only via getters (errorCode, type backed by
@@ -153,8 +151,8 @@ throws(() => new QuicError('msg', { errorCode: 0n, code: null }), {
   // The getters live on the prototype; assigning through the instance
   // is silently ignored in non-strict mode (modules are strict, so
   // this throws TypeError). We just assert the value is unchanged.
-  throws(() => { err.errorCode = 0xffn; }, { name: 'TypeError' });
-  throws(() => { err.type = 'transport'; }, { name: 'TypeError' });
-  strictEqual(err.errorCode, 0x1n);
-  strictEqual(err.type, 'application');
+  assert.throws(() => { err.errorCode = 0xffn; }, { name: 'TypeError' });
+  assert.throws(() => { err.type = 'transport'; }, { name: 'TypeError' });
+  assert.strictEqual(err.errorCode, 0x1n);
+  assert.strictEqual(err.type, 'application');
 }

--- a/test/parallel/test-quic-error-destroy-rejects-promises.mjs
+++ b/test/parallel/test-quic-error-destroy-rejects-promises.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -35,8 +33,8 @@ const serverEndpoint = await listen(async (serverSession) => {
   clientSession.destroy(testError);
 
   // Both opened and closed should reject with the same error.
-  await rejects(clientSession.opened, testError);
-  await rejects(clientSession.closed, testError);
+  await assert.rejects(clientSession.opened, testError);
+  await assert.rejects(clientSession.closed, testError);
 }
 
 // Second client: destroy AFTER the handshake completes.
@@ -53,7 +51,7 @@ const serverEndpoint = await listen(async (serverSession) => {
   await clientSession.opened;
 
   // Closed rejects with the error.
-  await rejects(clientSession.closed, testError);
+  await assert.rejects(clientSession.closed, testError);
 }
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-exports-constants.mjs
+++ b/test/parallel/test-quic-exports-constants.mjs
@@ -5,8 +5,6 @@
 import { hasQuic, skip } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, throws, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -14,36 +12,36 @@ if (!hasQuic) {
 const quic = await import('node:quic');
 
 // Top-level exports.
-strictEqual(typeof quic.listen, 'function');
-strictEqual(typeof quic.connect, 'function');
-strictEqual(typeof quic.QuicEndpoint, 'function');
-strictEqual(typeof quic.QuicSession, 'function');
-strictEqual(typeof quic.QuicStream, 'function');
-strictEqual(typeof quic.constants, 'object');
+assert.strictEqual(typeof quic.listen, 'function');
+assert.strictEqual(typeof quic.connect, 'function');
+assert.strictEqual(typeof quic.QuicEndpoint, 'function');
+assert.strictEqual(typeof quic.QuicSession, 'function');
+assert.strictEqual(typeof quic.QuicStream, 'function');
+assert.strictEqual(typeof quic.constants, 'object');
 
 // Congestion control constants.
-strictEqual(quic.constants.cc.RENO, 'reno');
-strictEqual(quic.constants.cc.CUBIC, 'cubic');
-strictEqual(quic.constants.cc.BBR, 'bbr');
+assert.strictEqual(quic.constants.cc.RENO, 'reno');
+assert.strictEqual(quic.constants.cc.CUBIC, 'cubic');
+assert.strictEqual(quic.constants.cc.BBR, 'bbr');
 
 // DEFAULT_CIPHERS.
-strictEqual(typeof quic.constants.DEFAULT_CIPHERS, 'string');
-ok(quic.constants.DEFAULT_CIPHERS.length > 0);
-ok(quic.constants.DEFAULT_CIPHERS.includes('TLS_AES_128_GCM_SHA256'));
+assert.strictEqual(typeof quic.constants.DEFAULT_CIPHERS, 'string');
+assert.ok(quic.constants.DEFAULT_CIPHERS.length > 0);
+assert.ok(quic.constants.DEFAULT_CIPHERS.includes('TLS_AES_128_GCM_SHA256'));
 
 // DEFAULT_GROUPS.
-strictEqual(typeof quic.constants.DEFAULT_GROUPS, 'string');
-ok(quic.constants.DEFAULT_GROUPS.length > 0);
+assert.strictEqual(typeof quic.constants.DEFAULT_GROUPS, 'string');
+assert.ok(quic.constants.DEFAULT_GROUPS.length > 0);
 
 // QuicEndpoint can be constructed directly.
 // QuicSession and QuicStream cannot — they throw ERR_ILLEGAL_CONSTRUCTOR.
 {
   const ep = new quic.QuicEndpoint();
-  ok(ep instanceof quic.QuicEndpoint);
+  assert.ok(ep instanceof quic.QuicEndpoint);
 }
-throws(() => new quic.QuicSession(), {
+assert.throws(() => new quic.QuicSession(), {
   code: 'ERR_ILLEGAL_CONSTRUCTOR',
 });
-throws(() => new quic.QuicStream(), {
+assert.throws(() => new quic.QuicStream(), {
   code: 'ERR_ILLEGAL_CONSTRUCTOR',
 });

--- a/test/parallel/test-quic-exports.mjs
+++ b/test/parallel/test-quic-exports.mjs
@@ -2,8 +2,6 @@
 import { hasQuic, skip } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -11,29 +9,29 @@ if (!hasQuic) {
 const quic = await import('node:quic');
 
 // Test that the main exports exist and are of the correct type.
-strictEqual(typeof quic.connect, 'function');
-strictEqual(typeof quic.listen, 'function');
-strictEqual(typeof quic.QuicEndpoint, 'function');
-strictEqual(typeof quic.QuicSession, 'function');
-strictEqual(typeof quic.QuicStream, 'function');
-strictEqual(typeof quic.QuicEndpoint.Stats, 'function');
-strictEqual(typeof quic.QuicSession.Stats, 'function');
-strictEqual(typeof quic.QuicStream.Stats, 'function');
-strictEqual(typeof quic.constants, 'object');
-strictEqual(typeof quic.constants.cc, 'object');
+assert.strictEqual(typeof quic.connect, 'function');
+assert.strictEqual(typeof quic.listen, 'function');
+assert.strictEqual(typeof quic.QuicEndpoint, 'function');
+assert.strictEqual(typeof quic.QuicSession, 'function');
+assert.strictEqual(typeof quic.QuicStream, 'function');
+assert.strictEqual(typeof quic.QuicEndpoint.Stats, 'function');
+assert.strictEqual(typeof quic.QuicSession.Stats, 'function');
+assert.strictEqual(typeof quic.QuicStream.Stats, 'function');
+assert.strictEqual(typeof quic.constants, 'object');
+assert.strictEqual(typeof quic.constants.cc, 'object');
 
 // Test that the constants exist and are of the correct type.
-strictEqual(quic.constants.cc.RENO, 'reno');
-strictEqual(quic.constants.cc.CUBIC, 'cubic');
-strictEqual(quic.constants.cc.BBR, 'bbr');
-strictEqual(quic.constants.DEFAULT_CIPHERS,
-            'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:' +
+assert.strictEqual(quic.constants.cc.RENO, 'reno');
+assert.strictEqual(quic.constants.cc.CUBIC, 'cubic');
+assert.strictEqual(quic.constants.cc.BBR, 'bbr');
+assert.strictEqual(quic.constants.DEFAULT_CIPHERS,
+                   'TLS_AES_128_GCM_SHA256:TLS_AES_256_GCM_SHA384:' +
             'TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_CCM_SHA256');
-strictEqual(quic.constants.DEFAULT_GROUPS, 'X25519:P-256:P-384:P-521');
+assert.strictEqual(quic.constants.DEFAULT_GROUPS, 'X25519:P-256:P-384:P-521');
 
 // Ensure the constants are.. well, constant.
-throws(() => { quic.constants.cc.RENO = 'foo'; }, TypeError);
-strictEqual(quic.constants.cc.RENO, 'reno');
+assert.throws(() => { quic.constants.cc.RENO = 'foo'; }, TypeError);
+assert.strictEqual(quic.constants.cc.RENO, 'reno');
 
-throws(() => { quic.constants.DEFAULT_CIPHERS = 123; }, TypeError);
-strictEqual(typeof quic.constants.DEFAULT_CIPHERS, 'string');
+assert.throws(() => { quic.constants.DEFAULT_CIPHERS = 123; }, TypeError);
+assert.strictEqual(typeof quic.constants.DEFAULT_CIPHERS, 'string');

--- a/test/parallel/test-quic-flow-control-blob.mjs
+++ b/test/parallel/test-quic-flow-control-blob.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,7 +25,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    deepStrictEqual(received, data);
+    assert.deepStrictEqual(received, data);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-flow-control-block-resume.mjs
+++ b/test/parallel/test-quic-flow-control-block-resume.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,7 +26,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     // Read all data — this extends the flow control window.
     const received = await bytes(stream);
-    strictEqual(received.byteLength, dataLength);
+    assert.strictEqual(received.byteLength, dataLength);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-flow-control-params.mjs
+++ b/test/parallel/test-quic-flow-control-params.mjs
@@ -13,8 +13,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -35,7 +33,7 @@ const encoder = new TextEncoder();
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const received = await bytes(stream);
-      strictEqual(received.byteLength, expected.byteLength);
+      assert.strictEqual(received.byteLength, expected.byteLength);
       stream.writer.endSync();
       await stream.closed;
       serverSession.close();

--- a/test/parallel/test-quic-flow-control-uni.mjs
+++ b/test/parallel/test-quic-flow-control-uni.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,7 +24,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(received.byteLength, expected.byteLength);
+    assert.strictEqual(received.byteLength, expected.byteLength);
     await stream.closed;
     serverSession.close();
     serverDone.resolve();

--- a/test/parallel/test-quic-h3-callback-errors.mjs
+++ b/test/parallel/test-quic-h3-callback-errors.mjs
@@ -11,9 +11,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -21,8 +18,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 
 async function makeServer(onheadersHandler, extraOpts = {}) {
@@ -73,11 +70,11 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
     }),
   });
 
-  await rejects(s.closed, mustCall((err) => {
-    strictEqual(err.message, 'onheaders sync error');
+  await assert.rejects(s.closed, mustCall((err) => {
+    assert.strictEqual(err.message, 'onheaders sync error');
     return true;
   }));
-  strictEqual(s.destroyed, true);
+  assert.strictEqual(s.destroyed, true);
 
   c.close();
   await done.promise;
@@ -113,11 +110,11 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
     }),
   });
 
-  await rejects(s.closed, mustCall((err) => {
-    strictEqual(err.message, 'onheaders async error');
+  await assert.rejects(s.closed, mustCall((err) => {
+    assert.strictEqual(err.message, 'onheaders async error');
     return true;
   }));
-  strictEqual(s.destroyed, true);
+  assert.strictEqual(s.destroyed, true);
 
   c.close();
   await done.promise;
@@ -154,18 +151,18 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
     ontrailers: mustCall(function() {
       throw new Error('ontrailers sync error');
     }),
   });
 
-  await rejects(s.closed, mustCall((err) => {
-    strictEqual(err.message, 'ontrailers sync error');
+  await assert.rejects(s.closed, mustCall((err) => {
+    assert.strictEqual(err.message, 'ontrailers sync error');
     return true;
   }));
-  strictEqual(s.destroyed, true);
+  assert.strictEqual(s.destroyed, true);
 
   c.close();
   await done.promise;
@@ -196,7 +193,7 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
       throw new Error('onorigin error');
     }),
     onerror: mustCall(function(error) {
-      strictEqual(error.message, 'onorigin error');
+      assert.strictEqual(error.message, 'onorigin error');
     }),
   });
   await clientSession.opened;
@@ -212,12 +209,12 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
 
   // The session is destroyed by the callback error, which
   // destroys the stream with the same error.
-  await rejects(stream.closed, mustCall((err) => {
-    strictEqual(err.message, 'onorigin error');
+  await assert.rejects(stream.closed, mustCall((err) => {
+    assert.strictEqual(err.message, 'onorigin error');
     return true;
   }));
 
-  await rejects(clientSession.closed, mustCall(() => true));
+  await assert.rejects(clientSession.closed, mustCall(() => true));
 
   serverEndpoint.close();
 }
@@ -232,8 +229,8 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
   const serverEndpoint = await listen(mustCall(async (ss) => {
     ss.onstream = mustCall(async (stream) => {
       // The server stream rejects because onwanttrailers threw.
-      await rejects(stream.closed, mustCall((err) => {
-        strictEqual(err.message, 'onwanttrailers error');
+      await assert.rejects(stream.closed, mustCall((err) => {
+        assert.strictEqual(err.message, 'onwanttrailers error');
         serverStreamRejected.resolve();
         return true;
       }));
@@ -268,7 +265,7 @@ async function makeServer(onheadersHandler, extraOpts = {}) {
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 

--- a/test/parallel/test-quic-h3-close-behavior.mjs
+++ b/test/parallel/test-quic-h3-close-behavior.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const decoder = new TextDecoder();
 
 // Two streams. The graceful close waits for both streams to complete,
@@ -65,7 +62,7 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall((headers) => {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
@@ -77,14 +74,14 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall((headers) => {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   // Both streams should complete normally despite the close.
   const bodies = await Promise.all([bytes(stream1), bytes(stream2)]);
-  strictEqual(decoder.decode(bodies[0]), '/one');
-  strictEqual(decoder.decode(bodies[1]), '/two');
+  assert.strictEqual(decoder.decode(bodies[0]), '/one');
+  assert.strictEqual(decoder.decode(bodies[1]), '/two');
 
   await Promise.all([stream1.closed,
                      stream2.closed,

--- a/test/parallel/test-quic-h3-concurrent-requests.mjs
+++ b/test/parallel/test-quic-h3-concurrent-requests.mjs
@@ -12,9 +12,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,8 +20,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const decoder = new TextDecoder();
 
@@ -75,7 +72,7 @@ const requests = paths.map(mustCall(async (path) => {
       ':authority': 'localhost',
     },
     onheaders: mustCall((headers) => {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
       headersReceived.resolve();
     }),
   });
@@ -83,7 +80,7 @@ const requests = paths.map(mustCall(async (path) => {
   await headersReceived.promise;
   const body = await bytes(stream);
   const text = decoder.decode(body);
-  strictEqual(text, `response for ${path}`);
+  assert.strictEqual(text, `response for ${path}`);
   await stream.closed;
 }, REQUEST_COUNT));
 

--- a/test/parallel/test-quic-h3-datagram.mjs
+++ b/test/parallel/test-quic-h3-datagram.mjs
@@ -10,9 +10,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { ok, strictEqual } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -23,8 +20,8 @@ const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 const { setTimeout: sleep } = await import('timers/promises');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const decoder = new TextDecoder();
 
 // Test 1: H3 datagrams with enableDatagrams: true on both sides.
@@ -48,11 +45,11 @@ const decoder = new TextDecoder();
     transportParams: { maxDatagramFrameSize: 100 },
     // Server echoes received datagram back to client.
     ondatagram: mustCall(function(data) {
-      ok(data instanceof Uint8Array);
-      strictEqual(data.byteLength, 3);
-      strictEqual(data[0], 10);
-      strictEqual(data[1], 20);
-      strictEqual(data[2], 30);
+      assert.ok(data instanceof Uint8Array);
+      assert.strictEqual(data.byteLength, 3);
+      assert.strictEqual(data[0], 10);
+      assert.strictEqual(data[1], 20);
+      assert.strictEqual(data[2], 30);
       // Echo it back.
       this.sendDatagram(new Uint8Array([42, 43, 44]));
       serverGotDatagram.resolve();
@@ -71,11 +68,11 @@ const decoder = new TextDecoder();
     transportParams: { maxDatagramFrameSize: 100 },
     // Client receives datagram from server.
     ondatagram: mustCall(function(data) {
-      ok(data instanceof Uint8Array);
-      strictEqual(data.byteLength, 3);
-      strictEqual(data[0], 42);
-      strictEqual(data[1], 43);
-      strictEqual(data[2], 44);
+      assert.ok(data instanceof Uint8Array);
+      assert.strictEqual(data.byteLength, 3);
+      assert.strictEqual(data[0], 42);
+      assert.strictEqual(data[1], 43);
+      assert.strictEqual(data[2], 44);
       clientGotDatagram.resolve();
     }),
   });
@@ -90,7 +87,7 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
@@ -99,7 +96,7 @@ const decoder = new TextDecoder();
 
   // H3 response body is received.
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
   await stream.closed;
 
   // Both sides received their datagram.
@@ -154,7 +151,7 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall((headers) => {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
@@ -162,12 +159,12 @@ const decoder = new TextDecoder();
   // SETTINGS (with h3_datagram=0) arrive, the client should know
   // the peer doesn't support H3 datagrams.
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'no-dgram');
+  assert.strictEqual(decoder.decode(body), 'no-dgram');
 
   // Attempt to send a datagram. Since the peer's H3 SETTINGS
   // indicate h3_datagram=0, this should return 0 (not sent).
   const dgId = await clientSession.sendDatagram(new Uint8Array([1, 2, 3]));
-  strictEqual(dgId, 0n);
+  assert.strictEqual(dgId, 0n);
 
   await Promise.all([stream.closed, serverDone.promise]);
   clientSession.close();

--- a/test/parallel/test-quic-h3-error-codes.mjs
+++ b/test/parallel/test-quic-h3-error-codes.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const decoder = new TextDecoder();
 
 // Server closes with explicit application error code.
@@ -58,16 +55,16 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
   await Promise.all([stream.closed, serverDone.promise]);
 
   // Client sees the application error code.
-  await rejects(clientSession.closed, {
+  await assert.rejects(clientSession.closed, {
     code: 'ERR_QUIC_APPLICATION_ERROR',
   });
 
@@ -109,12 +106,12 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
   await stream.closed;
 
   // Graceful close - session close promise resolves

--- a/test/parallel/test-quic-h3-goaway-non-h3.mjs
+++ b/test/parallel/test-quic-h3-goaway-non-h3.mjs
@@ -9,9 +9,6 @@ import assert from 'node:assert';
 import { setImmediate } from 'node:timers/promises';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,8 +17,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -31,7 +28,7 @@ const serverEndpoint = await listen(mustCall(async (ss) => {
   ss.onstream = mustCall(async (stream) => {
     // Read client data, send response, close stream.
     const data = await bytes(stream);
-    strictEqual(decoder.decode(data), 'ping');
+    assert.strictEqual(decoder.decode(data), 'ping');
     stream.writer.writeSync('pong');
     stream.writer.endSync();
     await stream.closed;
@@ -57,7 +54,7 @@ const stream = await clientSession.createBidirectionalStream({
 });
 
 const response = await bytes(stream);
-strictEqual(decoder.decode(response), 'pong');
+assert.strictEqual(decoder.decode(response), 'pong');
 await Promise.all([stream.closed, serverDone.promise]);
 
 // Wait a tick for any deferred callbacks to fire.

--- a/test/parallel/test-quic-h3-goaway.mjs
+++ b/test/parallel/test-quic-h3-goaway.mjs
@@ -14,9 +14,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { ok, strictEqual, rejects } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -26,15 +23,15 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
 // quic.session.goaway fires when the peer sends GOAWAY.
 dc.subscribe('quic.session.goaway', mustCall((msg) => {
-  ok(msg.session, 'goaway should include session');
-  strictEqual(typeof msg.lastStreamId, 'bigint', 'goaway should include lastStreamId');
+  assert.ok(msg.session, 'goaway should include session');
+  assert.strictEqual(typeof msg.lastStreamId, 'bigint'); // `goaway` should include lastStreamId
 }));
 
 {
@@ -74,14 +71,14 @@ dc.subscribe('quic.session.goaway', mustCall((msg) => {
     verifyPeer: 'manual',
     // Ongoaway fires when the peer sends GOAWAY.
     ongoaway: mustCall(function(lastStreamId) {
-      strictEqual(lastStreamId, -1n);
+      assert.strictEqual(lastStreamId, -1n);
       goawayReceived.resolve();
     }),
   });
   await clientSession.opened;
 
   const onClientHeaders = mustCall(function(headers) {
-    strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers[':status'], '200');
     if (++clientHeaderCount === 2) {
       bothHeadersReceived.resolve();
     }
@@ -109,7 +106,7 @@ dc.subscribe('quic.session.goaway', mustCall((msg) => {
 
   // First stream completes immediately.
   const body1 = await bytes(stream1);
-  strictEqual(decoder.decode(body1), 'first');
+  assert.strictEqual(decoder.decode(body1), 'first');
 
   // Wait for both streams' headers to arrive on the client, confirming
   // the server has processed both requests.
@@ -124,7 +121,7 @@ dc.subscribe('quic.session.goaway', mustCall((msg) => {
   await goawayReceived.promise;
 
   // After GOAWAY, new stream creation should fail.
-  await rejects(
+  await assert.rejects(
     clientSession.createBidirectionalStream({
       headers: {
         ':method': 'GET',
@@ -141,7 +138,7 @@ dc.subscribe('quic.session.goaway', mustCall((msg) => {
 
   // Second stream also completes despite GOAWAY.
   const body2 = await bytes(stream2);
-  strictEqual(decoder.decode(body2), 'second');
+  assert.strictEqual(decoder.decode(body2), 'second');
 
   // Both streams close cleanly.
   await Promise.all([stream1.closed, stream2.closed]);

--- a/test/parallel/test-quic-h3-handshake-failure.mjs
+++ b/test/parallel/test-quic-h3-handshake-failure.mjs
@@ -16,8 +16,6 @@ import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 import { setTimeout } from 'node:timers/promises';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,8 +23,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const serverEndpoint = await listen(async (serverSession) => {
   await serverSession.closed;

--- a/test/parallel/test-quic-h3-header-validation.mjs
+++ b/test/parallel/test-quic-h3-header-validation.mjs
@@ -17,9 +17,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, ok } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,8 +25,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const decoder = new TextDecoder();
 
 // H3V-01: Header names are lowercased on send.
@@ -50,19 +47,19 @@ const decoder = new TextDecoder();
       // H3V-01: All header names should be lowercase regardless
       // of how the client sent them.
       for (const name of Object.keys(headers)) {
-        strictEqual(name, name.toLowerCase(),
-                    `Header name "${name}" should be lowercase`);
+        assert.strictEqual(name, name.toLowerCase(),
+                           `Header name "${name}" should be lowercase`);
       }
 
       // Verify specific headers arrived lowercased.
-      strictEqual(headers[':method'], 'GET');
-      strictEqual(headers[':path'], '/test');
-      strictEqual(headers['x-custom-header'], 'Value1');
-      strictEqual(headers['content-type'], 'text/plain');
-      strictEqual(headers['x-mixed-case'], 'MixedValue');
+      assert.strictEqual(headers[':method'], 'GET');
+      assert.strictEqual(headers[':path'], '/test');
+      assert.strictEqual(headers['x-custom-header'], 'Value1');
+      assert.strictEqual(headers['content-type'], 'text/plain');
+      assert.strictEqual(headers['x-mixed-case'], 'MixedValue');
 
       // Verify values are NOT lowercased — only names are.
-      strictEqual(headers['x-custom-header'], 'Value1');
+      assert.strictEqual(headers['x-custom-header'], 'Value1');
 
       this.sendHeaders({
         // Response with mixed-case names — should be lowercased.
@@ -94,20 +91,20 @@ const decoder = new TextDecoder();
     },
     onheaders: mustCall(function(headers) {
       // Client should also receive lowercased response header names.
-      strictEqual(headers[':status'], '200');
-      strictEqual(headers['content-type'], 'text/html');
-      strictEqual(headers['x-response-header'], 'ResponseValue');
+      assert.strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers['content-type'], 'text/html');
+      assert.strictEqual(headers['x-response-header'], 'ResponseValue');
 
       // Verify all names are lowercase.
       for (const name of Object.keys(headers)) {
-        strictEqual(name, name.toLowerCase(),
-                    `Response header name "${name}" should be lowercase`);
+        assert.strictEqual(name, name.toLowerCase(),
+                           `Response header name "${name}" should be lowercase`);
       }
     }),
   });
 
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
   await Promise.all([stream.closed, serverDone.promise]);
   await clientSession.close();
   await serverEndpoint.close();
@@ -127,10 +124,10 @@ const decoder = new TextDecoder();
     sni: { '*': { keys: [key], certs: [cert] } },
     onheaders: mustCall(function(headers) {
       // All four required pseudo-headers present.
-      ok(headers[':method']);
-      ok(headers[':path']);
-      ok(headers[':scheme']);
-      ok(headers[':authority']);
+      assert.ok(headers[':method']);
+      assert.ok(headers[':path']);
+      assert.ok(headers[':scheme']);
+      assert.ok(headers[':authority']);
 
       this.sendHeaders({ ':status': '204' });
       this.writer.endSync();
@@ -151,7 +148,7 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall((headers) => {
-      strictEqual(headers[':status'], '204');
+      assert.strictEqual(headers[':status'], '204');
     }),
   });
 

--- a/test/parallel/test-quic-h3-headers-support.mjs
+++ b/test/parallel/test-quic-h3-headers-support.mjs
@@ -8,9 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { throws } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -19,35 +16,35 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 
 const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     // Sending headers on non-H3 stream throws.
-    throws(() => stream.sendHeaders({ ':status': '200' }), { code: 'ERR_INVALID_STATE' });
+    assert.throws(() => stream.sendHeaders({ ':status': '200' }), { code: 'ERR_INVALID_STATE' });
 
     // Setting onheaders on non-H3 stream throws.
-    throws(() => stream.onheaders = () => {}, { code: 'ERR_INVALID_STATE' });
+    assert.throws(() => stream.onheaders = () => {}, { code: 'ERR_INVALID_STATE' });
 
     // Setting ontrailers on non-H3 stream throws.
-    throws(() => stream.ontrailers = () => {}, { code: 'ERR_INVALID_STATE' });
+    assert.throws(() => stream.ontrailers = () => {}, { code: 'ERR_INVALID_STATE' });
 
     // Setting oninfo on non-H3 stream throws.
-    throws(() => stream.oninfo = () => {}, { code: 'ERR_INVALID_STATE' });
+    assert.throws(() => stream.oninfo = () => {}, { code: 'ERR_INVALID_STATE' });
 
     // Setting onwanttrailers on non-H3 stream throws.
-    throws(() => stream.onwanttrailers = () => {}, { code: 'ERR_INVALID_STATE' });
+    assert.throws(() => stream.onwanttrailers = () => {}, { code: 'ERR_INVALID_STATE' });
 
     // sendInformationalHeaders throws on non-H3.
-    throws(() => stream.sendInformationalHeaders({ ':status': '103' }), {
+    assert.throws(() => stream.sendInformationalHeaders({ ':status': '103' }), {
       code: 'ERR_INVALID_STATE',
     });
 
     // sendTrailers throws on non-H3.
-    throws(() => stream.sendTrailers({ 'x-trailer': 'value' }), { code: 'ERR_INVALID_STATE' });
+    assert.throws(() => stream.sendTrailers({ 'x-trailer': 'value' }), { code: 'ERR_INVALID_STATE' });
 
     stream.writer.endSync();
 
@@ -71,7 +68,7 @@ const stream = await clientSession.createBidirectionalStream({
 });
 
 // Client side — sending headers on non-H3 stream throws.
-throws(() => stream.sendHeaders({ ':method': 'GET' }), { code: 'ERR_INVALID_STATE' });
+assert.throws(() => stream.sendHeaders({ ':method': 'GET' }), { code: 'ERR_INVALID_STATE' });
 
 await serverDone.promise;
 await clientSession.close();

--- a/test/parallel/test-quic-h3-informational-headers.mjs
+++ b/test/parallel/test-quic-h3-informational-headers.mjs
@@ -15,9 +15,6 @@ import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,24 +23,24 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const decoder = new TextDecoder();
 const responseBody = 'final response';
 
 // quic.stream.info fires when informational (1xx) headers are received.
 dc.subscribe('quic.stream.info', mustCall((msg) => {
-  ok(msg.stream, 'stream.info should include stream');
-  ok(msg.session, 'stream.info should include session');
-  ok(msg.headers, 'stream.info should include headers');
-  strictEqual(msg.headers[':status'], '103');
+  assert.ok(msg.stream, 'stream.info should include stream');
+  assert.ok(msg.session, 'stream.info should include session');
+  assert.ok(msg.headers, 'stream.info should include headers');
+  assert.strictEqual(msg.headers[':status'], '103');
 }));
 
 // quic.stream.headers also fires for the final response headers.
 dc.subscribe('quic.stream.headers', mustCall((msg) => {
-  ok(msg.stream, 'stream.headers should include stream');
-  ok(msg.headers, 'stream.headers should include headers');
+  assert.ok(msg.stream, 'stream.headers should include stream');
+  assert.ok(msg.headers, 'stream.headers should include headers');
 }, 2));
 
 const serverDone = Promise.withResolvers();
@@ -92,13 +89,13 @@ const stream = await clientSession.createBidirectionalStream({
     ':authority': 'localhost',
   },
   oninfo: mustCall(function(headers) {
-    strictEqual(headers[':status'], '103');
-    strictEqual(headers.link, '</style.css>; rel=preload; as=style');
+    assert.strictEqual(headers[':status'], '103');
+    assert.strictEqual(headers.link, '</style.css>; rel=preload; as=style');
     clientInfoReceived.resolve();
   }),
   onheaders: mustCall(function(headers) {
-    strictEqual(headers[':status'], '200');
-    strictEqual(headers['content-type'], 'text/plain');
+    assert.strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers['content-type'], 'text/plain');
     clientHeadersReceived.resolve();
   }),
 });
@@ -107,10 +104,10 @@ await Promise.all([clientInfoReceived.promise, clientHeadersReceived.promise]);
 
 // Read the response body.
 const body = await bytes(stream);
-strictEqual(decoder.decode(body), responseBody);
+assert.strictEqual(decoder.decode(body), responseBody);
 
 // stream.headers should return the final (initial) headers, not 1xx.
-strictEqual(stream.headers[':status'], '200');
+assert.strictEqual(stream.headers[':status'], '200');
 
 await Promise.all([stream.closed, serverDone.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-h3-origin.mjs
+++ b/test/parallel/test-quic-h3-origin.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, ok } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,8 +17,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -58,15 +55,15 @@ const decoder = new TextDecoder();
     verifyPeer: 'manual',
     // Client receives ORIGIN frame via onorigin callback.
     onorigin: mustCall(function(origins) {
-      ok(Array.isArray(origins));
+      assert.ok(Array.isArray(origins));
       // The origins should include the specific SNI hostnames.
-      ok(origins.length >= 2);
+      assert.ok(origins.length >= 2);
       // The wildcard (*) should NOT be in the list.
       const originStrings = origins.join(',');
-      ok(originStrings.includes('example.com'), 'should include example.com');
-      ok(originStrings.includes('api.example.com'),
-         'should include api.example.com');
-      ok(!originStrings.includes('*'), 'should not include wildcard');
+      assert.ok(originStrings.includes('example.com'), 'should include example.com');
+      assert.ok(originStrings.includes('api.example.com'),
+                'should include api.example.com');
+      assert.ok(!originStrings.includes('*'), 'should not include wildcard');
       originReceived.resolve();
     }),
   });
@@ -80,12 +77,12 @@ const decoder = new TextDecoder();
       ':authority': 'example.com',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
 
   await Promise.all([originReceived.promise, stream.closed, serverDone.promise]);
   await clientSession.close();
@@ -135,33 +132,33 @@ const decoder = new TextDecoder();
     servername: 'custom-port.example.com',
     verifyPeer: 'manual',
     onorigin: mustCall(function(origins) {
-      ok(Array.isArray(origins));
+      assert.ok(Array.isArray(origins));
 
       // Custom port included in origin string.
-      ok(origins.includes('https://custom-port.example.com:8443'),
-         'should include origin with custom port');
+      assert.ok(origins.includes('https://custom-port.example.com:8443'),
+                'should include origin with custom port');
 
       // Default port 443 omitted from origin string.
-      ok(origins.includes('https://default-port.example.com'),
-         'should include origin without port for 443');
+      assert.ok(origins.includes('https://default-port.example.com'),
+                'should include origin without port for 443');
       // Verify port 443 is NOT appended.
       const defaultPortOrigin = origins.find((o) =>
         o.includes('default-port.example.com'));
-      ok(!defaultPortOrigin.includes(':443'),
-         'default port 443 should be omitted');
+      assert.ok(!defaultPortOrigin.includes(':443'),
+                'default port 443 should be omitted');
 
       // Non-authoritative entry excluded.
       const allOrigins = origins.join(',');
-      ok(!allOrigins.includes('not-authoritative'),
-         'non-authoritative entry should be excluded');
+      assert.ok(!allOrigins.includes('not-authoritative'),
+                'non-authoritative entry should be excluded');
 
       // Explicitly authoritative entry included.
-      ok(allOrigins.includes('authoritative.example.com'),
-         'explicitly authoritative entry should be included');
+      assert.ok(allOrigins.includes('authoritative.example.com'),
+                'explicitly authoritative entry should be included');
 
       // Default authoritative (true when omitted) included.
-      ok(allOrigins.includes('default-auth.example.com'),
-         'default authoritative entry should be included');
+      assert.ok(allOrigins.includes('default-auth.example.com'),
+                'default authoritative entry should be included');
 
       originReceived.resolve();
     }),
@@ -176,12 +173,12 @@ const decoder = new TextDecoder();
       ':authority': 'custom-port.example.com',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
 
   await Promise.all([originReceived.promise, stream.closed, serverDone.promise]);
   await clientSession.close();

--- a/test/parallel/test-quic-h3-pending-stream.mjs
+++ b/test/parallel/test-quic-h3-pending-stream.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, deepStrictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -40,8 +37,8 @@ const decoder = new TextDecoder();
     onheaders: mustCall(function(headers) {
       // Headers were enqueued before the stream opened
       // and should arrive correctly.
-      strictEqual(headers[':method'], 'GET');
-      strictEqual(headers[':path'], '/pending');
+      assert.strictEqual(headers[':method'], 'GET');
+      assert.strictEqual(headers[':path'], '/pending');
 
       this.sendHeaders({ ':status': '200' });
       this.writer.writeSync(encoder.encode('ok'));
@@ -67,22 +64,22 @@ const decoder = new TextDecoder();
     priority: 'high',
     incremental: true,
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   // Priority should reflect what was set even while pending.
-  deepStrictEqual(stream.priority, { level: 'high', incremental: true });
+  assert.deepStrictEqual(stream.priority, { level: 'high', incremental: true });
 
   // Now wait for the handshake.
   await clientSession.opened;
 
   // Priority persists after stream opens.
-  deepStrictEqual(stream.priority, { level: 'high', incremental: true });
+  assert.deepStrictEqual(stream.priority, { level: 'high', incremental: true });
 
   // Headers were sent and server responded.
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
   await Promise.all([stream.closed, serverDone.promise]);
   await clientSession.close();
   await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-post-filehandle.mjs
+++ b/test/parallel/test-quic-h3-post-filehandle.mjs
@@ -13,9 +13,6 @@ import { open } from 'node:fs/promises';
 
 const tmpdir = await import('../common/tmpdir.js');
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,8 +21,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const decoder = new TextDecoder();
 const testContent = 'Hello from a file!\nLine two.\n';
@@ -41,7 +38,7 @@ writeFileSync(testFile, testContent);
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const body = await bytes(stream);
-      strictEqual(decoder.decode(body), testContent);
+      assert.strictEqual(decoder.decode(body), testContent);
 
       await stream.closed;
       serverSession.close();
@@ -50,8 +47,8 @@ writeFileSync(testFile, testContent);
   }), {
     sni: { '*': { keys: [key], certs: [cert] } },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':method'], 'POST');
-      strictEqual(headers[':path'], '/upload');
+      assert.strictEqual(headers[':method'], 'POST');
+      assert.strictEqual(headers[':path'], '/upload');
 
       this.sendHeaders({ ':status': '200' });
       this.writer.writeSync('ok');
@@ -65,7 +62,7 @@ writeFileSync(testFile, testContent);
   });
 
   const info = await clientSession.opened;
-  strictEqual(info.protocol, 'h3');
+  assert.strictEqual(info.protocol, 'h3');
 
   const clientHeadersReceived = Promise.withResolvers();
 
@@ -79,7 +76,7 @@ writeFileSync(testFile, testContent);
     },
     body: fh,
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
       clientHeadersReceived.resolve();
     }),
   });
@@ -87,7 +84,7 @@ writeFileSync(testFile, testContent);
   await clientHeadersReceived.promise;
 
   const responseBody = await bytes(stream);
-  strictEqual(decoder.decode(responseBody), 'ok');
+  assert.strictEqual(decoder.decode(responseBody), 'ok');
 
   await Promise.all([stream.closed, serverDone.promise]);
   clientSession.close();

--- a/test/parallel/test-quic-h3-post-request.mjs
+++ b/test/parallel/test-quic-h3-post-request.mjs
@@ -13,9 +13,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,8 +21,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -38,7 +35,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
     // Read the full request body from the client.
     const body = await bytes(stream);
     const text = decoder.decode(body);
-    strictEqual(text, requestBody);
+    assert.strictEqual(text, requestBody);
 
     await stream.closed;
     serverSession.close();
@@ -47,8 +44,8 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 }), {
   sni: { '*': { keys: [key], certs: [cert] } },
   onheaders: mustCall(function(headers) {
-    strictEqual(headers[':method'], 'POST');
-    strictEqual(headers[':path'], '/submit');
+    assert.strictEqual(headers[':method'], 'POST');
+    assert.strictEqual(headers[':path'], '/submit');
 
     // Echo the request body back in the response.
     // At this point, request body hasn't arrived yet — we use onstream
@@ -72,7 +69,7 @@ const clientSession = await connect(serverEndpoint.address, {
 });
 
 const info = await clientSession.opened;
-strictEqual(info.protocol, 'h3');
+assert.strictEqual(info.protocol, 'h3');
 
 const clientHeadersReceived = Promise.withResolvers();
 
@@ -87,7 +84,7 @@ const stream = await clientSession.createBidirectionalStream({
   },
   body: encoder.encode(requestBody),
   onheaders: mustCall(function(headers) {
-    strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers[':status'], '200');
     clientHeadersReceived.resolve();
   }),
 });
@@ -96,7 +93,7 @@ await clientHeadersReceived.promise;
 
 // Read the response body.
 const responseBody = await bytes(stream);
-strictEqual(decoder.decode(responseBody), 'echo:' + requestBody);
+assert.strictEqual(decoder.decode(responseBody), 'echo:' + requestBody);
 
 await Promise.all([stream.closed, serverDone.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-h3-priority.mjs
+++ b/test/parallel/test-quic-h3-priority.mjs
@@ -12,9 +12,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { deepStrictEqual, strictEqual } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -24,8 +21,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -37,9 +34,9 @@ const decoder = new TextDecoder();
     ss.onstream = mustCall((stream) => {
       // Server sees priority on the stream.
       const pri = stream.priority;
-      strictEqual(typeof pri, 'object');
-      strictEqual(typeof pri.level, 'string');
-      strictEqual(typeof pri.incremental, 'boolean');
+      assert.strictEqual(typeof pri, 'object');
+      assert.strictEqual(typeof pri.level, 'string');
+      assert.strictEqual(typeof pri.incremental, 'boolean');
     }, 4);
   }), {
     sni: { '*': { keys: [key], certs: [cert] } },
@@ -70,12 +67,12 @@ const decoder = new TextDecoder();
     priority: 'high',
     incremental: false,
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   // Priority reflects what was set at creation.
-  deepStrictEqual(stream1.priority, { level: 'high', incremental: false });
+  assert.deepStrictEqual(stream1.priority, { level: 'high', incremental: false });
 
   // Priority 'low' + incremental at creation.
   const stream2 = await clientSession.createBidirectionalStream({
@@ -88,10 +85,10 @@ const decoder = new TextDecoder();
     priority: 'low',
     incremental: true,
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
-  deepStrictEqual(stream2.priority, { level: 'low', incremental: true });
+  assert.deepStrictEqual(stream2.priority, { level: 'low', incremental: true });
 
   // Default priority at creation.
   const stream3 = await clientSession.createBidirectionalStream({
@@ -102,10 +99,10 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
-  deepStrictEqual(stream3.priority, { level: 'default', incremental: false });
+  assert.deepStrictEqual(stream3.priority, { level: 'default', incremental: false });
 
   // setPriority after creation.
   const stream4 = await clientSession.createBidirectionalStream({
@@ -116,23 +113,23 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
   // Default priority initially.
-  deepStrictEqual(stream4.priority, { level: 'default', incremental: false });
+  assert.deepStrictEqual(stream4.priority, { level: 'default', incremental: false });
 
   // Change to high.
   stream4.setPriority({ level: 'high' });
-  deepStrictEqual(stream4.priority, { level: 'high', incremental: false });
+  assert.deepStrictEqual(stream4.priority, { level: 'high', incremental: false });
 
   // Change to incremental.
   stream4.setPriority({ level: 'low', incremental: true });
-  deepStrictEqual(stream4.priority, { level: 'low', incremental: true });
+  assert.deepStrictEqual(stream4.priority, { level: 'low', incremental: true });
 
   // Back to default.
   stream4.setPriority({ level: 'default', incremental: false });
-  deepStrictEqual(stream4.priority, { level: 'default', incremental: false });
+  assert.deepStrictEqual(stream4.priority, { level: 'default', incremental: false });
 
   // Read all bodies.
   const allBodies = await Promise.all([
@@ -142,10 +139,10 @@ const decoder = new TextDecoder();
     bytes(stream4),
   ]);
 
-  strictEqual(decoder.decode(allBodies[0]), '/high');
-  strictEqual(decoder.decode(allBodies[1]), '/low-inc');
-  strictEqual(decoder.decode(allBodies[2]), '/default');
-  strictEqual(decoder.decode(allBodies[3]), '/changed');
+  assert.strictEqual(decoder.decode(allBodies[0]), '/high');
+  assert.strictEqual(decoder.decode(allBodies[1]), '/low-inc');
+  assert.strictEqual(decoder.decode(allBodies[2]), '/default');
+  assert.strictEqual(decoder.decode(allBodies[3]), '/changed');
 
   await Promise.all([stream1.closed,
                      stream2.closed,
@@ -173,11 +170,11 @@ const decoder = new TextDecoder();
       // data in nghttp3, so by the time body arrives the priority
       // has been updated.
       const body = await bytes(stream);
-      strictEqual(decoder.decode(body), 'signal');
+      assert.strictEqual(decoder.decode(body), 'signal');
 
       // The server's priority getter should reflect the
       // client's PRIORITY_UPDATE (high, incremental).
-      deepStrictEqual(stream.priority, { level: 'high', incremental: true });
+      assert.deepStrictEqual(stream.priority, { level: 'high', incremental: true });
       serverSawHighPriority.resolve();
 
       await stream.closed;
@@ -218,21 +215,21 @@ const decoder = new TextDecoder();
     },
     body: encoder.encode('signal'),
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
-  deepStrictEqual(stream.priority, { level: 'default', incremental: false });
+  assert.deepStrictEqual(stream.priority, { level: 'default', incremental: false });
 
   // Change priority — this sends a PRIORITY_UPDATE frame on the
   // control stream. The body data was already provided at creation
   // but the PRIORITY_UPDATE travels on the control stream which
   // nghttp3 prioritizes over bidi streams.
   stream.setPriority({ level: 'high', incremental: true });
-  deepStrictEqual(stream.priority, { level: 'high', incremental: true });
+  assert.deepStrictEqual(stream.priority, { level: 'high', incremental: true });
 
   // Read the response.
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
 
   // Wait for server to confirm it saw the updated priority.
   await Promise.all([serverSawHighPriority.promise,

--- a/test/parallel/test-quic-h3-qpack-settings.mjs
+++ b/test/parallel/test-quic-h3-qpack-settings.mjs
@@ -13,9 +13,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,8 +21,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -38,11 +35,11 @@ async function makeRequest(clientSession, path) {
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), path);
+  assert.strictEqual(decoder.decode(body), path);
   await stream.closed;
 }
 

--- a/test/parallel/test-quic-h3-request-response.mjs
+++ b/test/parallel/test-quic-h3-request-response.mjs
@@ -12,9 +12,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { strictEqual } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -24,8 +21,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -53,14 +50,14 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   // headers and stream[kHeaders] asserts the callback exists.
   onheaders: mustCall(function(headers) {
     // Verify request pseudo-headers.
-    strictEqual(headers[':method'], 'GET');
-    strictEqual(headers[':path'], '/index.html');
-    strictEqual(headers[':scheme'], 'https');
-    strictEqual(headers[':authority'], 'localhost');
+    assert.strictEqual(headers[':method'], 'GET');
+    assert.strictEqual(headers[':path'], '/index.html');
+    assert.strictEqual(headers[':scheme'], 'https');
+    assert.strictEqual(headers[':authority'], 'localhost');
 
     // After onheaders, stream.headers returns the initial headers.
     // `this` is the stream (bound by the onheaders setter).
-    strictEqual(this.headers[':method'], 'GET');
+    assert.strictEqual(this.headers[':method'], 'GET');
 
     // Send response headers (terminal: false is the default — body follows).
     this.sendHeaders({
@@ -82,7 +79,7 @@ const clientSession = await connect(serverEndpoint.address, {
 });
 
 const info = await clientSession.opened;
-strictEqual(info.protocol, 'h3');
+assert.strictEqual(info.protocol, 'h3');
 
 const clientHeadersReceived = Promise.withResolvers();
 
@@ -96,8 +93,8 @@ const stream = await clientSession.createBidirectionalStream({
     ':authority': 'localhost',
   },
   onheaders: mustCall(function(headers) {
-    strictEqual(headers[':status'], '200');
-    strictEqual(headers['content-type'], 'text/plain');
+    assert.strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers['content-type'], 'text/plain');
     clientHeadersReceived.resolve();
   }),
 });
@@ -106,10 +103,10 @@ await clientHeadersReceived.promise;
 
 // Read the full response body.
 const body = await bytes(stream);
-strictEqual(decoder.decode(body), responseBody);
+assert.strictEqual(decoder.decode(body), responseBody);
 
 // stream.headers should return the buffered response headers.
-strictEqual(stream.headers[':status'], '200');
+assert.strictEqual(stream.headers[':status'], '200');
 
 await Promise.all([stream.closed, serverDone.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-h3-settings.mjs
+++ b/test/parallel/test-quic-h3-settings.mjs
@@ -9,9 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { strictEqual } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -21,8 +18,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -43,14 +40,14 @@ const decoder = new TextDecoder();
     // Allow 5 header pairs: 4 pseudo-headers + 1 custom.
     application: { maxHeaderPairs: 5 },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':method'], 'GET');
-      strictEqual(headers[':path'], '/limited');
-      strictEqual(headers[':scheme'], 'https');
-      strictEqual(headers[':authority'], 'localhost');
+      assert.strictEqual(headers[':method'], 'GET');
+      assert.strictEqual(headers[':path'], '/limited');
+      assert.strictEqual(headers[':scheme'], 'https');
+      assert.strictEqual(headers[':authority'], 'localhost');
       // x-first is the 5th pair — accepted.
-      strictEqual(headers['x-first'], 'one');
+      assert.strictEqual(headers['x-first'], 'one');
       // x-second would be the 6th pair — dropped.
-      strictEqual(headers['x-second'], undefined);
+      assert.strictEqual(headers['x-second'], undefined);
 
       this.sendHeaders({ ':status': '200' });
       this.writer.writeSync(encoder.encode('ok'));
@@ -74,12 +71,12 @@ const decoder = new TextDecoder();
       'x-second': 'two',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
   await stream.closed;
   await serverDone.promise;
   await clientSession.close();
@@ -106,10 +103,10 @@ const decoder = new TextDecoder();
     // bytes, but adding x-long (6 + 200 = 206 bytes) exceeds it.
     application: { maxHeaderLength: 100 },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':method'], 'GET');
-      strictEqual(headers[':path'], '/length-limited');
+      assert.strictEqual(headers[':method'], 'GET');
+      assert.strictEqual(headers[':path'], '/length-limited');
       // x-long should be dropped — would push total over 100 bytes.
-      strictEqual(headers['x-long'], undefined);
+      assert.strictEqual(headers['x-long'], undefined);
 
       this.sendHeaders({ ':status': '200' });
       this.writer.writeSync(encoder.encode('ok'));
@@ -132,12 +129,12 @@ const decoder = new TextDecoder();
       'x-long': longValue,
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
   await Promise.all([stream.closed, serverDone.promise]);
   await clientSession.close();
   await serverEndpoint.close();
@@ -163,8 +160,8 @@ const decoder = new TextDecoder();
       this.writer.endSync();
     }),
     onapplication: mustCall((appopt) => {
-      strictEqual(appopt.enableDatagrams, true);
-      strictEqual(appopt.enableConnectProtocol, false);
+      assert.strictEqual(appopt.enableDatagrams, true);
+      assert.strictEqual(appopt.enableConnectProtocol, false);
       // Must be false, as this is only sent from server side
     })
   });
@@ -175,8 +172,8 @@ const decoder = new TextDecoder();
     application: { enableConnectProtocol: true, enableDatagrams: true },
   });
   clientSession.onapplication = mustCall((appopt) => {
-    strictEqual(appopt.enableConnectProtocol, true);
-    strictEqual(appopt.enableDatagrams, true);
+    assert.strictEqual(appopt.enableConnectProtocol, true);
+    assert.strictEqual(appopt.enableDatagrams, true);
   });
   await clientSession.opened;
 
@@ -188,12 +185,12 @@ const decoder = new TextDecoder();
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
 
   const body = await bytes(stream);
-  strictEqual(decoder.decode(body), 'settings-ok');
+  assert.strictEqual(decoder.decode(body), 'settings-ok');
   await Promise.all([stream.closed, serverDone.promise]);
   await clientSession.close();
   await serverEndpoint.close();

--- a/test/parallel/test-quic-h3-stream-destroy-with-headers.mjs
+++ b/test/parallel/test-quic-h3-stream-destroy-with-headers.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -18,8 +15,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const serverDone = Promise.withResolvers();
 
@@ -52,7 +49,7 @@ const stream = await clientSession.createBidirectionalStream({
 stream.destroy();
 
 // Verify the stream is destroyed without crash.
-strictEqual(stream.destroyed, true);
+assert.strictEqual(stream.destroyed, true);
 
 // Close everything cleanly.
 await clientSession.close();

--- a/test/parallel/test-quic-h3-stream-idle-timeout.mjs
+++ b/test/parallel/test-quic-h3-stream-idle-timeout.mjs
@@ -13,9 +13,6 @@ import { setTimeout } from 'node:timers/promises';
 import * as fixtures from '../common/fixtures.mjs';
 import { text } from 'node:stream/iter';
 
-const { rejects, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,8 +20,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const encoder = new TextEncoder();
 
@@ -36,7 +33,7 @@ const encoder = new TextEncoder();
     serverSession.onstream = mustCall(async (stream) => {
       // Don't read — let the stream sit idle after the initial headers.
       // The stream idle timeout should destroy it, rejecting stream.closed.
-      await rejects(stream.closed, {
+      await assert.rejects(stream.closed, {
         code: 'ERR_QUIC_TRANSPORT_ERROR',
       });
       streamDestroyed.resolve();
@@ -77,7 +74,7 @@ const encoder = new TextEncoder();
   // The server sent STOP_SENDING / RESET_STREAM when it destroyed the
   // idle stream. ShutdownStream maps the transport error to the H3
   // internal error code (0x102) on the wire.
-  await rejects(stream.closed, {
+  await assert.rejects(stream.closed, {
     code: 'ERR_QUIC_APPLICATION_ERROR',
   });
 
@@ -92,7 +89,7 @@ const encoder = new TextEncoder();
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const data = await text(stream);
-      strictEqual(data, 'xy');
+      assert.strictEqual(data, 'xy');
       serverGotData.resolve();
       await serverSession.close();
     });
@@ -100,7 +97,7 @@ const encoder = new TextEncoder();
     sni: { '*': { keys: [key], certs: [cert] } },
     streamIdleTimeout: 500,
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':method'], 'POST');
+      assert.strictEqual(headers[':method'], 'POST');
       // Send response headers so the stream is fully established.
       this.sendHeaders({ ':status': '200' }, { terminal: true });
     }),
@@ -142,7 +139,7 @@ const encoder = new TextEncoder();
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const data = await text(stream);
-      strictEqual(data, 'xy');
+      assert.strictEqual(data, 'xy');
       streamSurvived.resolve();
     });
 

--- a/test/parallel/test-quic-h3-trailing-headers.mjs
+++ b/test/parallel/test-quic-h3-trailing-headers.mjs
@@ -13,9 +13,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { ok, strictEqual } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -25,8 +22,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
@@ -35,17 +32,17 @@ const responseBody = 'body with trailers';
 // quic.stream.headers fires when initial headers are received.
 // Fires for both the server (request headers) and client (response headers).
 dc.subscribe('quic.stream.headers', mustCall((msg) => {
-  ok(msg.stream, 'stream.headers should include stream');
-  ok(msg.session, 'stream.headers should include session');
-  ok(msg.headers, 'stream.headers should include headers');
+  assert.ok(msg.stream, 'stream.headers should include stream');
+  assert.ok(msg.session, 'stream.headers should include session');
+  assert.ok(msg.headers, 'stream.headers should include headers');
 }, 2));
 
 // quic.stream.trailers fires when trailing headers are received.
 dc.subscribe('quic.stream.trailers', mustCall((msg) => {
-  ok(msg.stream, 'stream.trailers should include stream');
-  ok(msg.session, 'stream.trailers should include session');
-  ok(msg.trailers, 'stream.trailers should include trailers');
-  strictEqual(msg.trailers['x-checksum'], 'abc123');
+  assert.ok(msg.stream, 'stream.trailers should include stream');
+  assert.ok(msg.session, 'stream.trailers should include session');
+  assert.ok(msg.trailers, 'stream.trailers should include trailers');
+  assert.strictEqual(msg.trailers['x-checksum'], 'abc123');
 }));
 
 const serverDone = Promise.withResolvers();
@@ -97,12 +94,12 @@ const stream = await clientSession.createBidirectionalStream({
     ':authority': 'localhost',
   },
   onheaders: mustCall(function(headers) {
-    strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers[':status'], '200');
     clientHeadersReceived.resolve();
   }),
   ontrailers: mustCall(function(trailers) {
-    strictEqual(trailers['x-checksum'], 'abc123');
-    strictEqual(trailers['x-request-id'], '42');
+    assert.strictEqual(trailers['x-checksum'], 'abc123');
+    assert.strictEqual(trailers['x-request-id'], '42');
     clientTrailersReceived.resolve();
   }),
 });
@@ -111,13 +108,13 @@ await clientHeadersReceived.promise;
 
 // Read the response body.
 const body = await bytes(stream);
-strictEqual(decoder.decode(body), responseBody);
+assert.strictEqual(decoder.decode(body), responseBody);
 
 // Trailers arrive after the body.
 await clientTrailersReceived.promise;
 
 // stream.headers should still be the initial headers, not trailers.
-strictEqual(stream.headers[':status'], '200');
+assert.strictEqual(stream.headers[':status'], '200');
 
 await Promise.all([stream.closed, serverDone.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-h3-zero-rtt-bogus-ticket.mjs
+++ b/test/parallel/test-quic-h3-zero-rtt-bogus-ticket.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,15 +16,15 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey, randomBytes } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const serverEndpoint = await listen(mustNotCall(), {
   sni: { '*': { keys: [key], certs: [cert] } },
 });
 
 // Bogus ticket data (random bytes) is rejected at the format level.
-await rejects(
+await assert.rejects(
   connect(serverEndpoint.address, {
     servername: 'localhost',
     verifyPeer: 'manual',

--- a/test/parallel/test-quic-h3-zero-rtt-rejected-settings.mjs
+++ b/test/parallel/test-quic-h3-zero-rtt-rejected-settings.mjs
@@ -13,9 +13,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual, rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,8 +21,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey, randomBytes } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const decoder = new TextDecoder();
 
@@ -55,16 +52,16 @@ async function getTicket(endpointOptions) {
     servername: 'localhost',
     verifyPeer: 'manual',
     ...endpointOptions,
-    onsessionticket(ticket) {
-      ok(Buffer.isBuffer(ticket));
+    onsessionticket: mustCall((ticket) => {
+      assert.ok(Buffer.isBuffer(ticket));
       savedTicket = ticket;
       gotTicket.resolve();
-    },
-    onnewtoken(token) {
-      ok(Buffer.isBuffer(token));
+    }, 2),
+    onnewtoken: mustCall((token) => {
+      assert.ok(Buffer.isBuffer(token));
       savedToken = token;
       gotToken.resolve();
-    },
+    }),
   });
   await cs.opened;
   await Promise.all([gotTicket.promise, gotToken.promise]);
@@ -77,11 +74,11 @@ async function getTicket(endpointOptions) {
       ':authority': 'localhost',
     },
     onheaders: mustCall(function(headers) {
-      strictEqual(headers[':status'], '200');
+      assert.strictEqual(headers[':status'], '200');
     }),
   });
   const body = await bytes(s);
-  strictEqual(decoder.decode(body), 'ok');
+  assert.strictEqual(decoder.decode(body), 'ok');
   await Promise.all([s.closed, cs.closed]);
   await ep.close();
 
@@ -122,13 +119,13 @@ async function attemptRejected0RTT(endpointOptions, ticket, token) {
       ':authority': 'localhost',
     },
   });
-  await rejects(s.closed, {
+  await assert.rejects(s.closed, {
     code: 'ERR_QUIC_APPLICATION_ERROR',
   });
 
   const info = await cs.opened;
-  strictEqual(info.earlyDataAttempted, true);
-  strictEqual(info.earlyDataAccepted, false);
+  assert.strictEqual(info.earlyDataAttempted, true);
+  assert.strictEqual(info.earlyDataAccepted, false);
 
   cs.close();
   ep.close();

--- a/test/parallel/test-quic-h3-zero-rtt.mjs
+++ b/test/parallel/test-quic-h3-zero-rtt.mjs
@@ -9,9 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { ok, strictEqual } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -21,8 +18,8 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { bytes } = await import('stream/iter');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -60,21 +57,21 @@ const cs1 = await connect(serverEndpoint.address, {
   servername: 'localhost',
   verifyPeer: 'manual',
   onsessionticket: mustCall(function(ticket) {
-    ok(Buffer.isBuffer(ticket));
-    ok(ticket.length > 0);
+    assert.ok(Buffer.isBuffer(ticket));
+    assert.ok(ticket.length > 0);
     savedTicket = ticket;
     gotTicket.resolve();
   }, 2),
   onnewtoken: mustCall(function(token) {
-    ok(Buffer.isBuffer(token));
+    assert.ok(Buffer.isBuffer(token));
     savedToken = token;
     gotToken.resolve();
   }),
 });
 
 const info1 = await cs1.opened;
-strictEqual(info1.earlyDataAttempted, false);
-strictEqual(info1.earlyDataAccepted, false);
+assert.strictEqual(info1.earlyDataAttempted, false);
+assert.strictEqual(info1.earlyDataAccepted, false);
 
 await Promise.all([gotTicket.promise, gotToken.promise]);
 
@@ -86,16 +83,16 @@ const s1 = await cs1.createBidirectionalStream({
     ':authority': 'localhost',
   },
   onheaders: mustCall(function(headers) {
-    strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers[':status'], '200');
   }),
 });
 const body1 = await bytes(s1);
-strictEqual(decoder.decode(body1), '/first');
+assert.strictEqual(decoder.decode(body1), '/first');
 await Promise.all([s1.closed, cs1.closed]);
 
 // Session ticket should have been received.
-ok(savedTicket);
-ok(savedToken);
+assert.ok(savedTicket);
+assert.ok(savedToken);
 
 // --- Second connection: 0-RTT with H3 ---
 const cs2 = await connect(serverEndpoint.address, {
@@ -114,20 +111,20 @@ const s2 = await cs2.createBidirectionalStream({
     ':authority': 'localhost',
   },
   onheaders: mustCall(function(headers) {
-    strictEqual(headers[':status'], '200');
+    assert.strictEqual(headers[':status'], '200');
   }),
 });
 
 const info2 = await cs2.opened;
-strictEqual(info2.earlyDataAttempted, true);
-strictEqual(info2.earlyDataAccepted, true);
+assert.strictEqual(info2.earlyDataAttempted, true);
+assert.strictEqual(info2.earlyDataAccepted, true);
 
 const body2 = await bytes(s2);
-strictEqual(decoder.decode(body2), '/early');
+assert.strictEqual(decoder.decode(body2), '/early');
 await s2.closed;
 
 const earlyStream = await secondDone.promise;
-strictEqual(earlyStream.early, true);
+assert.strictEqual(earlyStream.early, true);
 
 await cs2.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-handshake-ipv6-only.mjs
+++ b/test/parallel/test-quic-handshake-ipv6-only.mjs
@@ -4,9 +4,6 @@ import { hasQuic, hasIPv6, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { partialDeepStrictEqual, strictEqual, ok } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ if (!hasIPv6) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const check = {
   // The SNI value
@@ -38,7 +35,7 @@ const serverOpened = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const info = await serverSession.opened;
-  partialDeepStrictEqual(info, check);
+  assert.partialDeepStrictEqual(info, check);
   serverOpened.resolve();
   await serverSession.close();
 }), {
@@ -53,10 +50,10 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   },
 });
 // Buffer is not detached.
-strictEqual(cert.buffer.detached, false);
+assert.strictEqual(cert.buffer.detached, false);
 
 // The server must have an address to connect to after listen resolves.
-ok(serverEndpoint.address !== undefined);
+assert.ok(serverEndpoint.address !== undefined);
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
@@ -70,7 +67,7 @@ const clientSession = await connect(serverEndpoint.address, {
 });
 
 const info = await clientSession.opened;
-partialDeepStrictEqual(info, check);
+assert.partialDeepStrictEqual(info, check);
 
 await serverOpened.promise;
 await clientSession.close();

--- a/test/parallel/test-quic-handshake-timeout.mjs
+++ b/test/parallel/test-quic-handshake-timeout.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,6 +26,6 @@ const clientSession = await connect(serverEndpoint.address, {
 await Promise.all([clientSession.opened, clientSession.closed]);
 
 // The session closed via idle timeout. Verify it was destroyed.
-strictEqual(clientSession.destroyed, true);
+assert.strictEqual(clientSession.destroyed, true);
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-handshake.mjs
+++ b/test/parallel/test-quic-handshake.mjs
@@ -3,9 +3,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { partialDeepStrictEqual, strictEqual, ok } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -15,8 +12,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const check = {
   // The SNI value
@@ -37,7 +34,7 @@ const serverOpened = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.opened.then((info) => {
-    partialDeepStrictEqual(info, check);
+    assert.partialDeepStrictEqual(info, check);
     serverOpened.resolve();
     serverSession.close();
   }).then(mustCall());
@@ -47,10 +44,10 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
 });
 
 // Buffer is not detached.
-strictEqual(cert.buffer.detached, false);
+assert.strictEqual(cert.buffer.detached, false);
 
 // The server must have an address to connect to after listen resolves.
-ok(serverEndpoint.address !== undefined);
+assert.ok(serverEndpoint.address !== undefined);
 
 const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
@@ -58,7 +55,7 @@ const clientSession = await connect(serverEndpoint.address, {
 });
 
 const info = await clientSession.opened;
-partialDeepStrictEqual(info, check);
+assert.partialDeepStrictEqual(info, check);
 
 await serverOpened.promise;
 await clientSession.close();

--- a/test/parallel/test-quic-internal-endpoint-listen-defaults.mjs
+++ b/test/parallel/test-quic-internal-endpoint-listen-defaults.mjs
@@ -3,10 +3,7 @@ import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
 import { SocketAddress } from 'node:net';
-
-const { strictEqual, rejects, ok, throws } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -17,65 +14,65 @@ const { listen, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 const { getQuicEndpointState } = (await import('internal/quic/quic')).default;
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 
 const endpoint = new QuicEndpoint();
 const state = getQuicEndpointState(endpoint);
-ok(!state.isBound);
-ok(!state.isReceiving);
-ok(!state.isListening);
+assert.ok(!state.isBound);
+assert.ok(!state.isReceiving);
+assert.ok(!state.isListening);
 
-strictEqual(endpoint.address, undefined);
+assert.strictEqual(endpoint.address, undefined);
 
-await rejects(listen(123, { sni, endpoint }), {
+await assert.rejects(listen(123, { sni, endpoint }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 // Buffer is not detached.
-strictEqual(cert.buffer.detached, false);
+assert.strictEqual(cert.buffer.detached, false);
 
-await rejects(listen(mustNotCall(), 123), {
+await assert.rejects(listen(mustNotCall(), 123), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
 
 await listen(mustNotCall(), { sni, endpoint });
 // Buffer is not detached.
-strictEqual(cert.buffer.detached, false);
+assert.strictEqual(cert.buffer.detached, false);
 
-await rejects(listen(mustNotCall(), { sni, endpoint }), {
+await assert.rejects(listen(mustNotCall(), { sni, endpoint }), {
   code: 'ERR_INVALID_STATE',
 });
 // Buffer is not detached.
-strictEqual(cert.buffer.detached, false);
+assert.strictEqual(cert.buffer.detached, false);
 
-ok(state.isBound);
-ok(state.isReceiving);
-ok(state.isListening);
+assert.ok(state.isBound);
+assert.ok(state.isReceiving);
+assert.ok(state.isListening);
 
 const address = endpoint.address;
-ok(address instanceof SocketAddress);
+assert.ok(address instanceof SocketAddress);
 
-strictEqual(address.address, '127.0.0.1');
-strictEqual(address.family, 'ipv4');
-strictEqual(address.flowlabel, 0);
-ok(address.port !== 0);
+assert.strictEqual(address.address, '127.0.0.1');
+assert.strictEqual(address.family, 'ipv4');
+assert.strictEqual(address.flowlabel, 0);
+assert.ok(address.port !== 0);
 
-ok(!endpoint.destroyed);
+assert.ok(!endpoint.destroyed);
 endpoint.destroy();
-strictEqual(endpoint.closed, endpoint.close());
+assert.strictEqual(endpoint.closed, endpoint.close());
 await endpoint.closed;
-ok(endpoint.destroyed);
+assert.ok(endpoint.destroyed);
 
-await rejects(listen(mustNotCall(), { sni, endpoint }), {
+await assert.rejects(listen(mustNotCall(), { sni, endpoint }), {
   code: 'ERR_INVALID_STATE',
 });
 // Buffer is not detached.
-strictEqual(cert.buffer.detached, false);
+assert.strictEqual(cert.buffer.detached, false);
 
-throws(() => { endpoint.busy = true; }, {
+assert.throws(() => { endpoint.busy = true; }, {
   code: 'ERR_INVALID_STATE',
 });
 await endpoint[Symbol.asyncDispose]();
 
-strictEqual(endpoint.address, undefined);
+assert.strictEqual(endpoint.address, undefined);

--- a/test/parallel/test-quic-internal-endpoint-options.mjs
+++ b/test/parallel/test-quic-internal-endpoint-options.mjs
@@ -3,8 +3,6 @@ import { hasQuic, skip } from '../common/index.mjs';
 import assert from 'node:assert';
 import { inspect } from 'node:util';
 
-const { strictEqual, throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -15,7 +13,7 @@ const { BlockList } = await import('node:net');
 
 // Reject invalid options
 ['a', null, false, NaN].forEach((i) => {
-  throws(() => new QuicEndpoint(i), {
+  assert.throws(() => new QuicEndpoint(i), {
     code: 'ERR_INVALID_ARG_TYPE',
   });
 });
@@ -196,7 +194,7 @@ for (const { key, valid, invalid } of cases) {
   for (const value of invalid) {
     const options = {};
     options[key] = value;
-    throws(() => new QuicEndpoint(options), {
+    assert.throws(() => new QuicEndpoint(options), {
       message: new RegExp(`${RegExp.escape(key)}`),
     }, value);
   }
@@ -204,7 +202,7 @@ for (const { key, valid, invalid } of cases) {
 
 // It can be inspected
 const endpoint = new QuicEndpoint({});
-strictEqual(typeof inspect(endpoint), 'string');
+assert.strictEqual(typeof inspect(endpoint), 'string');
 endpoint.close();
 await endpoint.closed;
 
@@ -215,6 +213,6 @@ new QuicEndpoint({
 new QuicEndpoint({
   address: '127.0.0.1:0',
 });
-throws(() => new QuicEndpoint({ address: 123 }), {
+assert.throws(() => new QuicEndpoint({ address: 123 }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });

--- a/test/parallel/test-quic-internal-endpoint-stats-state.mjs
+++ b/test/parallel/test-quic-internal-endpoint-stats-state.mjs
@@ -3,8 +3,6 @@ import { hasQuic, skip } from '../common/index.mjs';
 import { inspect } from 'node:util';
 import assert from 'node:assert';
 
-const { strictEqual, deepStrictEqual, throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,14 +28,14 @@ const {
   const endpoint = new QuicEndpoint();
   const state = getQuicEndpointState(endpoint);
 
-  strictEqual(state.isBound, false);
-  strictEqual(state.isReceiving, false);
-  strictEqual(state.isListening, false);
-  strictEqual(state.isClosing, false);
-  strictEqual(state.isBusy, false);
-  strictEqual(state.pendingCallbacks, 0n);
+  assert.strictEqual(state.isBound, false);
+  assert.strictEqual(state.isReceiving, false);
+  assert.strictEqual(state.isListening, false);
+  assert.strictEqual(state.isClosing, false);
+  assert.strictEqual(state.isBusy, false);
+  assert.strictEqual(state.pendingCallbacks, 0n);
 
-  deepStrictEqual(JSON.parse(JSON.stringify(state)), {
+  assert.deepStrictEqual(JSON.parse(JSON.stringify(state)), {
     isBound: false,
     isReceiving: false,
     isListening: false,
@@ -49,10 +47,10 @@ const {
   });
 
   endpoint.busy = true;
-  strictEqual(state.isBusy, true);
+  assert.strictEqual(state.isBusy, true);
   endpoint.busy = false;
-  strictEqual(state.isBusy, false);
-  strictEqual(typeof inspect(state), 'string');
+  assert.strictEqual(state.isBusy, false);
+  assert.strictEqual(typeof inspect(state), 'string');
 }
 
 {
@@ -60,7 +58,7 @@ const {
   const endpoint = new QuicEndpoint();
   const state = getQuicEndpointState(endpoint);
   state[kFinishClose]();
-  strictEqual(state.isBound, undefined);
+  assert.strictEqual(state.isBound, undefined);
 }
 
 {
@@ -68,7 +66,7 @@ const {
   const endpoint = new QuicEndpoint();
   const state = getQuicEndpointState(endpoint);
   const StateCons = state.constructor;
-  throws(() => new StateCons(kPrivateConstructor, 1), {
+  assert.throws(() => new StateCons(kPrivateConstructor, 1), {
     code: 'ERR_INVALID_ARG_TYPE'
   });
 }
@@ -77,28 +75,28 @@ const {
   // Endpoint stats are readable and have expected properties
   const endpoint = new QuicEndpoint();
 
-  strictEqual(typeof endpoint.stats.isConnected, 'boolean');
-  strictEqual(typeof endpoint.stats.createdAt, 'bigint');
-  strictEqual(typeof endpoint.stats.destroyedAt, 'bigint');
-  strictEqual(typeof endpoint.stats.bytesReceived, 'bigint');
-  strictEqual(typeof endpoint.stats.bytesSent, 'bigint');
-  strictEqual(typeof endpoint.stats.packetsReceived, 'bigint');
-  strictEqual(typeof endpoint.stats.packetsSent, 'bigint');
-  strictEqual(typeof endpoint.stats.serverSessions, 'bigint');
-  strictEqual(typeof endpoint.stats.clientSessions, 'bigint');
-  strictEqual(typeof endpoint.stats.serverBusyCount, 'bigint');
-  strictEqual(typeof endpoint.stats.retryCount, 'bigint');
-  strictEqual(typeof endpoint.stats.retryRateLimited, 'bigint');
-  strictEqual(typeof endpoint.stats.versionNegotiationCount, 'bigint');
-  strictEqual(typeof endpoint.stats.versionNegotiationRateLimited, 'bigint');
-  strictEqual(typeof endpoint.stats.statelessResetCount, 'bigint');
-  strictEqual(typeof endpoint.stats.statelessResetRateLimited, 'bigint');
-  strictEqual(typeof endpoint.stats.immediateCloseCount, 'bigint');
-  strictEqual(typeof endpoint.stats.immediateCloseRateLimited, 'bigint');
-  strictEqual(typeof endpoint.stats.sessionCreationRateLimited, 'bigint');
-  strictEqual(typeof endpoint.stats.packetsBlocked, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.isConnected, 'boolean');
+  assert.strictEqual(typeof endpoint.stats.createdAt, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.destroyedAt, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.bytesReceived, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.bytesSent, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.packetsReceived, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.packetsSent, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.serverSessions, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.clientSessions, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.serverBusyCount, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.retryCount, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.retryRateLimited, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.versionNegotiationCount, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.versionNegotiationRateLimited, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.statelessResetCount, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.statelessResetRateLimited, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.immediateCloseCount, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.immediateCloseRateLimited, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.sessionCreationRateLimited, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.packetsBlocked, 'bigint');
 
-  deepStrictEqual(Object.keys(endpoint.stats.toJSON()), [
+  assert.deepStrictEqual(Object.keys(endpoint.stats.toJSON()), [
     'connected',
     'createdAt',
     'destroyedAt',
@@ -120,24 +118,24 @@ const {
     'sessionCreationRateLimited',
     'packetsBlocked',
   ]);
-  strictEqual(typeof inspect(endpoint.stats), 'string');
+  assert.strictEqual(typeof inspect(endpoint.stats), 'string');
 }
 
 {
   // Stats are still readable after close
   const endpoint = new QuicEndpoint();
-  strictEqual(typeof endpoint.stats.toJSON(), 'object');
+  assert.strictEqual(typeof endpoint.stats.toJSON(), 'object');
   endpoint.stats[kFinishClose]();
-  strictEqual(endpoint.stats.isConnected, false);
-  strictEqual(typeof endpoint.stats.destroyedAt, 'bigint');
-  strictEqual(typeof endpoint.stats.toJSON(), 'object');
+  assert.strictEqual(endpoint.stats.isConnected, false);
+  assert.strictEqual(typeof endpoint.stats.destroyedAt, 'bigint');
+  assert.strictEqual(typeof endpoint.stats.toJSON(), 'object');
 }
 
 {
   // Stats constructor argument is ArrayBuffer
   const endpoint = new QuicEndpoint();
   const StatsCons = endpoint.stats.constructor;
-  throws(() => new StatsCons(kPrivateConstructor, 1), {
+  assert.throws(() => new StatsCons(kPrivateConstructor, 1), {
     code: 'ERR_INVALID_ARG_TYPE',
   });
 }
@@ -149,90 +147,90 @@ const {
 const streamState = new QuicStreamState(kPrivateConstructor, new ArrayBuffer(1024));
 const sessionState = new QuicSessionState(kPrivateConstructor, new ArrayBuffer(1024));
 
-strictEqual(streamState.pending, false);
-strictEqual(streamState.finSent, false);
-strictEqual(streamState.finReceived, false);
-strictEqual(streamState.readEnded, false);
-strictEqual(streamState.writeEnded, false);
-strictEqual(streamState.reset, false);
-strictEqual(streamState.hasReader, false);
-strictEqual(streamState.wantsBlock, false);
-strictEqual(streamState.wantsReset, false);
+assert.strictEqual(streamState.pending, false);
+assert.strictEqual(streamState.finSent, false);
+assert.strictEqual(streamState.finReceived, false);
+assert.strictEqual(streamState.readEnded, false);
+assert.strictEqual(streamState.writeEnded, false);
+assert.strictEqual(streamState.reset, false);
+assert.strictEqual(streamState.hasReader, false);
+assert.strictEqual(streamState.wantsBlock, false);
+assert.strictEqual(streamState.wantsReset, false);
 
-strictEqual(sessionState.hasPathValidationListener, false);
-strictEqual(sessionState.hasDatagramListener, false);
-strictEqual(sessionState.hasDatagramStatusListener, false);
-strictEqual(sessionState.hasSessionTicketListener, false);
-strictEqual(sessionState.hasNewTokenListener, false);
-strictEqual(sessionState.hasOriginListener, false);
-strictEqual(sessionState.isClosing, false);
-strictEqual(sessionState.isGracefulClose, false);
-strictEqual(sessionState.isSilentClose, false);
-strictEqual(sessionState.isStatelessReset, false);
-strictEqual(sessionState.isHandshakeCompleted, false);
-strictEqual(sessionState.isHandshakeConfirmed, false);
-strictEqual(sessionState.isStreamOpenAllowed, false);
-strictEqual(sessionState.isPrioritySupported, false);
-strictEqual(sessionState.headersSupported, 0);
-strictEqual(sessionState.isWrapped, false);
-strictEqual(sessionState.maxDatagramSize, 0);
-strictEqual(sessionState.lastDatagramId, 0n);
+assert.strictEqual(sessionState.hasPathValidationListener, false);
+assert.strictEqual(sessionState.hasDatagramListener, false);
+assert.strictEqual(sessionState.hasDatagramStatusListener, false);
+assert.strictEqual(sessionState.hasSessionTicketListener, false);
+assert.strictEqual(sessionState.hasNewTokenListener, false);
+assert.strictEqual(sessionState.hasOriginListener, false);
+assert.strictEqual(sessionState.isClosing, false);
+assert.strictEqual(sessionState.isGracefulClose, false);
+assert.strictEqual(sessionState.isSilentClose, false);
+assert.strictEqual(sessionState.isStatelessReset, false);
+assert.strictEqual(sessionState.isHandshakeCompleted, false);
+assert.strictEqual(sessionState.isHandshakeConfirmed, false);
+assert.strictEqual(sessionState.isStreamOpenAllowed, false);
+assert.strictEqual(sessionState.isPrioritySupported, false);
+assert.strictEqual(sessionState.headersSupported, 0);
+assert.strictEqual(sessionState.isWrapped, false);
+assert.strictEqual(sessionState.maxDatagramSize, 0);
+assert.strictEqual(sessionState.lastDatagramId, 0n);
 
-strictEqual(typeof streamState.toJSON(), 'object');
-strictEqual(JSON.parse(streamState.toString()).resetCode, '0');
-strictEqual(typeof sessionState.toJSON(), 'object');
-strictEqual(typeof inspect(streamState), 'string');
-strictEqual(typeof inspect(sessionState), 'string');
+assert.strictEqual(typeof streamState.toJSON(), 'object');
+assert.strictEqual(JSON.parse(streamState.toString()).resetCode, '0');
+assert.strictEqual(typeof sessionState.toJSON(), 'object');
+assert.strictEqual(typeof inspect(streamState), 'string');
+assert.strictEqual(typeof inspect(sessionState), 'string');
 
 const streamStats = new QuicStreamStats(kPrivateConstructor, new ArrayBuffer(1024));
 const sessionStats = new QuicSessionStats(kPrivateConstructor, new ArrayBuffer(1024));
-strictEqual(streamStats.createdAt, 0n);
-strictEqual(streamStats.openedAt, 0n);
-strictEqual(streamStats.receivedAt, 0n);
-strictEqual(streamStats.ackedAt, 0n);
-strictEqual(streamStats.destroyedAt, 0n);
-strictEqual(streamStats.bytesReceived, 0n);
-strictEqual(streamStats.bytesSent, 0n);
-strictEqual(streamStats.maxOffset, 0n);
-strictEqual(streamStats.maxOffsetAcknowledged, 0n);
-strictEqual(streamStats.maxOffsetReceived, 0n);
-strictEqual(streamStats.finalSize, 0n);
-strictEqual(typeof streamStats.toJSON(), 'object');
-strictEqual(typeof inspect(streamStats), 'string');
+assert.strictEqual(streamStats.createdAt, 0n);
+assert.strictEqual(streamStats.openedAt, 0n);
+assert.strictEqual(streamStats.receivedAt, 0n);
+assert.strictEqual(streamStats.ackedAt, 0n);
+assert.strictEqual(streamStats.destroyedAt, 0n);
+assert.strictEqual(streamStats.bytesReceived, 0n);
+assert.strictEqual(streamStats.bytesSent, 0n);
+assert.strictEqual(streamStats.maxOffset, 0n);
+assert.strictEqual(streamStats.maxOffsetAcknowledged, 0n);
+assert.strictEqual(streamStats.maxOffsetReceived, 0n);
+assert.strictEqual(streamStats.finalSize, 0n);
+assert.strictEqual(typeof streamStats.toJSON(), 'object');
+assert.strictEqual(typeof inspect(streamStats), 'string');
 streamStats[kFinishClose]();
 
-strictEqual(typeof sessionStats.createdAt, 'bigint');
-strictEqual(typeof sessionStats.closingAt, 'bigint');
-strictEqual(typeof sessionStats.handshakeCompletedAt, 'bigint');
-strictEqual(typeof sessionStats.handshakeConfirmedAt, 'bigint');
-strictEqual(typeof sessionStats.bytesReceived, 'bigint');
-strictEqual(typeof sessionStats.bytesSent, 'bigint');
-strictEqual(typeof sessionStats.bidiInStreamCount, 'bigint');
-strictEqual(typeof sessionStats.bidiOutStreamCount, 'bigint');
-strictEqual(typeof sessionStats.uniInStreamCount, 'bigint');
-strictEqual(typeof sessionStats.uniOutStreamCount, 'bigint');
-strictEqual(typeof sessionStats.maxBytesInFlight, 'bigint');
-strictEqual(typeof sessionStats.bytesInFlight, 'bigint');
-strictEqual(typeof sessionStats.blockCount, 'bigint');
-strictEqual(typeof sessionStats.cwnd, 'bigint');
-strictEqual(typeof sessionStats.latestRtt, 'bigint');
-strictEqual(typeof sessionStats.minRtt, 'bigint');
-strictEqual(typeof sessionStats.rttVar, 'bigint');
-strictEqual(typeof sessionStats.smoothedRtt, 'bigint');
-strictEqual(typeof sessionStats.ssthresh, 'bigint');
-strictEqual(typeof sessionStats.pktSent, 'bigint');
-strictEqual(typeof sessionStats.bytesSent, 'bigint');
-strictEqual(typeof sessionStats.pktRecv, 'bigint');
-strictEqual(typeof sessionStats.bytesRecv, 'bigint');
-strictEqual(typeof sessionStats.pktLost, 'bigint');
-strictEqual(typeof sessionStats.bytesLost, 'bigint');
-strictEqual(typeof sessionStats.pingRecv, 'bigint');
-strictEqual(typeof sessionStats.pktDiscarded, 'bigint');
-strictEqual(typeof sessionStats.datagramsReceived, 'bigint');
-strictEqual(typeof sessionStats.datagramsSent, 'bigint');
-strictEqual(typeof sessionStats.datagramsAcknowledged, 'bigint');
-strictEqual(typeof sessionStats.datagramsLost, 'bigint');
-strictEqual(typeof sessionStats.streamsIdleTimedOut, 'bigint');
-strictEqual(typeof sessionStats.toJSON(), 'object');
-strictEqual(typeof inspect(sessionStats), 'string');
+assert.strictEqual(typeof sessionStats.createdAt, 'bigint');
+assert.strictEqual(typeof sessionStats.closingAt, 'bigint');
+assert.strictEqual(typeof sessionStats.handshakeCompletedAt, 'bigint');
+assert.strictEqual(typeof sessionStats.handshakeConfirmedAt, 'bigint');
+assert.strictEqual(typeof sessionStats.bytesReceived, 'bigint');
+assert.strictEqual(typeof sessionStats.bytesSent, 'bigint');
+assert.strictEqual(typeof sessionStats.bidiInStreamCount, 'bigint');
+assert.strictEqual(typeof sessionStats.bidiOutStreamCount, 'bigint');
+assert.strictEqual(typeof sessionStats.uniInStreamCount, 'bigint');
+assert.strictEqual(typeof sessionStats.uniOutStreamCount, 'bigint');
+assert.strictEqual(typeof sessionStats.maxBytesInFlight, 'bigint');
+assert.strictEqual(typeof sessionStats.bytesInFlight, 'bigint');
+assert.strictEqual(typeof sessionStats.blockCount, 'bigint');
+assert.strictEqual(typeof sessionStats.cwnd, 'bigint');
+assert.strictEqual(typeof sessionStats.latestRtt, 'bigint');
+assert.strictEqual(typeof sessionStats.minRtt, 'bigint');
+assert.strictEqual(typeof sessionStats.rttVar, 'bigint');
+assert.strictEqual(typeof sessionStats.smoothedRtt, 'bigint');
+assert.strictEqual(typeof sessionStats.ssthresh, 'bigint');
+assert.strictEqual(typeof sessionStats.pktSent, 'bigint');
+assert.strictEqual(typeof sessionStats.bytesSent, 'bigint');
+assert.strictEqual(typeof sessionStats.pktRecv, 'bigint');
+assert.strictEqual(typeof sessionStats.bytesRecv, 'bigint');
+assert.strictEqual(typeof sessionStats.pktLost, 'bigint');
+assert.strictEqual(typeof sessionStats.bytesLost, 'bigint');
+assert.strictEqual(typeof sessionStats.pingRecv, 'bigint');
+assert.strictEqual(typeof sessionStats.pktDiscarded, 'bigint');
+assert.strictEqual(typeof sessionStats.datagramsReceived, 'bigint');
+assert.strictEqual(typeof sessionStats.datagramsSent, 'bigint');
+assert.strictEqual(typeof sessionStats.datagramsAcknowledged, 'bigint');
+assert.strictEqual(typeof sessionStats.datagramsLost, 'bigint');
+assert.strictEqual(typeof sessionStats.streamsIdleTimedOut, 'bigint');
+assert.strictEqual(typeof sessionStats.toJSON(), 'object');
+assert.strictEqual(typeof inspect(sessionStats), 'string');
 streamStats[kFinishClose]();

--- a/test/parallel/test-quic-internal-setcallbacks.mjs
+++ b/test/parallel/test-quic-internal-setcallbacks.mjs
@@ -2,8 +2,6 @@
 import { hasQuic, skip } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -40,7 +38,7 @@ const callbacks = {
 for (const fn of Object.keys(callbacks)) {
   // eslint-disable-next-line no-unused-vars
   const { [fn]: _, ...rest } = callbacks;
-  throws(() => quic.setCallbacks(rest), {
+  assert.throws(() => quic.setCallbacks(rest), {
     code: 'ERR_MISSING_ARGS',
   });
 }

--- a/test/parallel/test-quic-keepalive.mjs
+++ b/test/parallel/test-quic-keepalive.mjs
@@ -9,8 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,8 +26,8 @@ const { listen, connect } = await import('../common/quic.mjs');
     // Wait for keep-alive PINGs to arrive.
     await setTimeout(300);
     // Server should have received PING frames.
-    ok(serverSession.stats.pingRecv > 0n,
-       'Server should receive keep-alive PINGs');
+    assert.ok(serverSession.stats.pingRecv > 0n,
+              'Server should receive keep-alive PINGs');
     serverSession.close();
     serverDone.resolve();
   }), {
@@ -55,7 +53,7 @@ const { listen, connect } = await import('../common/quic.mjs');
     const handshakePings = serverSession.stats.pingRecv;
     await setTimeout(200);
     // No additional PINGs should arrive without keepAlive.
-    strictEqual(serverSession.stats.pingRecv, handshakePings);
+    assert.strictEqual(serverSession.stats.pingRecv, handshakePings);
     serverSession.close();
     serverDone.resolve();
   }));

--- a/test/parallel/test-quic-key-update-peer.mjs
+++ b/test/parallel/test-quic-key-update-peer.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,7 +26,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const data = await bytes(stream);
     // Data should arrive correctly despite key update.
-    strictEqual(Buffer.from(data).toString(), 'after key update');
+    assert.strictEqual(Buffer.from(data).toString(), 'after key update');
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-key-update.mjs
+++ b/test/parallel/test-quic-key-update.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,7 +24,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(received.byteLength, dataLength);
+    assert.strictEqual(received.byteLength, dataLength);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-list-endpoints.mjs
+++ b/test/parallel/test-quic-list-endpoints.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual, strictEqual, throws, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,11 +17,11 @@ if (!hasQuic) {
 const { listEndpoints, QuicEndpoint } = await import('node:quic');
 
 // listEndpoints is exported as a function.
-strictEqual(typeof listEndpoints, 'function');
+assert.strictEqual(typeof listEndpoints, 'function');
 
 // Empty when no endpoints have been created.
-deepStrictEqual(listEndpoints(), []);
-deepStrictEqual(listEndpoints({ active: false }), []);
+assert.deepStrictEqual(listEndpoints(), []);
+assert.deepStrictEqual(listEndpoints({ active: false }), []);
 
 // Created endpoints appear in the list.
 {
@@ -31,19 +29,19 @@ deepStrictEqual(listEndpoints({ active: false }), []);
   const ep2 = new QuicEndpoint();
 
   const list = listEndpoints();
-  strictEqual(list.length, 2);
-  ok(list.includes(ep1));
-  ok(list.includes(ep2));
+  assert.strictEqual(list.length, 2);
+  assert.ok(list.includes(ep1));
+  assert.ok(list.includes(ep2));
 
   // active=false also returns them.
   const all = listEndpoints({ active: false });
-  strictEqual(all.length, 2);
-  ok(all.includes(ep1));
-  ok(all.includes(ep2));
+  assert.strictEqual(all.length, 2);
+  assert.ok(all.includes(ep1));
+  assert.ok(all.includes(ep2));
 
   // Returns plain QuicEndpoint instances, not wrapped in arrays.
-  ok(list[0] instanceof QuicEndpoint);
-  ok(list[1] instanceof QuicEndpoint);
+  assert.ok(list[0] instanceof QuicEndpoint);
+  assert.ok(list[1] instanceof QuicEndpoint);
 
   await ep1.close();
   await ep2.close();
@@ -52,54 +50,54 @@ deepStrictEqual(listEndpoints({ active: false }), []);
 // Destroyed endpoints are excluded by active filter.
 {
   const ep = new QuicEndpoint();
-  strictEqual(listEndpoints().length, 1);
+  assert.strictEqual(listEndpoints().length, 1);
 
   await ep.close();
   await ep.closed;
-  strictEqual(ep.destroyed, true);
+  assert.strictEqual(ep.destroyed, true);
 
   // Default (active=true) excludes destroyed endpoint.
-  strictEqual(listEndpoints().length, 0);
+  assert.strictEqual(listEndpoints().length, 0);
 
   // active=false still includes it... but destroyed endpoints are removed
   // from the registry entirely in kFinishClose, so it won't appear at all.
-  strictEqual(listEndpoints({ active: false }).length, 0);
+  assert.strictEqual(listEndpoints({ active: false }).length, 0);
 }
 
 // Busy endpoints are excluded by the active filter.
 {
   const ep = new QuicEndpoint();
-  strictEqual(listEndpoints().length, 1);
+  assert.strictEqual(listEndpoints().length, 1);
 
   ep.busy = true;
-  strictEqual(ep.busy, true);
+  assert.strictEqual(ep.busy, true);
 
   // active=true excludes busy endpoint.
-  strictEqual(listEndpoints().length, 0);
+  assert.strictEqual(listEndpoints().length, 0);
 
   // active=false includes it.
   const all = listEndpoints({ active: false });
-  strictEqual(all.length, 1);
-  ok(all.includes(ep));
+  assert.strictEqual(all.length, 1);
+  assert.ok(all.includes(ep));
 
   ep.busy = false;
 
   // After un-busying, it reappears in the active list.
-  strictEqual(listEndpoints().length, 1);
+  assert.strictEqual(listEndpoints().length, 1);
 
   await ep.close();
 }
 
 // Options validation.
-throws(() => listEndpoints('bad'), {
+assert.throws(() => listEndpoints('bad'), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-throws(() => listEndpoints(null), {
+assert.throws(() => listEndpoints(null), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-throws(() => listEndpoints({ active: 'yes' }), {
+assert.throws(() => listEndpoints({ active: 'yes' }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-throws(() => listEndpoints({ active: 1 }), {
+assert.throws(() => listEndpoints({ active: 1 }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });

--- a/test/parallel/test-quic-max-payload-size.mjs
+++ b/test/parallel/test-quic-max-payload-size.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,7 +24,7 @@ async function transferAndGetPacketCount(maxPayloadSize) {
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const received = await bytes(stream);
-      strictEqual(received.byteLength, dataLength);
+      assert.strictEqual(received.byteLength, dataLength);
       stream.writer.endSync();
       await stream.closed;
       serverSession.close();
@@ -54,5 +52,5 @@ const smallPkts = await transferAndGetPacketCount(1200);
 
 // With the same or default payload size, packet counts should be similar.
 // The key assertion: the option is accepted and data transfers correctly.
-ok(defaultPkts > 0n);
-ok(smallPkts > 0n);
+assert.ok(defaultPkts > 0n);
+assert.ok(smallPkts > 0n);

--- a/test/parallel/test-quic-max-window.mjs
+++ b/test/parallel/test-quic-max-window.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,7 +25,7 @@ const dataLength = 8192;
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const received = await bytes(stream);
-      strictEqual(received.byteLength, dataLength);
+      assert.strictEqual(received.byteLength, dataLength);
       stream.writer.endSync();
       await stream.closed;
       serverSession.close();
@@ -55,7 +53,7 @@ const dataLength = 8192;
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const received = await bytes(stream);
-      strictEqual(received.byteLength, dataLength);
+      assert.strictEqual(received.byteLength, dataLength);
       stream.writer.endSync();
       await stream.closed;
       serverSession.close();

--- a/test/parallel/test-quic-module-exports.mjs
+++ b/test/parallel/test-quic-module-exports.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,10 +18,10 @@ const quic = await import('node:quic');
 const { listen, connect } = await import('../common/quic.mjs');
 
 // Module exports are frozen/sealed.
-throws(() => { quic.newProperty = true; }, TypeError);
+assert.throws(() => { quic.newProperty = true; }, TypeError);
 
 // Stats classes exist.
-ok(quic.QuicEndpoint);
+assert.ok(quic.QuicEndpoint);
 
 // CONST-08/09: Session ticket and token getters.
 {
@@ -50,12 +48,12 @@ ok(quic.QuicEndpoint);
   await Promise.all([clientSession.opened, gotTicket.promise, gotToken.promise]);
 
   // Session ticket is a Buffer.
-  ok(Buffer.isBuffer(savedTicket));
-  ok(savedTicket.length > 0);
+  assert.ok(Buffer.isBuffer(savedTicket));
+  assert.ok(savedTicket.length > 0);
 
   // Token is a Buffer.
-  ok(Buffer.isBuffer(savedToken));
-  ok(savedToken.length > 0);
+  assert.ok(Buffer.isBuffer(savedToken));
+  assert.ok(savedToken.length > 0);
 
   await clientSession.close();
   await serverEndpoint.close();

--- a/test/parallel/test-quic-new-token.mjs
+++ b/test/parallel/test-quic-new-token.mjs
@@ -4,9 +4,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -14,11 +11,11 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // The token option must be an ArrayBufferView if provided
-await rejects(connect({ port: 1234 }, {
+await assert.rejects(connect({ port: 1234 }, {
   alpn: 'quic-test',
   token: 'not-a-buffer',
 }), {
@@ -44,9 +41,9 @@ const clientSession = await connect(serverEndpoint.address, {
   servername: 'localhost',
   // Set onnewtoken at connection time to avoid missing the event.
   onnewtoken: mustCall(function(token, address) {
-    ok(Buffer.isBuffer(token), 'token should be a Buffer');
-    ok(token.length > 0, 'token should not be empty');
-    ok(address !== undefined, 'address should be defined');
+    assert.ok(Buffer.isBuffer(token), 'token should be a Buffer');
+    assert.ok(token.length > 0, 'token should not be empty');
+    assert.ok(address !== undefined, 'address should be defined');
     clientToken.resolve();
   }),
 });

--- a/test/parallel/test-quic-perf-hooks.mjs
+++ b/test/parallel/test-quic-perf-hooks.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall, mustCallAtLeast } from '../common/index.mjs';
 import assert from 'node:assert';
 import { PerformanceObserver } from 'node:perf_hooks';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -68,31 +66,31 @@ const endpointEntries = entries.filter((e) => e.name === 'QuicEndpoint');
 const sessionEntries = entries.filter((e) => e.name === 'QuicSession');
 const streamEntries = entries.filter((e) => e.name === 'QuicStream');
 
-ok(endpointEntries.length >= 1, `Expected QuicEndpoint entries, got ${endpointEntries.length}`);
-ok(sessionEntries.length >= 2, `Expected >= 2 QuicSession entries, got ${sessionEntries.length}`);
-ok(streamEntries.length >= 2, `Expected >= 2 QuicStream entries, got ${streamEntries.length}`);
+assert.ok(endpointEntries.length >= 1, `Expected QuicEndpoint entries, got ${endpointEntries.length}`);
+assert.ok(sessionEntries.length >= 2, `Expected >= 2 QuicSession entries, got ${sessionEntries.length}`);
+assert.ok(streamEntries.length >= 2, `Expected >= 2 QuicStream entries, got ${streamEntries.length}`);
 
 // Verify common fields on all entries.
 for (const entry of entries) {
-  strictEqual(entry.entryType, 'quic');
-  strictEqual(typeof entry.startTime, 'number');
-  ok(entry.duration >= 0, `duration should be >= 0, got ${entry.duration}`);
-  ok(entry.detail, 'entry should have detail');
-  ok(entry.detail.stats, 'entry.detail should have stats');
+  assert.strictEqual(entry.entryType, 'quic');
+  assert.strictEqual(typeof entry.startTime, 'number');
+  assert.ok(entry.duration >= 0, `duration should be >= 0, got ${entry.duration}`);
+  assert.ok(entry.detail, 'entry should have detail');
+  assert.ok(entry.detail.stats, 'entry.detail should have stats');
 }
 
 // Verify session-specific detail fields.
 for (const entry of sessionEntries) {
   // The handshake may be undefined if destroyed before handshake completes,
   // but in this test both sessions complete handshakes.
-  ok(entry.detail.handshake, 'session entry should have handshake info');
-  strictEqual(typeof entry.detail.handshake.protocol, 'string');
-  strictEqual(typeof entry.detail.handshake.earlyDataAttempted, 'boolean');
-  strictEqual(typeof entry.detail.handshake.earlyDataAccepted, 'boolean');
+  assert.ok(entry.detail.handshake, 'session entry should have handshake info');
+  assert.strictEqual(typeof entry.detail.handshake.protocol, 'string');
+  assert.strictEqual(typeof entry.detail.handshake.earlyDataAttempted, 'boolean');
+  assert.strictEqual(typeof entry.detail.handshake.earlyDataAccepted, 'boolean');
 }
 
 // Verify stream-specific detail fields.
 for (const entry of streamEntries) {
-  ok(entry.detail.direction === 'bidi' || entry.detail.direction === 'uni',
-     `stream direction should be bidi or uni, got ${entry.detail.direction}`);
+  assert.ok(entry.detail.direction === 'bidi' || entry.detail.direction === 'uni',
+            `stream direction should be bidi or uni, got ${entry.detail.direction}`);
 }

--- a/test/parallel/test-quic-preferred-address-ignore.mjs
+++ b/test/parallel/test-quic-preferred-address-ignore.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -52,8 +50,8 @@ await clientSession.sendDatagram(new Uint8Array([2]));
 
 await Promise.all([serverGot.promise, allStatusDone.promise]);
 
-strictEqual(clientSession.stats.datagramsSent, 2n);
-ok(clientSession.stats.datagramsAcknowledged >= 1n);
+assert.strictEqual(clientSession.stats.datagramsSent, 2n);
+assert.ok(clientSession.stats.datagramsAcknowledged >= 1n);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-qlog.mjs
+++ b/test/parallel/test-quic-qlog.mjs
@@ -10,8 +10,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import { setImmediate } from 'node:timers/promises';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,42 +22,42 @@ let clientFinReceived = false;
 let serverFinReceived = false;
 
 function assertQlogOutput(chunks, finReceived, side) {
-  ok(chunks.length > 0, `Expected ${side} qlog chunks, got ${chunks.length}`);
-  ok(finReceived, `Expected ${side} to receive fin`);
+  assert.ok(chunks.length > 0, `Expected ${side} qlog chunks, got ${chunks.length}`);
+  assert.ok(finReceived, `Expected ${side} to receive fin`);
 
   for (const { data, fin } of chunks) {
-    strictEqual(typeof data, 'string',
-                `Each ${side} qlog chunk should be a string`);
-    strictEqual(typeof fin, 'boolean',
-                `Each ${side} fin flag should be a boolean`);
+    assert.strictEqual(typeof data, 'string',
+                       `Each ${side} qlog chunk should be a string`);
+    assert.strictEqual(typeof fin, 'boolean',
+                       `Each ${side} fin flag should be a boolean`);
   }
 
   // Only the last chunk should have fin=true.
   for (let i = 0; i < chunks.length - 1; i++) {
-    strictEqual(chunks[i].fin, false,
-                `${side} chunk ${i} should not be fin`);
+    assert.strictEqual(chunks[i].fin, false,
+                       `${side} chunk ${i} should not be fin`);
   }
-  strictEqual(chunks[chunks.length - 1].fin, true,
-              `${side} last chunk should be fin`);
+  assert.strictEqual(chunks[chunks.length - 1].fin, true,
+                     `${side} last chunk should be fin`);
 
   // ngtcp2 emits qlog in JSON-SEQ format (RFC 7464): each record is
   // prefixed with 0x1e (Record Separator) and terminated by a newline.
   // Parse the individual records and verify the header has expected fields.
   const joined = chunks.map((c) => c.data).join('');
   const records = joined.split('\x1e').filter((s) => s.trim().length > 0);
-  ok(records.length > 0, `${side} qlog should have at least one record`);
+  assert.ok(records.length > 0, `${side} qlog should have at least one record`);
 
   // The first record is the qlog header with format metadata.
   const header = JSON.parse(records[0]);
 
-  ok(header.qlog_version !== undefined || header.qlog_format !== undefined,
-     `${side} qlog header should have qlog_version or qlog_format field`);
+  assert.ok(header.qlog_version !== undefined || header.qlog_format !== undefined,
+            `${side} qlog header should have qlog_version or qlog_format field`);
 
   for (let i = 1; i < records.length; i++) {
     const record = JSON.parse(records[i]);
-    ok('name' in record);
-    ok('data' in record);
-    ok('time' in record);
+    assert.ok('name' in record);
+    assert.ok('data' in record);
+    assert.ok('time' in record);
   }
 }
 

--- a/test/parallel/test-quic-reject-unauthorized.mjs
+++ b/test/parallel/test-quic-reject-unauthorized.mjs
@@ -3,9 +3,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { strictEqual, ok, rejects } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -14,11 +11,11 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // rejectUnauthorized must be a boolean
-await rejects(connect({ port: 1234 }, {
+await assert.rejects(connect({ port: 1234 }, {
   alpn: 'quic-test',
   rejectUnauthorized: 'yes',
 }), {
@@ -26,22 +23,22 @@ await rejects(connect({ port: 1234 }, {
 });
 
 // verifyPeer must be one of 'strict', 'auto', 'manual'
-await rejects(connect({ port: 1234 }, {
+await assert.rejects(connect({ port: 1234 }, {
   alpn: 'quic-test',
   verifyPeer: 'invalid',
 }), {
   code: 'ERR_INVALID_ARG_VALUE',
 });
 
-const serverEndpoint = await listen(async (serverSession) => {
+const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onerror = () => {};
-  await rejects(serverSession.opened, (err) => {
-    ok(err.code === 'ERR_QUIC_TRANSPORT_ERROR' ||
-        err.code === 'ERR_INVALID_STATE');
-    return true;
-  });
-  serverSession.close();
-}, {
+  return assert.rejects(serverSession.opened, (err) =>
+    err.code === 'ERR_QUIC_TRANSPORT_ERROR' ||
+        err.code === 'ERR_INVALID_STATE',
+  ).then(mustCall(() => {
+    serverSession.close();
+  }));
+}, 3), {
   sni: { '*': { keys: [key], certs: [cert] } },
   alpn: ['quic-test'],
 });
@@ -58,10 +55,10 @@ const serverEndpoint = await listen(async (serverSession) => {
 
   const info = await clientSession.opened;
   // Self-signed cert without CA should produce a validation error.
-  strictEqual(typeof info.validationErrorReason, 'string');
-  ok(info.validationErrorReason.length > 0);
-  strictEqual(typeof info.validationErrorCode, 'string');
-  ok(info.validationErrorCode.length > 0);
+  assert.strictEqual(typeof info.validationErrorReason, 'string');
+  assert.ok(info.validationErrorReason.length > 0);
+  assert.strictEqual(typeof info.validationErrorCode, 'string');
+  assert.ok(info.validationErrorCode.length > 0);
 
   await clientSession.close();
 }
@@ -75,7 +72,7 @@ const serverEndpoint = await listen(async (serverSession) => {
     // verifyPeer defaults to 'auto'
   });
 
-  await rejects(clientSession.opened, {
+  await assert.rejects(clientSession.opened, {
     code: 'ERR_QUIC_TRANSPORT_ERROR',
   });
 }
@@ -89,11 +86,11 @@ const serverEndpoint = await listen(async (serverSession) => {
     verifyPeer: 'strict',
     // The TLS failure triggers onerror before opened rejects.
     onerror: mustCall((err) => {
-      ok(err, 'strict mode should fire onerror on invalid cert');
+      assert.ok(err, 'strict mode should fire onerror on invalid cert');
     }),
   });
 
-  await rejects(clientSession.opened, {
+  await assert.rejects(clientSession.opened, {
     code: 'ERR_QUIC_TRANSPORT_ERROR',
   });
 }

--- a/test/parallel/test-quic-session-application-options.mjs
+++ b/test/parallel/test-quic-session-application-options.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -35,24 +33,24 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     // complete, so applicationOptions should be available.
     const opts = serverSession.applicationOptions;
 
-    ok(opts != null, 'server applicationOptions should be available after handshake');
-    strictEqual(typeof opts, 'object');
-    strictEqual(Object.getPrototypeOf(opts), null);
+    assert.ok(opts != null, 'server applicationOptions should be available after handshake');
+    assert.strictEqual(typeof opts, 'object');
+    assert.strictEqual(Object.getPrototypeOf(opts), null);
 
     // Verify configured values are reflected.
-    strictEqual(opts.maxHeaderPairs, BigInt(customAppOptions.maxHeaderPairs));
-    strictEqual(opts.maxHeaderLength, BigInt(customAppOptions.maxHeaderLength));
-    strictEqual(opts.maxFieldSectionSize,
-                BigInt(customAppOptions.maxFieldSectionSize));
-    strictEqual(opts.qpackMaxDtableCapacity,
-                BigInt(customAppOptions.qpackMaxDTableCapacity));
-    strictEqual(opts.qpackEncoderMaxDtableCapacity,
-                BigInt(customAppOptions.qpackEncoderMaxDTableCapacity));
-    strictEqual(opts.qpackBlockedStreams,
-                BigInt(customAppOptions.qpackBlockedStreams));
-    strictEqual(opts.enableConnectProtocol,
-                customAppOptions.enableConnectProtocol);
-    strictEqual(opts.enableDatagrams, customAppOptions.enableDatagrams);
+    assert.strictEqual(opts.maxHeaderPairs, BigInt(customAppOptions.maxHeaderPairs));
+    assert.strictEqual(opts.maxHeaderLength, BigInt(customAppOptions.maxHeaderLength));
+    assert.strictEqual(opts.maxFieldSectionSize,
+                       BigInt(customAppOptions.maxFieldSectionSize));
+    assert.strictEqual(opts.qpackMaxDtableCapacity,
+                       BigInt(customAppOptions.qpackMaxDTableCapacity));
+    assert.strictEqual(opts.qpackEncoderMaxDtableCapacity,
+                       BigInt(customAppOptions.qpackEncoderMaxDTableCapacity));
+    assert.strictEqual(opts.qpackBlockedStreams,
+                       BigInt(customAppOptions.qpackBlockedStreams));
+    assert.strictEqual(opts.enableConnectProtocol,
+                       customAppOptions.enableConnectProtocol);
+    assert.strictEqual(opts.enableDatagrams, customAppOptions.enableDatagrams);
 
     stream.writer.endSync();
     await stream.closed;
@@ -71,24 +69,24 @@ await clientSession.opened;
 // After opened, ALPN negotiation is complete and applicationOptions
 // should be available on the client session.
 const clientOpts = clientSession.applicationOptions;
-ok(clientOpts != null, 'client applicationOptions should be available after handshake');
-strictEqual(typeof clientOpts, 'object');
-strictEqual(Object.getPrototypeOf(clientOpts), null);
+assert.ok(clientOpts != null, 'client applicationOptions should be available after handshake');
+assert.strictEqual(typeof clientOpts, 'object');
+assert.strictEqual(Object.getPrototypeOf(clientOpts), null);
 
 // Verify configured values on the client side.
-strictEqual(clientOpts.maxHeaderPairs, BigInt(customAppOptions.maxHeaderPairs));
-strictEqual(clientOpts.maxHeaderLength, BigInt(customAppOptions.maxHeaderLength));
-strictEqual(clientOpts.maxFieldSectionSize,
-            customAppOptions.maxFieldSectionSize);
-strictEqual(clientOpts.qpackMaxDtableCapacity,
-            customAppOptions.qpackMaxDTableCapacity);
-strictEqual(clientOpts.qpackEncoderMaxDtableCapacity,
-            customAppOptions.qpackEncoderMaxDTableCapacity);
-strictEqual(clientOpts.qpackBlockedStreams,
-            customAppOptions.qpackBlockedStreams);
-strictEqual(clientOpts.enableConnectProtocol,
-            customAppOptions.enableConnectProtocol);
-strictEqual(clientOpts.enableDatagrams, customAppOptions.enableDatagrams);
+assert.strictEqual(clientOpts.maxHeaderPairs, BigInt(customAppOptions.maxHeaderPairs));
+assert.strictEqual(clientOpts.maxHeaderLength, BigInt(customAppOptions.maxHeaderLength));
+assert.strictEqual(clientOpts.maxFieldSectionSize,
+                   customAppOptions.maxFieldSectionSize);
+assert.strictEqual(clientOpts.qpackMaxDtableCapacity,
+                   customAppOptions.qpackMaxDTableCapacity);
+assert.strictEqual(clientOpts.qpackEncoderMaxDtableCapacity,
+                   customAppOptions.qpackEncoderMaxDTableCapacity);
+assert.strictEqual(clientOpts.qpackBlockedStreams,
+                   customAppOptions.qpackBlockedStreams);
+assert.strictEqual(clientOpts.enableConnectProtocol,
+                   customAppOptions.enableConnectProtocol);
+assert.strictEqual(clientOpts.enableDatagrams, customAppOptions.enableDatagrams);
 
 // Exchange data to let the server side run its assertions.
 const stream = await clientSession.createBidirectionalStream();
@@ -100,6 +98,6 @@ await Promise.all([stream.closed, serverDone.promise]);
 
 // After close, applicationOptions should return null.
 await clientSession.close();
-strictEqual(clientSession.applicationOptions, null);
+assert.strictEqual(clientSession.applicationOptions, null);
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-close-error-code.mjs
+++ b/test/parallel/test-quic-session-close-error-code.mjs
@@ -12,8 +12,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
 
-const { strictEqual, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,16 +26,14 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onerror = mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
-      strictEqual(err.message.includes('42'), true,
-                  'error message should contain the code');
-      strictEqual(err.message.includes('client shutdown'), true,
-                  'error message should contain the reason');
-      strictEqual(err.errorCode, 42n);
-      strictEqual(err.type, 'application');
-      strictEqual(err.reason, 'client shutdown');
+      assert.strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.strictEqual(err.message.includes('42'), true); // Error message should contain the code
+      assert.strictEqual(err.message.includes('client shutdown'), true); // Error message should contain the reason
+      assert.strictEqual(err.errorCode, 42n);
+      assert.strictEqual(err.type, 'application');
+      assert.strictEqual(err.reason, 'client shutdown');
     });
-    await rejects(serverSession.closed, {
+    await assert.rejects(serverSession.closed, {
       code: 'ERR_QUIC_APPLICATION_ERROR',
       errorCode: 42n,
       reason: 'client shutdown',
@@ -75,13 +71,12 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onerror = mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
-      strictEqual(err.message.includes('1'), true,
-                  'error message should contain the code');
-      strictEqual(err.errorCode, 1n);
-      strictEqual(err.type, 'transport');
+      assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+      assert.strictEqual(err.message.includes('1'), true); // Error message should contain the code
+      assert.strictEqual(err.errorCode, 1n);
+      assert.strictEqual(err.type, 'transport');
     });
-    await rejects(serverSession.closed, {
+    await assert.rejects(serverSession.closed, {
       code: 'ERR_QUIC_TRANSPORT_ERROR',
     });
     serverGot.resolve();
@@ -108,13 +103,13 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onerror = mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
-      strictEqual(err.message.includes('99'), true);
-      strictEqual(err.errorCode, 99n);
-      strictEqual(err.type, 'application');
-      strictEqual(err.reason, 'destroy with code');
+      assert.strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.strictEqual(err.message.includes('99'), true);
+      assert.strictEqual(err.errorCode, 99n);
+      assert.strictEqual(err.type, 'application');
+      assert.strictEqual(err.reason, 'destroy with code');
     });
-    await rejects(serverSession.closed, {
+    await assert.rejects(serverSession.closed, {
       code: 'ERR_QUIC_APPLICATION_ERROR',
     });
     serverGot.resolve();
@@ -124,7 +119,7 @@ const { listen, connect } = await import('../common/quic.mjs');
     reuseEndpoint: false,
     onerror: mustCall((err) => {
       // The JS error passed to destroy is delivered via onerror.
-      strictEqual(err.message, 'fatal error');
+      assert.strictEqual(err.message, 'fatal error');
     }),
   });
   await clientSession.opened;
@@ -138,7 +133,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   });
 
   // The closed promise rejects with the JS error, not the QUIC error.
-  await rejects(clientSession.closed, jsError);
+  await assert.rejects(clientSession.closed, jsError);
 
   await serverGot.promise;
   await serverEndpoint.close();

--- a/test/parallel/test-quic-session-close-graceful.mjs
+++ b/test/parallel/test-quic-session-close-graceful.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,7 +26,7 @@ const encoder = new TextEncoder();
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const received = await bytes(stream);
-      strictEqual(received.byteLength, 5);
+      assert.strictEqual(received.byteLength, 5);
       stream.writer.endSync();
       await stream.closed;
       serverDone.resolve();
@@ -56,8 +54,8 @@ const encoder = new TextEncoder();
 
   // Now the closed promise should resolve.
   await closePromise;
-  strictEqual(closedResolved, true);
-  strictEqual(clientSession.destroyed, true);
+  assert.strictEqual(closedResolved, true);
+  assert.strictEqual(clientSession.destroyed, true);
 
   await serverEndpoint.close();
 }
@@ -76,7 +74,7 @@ const encoder = new TextEncoder();
   clientSession.close();
 
   // Attempting to create a stream after close() should reject.
-  await rejects(
+  await assert.rejects(
     clientSession.createBidirectionalStream({
       body: encoder.encode('too late'),
     }),

--- a/test/parallel/test-quic-session-close.mjs
+++ b/test/parallel/test-quic-session-close.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,7 +28,7 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   // No streams opened. close() should resolve.
   await clientSession.close();
-  strictEqual(clientSession.destroyed, true);
+  assert.strictEqual(clientSession.destroyed, true);
   await serverEndpoint.close();
 }
 
@@ -50,7 +48,7 @@ const { listen, connect } = await import('../common/quic.mjs');
 
   // Client's closed promise should resolve when the server closes.
   await clientSession.closed;
-  strictEqual(clientSession.destroyed, true);
+  assert.strictEqual(clientSession.destroyed, true);
   await serverEndpoint.close();
 }
 
@@ -63,7 +61,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     // The server's closed promise should resolve when the client closes.
     await serverSession.closed;
-    strictEqual(serverSession.destroyed, true);
+    assert.strictEqual(serverSession.destroyed, true);
     serverDone.resolve();
   }));
 

--- a/test/parallel/test-quic-session-destroy-reentrant.mjs
+++ b/test/parallel/test-quic-session-destroy-reentrant.mjs
@@ -29,8 +29,6 @@ import assert from 'node:assert';
 import diagnostics_channel from 'node:diagnostics_channel';
 import { setImmediate } from 'node:timers/promises';
 
-const { strictEqual, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -61,10 +59,10 @@ const transportParams = { maxIdleTimeout: 1 };
   // `onerror` handler), the `#destroying` guard makes the second call
   // a true no-op so each channel publishes exactly once.
   const errSub = mustCall((msg) => {
-    strictEqual(msg.session, clientSession);
+    assert.strictEqual(msg.session, clientSession);
   });
   const closedSub = mustCall((msg) => {
-    strictEqual(msg.session, clientSession);
+    assert.strictEqual(msg.session, clientSession);
   });
   diagnostics_channel.subscribe('quic.session.error', errSub);
   diagnostics_channel.subscribe('quic.session.closed', closedSub);
@@ -72,7 +70,7 @@ const transportParams = { maxIdleTimeout: 1 };
   const testError = new Error('reentrant destroy test');
 
   clientSession.onerror = mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
     // Re-enter destroy synchronously from the error handler. This must
     // be a no-op because `#destroying` is already set; `destroyed` is
     // still false here because `#handle` is cleared at the end of
@@ -84,9 +82,9 @@ const transportParams = { maxIdleTimeout: 1 };
 
   clientSession.destroy(testError);
   // Once `destroy()` has returned, `destroyed` flips to true.
-  strictEqual(clientSession.destroyed, true);
+  assert.strictEqual(clientSession.destroyed, true);
 
-  await rejects(clientSession.closed, testError);
+  await assert.rejects(clientSession.closed, testError);
 
   // Give the diagnostics_channel a tick to deliver any deferred messages.
   await setImmediate();
@@ -125,7 +123,7 @@ const transportParams = { maxIdleTimeout: 1 };
   const testError = new Error('cascade reentrant destroy test');
 
   stream.onerror = mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
     // Re-enter session.destroy from inside the stream's onerror. This
     // is happening DURING the session's stream cascade, so the session
     // is mid-destroy. The second destroy() call must be a no-op.
@@ -133,15 +131,15 @@ const transportParams = { maxIdleTimeout: 1 };
   });
 
   clientSession.onerror = mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
   });
 
   clientSession.destroy(testError);
-  strictEqual(clientSession.destroyed, true);
-  strictEqual(stream.destroyed, true);
+  assert.strictEqual(clientSession.destroyed, true);
+  assert.strictEqual(stream.destroyed, true);
 
-  await rejects(clientSession.closed, testError);
-  await rejects(stream.closed, testError);
+  await assert.rejects(clientSession.closed, testError);
+  await assert.rejects(stream.closed, testError);
 
   await serverDone.promise;
   await serverEndpoint.close();
@@ -167,7 +165,7 @@ const transportParams = { maxIdleTimeout: 1 };
   const testError = new Error('stream reentrant destroy test');
 
   stream.onerror = mustCall((err) => {
-    strictEqual(err, testError);
+    assert.strictEqual(err, testError);
     // Re-enter stream.destroy from inside its own onerror. The
     // `#destroying` flag traps the recursive call; `destroyed` (i.e.
     // `#handle === undefined`) is still false here because the handle
@@ -177,9 +175,9 @@ const transportParams = { maxIdleTimeout: 1 };
 
   stream.destroy(testError);
   // Once `destroy()` has returned, `destroyed` flips to true.
-  strictEqual(stream.destroyed, true);
+  assert.strictEqual(stream.destroyed, true);
 
-  await rejects(stream.closed, testError);
+  await assert.rejects(stream.closed, testError);
 
   clientSession.close();
   await clientSession.closed;

--- a/test/parallel/test-quic-session-destroy-validate-options.mjs
+++ b/test/parallel/test-quic-session-destroy-validate-options.mjs
@@ -18,8 +18,6 @@ import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import diagnostics_channel from 'node:diagnostics_channel';
 
-const { strictEqual, rejects, throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -72,47 +70,47 @@ clientSession.onerror = mustNotCall(
 const goodError = new Error('intended teardown');
 
 // 1. options is not an object -> throws ERR_INVALID_ARG_TYPE.
-throws(() => clientSession.destroy(goodError, 'not an object'), {
+assert.throws(() => clientSession.destroy(goodError, 'not an object'), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-strictEqual(clientSession.destroyed, false);
-strictEqual(stream.destroyed, false);
+assert.strictEqual(clientSession.destroyed, false);
+assert.strictEqual(stream.destroyed, false);
 
 // 2. options.code is the wrong type -> throws ERR_INVALID_ARG_TYPE.
-throws(() => clientSession.destroy(goodError, { code: 'oops' }), {
+assert.throws(() => clientSession.destroy(goodError, { code: 'oops' }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-strictEqual(clientSession.destroyed, false);
-strictEqual(stream.destroyed, false);
+assert.strictEqual(clientSession.destroyed, false);
+assert.strictEqual(stream.destroyed, false);
 
 // 3. options.type is not in the allowed set -> throws ERR_INVALID_ARG_VALUE.
-throws(() => clientSession.destroy(goodError, { type: 'bogus' }), {
+assert.throws(() => clientSession.destroy(goodError, { type: 'bogus' }), {
   code: 'ERR_INVALID_ARG_VALUE',
 });
-strictEqual(clientSession.destroyed, false);
-strictEqual(stream.destroyed, false);
+assert.strictEqual(clientSession.destroyed, false);
+assert.strictEqual(stream.destroyed, false);
 
 // 4. options.reason is the wrong type -> throws ERR_INVALID_ARG_TYPE.
-throws(() => clientSession.destroy(goodError, { reason: 42 }), {
+assert.throws(() => clientSession.destroy(goodError, { reason: 42 }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-strictEqual(clientSession.destroyed, false);
-strictEqual(stream.destroyed, false);
+assert.strictEqual(clientSession.destroyed, false);
+assert.strictEqual(stream.destroyed, false);
 
 // Now switch the handlers to expect the real teardown so the final
 // destroy with valid options can run cleanly.
 diagnostics_channel.unsubscribe('quic.session.error', errSub);
-clientSession.onerror = mustCall((err) => { strictEqual(err, goodError); });
-stream.onerror = mustCall((err) => { strictEqual(err, goodError); });
+clientSession.onerror = mustCall((err) => { assert.strictEqual(err, goodError); });
+stream.onerror = mustCall((err) => { assert.strictEqual(err, goodError); });
 
 // Pre-attach rejection handlers on both sides BEFORE triggering the
 // final destroy, so the rejections do not race ahead of any awaits in
 // the test body. The client rejects with the original `goodError`;
 // the server decodes the CONNECTION_CLOSE frame transport code into
 // an `ERR_QUIC_TRANSPORT_ERROR`.
-const clientClosedAssertion = rejects(clientSession.closed, goodError);
-const serverClosedAssertion = rejects(serverSession.closed, mustCall((err) => {
-  strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+const clientClosedAssertion = assert.rejects(clientSession.closed, goodError);
+const serverClosedAssertion = assert.rejects(serverSession.closed, mustCall((err) => {
+  assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
   return true;
 }));
 
@@ -125,8 +123,8 @@ clientSession.destroy(goodError, {
   type: 'transport',
   reason: 'after validation throw',
 });
-strictEqual(clientSession.destroyed, true);
-strictEqual(stream.destroyed, true);
+assert.strictEqual(clientSession.destroyed, true);
+assert.strictEqual(stream.destroyed, true);
 
 await clientClosedAssertion;
 await serverClosedAssertion;

--- a/test/parallel/test-quic-session-destroy.mjs
+++ b/test/parallel/test-quic-session-destroy.mjs
@@ -12,8 +12,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -41,7 +39,7 @@ const transportParams = { maxIdleTimeout: 1 };
   await clientSession.opened;
 
   clientSession.destroy();
-  strictEqual(clientSession.destroyed, true);
+  assert.strictEqual(clientSession.destroyed, true);
 
   // Closed should resolve (no error).
   await clientSession.closed;
@@ -68,10 +66,10 @@ const transportParams = { maxIdleTimeout: 1 };
 
   const testError = new Error('intentional destroy error');
   clientSession.destroy(testError);
-  strictEqual(clientSession.destroyed, true);
+  assert.strictEqual(clientSession.destroyed, true);
 
   // Closed should reject with the same error.
-  await rejects(clientSession.closed, testError);
+  await assert.rejects(clientSession.closed, testError);
 
   await serverDone.promise;
   await serverEndpoint.close();
@@ -95,7 +93,7 @@ const transportParams = { maxIdleTimeout: 1 };
 
   // Destroy directly without calling close() first.
   clientSession.destroy();
-  strictEqual(clientSession.destroyed, true);
+  assert.strictEqual(clientSession.destroyed, true);
   await clientSession.closed;
 
   await serverDone.promise;

--- a/test/parallel/test-quic-session-emit-ordering.mjs
+++ b/test/parallel/test-quic-session-emit-ordering.mjs
@@ -6,8 +6,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, notStrictEqual, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,19 +21,19 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   // All assertions run synchronously in the onsession emit frame.
 
   // The TLS details from the ClientHello are readable on the session.
-  strictEqual(serverSession.servername, 'localhost');
-  strictEqual(serverSession.alpnProtocol, 'quic-test');
+  assert.strictEqual(serverSession.servername, 'localhost');
+  assert.strictEqual(serverSession.alpnProtocol, 'quic-test');
 
   // The client's transport params arrived in the first flight and have
   // been processed by the time the session is surfaced.
   const params = serverSession.remoteTransportParams;
-  notStrictEqual(params, undefined);
-  notStrictEqual(params, null);
-  ok(params.initialMaxStreamsBidi >= 0n);
+  assert.notStrictEqual(params, undefined);
+  assert.notStrictEqual(params, null);
+  assert.ok(params.initialMaxStreamsBidi >= 0n);
 
   // ALPN negotiation has completed: headers support is resolved (2 =
   // unsupported, confirming non-h3 test ALPN)
-  strictEqual(getQuicSessionState(serverSession).headersSupported, 2);
+  assert.strictEqual(getQuicSessionState(serverSession).headersSupported, 2);
 
   sessionSeen.resolve();
 }));

--- a/test/parallel/test-quic-session-initial-rtt.mjs
+++ b/test/parallel/test-quic-session-initial-rtt.mjs
@@ -6,8 +6,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,7 +23,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const data = await bytes(stream);
-    ok(data.byteLength > 0);
+    assert.ok(data.byteLength > 0);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();
@@ -52,9 +50,9 @@ await serverDone.promise;
 // realistic value. On loopback it should be well under 10ms (10,000,000ns).
 // The stat is in nanoseconds.
 const smoothedRtt = clientSession.stats.smoothedRtt;
-ok(smoothedRtt > 0n, 'smoothedRtt should be non-zero after data exchange');
-ok(smoothedRtt < 10_000_000n,
-   `smoothedRtt should be under 10ms on loopback, got ${smoothedRtt}ns`);
+assert.ok(smoothedRtt > 0n, 'smoothedRtt should be non-zero after data exchange');
+assert.ok(smoothedRtt < 10_000_000n,
+          `smoothedRtt should be under 10ms on loopback, got ${smoothedRtt}ns`);
 
 await clientSession.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-opened-early-destroy.mjs
+++ b/test/parallel/test-quic-session-opened-early-destroy.mjs
@@ -20,8 +20,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -53,7 +51,7 @@ const transportParams = { maxIdleTimeout: 1 };
   // the handshake itself happens asynchronously over the network.
   clientSession.destroy();
 
-  await rejects(clientSession.opened, {
+  await assert.rejects(clientSession.opened, {
     code: 'ERR_INVALID_STATE',
     message: /destroyed before it opened/,
   });
@@ -108,7 +106,7 @@ const transportParams = { maxIdleTimeout: 1 };
   // session, which should reject session.opened.
   clientEndpoint.destroy();
 
-  await rejects(clientSession.opened, {
+  await assert.rejects(clientSession.opened, {
     code: 'ERR_INVALID_STATE',
     message: /destroyed before it opened/,
   });
@@ -135,7 +133,7 @@ const transportParams = { maxIdleTimeout: 1 };
   });
 
   const info = await clientSession.opened;
-  strictEqual(typeof info.protocol, 'string');
+  assert.strictEqual(typeof info.protocol, 'string');
 
   clientSession.destroy();
 
@@ -143,7 +141,7 @@ const transportParams = { maxIdleTimeout: 1 };
   // info object (PromiseWithResolvers caches it; we just assert the
   // promise is not rejected).
   const infoAgain = await clientSession.opened;
-  strictEqual(infoAgain, info);
+  assert.strictEqual(infoAgain, info);
 
   await serverDone.promise;
   await serverEndpoint.close();

--- a/test/parallel/test-quic-session-opened-info.mjs
+++ b/test/parallel/test-quic-session-opened-info.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { notStrictEqual, strictEqual, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,26 +22,26 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const info = await serverSession.opened;
 
   // Server sees its own local address and the client's remote.
-  strictEqual(info.local.address, '127.0.0.1');
-  strictEqual(info.local.family, 'ipv4');
-  strictEqual(typeof info.local.port, 'number');
-  strictEqual(info.remote.address, '127.0.0.1');
-  strictEqual(info.remote.family, 'ipv4');
-  strictEqual(typeof info.remote.port, 'number');
+  assert.strictEqual(info.local.address, '127.0.0.1');
+  assert.strictEqual(info.local.family, 'ipv4');
+  assert.strictEqual(typeof info.local.port, 'number');
+  assert.strictEqual(info.remote.address, '127.0.0.1');
+  assert.strictEqual(info.remote.family, 'ipv4');
+  assert.strictEqual(typeof info.remote.port, 'number');
 
   // Local and remote ports should differ.
-  notStrictEqual(info.local.port, info.remote.port);
+  assert.notStrictEqual(info.local.port, info.remote.port);
 
   // Servername matches the SNI.
-  strictEqual(info.servername, 'localhost');
+  assert.strictEqual(info.servername, 'localhost');
 
   // Protocol matches ALPN.
-  strictEqual(info.protocol, 'quic-test');
+  assert.strictEqual(info.protocol, 'quic-test');
 
   // cipher info.
-  strictEqual(typeof info.cipher, 'string');
-  ok(info.cipher.length > 0);
-  strictEqual(info.cipherVersion, 'TLSv1.3');
+  assert.strictEqual(typeof info.cipher, 'string');
+  assert.ok(info.cipher.length > 0);
+  assert.strictEqual(info.cipherVersion, 'TLSv1.3');
 
   serverSession.close();
   serverDone.resolve();
@@ -53,20 +51,20 @@ const clientSession = await connect(serverEndpoint.address);
 const clientInfo = await clientSession.opened;
 
 // Client sees its own local address and the server's remote.
-strictEqual(clientInfo.local.address, '127.0.0.1');
-strictEqual(clientInfo.remote.address, '127.0.0.1');
-notStrictEqual(clientInfo.local.port, clientInfo.remote.port);
+assert.strictEqual(clientInfo.local.address, '127.0.0.1');
+assert.strictEqual(clientInfo.remote.address, '127.0.0.1');
+assert.notStrictEqual(clientInfo.local.port, clientInfo.remote.port);
 
 // servername matches.
-strictEqual(clientInfo.servername, 'localhost');
+assert.strictEqual(clientInfo.servername, 'localhost');
 
 // Protocol matches ALPN.
-strictEqual(clientInfo.protocol, 'quic-test');
+assert.strictEqual(clientInfo.protocol, 'quic-test');
 
 // cipher info.
-strictEqual(typeof clientInfo.cipher, 'string');
-ok(clientInfo.cipher.length > 0);
-strictEqual(clientInfo.cipherVersion, 'TLSv1.3');
+assert.strictEqual(typeof clientInfo.cipher, 'string');
+assert.ok(clientInfo.cipher.length > 0);
+assert.strictEqual(clientInfo.cipherVersion, 'TLSv1.3');
 
 await Promise.all([serverDone.promise, clientSession.closed]);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-opened-validation.mjs
+++ b/test/parallel/test-quic-session-opened-validation.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -21,8 +19,8 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const serverInfo = await serverSession.opened;
 
   // Server also sees validation info about the peer.
-  strictEqual(typeof serverInfo.validationErrorReason, 'string');
-  strictEqual(typeof serverInfo.validationErrorCode, 'string');
+  assert.strictEqual(typeof serverInfo.validationErrorReason, 'string');
+  assert.strictEqual(typeof serverInfo.validationErrorCode, 'string');
 
   serverSession.close();
 }));
@@ -34,12 +32,12 @@ const clientInfo = await clientSession.opened;
 
 // validationErrorReason is a non-empty string describing
 // why the cert failed validation (self-signed cert).
-strictEqual(typeof clientInfo.validationErrorReason, 'string');
-ok(clientInfo.validationErrorReason.length > 0);
+assert.strictEqual(typeof clientInfo.validationErrorReason, 'string');
+assert.ok(clientInfo.validationErrorReason.length > 0);
 
 // validationErrorCode is the OpenSSL error code string.
-strictEqual(typeof clientInfo.validationErrorCode, 'string');
-ok(clientInfo.validationErrorCode.length > 0);
+assert.strictEqual(typeof clientInfo.validationErrorCode, 'string');
+assert.ok(clientInfo.validationErrorCode.length > 0);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-preferred-address-ignore.mjs
+++ b/test/parallel/test-quic-session-preferred-address-ignore.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -61,8 +59,8 @@ await clientSession.sendDatagram(new Uint8Array([4]));
 
 await Promise.all([serverGot.promise, allStatusDone.promise]);
 
-strictEqual(clientSession.stats.datagramsSent, 4n);
-ok(clientSession.stats.datagramsAcknowledged >= 1n);
+assert.strictEqual(clientSession.stats.datagramsSent, 4n);
+assert.ok(clientSession.stats.datagramsAcknowledged >= 1n);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-preferred-address-ipv6.mjs
+++ b/test/parallel/test-quic-session-preferred-address-ipv6.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual, notStrictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -31,13 +28,13 @@ const handleSession = mustCall(async (serverSession) => {
 });
 
 function assertEqualAddress(addr1, addr2) {
-  strictEqual(addr1.address, addr2.address);
-  strictEqual(addr1.port, addr2.port);
-  strictEqual(addr1.family, addr2.family);
+  assert.strictEqual(addr1.address, addr2.address);
+  assert.strictEqual(addr1.port, addr2.port);
+  assert.strictEqual(addr1.family, addr2.family);
 }
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const sessionOptions = {
   ondatagram: mustCall((data) => {
@@ -48,12 +45,12 @@ const sessionOptions = {
     // The 'aborted' status only means that path validation is no longer
     // necessary for a number of reasons (usually ngtcp2 received a non-probing
     // packet on the new path).
-    notStrictEqual(result, 'failure');
+    assert.notStrictEqual(result, 'failure');
     assertEqualAddress(newLocal, preferredEndpoint.address);
     assertEqualAddress(oldLocal, serverEndpoint.address);
     assertEqualAddress(newRemote, oldRemote);
     // The preferred arg is only passed on client side
-    strictEqual(preferred, undefined);
+    assert.strictEqual(preferred, undefined);
     serverPathValidated.resolve();
   }),
   sni: { '*': { keys: [key], certs: [cert] } },
@@ -87,12 +84,12 @@ const clientSession = await connect(serverEndpoint.address, {
     if (++statusCount >= 4) allStatusDone.resolve();
   }, 4),
   onpathvalidation: mustCall((result, newLocal, newRemote, oldLocal, oldRemote, preferred) => {
-    strictEqual(result, 'success');
+    assert.strictEqual(result, 'success');
     assertEqualAddress(newLocal, clientSession.endpoint.address);
     assertEqualAddress(newRemote, preferredEndpoint.address);
-    strictEqual(oldLocal, null);
-    strictEqual(oldRemote, null);
-    strictEqual(preferred, true);
+    assert.strictEqual(oldLocal, null);
+    assert.strictEqual(oldRemote, null);
+    assert.strictEqual(preferred, true);
   }),
   endpoint: {
     address: {
@@ -120,8 +117,8 @@ await clientSession.sendDatagram(new Uint8Array([4]));
 
 await Promise.all([serverGot.promise, allStatusDone.promise]);
 
-strictEqual(clientSession.stats.datagramsSent, 4n);
-ok(clientSession.stats.datagramsAcknowledged >= 1n);
+assert.strictEqual(clientSession.stats.datagramsSent, 4n);
+assert.ok(clientSession.stats.datagramsAcknowledged >= 1n);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-preferred-address.mjs
+++ b/test/parallel/test-quic-session-preferred-address.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual, notStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,9 +28,9 @@ const handleSession = mustCall(async (serverSession) => {
 });
 
 function assertEqualAddress(addr1, addr2) {
-  strictEqual(addr1.address, addr2.address);
-  strictEqual(addr1.port, addr2.port);
-  strictEqual(addr1.family, addr2.family);
+  assert.strictEqual(addr1.address, addr2.address);
+  assert.strictEqual(addr1.port, addr2.port);
+  assert.strictEqual(addr1.family, addr2.family);
 }
 
 const sessionOptions = {
@@ -44,12 +42,12 @@ const sessionOptions = {
     // The 'aborted' status only means that path validation is no longer
     // necessary for a number of reasons (usually ngtcp2 received a non-probing
     // packet on the new path).
-    notStrictEqual(result, 'failure');
+    assert.notStrictEqual(result, 'failure');
     assertEqualAddress(newLocal, preferredEndpoint.address);
     assertEqualAddress(oldLocal, serverEndpoint.address);
     assertEqualAddress(newRemote, oldRemote);
     // The preferred arg is only passed on client side
-    strictEqual(preferred, undefined);
+    assert.strictEqual(preferred, undefined);
     serverPathValidated.resolve();
   }),
 };
@@ -71,12 +69,12 @@ const clientSession = await connect(serverEndpoint.address, {
     if (++statusCount >= 4) allStatusDone.resolve();
   }, 4),
   onpathvalidation: mustCall((result, newLocal, newRemote, oldLocal, oldRemote, preferred) => {
-    strictEqual(result, 'success');
+    assert.strictEqual(result, 'success');
     assertEqualAddress(newLocal, clientSession.endpoint.address);
     assertEqualAddress(newRemote, preferredEndpoint.address);
-    strictEqual(oldLocal, null);
-    strictEqual(oldRemote, null);
-    strictEqual(preferred, true);
+    assert.strictEqual(oldLocal, null);
+    assert.strictEqual(oldRemote, null);
+    assert.strictEqual(preferred, true);
   }),
   maxDatagramSendAttempts: 100, // While the connection is restablished,
   // all the acknowledgement packets of ngtcp2 are counted as send attempts
@@ -98,8 +96,8 @@ await clientSession.sendDatagram(new Uint8Array([4]));
 
 await Promise.all([serverGot.promise, allStatusDone.promise]);
 
-strictEqual(clientSession.stats.datagramsSent, 4n);
-ok(clientSession.stats.datagramsAcknowledged >= 1n);
+assert.strictEqual(clientSession.stats.datagramsSent, 4n);
+assert.ok(clientSession.stats.datagramsAcknowledged >= 1n);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-properties.mjs
+++ b/test/parallel/test-quic-session-properties.mjs
@@ -15,8 +15,6 @@ import { hasQuic, skip, mustCall, hasCrypto } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasCrypto)
   skip('missing crypto');
 
@@ -38,26 +36,26 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
 
   // PATH-03/06: Server path has local and remote.
   const path = serverSession.path;
-  ok(path);
-  ok(path.local);
-  ok(path.remote);
+  assert.ok(path);
+  assert.ok(path.local);
+  assert.ok(path.remote);
 
   // Cached.
-  strictEqual(serverSession.path, path);
+  assert.strictEqual(serverSession.path, path);
 
   // Own certificate.
   const cert = serverSession.certificate;
-  ok(cert instanceof X509Certificate);
-  strictEqual(cert.subject, expectedCert.subject);
-  strictEqual(cert.issuer, expectedCert.issuer);
-  strictEqual(cert.fingerprint256, expectedCert.fingerprint256);
+  assert.ok(cert instanceof X509Certificate);
+  assert.strictEqual(cert.subject, expectedCert.subject);
+  assert.strictEqual(cert.issuer, expectedCert.issuer);
+  assert.strictEqual(cert.fingerprint256, expectedCert.fingerprint256);
 
   // Peer certificate (client's cert — not set in this
   // test since we don't use verifyClient, so it's undefined).
-  strictEqual(serverSession.peerCertificate, undefined);
+  assert.strictEqual(serverSession.peerCertificate, undefined);
 
   // Cached.
-  strictEqual(serverSession.certificate, cert);
+  assert.strictEqual(serverSession.certificate, cert);
 
   await serverSession.close();
   serverDone.resolve();
@@ -68,36 +66,36 @@ await clientSession.opened;
 
 // PATH-03/06: Client path.
 const path = clientSession.path;
-ok(path);
-ok(path.local);
-ok(path.remote);
+assert.ok(path);
+assert.ok(path.local);
+assert.ok(path.remote);
 
 // Cached.
-strictEqual(clientSession.path, path);
+assert.strictEqual(clientSession.path, path);
 
 // Peer certificate (server's cert).
 const peerCert = clientSession.peerCertificate;
-ok(peerCert instanceof X509Certificate);
-strictEqual(peerCert.subject, expectedCert.subject);
-strictEqual(peerCert.issuer, expectedCert.issuer);
-strictEqual(peerCert.fingerprint256, expectedCert.fingerprint256);
+assert.ok(peerCert instanceof X509Certificate);
+assert.strictEqual(peerCert.subject, expectedCert.subject);
+assert.strictEqual(peerCert.issuer, expectedCert.issuer);
+assert.strictEqual(peerCert.fingerprint256, expectedCert.fingerprint256);
 
 // Ephemeral key info (client only).
 const keyInfo = clientSession.ephemeralKeyInfo;
-ok(keyInfo);
+assert.ok(keyInfo);
 
 // Cached.
-strictEqual(clientSession.peerCertificate, peerCert);
-strictEqual(clientSession.ephemeralKeyInfo, keyInfo);
+assert.strictEqual(clientSession.peerCertificate, peerCert);
+assert.strictEqual(clientSession.ephemeralKeyInfo, keyInfo);
 
 await Promise.all([clientSession.closed, serverDone.promise]);
 
 // Returns undefined after destroy.
-strictEqual(clientSession.path, undefined);
+assert.strictEqual(clientSession.path, undefined);
 
 // Returns undefined after destroy.
-strictEqual(clientSession.certificate, undefined);
-strictEqual(clientSession.peerCertificate, undefined);
-strictEqual(clientSession.ephemeralKeyInfo, undefined);
+assert.strictEqual(clientSession.certificate, undefined);
+assert.strictEqual(clientSession.peerCertificate, undefined);
+assert.strictEqual(clientSession.ephemeralKeyInfo, undefined);
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-stats-datagram.mjs
+++ b/test/parallel/test-quic-session-stats-datagram.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,7 +23,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   await allStatusDone.promise;
 
   // Server received datagrams.
-  ok(serverSession.stats.datagramsReceived > 0n);
+  assert.ok(serverSession.stats.datagramsReceived > 0n);
 
   serverSession.close();
   await serverSession.closed;
@@ -51,8 +49,8 @@ await clientSession.sendDatagram(new Uint8Array([2]));
 await Promise.all([serverGot.promise, allStatusDone.promise]);
 
 // Client sent datagrams.
-strictEqual(clientSession.stats.datagramsSent, 2n);
-ok(clientSession.stats.datagramsAcknowledged >= 1n);
+assert.strictEqual(clientSession.stats.datagramsSent, 2n);
+assert.ok(clientSession.stats.datagramsAcknowledged >= 1n);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-stats-detailed.mjs
+++ b/test/parallel/test-quic-session-stats-detailed.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -43,23 +41,23 @@ await Promise.all([stream.closed, serverDone.promise]);
 const stats = clientSession.stats;
 
 // RTT fields populated.
-ok(stats.smoothedRtt >= 0n, 'smoothedRtt should be >= 0');
-ok(stats.latestRtt >= 0n, 'latestRtt should be >= 0');
-ok(stats.minRtt >= 0n, 'minRtt should be >= 0');
-strictEqual(typeof stats.rttVar, 'bigint');
+assert.ok(stats.smoothedRtt >= 0n, 'smoothedRtt should be >= 0');
+assert.ok(stats.latestRtt >= 0n, 'latestRtt should be >= 0');
+assert.ok(stats.minRtt >= 0n, 'minRtt should be >= 0');
+assert.strictEqual(typeof stats.rttVar, 'bigint');
 
 // Congestion fields.
-ok(stats.cwnd > 0n, 'cwnd should be > 0');
-strictEqual(typeof stats.bytesInFlight, 'bigint');
-strictEqual(typeof stats.ssthresh, 'bigint');
+assert.ok(stats.cwnd > 0n, 'cwnd should be > 0');
+assert.strictEqual(typeof stats.bytesInFlight, 'bigint');
+assert.strictEqual(typeof stats.ssthresh, 'bigint');
 
 // V2 packet/byte fields.
-ok(stats.pktSent > 0n, 'pktSent should be > 0');
-ok(stats.pktRecv > 0n, 'pktRecv should be > 0');
-strictEqual(typeof stats.pktLost, 'bigint');
-ok(stats.bytesSent > 0n, 'bytesSent should be > 0');
-ok(stats.bytesRecv > 0n, 'bytesRecv should be > 0');
-strictEqual(typeof stats.bytesLost, 'bigint');
+assert.ok(stats.pktSent > 0n, 'pktSent should be > 0');
+assert.ok(stats.pktRecv > 0n, 'pktRecv should be > 0');
+assert.strictEqual(typeof stats.pktLost, 'bigint');
+assert.ok(stats.bytesSent > 0n, 'bytesSent should be > 0');
+assert.ok(stats.bytesRecv > 0n, 'bytesRecv should be > 0');
+assert.strictEqual(typeof stats.bytesLost, 'bigint');
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-stats.mjs
+++ b/test/parallel/test-quic-session-stats.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,17 +22,17 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const data = await bytes(stream);
-    strictEqual(data.byteLength, payloadLength);
+    assert.strictEqual(data.byteLength, payloadLength);
     stream.writer.endSync();
     await stream.closed;
 
     // Server sees one inbound bidi stream.
-    strictEqual(serverSession.stats.bidiInStreamCount, 1n);
-    strictEqual(serverSession.stats.bidiOutStreamCount, 0n);
+    assert.strictEqual(serverSession.stats.bidiInStreamCount, 1n);
+    assert.strictEqual(serverSession.stats.bidiOutStreamCount, 0n);
 
     // Server received data bytes.
-    ok(serverSession.stats.bytesReceived > 0n);
-    ok(serverSession.stats.bytesSent > 0n);
+    assert.ok(serverSession.stats.bytesReceived > 0n);
+    assert.ok(serverSession.stats.bytesSent > 0n);
 
     serverSession.close();
     serverDone.resolve();
@@ -46,7 +44,7 @@ await clientSession.opened;
 
 // Before sending, bytes should be from handshake only.
 const bytesSentBefore = clientSession.stats.bytesSent;
-ok(bytesSentBefore > 0n, 'handshake bytes should be counted');
+assert.ok(bytesSentBefore > 0n, 'handshake bytes should be counted');
 
 const stream = await clientSession.createBidirectionalStream({
   body: payload,
@@ -57,16 +55,16 @@ await stream.closed;
 await serverDone.promise;
 
 // After sending, bytesSent should have increased.
-ok(clientSession.stats.bytesSent > bytesSentBefore,
-   'bytesSent should increase after data transfer');
-ok(clientSession.stats.bytesReceived > 0n);
+assert.ok(clientSession.stats.bytesSent > bytesSentBefore,
+          'bytesSent should increase after data transfer');
+assert.ok(clientSession.stats.bytesReceived > 0n);
 
 // Client opened one outbound bidi stream.
-strictEqual(clientSession.stats.bidiOutStreamCount, 1n);
-strictEqual(clientSession.stats.bidiInStreamCount, 0n);
+assert.strictEqual(clientSession.stats.bidiOutStreamCount, 1n);
+assert.strictEqual(clientSession.stats.bidiInStreamCount, 0n);
 
 // Verify RTT fields are populated (connection was active).
-ok(clientSession.stats.smoothedRtt > 0n);
+assert.ok(clientSession.stats.smoothedRtt > 0n);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-stream-lifecycle.mjs
+++ b/test/parallel/test-quic-session-stream-lifecycle.mjs
@@ -3,9 +3,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { ok, strictEqual } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -15,88 +12,88 @@ if (!hasQuic) {
 const quic = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const keys = createPrivateKey(readKey('agent1-key.pem'));
-const certs = readKey('agent1-cert.pem');
+const keys = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const certs = fixtures.readKey('agent1-cert.pem');
 
 const serverDone = Promise.withResolvers();
 
 // Create a server endpoint
 const serverEndpoint = await quic.listen(mustCall(async (serverSession) => {
   await serverSession.opened;
-  ok(serverSession.endpoint !== null);
-  strictEqual(serverSession.destroyed, false);
+  assert.ok(serverSession.endpoint !== null);
+  assert.strictEqual(serverSession.destroyed, false);
 
   const stats = serverSession.stats;
-  strictEqual(stats.isConnected, true);
-  ok(stats.handshakeCompletedAt > 0n);
-  ok(stats.handshakeConfirmedAt > 0n);
-  strictEqual(stats.closingAt, 0n);
+  assert.strictEqual(stats.isConnected, true);
+  assert.ok(stats.handshakeCompletedAt > 0n);
+  assert.ok(stats.handshakeConfirmedAt > 0n);
+  assert.strictEqual(stats.closingAt, 0n);
 
   serverDone.resolve();
   serverSession.close();
 }), { sni: { '*': { keys, certs } } });
 
-strictEqual(serverEndpoint.busy, false);
-strictEqual(serverEndpoint.closing, false);
-strictEqual(serverEndpoint.destroyed, false);
-strictEqual(serverEndpoint.listening, true);
+assert.strictEqual(serverEndpoint.busy, false);
+assert.strictEqual(serverEndpoint.closing, false);
+assert.strictEqual(serverEndpoint.destroyed, false);
+assert.strictEqual(serverEndpoint.listening, true);
 
-ok(serverEndpoint.address !== undefined);
-strictEqual(serverEndpoint.address.family, 'ipv4');
-strictEqual(serverEndpoint.address.address, '127.0.0.1');
-ok(typeof serverEndpoint.address.port === 'number');
-ok(serverEndpoint.address.port > 0);
+assert.ok(serverEndpoint.address !== undefined);
+assert.strictEqual(serverEndpoint.address.family, 'ipv4');
+assert.strictEqual(serverEndpoint.address.address, '127.0.0.1');
+assert.ok(typeof serverEndpoint.address.port === 'number');
+assert.ok(serverEndpoint.address.port > 0);
 
 const epStats = serverEndpoint.stats;
-strictEqual(epStats.isConnected, true);
-ok(epStats.createdAt > 0n);
+assert.strictEqual(epStats.isConnected, true);
+assert.ok(epStats.createdAt > 0n);
 
 // Connect with a client
 const clientSession = await quic.connect(serverEndpoint.address, {
   verifyPeer: 'manual',
 });
 
-strictEqual(clientSession.destroyed, false);
-ok(clientSession.endpoint !== null);
-strictEqual(clientSession.stats.isConnected, true);
+assert.strictEqual(clientSession.destroyed, false);
+assert.ok(clientSession.endpoint !== null);
+assert.strictEqual(clientSession.stats.isConnected, true);
 
 const clientInfo = await clientSession.opened;
-strictEqual(clientInfo.servername, 'localhost');
-strictEqual(clientInfo.protocol, 'h3');
-strictEqual(clientInfo.cipherVersion, 'TLSv1.3');
-ok(clientInfo.local !== undefined);
-ok(clientInfo.remote !== undefined);
+assert.strictEqual(clientInfo.servername, 'localhost');
+assert.strictEqual(clientInfo.protocol, 'h3');
+assert.strictEqual(clientInfo.cipherVersion, 'TLSv1.3');
+assert.ok(clientInfo.local !== undefined);
+assert.ok(clientInfo.remote !== undefined);
 
 const cStats = clientSession.stats;
-strictEqual(cStats.isConnected, true);
-ok(cStats.handshakeCompletedAt > 0n);
-ok(cStats.bytesSent > 0n, 'Expected bytesSent > 0 after handshake');
+assert.strictEqual(cStats.isConnected, true);
+assert.ok(cStats.handshakeCompletedAt > 0n);
+assert.ok(cStats.bytesSent > 0n, 'Expected bytesSent > 0 after handshake');
 
 await serverDone.promise;
 
 // Open a bidirectional stream.
 const stream = await clientSession.createBidirectionalStream();
 
-strictEqual(stream.destroyed, false);
-strictEqual(stream.direction, 'bidi');
-strictEqual(stream.session, clientSession);
-ok(stream.id !== null, 'Non-pending stream should have an id');
-strictEqual(typeof stream.id, 'bigint');
-strictEqual(stream.pending, false);
-strictEqual(stream.stats.isConnected, true);
+assert.strictEqual(stream.destroyed, false);
+assert.strictEqual(stream.direction, 'bidi');
+assert.strictEqual(stream.session, clientSession);
+assert.ok(stream.id !== null, 'Non-pending stream should have an id');
+assert.strictEqual(typeof stream.id, 'bigint');
+assert.strictEqual(stream.pending, false);
+assert.strictEqual(stream.stats.isConnected, true);
 
 // Destroying the session should destroy it and the stream, and clear its properties.
 clientSession.destroy();
-strictEqual(clientSession.destroyed, true);
-strictEqual(clientSession.endpoint, null);
-strictEqual(clientSession.stats.isConnected, false);
-strictEqual(typeof clientSession.stats.cwnd, 'bigint');
-strictEqual(typeof clientSession.stats.streamsIdleTimedOut, 'bigint');
+assert.strictEqual(clientSession.destroyed, true);
+assert.strictEqual(clientSession.endpoint, null);
+assert.strictEqual(clientSession.stats.isConnected, false);
+assert.strictEqual(typeof clientSession.stats.cwnd, 'bigint');
+assert.strictEqual(typeof clientSession.stats.streamsIdleTimedOut, 'bigint');
 
-strictEqual(stream.destroyed, true);
+assert.strictEqual(stream.destroyed, true);
 
 // The stream id and direction should still be available after destruction
-strictEqual(stream.id, 0n);
-strictEqual(stream.direction, 'bidi');
+assert.strictEqual(stream.id, 0n);
+assert.strictEqual(stream.direction, 'bidi');
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-session-transport-params.mjs
+++ b/test/parallel/test-quic-session-transport-params.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -33,44 +31,44 @@ let serverRemoteParams;
 const serverEndpoint = await listen(mustCall((serverSession) => {
   // localTransportParams should be available immediately.
   serverLocalParams = serverSession.localTransportParams;
-  ok(serverLocalParams != null, 'server localTransportParams should be available immediately');
-  strictEqual(typeof serverLocalParams, 'object');
-  strictEqual(Object.getPrototypeOf(serverLocalParams), null);
+  assert.ok(serverLocalParams != null, 'server localTransportParams should be available immediately');
+  assert.strictEqual(typeof serverLocalParams, 'object');
+  assert.strictEqual(Object.getPrototypeOf(serverLocalParams), null);
 
   // Verify server's configured values are reflected.
-  strictEqual(serverLocalParams.initialMaxStreamsBidi,
-              BigInt(serverTransportParams.initialMaxStreamsBidi));
-  strictEqual(serverLocalParams.initialMaxData,
-              BigInt(serverTransportParams.initialMaxData));
+  assert.strictEqual(serverLocalParams.initialMaxStreamsBidi,
+                     BigInt(serverTransportParams.initialMaxStreamsBidi));
+  assert.strictEqual(serverLocalParams.initialMaxData,
+                     BigInt(serverTransportParams.initialMaxData));
 
   // Verify defaults are present and reasonable.
-  ok(serverLocalParams.activeConnectionIDLimit > 0n,
-     'activeConnectionIDLimit should be positive');
-  ok(serverLocalParams.ackDelayExponent > 0n,
-     'ackDelayExponent should be positive');
-  ok(serverLocalParams.maxAckDelay > 0n,
-     'maxAckDelay should be positive');
-  strictEqual(serverLocalParams.disableActiveMigration, false);
+  assert.ok(serverLocalParams.activeConnectionIDLimit > 0n,
+            'activeConnectionIDLimit should be positive');
+  assert.ok(serverLocalParams.ackDelayExponent > 0n,
+            'ackDelayExponent should be positive');
+  assert.ok(serverLocalParams.maxAckDelay > 0n,
+            'maxAckDelay should be positive');
+  assert.strictEqual(serverLocalParams.disableActiveMigration, false);
 
   serverSession.onstream = mustCall(async (stream) => {
     // After the stream arrives, the handshake is complete and
     // remoteTransportParams should be available.
     serverRemoteParams = serverSession.remoteTransportParams;
-    ok(serverRemoteParams != null,
-       'server remoteTransportParams should be available after handshake');
-    strictEqual(typeof serverRemoteParams, 'object');
-    strictEqual(Object.getPrototypeOf(serverRemoteParams), null);
+    assert.ok(serverRemoteParams != null,
+              'server remoteTransportParams should be available after handshake');
+    assert.strictEqual(typeof serverRemoteParams, 'object');
+    assert.strictEqual(Object.getPrototypeOf(serverRemoteParams), null);
 
     // Remote params should reflect the client's configured values.
-    strictEqual(serverRemoteParams.initialMaxStreamsBidi,
-                BigInt(clientTransportParams.initialMaxStreamsBidi));
-    strictEqual(serverRemoteParams.initialMaxData,
-                BigInt(clientTransportParams.initialMaxData));
+    assert.strictEqual(serverRemoteParams.initialMaxStreamsBidi,
+                       BigInt(clientTransportParams.initialMaxStreamsBidi));
+    assert.strictEqual(serverRemoteParams.initialMaxData,
+                       BigInt(clientTransportParams.initialMaxData));
 
     // CID fields should be present.
-    strictEqual(typeof serverRemoteParams.initialSCID, 'string');
-    ok(serverRemoteParams.initialSCID.length > 0,
-       'remote initialSCID should be non-empty');
+    assert.strictEqual(typeof serverRemoteParams.initialSCID, 'string');
+    assert.ok(serverRemoteParams.initialSCID.length > 0,
+              'remote initialSCID should be non-empty');
 
     stream.writer.endSync();
     await stream.closed;
@@ -89,32 +87,32 @@ await clientSession.opened;
 // After opened, the handshake is complete. Both local and remote
 // transport params should be available on the client session.
 const clientLocalParams = clientSession.localTransportParams;
-ok(clientLocalParams != null, 'client localTransportParams should be available');
-strictEqual(typeof clientLocalParams, 'object');
-strictEqual(Object.getPrototypeOf(clientLocalParams), null);
+assert.ok(clientLocalParams != null, 'client localTransportParams should be available');
+assert.strictEqual(typeof clientLocalParams, 'object');
+assert.strictEqual(Object.getPrototypeOf(clientLocalParams), null);
 
 // Verify client's configured values.
-strictEqual(clientLocalParams.initialMaxStreamsBidi,
-            BigInt(clientTransportParams.initialMaxStreamsBidi));
-strictEqual(clientLocalParams.initialMaxData,
-            BigInt(clientTransportParams.initialMaxData));
+assert.strictEqual(clientLocalParams.initialMaxStreamsBidi,
+                   BigInt(clientTransportParams.initialMaxStreamsBidi));
+assert.strictEqual(clientLocalParams.initialMaxData,
+                   BigInt(clientTransportParams.initialMaxData));
 
 const clientRemoteParams = clientSession.remoteTransportParams;
-ok(clientRemoteParams != null,
-   'client remoteTransportParams should be available after handshake');
-strictEqual(typeof clientRemoteParams, 'object');
-strictEqual(Object.getPrototypeOf(clientRemoteParams), null);
+assert.ok(clientRemoteParams != null,
+          'client remoteTransportParams should be available after handshake');
+assert.strictEqual(typeof clientRemoteParams, 'object');
+assert.strictEqual(Object.getPrototypeOf(clientRemoteParams), null);
 
 // Remote params should reflect the server's configured values.
-strictEqual(clientRemoteParams.initialMaxStreamsBidi,
-            BigInt(serverTransportParams.initialMaxStreamsBidi));
-strictEqual(clientRemoteParams.initialMaxData,
-            BigInt(serverTransportParams.initialMaxData));
+assert.strictEqual(clientRemoteParams.initialMaxStreamsBidi,
+                   BigInt(serverTransportParams.initialMaxStreamsBidi));
+assert.strictEqual(clientRemoteParams.initialMaxData,
+                   BigInt(serverTransportParams.initialMaxData));
 
 // CID fields should be present on the client's view of server params.
-strictEqual(typeof clientRemoteParams.initialSCID, 'string');
-ok(clientRemoteParams.initialSCID.length > 0,
-   'remote initialSCID should be non-empty');
+assert.strictEqual(typeof clientRemoteParams.initialSCID, 'string');
+assert.ok(clientRemoteParams.initialSCID.length > 0,
+          'remote initialSCID should be non-empty');
 
 // Cross-validation: server's remote matches client's local and vice versa.
 const stream = await clientSession.createBidirectionalStream();
@@ -126,14 +124,14 @@ await stream.closed;
 await serverDone.promise;
 
 // Cross-validate after both sides have captured params.
-strictEqual(serverRemoteParams.initialMaxStreamsBidi,
-            clientLocalParams.initialMaxStreamsBidi);
-strictEqual(serverRemoteParams.initialMaxData,
-            clientLocalParams.initialMaxData);
-strictEqual(clientRemoteParams.initialMaxStreamsBidi,
-            serverLocalParams.initialMaxStreamsBidi);
-strictEqual(clientRemoteParams.initialMaxData,
-            serverLocalParams.initialMaxData);
+assert.strictEqual(serverRemoteParams.initialMaxStreamsBidi,
+                   clientLocalParams.initialMaxStreamsBidi);
+assert.strictEqual(serverRemoteParams.initialMaxData,
+                   clientLocalParams.initialMaxData);
+assert.strictEqual(clientRemoteParams.initialMaxStreamsBidi,
+                   serverLocalParams.initialMaxStreamsBidi);
+assert.strictEqual(clientRemoteParams.initialMaxData,
+                   serverLocalParams.initialMaxData);
 
 await clientSession.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-sni-mismatch.mjs
+++ b/test/parallel/test-quic-sni-mismatch.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { rejects, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // Server only has an entry for 'specific.example.com', no wildcard.
 // Connections to any other hostname will be rejected at the TLS level.
@@ -41,15 +38,15 @@ const clientSession = await connect(serverEndpoint.address, {
   verifyPeer: 'manual',
   transportParams: { maxIdleTimeout: 1 },
   onerror: mustCall((err) => {
-    strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+    assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
   }),
 });
 
-await rejects(clientSession.opened, {
+await assert.rejects(clientSession.opened, {
   code: 'ERR_QUIC_TRANSPORT_ERROR',
 });
 
-await rejects(clientSession.closed, {
+await assert.rejects(clientSession.closed, {
   code: 'ERR_QUIC_TRANSPORT_ERROR',
 });
 

--- a/test/parallel/test-quic-sni-multi-entry.mjs
+++ b/test/parallel/test-quic-sni-multi-entry.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -18,12 +15,12 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key1 = createPrivateKey(readKey('agent1-key.pem'));
-const cert1 = readKey('agent1-cert.pem');
-const key2 = createPrivateKey(readKey('agent2-key.pem'));
-const cert2 = readKey('agent2-cert.pem');
-const key3 = createPrivateKey(readKey('agent3-key.pem'));
-const cert3 = readKey('agent3-cert.pem');
+const key1 = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert1 = fixtures.readKey('agent1-cert.pem');
+const key2 = createPrivateKey(fixtures.readKey('agent2-key.pem'));
+const cert2 = fixtures.readKey('agent2-cert.pem');
+const key3 = createPrivateKey(fixtures.readKey('agent3-key.pem'));
+const cert3 = fixtures.readKey('agent3-cert.pem');
 
 let sessionCount = 0;
 const allDone = Promise.withResolvers();
@@ -31,7 +28,7 @@ const allDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const info = await serverSession.opened;
   // Each client should negotiate with the correct servername.
-  strictEqual(typeof info.servername, 'string');
+  assert.strictEqual(typeof info.servername, 'string');
   serverSession.close();
   await serverSession.closed;
   if (++sessionCount === 3) allDone.resolve();
@@ -52,7 +49,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
     alpn: 'quic-test',
   });
   const info = await cs.opened;
-  strictEqual(info.servername, 'host1.example.com');
+  assert.strictEqual(info.servername, 'host1.example.com');
   await cs.closed;
 }
 
@@ -64,7 +61,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
     alpn: 'quic-test',
   });
   const info = await cs.opened;
-  strictEqual(info.servername, 'host2.example.com');
+  assert.strictEqual(info.servername, 'host2.example.com');
   await cs.closed;
 }
 

--- a/test/parallel/test-quic-sni-setcontexts.mjs
+++ b/test/parallel/test-quic-sni-setcontexts.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,10 +16,10 @@ if (!hasQuic) {
 const { listen, connect, QuicEndpoint } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key1 = createPrivateKey(readKey('agent1-key.pem'));
-const cert1 = readKey('agent1-cert.pem');
-const key2 = createPrivateKey(readKey('agent2-key.pem'));
-const cert2 = readKey('agent2-cert.pem');
+const key1 = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert1 = fixtures.readKey('agent1-cert.pem');
+const key2 = createPrivateKey(fixtures.readKey('agent2-key.pem'));
+const cert2 = fixtures.readKey('agent2-cert.pem');
 
 const endpoint = new QuicEndpoint();
 
@@ -46,7 +43,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
     transportParams: { maxIdleTimeout: 2 },
   });
   const info = await cs.opened;
-  strictEqual(info.servername, 'localhost');
+  assert.strictEqual(info.servername, 'localhost');
   await cs.closed;
 }
 
@@ -63,7 +60,7 @@ endpoint.setSNIContexts(
     transportParams: { maxIdleTimeout: 2 },
   });
   const info = await cs.opened;
-  strictEqual(info.servername, 'localhost');
+  assert.strictEqual(info.servername, 'localhost');
   // The cert changed — we can verify by checking the connection succeeded
   // (if the old cert was still used and the new one was expected, the
   // handshake would still succeed since both are self-signed and

--- a/test/parallel/test-quic-sni.mjs
+++ b/test/parallel/test-quic-sni.mjs
@@ -4,9 +4,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -15,16 +12,16 @@ const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
 // Use two different keys/certs for the default and SNI host.
-const defaultKey = createPrivateKey(readKey('agent1-key.pem'));
-const defaultCert = readKey('agent1-cert.pem');
-const sniKey = createPrivateKey(readKey('agent2-key.pem'));
-const sniCert = readKey('agent2-cert.pem');
+const defaultKey = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const defaultCert = fixtures.readKey('agent1-cert.pem');
+const sniKey = createPrivateKey(fixtures.readKey('agent2-key.pem'));
+const sniCert = fixtures.readKey('agent2-cert.pem');
 
 // Server with SNI: default ('*') uses agent1, 'localhost' uses agent2.
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const info = await serverSession.opened;
   // The server should see the client's requested servername.
-  strictEqual(info.servername, 'localhost');
+  assert.strictEqual(info.servername, 'localhost');
   await serverSession.close();
 }), {
   sni: {
@@ -34,7 +31,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
   alpn: ['quic-test'],
 });
 
-ok(serverEndpoint.address !== undefined);
+assert.ok(serverEndpoint.address !== undefined);
 
 // Client connects with servername 'localhost' — should match the SNI entry.
 const clientSession = await connect(serverEndpoint.address, {
@@ -43,7 +40,7 @@ const clientSession = await connect(serverEndpoint.address, {
   alpn: 'quic-test',
 });
 const clientInfo = await clientSession.opened;
-strictEqual(clientInfo.servername, 'localhost');
+assert.strictEqual(clientInfo.servername, 'localhost');
 
 await clientSession.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-stateless-reset.mjs
+++ b/test/parallel/test-quic-stateless-reset.mjs
@@ -8,10 +8,8 @@
 //        send a stateless reset.
 // Global token bucket rate limits the total number of resets.
 
-import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import { hasQuic, skip, mustCall, expectsError, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
-
-const { ok, strictEqual, rejects } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -31,7 +29,7 @@ const encoder = new TextEncoder();
       // Do a complete data exchange first so both sides are
       // fully at 1-RTT with all ACKs exchanged.
       const data = await bytes(stream);
-      ok(data.byteLength > 0);
+      assert.ok(data.byteLength > 0);
       stream.writer.endSync();
       await stream.closed;
 
@@ -42,15 +40,13 @@ const encoder = new TextEncoder();
       serverDestroyed.resolve();
     });
   }), {
-    onerror(err) { ok(err); },
+    onerror: mustNotCall(),
   });
 
   const clientSession = await connect(serverEndpoint.address, {
     reuseEndpoint: false,
     verifyPeer: 'manual',
-    onerror: mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
-    }),
+    onerror: expectsError({ code: 'ERR_QUIC_TRANSPORT_ERROR' }),
   });
   await clientSession.opened;
 
@@ -73,12 +69,12 @@ const encoder = new TextEncoder();
   });
 
   // The client session should be closed by the stateless reset.
-  await rejects(clientSession.closed, {
+  await assert.rejects(clientSession.closed, {
     code: 'ERR_QUIC_TRANSPORT_ERROR',
   });
 
-  ok(serverEndpoint.stats.statelessResetCount > 0n,
-     'Server should have sent a stateless reset');
+  assert.ok(serverEndpoint.stats.statelessResetCount > 0n,
+            'Server should have sent a stateless reset');
 
   await serverEndpoint.close();
 }
@@ -90,7 +86,7 @@ const encoder = new TextEncoder();
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const data = await bytes(stream);
-      ok(data.byteLength > 0);
+      assert.ok(data.byteLength > 0);
       stream.writer.endSync();
       await stream.closed;
 
@@ -99,7 +95,7 @@ const encoder = new TextEncoder();
     });
   }), {
     endpoint: { disableStatelessReset: true },
-    onerror(err) { ok(err); },
+    onerror: mustNotCall(),
   });
 
   const clientSession = await connect(serverEndpoint.address, {
@@ -110,7 +106,7 @@ const encoder = new TextEncoder();
     transportParams: { maxIdleTimeout: 1 },
     // Onerror marks stream closed promises as handled so that the
     // idle-timeout stream destruction doesn't cause unhandled rejections.
-    onerror(err) { ok(err); },
+    onerror: mustNotCall(),
   });
   await clientSession.opened;
 
@@ -133,8 +129,7 @@ const encoder = new TextEncoder();
   // via idle timeout instead.
   await clientSession.closed;
 
-  strictEqual(serverEndpoint.stats.statelessResetCount, 0n,
-              'No stateless reset should have been sent');
+  assert.strictEqual(serverEndpoint.stats.statelessResetCount, 0n); // No stateless reset should have been sent
 
   await serverEndpoint.close();
 }
@@ -153,7 +148,7 @@ const encoder = new TextEncoder();
 
     serverSession.onstream = mustCall(async (stream) => {
       const data = await bytes(stream);
-      ok(data.byteLength > 0);
+      assert.ok(data.byteLength > 0);
       stream.writer.endSync();
       await stream.closed;
 
@@ -162,7 +157,7 @@ const encoder = new TextEncoder();
     });
   }, 2), {
     endpoint: { statelessResetBurst: 1, statelessResetRate: 0 },
-    onerror(err) { ok(err); },
+    onerror: mustNotCall(),
   });
 
   // The global token bucket rate limiter applies regardless of
@@ -175,9 +170,7 @@ const encoder = new TextEncoder();
   const client1 = await connect(serverEndpoint.address, {
     endpoint: clientEndpoint,
     verifyPeer: 'manual',
-    onerror: mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
-    }),
+    onerror: expectsError({ code: 'ERR_QUIC_TRANSPORT_ERROR' }),
   });
   await client1.opened;
 
@@ -192,10 +185,9 @@ const encoder = new TextEncoder();
   const s1b = await client1.createBidirectionalStream({
     body: encoder.encode('after destroy 1'),
   });
-  await rejects(client1.closed, { code: 'ERR_QUIC_TRANSPORT_ERROR' });
+  await assert.rejects(client1.closed, { code: 'ERR_QUIC_TRANSPORT_ERROR' });
 
-  strictEqual(serverEndpoint.stats.statelessResetCount, 1n,
-              'First reset should have been sent');
+  assert.strictEqual(serverEndpoint.stats.statelessResetCount, 1n); // First reset should have been sent
 
   // --- Second session: rate-limited, no reset sent ---
 
@@ -206,7 +198,7 @@ const encoder = new TextEncoder();
     // destroys (no stateless reset will arrive, rate-limited).
     transportParams: { maxIdleTimeout: 1 },
     // Onerror marks stream closed promises as handled.
-    onerror(err) { ok(err); },
+    onerror: mustNotCall(),
   });
   await client2.opened;
 
@@ -226,10 +218,8 @@ const encoder = new TextEncoder();
   // The client closes via idle timeout (no stateless reset).
   await client2.closed;
 
-  strictEqual(serverEndpoint.stats.statelessResetCount, 1n,
-              'Second reset should have been rate-limited');
-  ok(serverEndpoint.stats.statelessResetRateLimited > 0n,
-     'Rate-limited counter should be non-zero');
+  assert.strictEqual(serverEndpoint.stats.statelessResetCount, 1n); // Second reset should have been rate-limited
+  assert.ok(serverEndpoint.stats.statelessResetRateLimited > 0); // Rate-limited counter should be non-zero
 
   await clientEndpoint.close();
   await serverEndpoint.close();

--- a/test/parallel/test-quic-stats-tojson-inspect.mjs
+++ b/test/parallel/test-quic-stats-tojson-inspect.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import { inspect } from 'node:util';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -21,12 +19,12 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   // Session stats toJSON and inspect.
   const sessionStatsJson = serverSession.stats.toJSON();
-  ok(sessionStatsJson);
-  strictEqual(typeof sessionStatsJson.createdAt, 'string');
-  strictEqual(typeof sessionStatsJson.bytesSent, 'string');
+  assert.ok(sessionStatsJson);
+  assert.strictEqual(typeof sessionStatsJson.createdAt, 'string');
+  assert.strictEqual(typeof sessionStatsJson.bytesSent, 'string');
 
   const sessionStatsInspect = inspect(serverSession.stats);
-  ok(sessionStatsInspect.includes('QuicSessionStats'));
+  assert.ok(sessionStatsInspect.includes('QuicSessionStats'));
 
   serverSession.onstream = mustCall(async (stream) => {
     for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
@@ -39,22 +37,22 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
 
 // Endpoint stats toJSON and inspect.
 const endpointStatsJson = serverEndpoint.stats.toJSON();
-ok(endpointStatsJson);
-strictEqual(typeof endpointStatsJson.createdAt, 'string');
+assert.ok(endpointStatsJson);
+assert.strictEqual(typeof endpointStatsJson.createdAt, 'string');
 
 const endpointStatsInspect = inspect(serverEndpoint.stats);
-ok(endpointStatsInspect.includes('QuicEndpointStats'));
+assert.ok(endpointStatsInspect.includes('QuicEndpointStats'));
 
 const clientSession = await connect(serverEndpoint.address);
 await clientSession.opened;
 
 // Client session stats.
 const clientStatsJson = clientSession.stats.toJSON();
-ok(clientStatsJson);
-strictEqual(typeof clientStatsJson.createdAt, 'string');
+assert.ok(clientStatsJson);
+assert.strictEqual(typeof clientStatsJson.createdAt, 'string');
 
 const clientStatsInspect = inspect(clientSession.stats);
-ok(clientStatsInspect.includes('QuicSessionStats'));
+assert.ok(clientStatsInspect.includes('QuicSessionStats'));
 
 const stream = await clientSession.createBidirectionalStream({
   body: new TextEncoder().encode('test'),

--- a/test/parallel/test-quic-stream-bidi-basic.mjs
+++ b/test/parallel/test-quic-stream-bidi-basic.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -32,8 +30,8 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
 
-    deepStrictEqual(received, expected);
-    strictEqual(decoder.decode(received), message);
+    assert.deepStrictEqual(received, expected);
+    assert.strictEqual(decoder.decode(received), message);
 
     // Close the server's write side of the bidi stream (FIN with no data)
     // so the stream is fully closed on both directions.

--- a/test/parallel/test-quic-stream-bidi-concurrent.mjs
+++ b/test/parallel/test-quic-stream-bidi-concurrent.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -34,8 +32,8 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     const text = decoder.decode(received);
 
     // Verify it's one of the expected messages.
-    ok(messages.includes(text),
-       `Unexpected message: ${text}`);
+    assert.ok(messages.includes(text),
+              `Unexpected message: ${text}`);
 
     stream.writer.endSync();
     await stream.closed;

--- a/test/parallel/test-quic-stream-bidi-echo.mjs
+++ b/test/parallel/test-quic-stream-bidi-echo.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -47,7 +45,7 @@ const stream = await clientSession.createBidirectionalStream({ body });
 
 // Read the echoed response from the server.
 const echoed = await bytes(stream);
-strictEqual(decoder.decode(echoed), message);
+assert.strictEqual(decoder.decode(echoed), message);
 
 await Promise.all([stream.closed, done.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-stream-bidi-halfclose.mjs
+++ b/test/parallel/test-quic-stream-bidi-halfclose.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -29,7 +27,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     // Read the client's data (client has already sent FIN).
     const received = await bytes(stream);
-    strictEqual(decoder.decode(received), clientMessage);
+    assert.strictEqual(decoder.decode(received), clientMessage);
 
     // The server's writable side is still open. Send a response.
     const w = stream.writer;
@@ -53,7 +51,7 @@ const stream = await clientSession.createBidirectionalStream({
 // The client's writable side is closed (FIN sent with body), but
 // the readable side is still open. Read the server's response.
 const response = await bytes(stream);
-strictEqual(decoder.decode(response), serverMessage);
+assert.strictEqual(decoder.decode(response), serverMessage);
 
 await Promise.all([stream.closed, done.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-stream-bidi-large.mjs
+++ b/test/parallel/test-quic-stream-bidi-large.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -54,8 +52,8 @@ const done = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(received.byteLength, numChunks * chunkSize);
-    strictEqual(checksum(received), expectedChecksum);
+    assert.strictEqual(received.byteLength, numChunks * chunkSize);
+    assert.strictEqual(checksum(received), expectedChecksum);
 
     stream.writer.endSync();
     await stream.closed;
@@ -81,7 +79,7 @@ for (let i = 0; i < numChunks; i++) {
 }
 
 const totalWritten = w.endSync();
-strictEqual(totalWritten, numChunks * chunkSize);
+assert.strictEqual(totalWritten, numChunks * chunkSize);
 
 await Promise.all([stream.closed, done.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-stream-bidi-server-initiated.mjs
+++ b/test/parallel/test-quic-stream-bidi-server-initiated.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -42,8 +40,8 @@ await clientSession.opened;
 clientSession.onstream = mustCall(async (stream) => {
   const received = await bytes(stream);
 
-  deepStrictEqual(received, expected);
-  strictEqual(decoder.decode(received), message);
+  assert.deepStrictEqual(received, expected);
+  assert.strictEqual(decoder.decode(received), message);
 
   // Close the client's write side so the stream fully closes.
   stream.writer.endSync();

--- a/test/parallel/test-quic-stream-bidi-setbody.mjs
+++ b/test/parallel/test-quic-stream-bidi-setbody.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual, strictEqual, throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,8 +26,8 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
 
-    deepStrictEqual(received, expected);
-    strictEqual(decoder.decode(received), message);
+    assert.deepStrictEqual(received, expected);
+    assert.strictEqual(decoder.decode(received), message);
 
     stream.writer.endSync();
     await stream.closed;
@@ -48,7 +46,7 @@ const stream = await clientSession.createBidirectionalStream();
 stream.setBody(encoder.encode(message));
 
 // Calling setBody() again should throw.
-throws(() => {
+assert.throws(() => {
   stream.setBody(encoder.encode('second body'));
 }, {
   code: 'ERR_INVALID_STATE',

--- a/test/parallel/test-quic-stream-bidi-varchunklen.mjs
+++ b/test/parallel/test-quic-stream-bidi-varchunklen.mjs
@@ -12,8 +12,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -57,8 +55,8 @@ const done = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(received.byteLength, byteLength);
-    strictEqual(checksum(received), expectedChecksum);
+    assert.strictEqual(received.byteLength, byteLength);
+    assert.strictEqual(checksum(received), expectedChecksum);
 
     stream.writer.endSync();
     await stream.closed;
@@ -84,7 +82,7 @@ for (let i = 0; i < numChunks; i++) {
 }
 
 const totalWritten = w.endSync();
-strictEqual(totalWritten, byteLength);
+assert.strictEqual(totalWritten, byteLength);
 
 await Promise.all([stream.closed, done.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-stream-bidi-writer.mjs
+++ b/test/parallel/test-quic-stream-bidi-writer.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,7 +23,7 @@ const done = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(decoder.decode(received), 'chunk1chunk2chunk3');
+    assert.strictEqual(decoder.decode(received), 'chunk1chunk2chunk3');
 
     stream.writer.endSync();
     await stream.closed;
@@ -41,22 +39,22 @@ const stream = await clientSession.createBidirectionalStream();
 const w = stream.writer;
 
 // Writer should be open.
-strictEqual(typeof w.canWrite, 'boolean');
+assert.strictEqual(typeof w.canWrite, 'boolean');
 
 // Write multiple chunks synchronously.
-strictEqual(w.writeSync(encoder.encode('chunk1')), true);
-strictEqual(w.writeSync(encoder.encode('chunk2')), true);
-strictEqual(w.writeSync(encoder.encode('chunk3')), true);
+assert.strictEqual(w.writeSync(encoder.encode('chunk1')), true);
+assert.strictEqual(w.writeSync(encoder.encode('chunk2')), true);
+assert.strictEqual(w.writeSync(encoder.encode('chunk3')), true);
 
 // End the write side — returns total bytes written.
 const totalWritten = w.endSync();
-strictEqual(totalWritten, 18); // 6 * 3
+assert.strictEqual(totalWritten, 18); // 6 * 3
 
 // After end, write should return false.
-strictEqual(w.writeSync(encoder.encode('nope')), false);
+assert.strictEqual(w.writeSync(encoder.encode('nope')), false);
 
 // canWrite should be null after close.
-strictEqual(w.canWrite, null);
+assert.strictEqual(w.canWrite, null);
 
 await Promise.all([stream.closed, done.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-stream-body-async-error.mjs
+++ b/test/parallel/test-quic-stream-body-async-error.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -37,7 +35,7 @@ const stream = await clientSession.createBidirectionalStream();
 
 // Attach the closed handler BEFORE setBody so the rejection from
 // stream.destroy(err) is caught before it becomes unhandled.
-const closedPromise = rejects(stream.closed, testError);
+const closedPromise = assert.rejects(stream.closed, testError);
 
 stream.setBody(failingSource());
 

--- a/test/parallel/test-quic-stream-body-async-iterable.mjs
+++ b/test/parallel/test-quic-stream-body-async-iterable.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,7 +23,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    deepStrictEqual(received, expected);
+    assert.deepStrictEqual(received, expected);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-stream-body-error.mjs
+++ b/test/parallel/test-quic-stream-body-error.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 const { setTimeout } = await import('node:timers/promises');
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -45,7 +43,7 @@ await stream.closed;
 
 // The source should have stopped. It may yield a few chunks
 // but not an unbounded number.
-ok(yieldCount < 50, `yieldCount too high: ${yieldCount}`);
+assert.ok(yieldCount < 50, `yieldCount too high: ${yieldCount}`);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-body-filehandle.mjs
+++ b/test/parallel/test-quic-stream-body-filehandle.mjs
@@ -11,8 +11,6 @@ import { open } from 'node:fs/promises';
 
 const tmpdir = await import('../common/tmpdir.js');
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -34,7 +32,7 @@ writeFileSync(testFile, testContent);
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const body = await bytes(stream);
-      strictEqual(decoder.decode(body), testContent);
+      assert.strictEqual(decoder.decode(body), testContent);
       stream.writer.writeSync('ok');
       stream.writer.endSync();
       await stream.closed;
@@ -52,7 +50,7 @@ writeFileSync(testFile, testContent);
   });
 
   const response = await bytes(stream);
-  strictEqual(decoder.decode(response), 'ok');
+  assert.strictEqual(decoder.decode(response), 'ok');
   await Promise.all([stream.closed, serverDone.promise, clientSession.closed]);
   await serverEndpoint.close();
   // FileHandle is closed automatically when the stream finishes.
@@ -65,7 +63,7 @@ writeFileSync(testFile, testContent);
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const body = await bytes(stream);
-      strictEqual(decoder.decode(body), testContent);
+      assert.strictEqual(decoder.decode(body), testContent);
       stream.writer.writeSync('ok');
       stream.writer.endSync();
       await stream.closed;
@@ -82,7 +80,7 @@ writeFileSync(testFile, testContent);
   stream.setBody(fh);
 
   const response = await bytes(stream);
-  strictEqual(decoder.decode(response), 'ok');
+  assert.strictEqual(decoder.decode(response), 'ok');
   await Promise.all([stream.closed, serverDone.promise, clientSession.closed]);
   await serverEndpoint.close();
   // FileHandle is closed automatically when the stream finishes.

--- a/test/parallel/test-quic-stream-body-pooled-buffer.mjs
+++ b/test/parallel/test-quic-stream-body-pooled-buffer.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,7 +18,7 @@ const message = 'pooled buffer test data';
 const expected = Buffer.from(message);
 
 // Verify this IS a pooled buffer (byteLength < buffer.byteLength).
-ok(
+assert.ok(
   expected.buffer.byteLength > expected.byteLength,
   'Buffer should be pooled for this test to be meaningful',
 );
@@ -30,7 +28,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(Buffer.from(received).toString(), message);
+    assert.strictEqual(Buffer.from(received).toString(), message);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-stream-body-promise-error.mjs
+++ b/test/parallel/test-quic-stream-body-promise-error.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -29,7 +27,7 @@ const stream = await clientSession.createBidirectionalStream();
 
 // Attach the closed handler BEFORE setBody so the rejection from
 // stream.destroy(err) is caught before it becomes unhandled.
-const closedPromise = rejects(stream.closed, testError);
+const closedPromise = assert.rejects(stream.closed, testError);
 
 stream.setBody(Promise.reject(testError));
 

--- a/test/parallel/test-quic-stream-body-promise-reject.mjs
+++ b/test/parallel/test-quic-stream-body-promise-reject.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,7 +22,7 @@ const { bytes } = await import('stream/iter');
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const received = await bytes(stream);
-      strictEqual(
+      assert.strictEqual(
         new TextDecoder().decode(received),
         'nested promise',
       );

--- a/test/parallel/test-quic-stream-body-promise.mjs
+++ b/test/parallel/test-quic-stream-body-promise.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,11 +28,11 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     if (idx === 0) {
       // Promise<string> resolved to string data.
       const received = await text(stream);
-      strictEqual(received, 'resolved string');
+      assert.strictEqual(received, 'resolved string');
     } else if (idx === 1) {
       // Promise<null> closes the writable side.
       const received = await bytes(stream);
-      strictEqual(received.byteLength, 0);
+      assert.strictEqual(received.byteLength, 0);
     }
 
     stream.writer.endSync();

--- a/test/parallel/test-quic-stream-body-readable-stream.mjs
+++ b/test/parallel/test-quic-stream-body-readable-stream.mjs
@@ -5,8 +5,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,7 +23,7 @@ const allDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    deepStrictEqual(received, expected);
+    assert.deepStrictEqual(received, expected);
     stream.writer.endSync();
     await stream.closed;
     if (++serverStreamCount === 2) {

--- a/test/parallel/test-quic-stream-body-sources.mjs
+++ b/test/parallel/test-quic-stream-body-sources.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -70,7 +68,7 @@ await clientSession.opened;
   sabView.set(expectedBytes);
   const stream = await clientSession.createBidirectionalStream({ body: sabView });
   // The SharedArrayBuffer should still be usable (copied, not transferred).
-  strictEqual(sab.byteLength, expectedBytes.byteLength);
+  assert.strictEqual(sab.byteLength, expectedBytes.byteLength);
   for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
   await stream.closed;
 }

--- a/test/parallel/test-quic-stream-body-state.mjs
+++ b/test/parallel/test-quic-stream-body-state.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -45,8 +43,8 @@ await clientSession.opened;
   const stream = await clientSession.createBidirectionalStream();
   // Access the writer — this initializes the streaming source.
   const w = stream.writer;
-  ok(w);
-  throws(() => {
+  assert.ok(w);
+  assert.throws(() => {
     stream.setBody(encoder.encode('too late'));
   }, {
     code: 'ERR_INVALID_STATE',
@@ -59,7 +57,7 @@ await clientSession.opened;
 {
   const stream = await clientSession.createBidirectionalStream();
   stream.setBody(encoder.encode('body set'));
-  throws(() => {
+  assert.throws(() => {
     stream.writer; // eslint-disable-line no-unused-expressions
   }, {
     code: 'ERR_INVALID_STATE',
@@ -71,7 +69,7 @@ await clientSession.opened;
 {
   const stream = await clientSession.createBidirectionalStream();
   stream.destroy();
-  throws(() => {
+  assert.throws(() => {
     stream.setBody(encoder.encode('destroyed'));
   }, {
     code: 'ERR_INVALID_STATE',

--- a/test/parallel/test-quic-stream-body-string-shorthand.mjs
+++ b/test/parallel/test-quic-stream-body-string-shorthand.mjs
@@ -6,8 +6,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,7 +22,7 @@ const decoder = new TextDecoder();
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const body = await bytes(stream);
-      strictEqual(decoder.decode(body), 'hello from string body');
+      assert.strictEqual(decoder.decode(body), 'hello from string body');
       stream.writer.writeSync(new TextEncoder().encode('ok'));
       stream.writer.endSync();
       await stream.closed;
@@ -42,7 +40,7 @@ const decoder = new TextDecoder();
   });
 
   const response = await bytes(stream);
-  strictEqual(decoder.decode(response), 'ok');
+  assert.strictEqual(decoder.decode(response), 'ok');
   await Promise.all([stream.closed, serverDone.promise, clientSession.closed]);
   await serverEndpoint.close();
 }
@@ -54,7 +52,7 @@ const decoder = new TextDecoder();
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const body = await bytes(stream);
-      strictEqual(decoder.decode(body), 'setBody string');
+      assert.strictEqual(decoder.decode(body), 'setBody string');
       stream.writer.writeSync(new TextEncoder().encode('ok'));
       stream.writer.endSync();
       await stream.closed;
@@ -70,7 +68,7 @@ const decoder = new TextDecoder();
   stream.setBody('setBody string');
 
   const response = await bytes(stream);
-  strictEqual(decoder.decode(response), 'ok');
+  assert.strictEqual(decoder.decode(response), 'ok');
   await Promise.all([stream.closed, serverDone.promise, clientSession.closed]);
   await serverEndpoint.close();
 }
@@ -83,7 +81,7 @@ const decoder = new TextDecoder();
   const serverEndpoint = await listen(mustCall((serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const body = await bytes(stream);
-      strictEqual(decoder.decode(body), testString);
+      assert.strictEqual(decoder.decode(body), testString);
       stream.writer.writeSync(new TextEncoder().encode('ok'));
       stream.writer.endSync();
       await stream.closed;
@@ -100,7 +98,7 @@ const decoder = new TextDecoder();
   });
 
   const response = await bytes(stream);
-  strictEqual(decoder.decode(response), 'ok');
+  assert.strictEqual(decoder.decode(response), 'ok');
   await Promise.all([stream.closed, serverDone.promise, clientSession.closed]);
   await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-stream-body-string.mjs
+++ b/test/parallel/test-quic-stream-body-string.mjs
@@ -5,8 +5,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -21,7 +19,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await text(stream);
-    strictEqual(received, message);
+    assert.strictEqual(received, message);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-stream-body-sync-iterable.mjs
+++ b/test/parallel/test-quic-stream-body-sync-iterable.mjs
@@ -5,8 +5,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,7 +21,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    deepStrictEqual(received, expected);
+    assert.deepStrictEqual(received, expected);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-stream-closed-rejects.mjs
+++ b/test/parallel/test-quic-stream-closed-rejects.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,9 +23,9 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
 
     // The server's own stream.closed should also reject with the
     // reset error code.
-    await rejects(stream.closed, (error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-      ok(error.message.includes('1'));
+    await assert.rejects(stream.closed, (error) => {
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.ok(error.message.includes('1'));
       return true;
     });
 
@@ -44,9 +42,9 @@ const stream = await clientSession.createBidirectionalStream({
 });
 
 // Client's closed should reject with the reset error code.
-await rejects(stream.closed, (error) => {
-  strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-  ok(error.message.includes('1'));
+await assert.rejects(stream.closed, (error) => {
+  assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+  assert.ok(error.message.includes('1'));
   return true;
 });
 

--- a/test/parallel/test-quic-stream-destroy-emits-reset.mjs
+++ b/test/parallel/test-quic-stream-destroy-emits-reset.mjs
@@ -17,8 +17,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,15 +28,15 @@ const serverResetSeen = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     stream.onreset = mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
       // The DefaultApplication's internal error code is 0x1n.
-      strictEqual(err.errorCode, 1n);
+      assert.strictEqual(err.errorCode, 1n);
       serverResetSeen.resolve();
     });
 
     // The peer's reset causes stream.closed to reject with the reset
     // error code.
-    await rejects(stream.closed, {
+    await assert.rejects(stream.closed, {
       code: 'ERR_QUIC_APPLICATION_ERROR',
     });
   });
@@ -59,7 +57,7 @@ const stream = await clientSession.createBidirectionalStream({
 const err = new Error('destroy without writer');
 // Pre-attach the rejection assertion before destroying so the
 // resulting `stream.closed` rejection isn't reported as unhandled.
-const clientClosedAssertion = rejects(stream.closed, err);
+const clientClosedAssertion = assert.rejects(stream.closed, err);
 
 stream.destroy(err);
 

--- a/test/parallel/test-quic-stream-destroy-emits-stop-sending.mjs
+++ b/test/parallel/test-quic-stream-destroy-emits-stop-sending.mjs
@@ -24,8 +24,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -79,7 +77,7 @@ const clientClosedAssertion = assert.rejects(stream.closed, err);
 stream.destroy(err);
 
 const observedCanWrite = await serverObservation.promise;
-strictEqual(observedCanWrite, null);
+assert.strictEqual(observedCanWrite, null);
 
 await clientClosedAssertion;
 

--- a/test/parallel/test-quic-stream-destroy-options-code.mjs
+++ b/test/parallel/test-quic-stream-destroy-options-code.mjs
@@ -13,8 +13,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,14 +24,14 @@ const serverResetSeen = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     stream.onreset = mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
-      strictEqual(err.errorCode, 66n);
+      assert.strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.strictEqual(err.errorCode, 66n);
       serverResetSeen.resolve();
     });
 
     // The peer's reset causes stream.closed to reject with the reset
     // error code.
-    await rejects(stream.closed, {
+    await assert.rejects(stream.closed, {
       code: 'ERR_QUIC_APPLICATION_ERROR',
     });
   });
@@ -47,7 +45,7 @@ const stream = await clientSession.createBidirectionalStream({
 });
 
 const err = new Error('explicit code via options');
-const clientClosedAssertion = rejects(stream.closed, err);
+const clientClosedAssertion = assert.rejects(stream.closed, err);
 
 // `options.code` (0x42n) takes precedence over the default that
 // would have been derived from `error` (which would be the session's

--- a/test/parallel/test-quic-stream-destroy-options-validate.mjs
+++ b/test/parallel/test-quic-stream-destroy-options-validate.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, throws, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -29,43 +27,43 @@ stream.onerror = mustNotCall(
   'stream.onerror must not fire when destroy() throws on bad options');
 
 // 1. options is not an object -> throws ERR_INVALID_ARG_TYPE.
-throws(() => stream.destroy(new Error('x'), 'not an object'), {
+assert.throws(() => stream.destroy(new Error('x'), 'not an object'), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-strictEqual(stream.destroyed, false);
+assert.strictEqual(stream.destroyed, false);
 
 // 2. options.code is the wrong type -> throws ERR_INVALID_ARG_TYPE.
-throws(() => stream.destroy(new Error('x'), { code: 'oops' }), {
+assert.throws(() => stream.destroy(new Error('x'), { code: 'oops' }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-strictEqual(stream.destroyed, false);
+assert.strictEqual(stream.destroyed, false);
 
-throws(() => stream.destroy(new Error('x'), { code: true }), {
+assert.throws(() => stream.destroy(new Error('x'), { code: true }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-strictEqual(stream.destroyed, false);
+assert.strictEqual(stream.destroyed, false);
 
 // 3. options.reason is the wrong type -> throws ERR_INVALID_ARG_TYPE.
-throws(() => stream.destroy(new Error('x'), { reason: 42 }), {
+assert.throws(() => stream.destroy(new Error('x'), { reason: 42 }), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
-strictEqual(stream.destroyed, false);
+assert.strictEqual(stream.destroyed, false);
 
 // Switch to the real error handler before the final destroy so the
 // `mustNotCall` above does not fire on the legitimate teardown.
 const finalError = new Error('final destroy');
-stream.onerror = mustCall((err) => { strictEqual(err, finalError); });
+stream.onerror = mustCall((err) => { assert.strictEqual(err, finalError); });
 
-const clientClosedAssertion = rejects(stream.closed, finalError);
+const clientClosedAssertion = assert.rejects(stream.closed, finalError);
 
 // 4. Valid options accepted: bigint code.
 stream.destroy(finalError, { code: 0x10n, reason: 'cleanup' });
-strictEqual(stream.destroyed, true);
+assert.strictEqual(stream.destroyed, true);
 
 // 5. Re-entry with arbitrarily bad options is a no-op (the
 //    re-entrancy guard returns before validation runs).
 stream.destroy(new Error('after-destroy'), { code: 'still-bad' });
-strictEqual(stream.destroyed, true);
+assert.strictEqual(stream.destroyed, true);
 
 await clientClosedAssertion;
 

--- a/test/parallel/test-quic-stream-error-graceful-close.mjs
+++ b/test/parallel/test-quic-stream-error-graceful-close.mjs
@@ -4,10 +4,8 @@
 // When a session is gracefully closing and an open stream encounters
 // an error, the session should still close cleanly without crashing.
 
-import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
-
-const { ok, rejects, strictEqual } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -23,18 +21,18 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     // Read some data then reset the stream while the client
     // is still sending — this creates a stream error.
     const data = await bytes(stream);
-    ok(data.byteLength > 0);
+    assert.ok(data.byteLength > 0);
     stream.resetStream(99n);
     serverSession.close();
     serverDone.resolve();
   });
 }), {
   transportParams: { initialMaxStreamDataBidiRemote: 256 },
-  onerror(err) { ok(err); },
+  onerror: mustNotCall(),
 });
 
 const clientSession = await connect(serverEndpoint.address, {
-  onerror(err) { ok(err); },
+  onerror: mustNotCall(),
 });
 await clientSession.opened;
 
@@ -44,9 +42,8 @@ stream.setBody(new Uint8Array(4096));
 
 // The stream will error due to the server's reset.
 // The session should still close gracefully.
-await rejects(stream.closed, (error) => {
-  strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-  return true;
+await assert.rejects(stream.closed, {
+  code: 'ERR_QUIC_APPLICATION_ERROR',
 });
 await Promise.all([serverDone.promise, clientSession.closed]);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-id-ordering.mjs
+++ b/test/parallel/test-quic-stream-id-ordering.mjs
@@ -5,8 +5,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -44,13 +42,13 @@ for (let i = 0; i < 10; i++) {
 
 // Verify IDs are strictly increasing.
 for (let i = 1; i < ids.length; i++) {
-  ok(ids[i] > ids[i - 1],
-     `Stream ID ${ids[i]} should be > ${ids[i - 1]}`);
+  assert.ok(ids[i] > ids[i - 1],
+            `Stream ID ${ids[i]} should be > ${ids[i - 1]}`);
 }
 
 // Verify all IDs are unique.
 const uniqueIds = new Set(ids);
-strictEqual(uniqueIds.size, ids.length);
+assert.strictEqual(uniqueIds.size, ids.length);
 
 await Promise.all([serverDone.promise, clientSession.closed]);
 await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-idle-timeout.mjs
+++ b/test/parallel/test-quic-stream-idle-timeout.mjs
@@ -9,8 +9,6 @@ import assert from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
 import { text } from 'node:stream/iter';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,7 +23,7 @@ const { listen, connect } = await import('../common/quic.mjs');
     serverSession.onstream = mustCall(async (stream) => {
       // Don't read — let the stream sit idle after the initial data.
       // The stream idle timeout should destroy it, rejecting stream.closed.
-      await rejects(stream.closed, {
+      await assert.rejects(stream.closed, {
         code: 'ERR_QUIC_TRANSPORT_ERROR',
       });
       streamDestroyed.resolve();
@@ -55,7 +53,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   // ShutdownStream maps the transport error to the application's
   // internal error code on the wire, so the client sees an application
   // error indicating the server rejected the stream.
-  await rejects(clientStream.closed, {
+  await assert.rejects(clientStream.closed, {
     code: 'ERR_QUIC_APPLICATION_ERROR',
   });
 
@@ -71,7 +69,7 @@ const { listen, connect } = await import('../common/quic.mjs');
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     serverSession.onstream = mustCall(async (stream) => {
       const data = await text(stream);
-      strictEqual(data, 'xy');
+      assert.strictEqual(data, 'xy');
       serverGotData.resolve();
       await serverSession.close();
     });
@@ -111,7 +109,7 @@ const { listen, connect } = await import('../common/quic.mjs');
 
       // We should receive all the data, even though it is sent with a pause
       // longer than the default idle timeout.
-      strictEqual(data, 'xy');
+      assert.strictEqual(data, 'xy');
       streamSurvived.resolve();
     });
 

--- a/test/parallel/test-quic-stream-iteration-batching.mjs
+++ b/test/parallel/test-quic-stream-iteration-batching.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -47,9 +45,9 @@ let batchCount = 0;
 let totalChunks = 0;
 for await (const batch of stream) {
   batchCount++;
-  ok(Array.isArray(batch), 'Each iteration step yields an array');
+  assert.ok(Array.isArray(batch), 'Each iteration step yields an array');
   for (const chunk of batch) {
-    ok(chunk instanceof Uint8Array, 'Each item is a Uint8Array');
+    assert.ok(chunk instanceof Uint8Array, 'Each item is a Uint8Array');
     totalChunks++;
   }
 }
@@ -58,8 +56,8 @@ for await (const batch of stream) {
 // (On very slow machines, each chunk might arrive separately, so we
 // can't assert batchCount < totalChunks strictly. But totalChunks
 // should be > 0.)
-ok(totalChunks > 0, 'Should have received chunks');
-ok(batchCount > 0, 'Should have received batches');
+assert.ok(totalChunks > 0, 'Should have received chunks');
+assert.ok(batchCount > 0, 'Should have received batches');
 
 await Promise.all([stream.closed, serverDone.promise]);
 await clientSession.close();

--- a/test/parallel/test-quic-stream-iteration-break.mjs
+++ b/test/parallel/test-quic-stream-iteration-break.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -45,10 +43,10 @@ const stream = await clientSession.createBidirectionalStream({
 let batchCount = 0;
 for await (const batch of stream) {
   batchCount++;
-  ok(Array.isArray(batch));
+  assert.ok(Array.isArray(batch));
   break;  // Exit early — should trigger iterator cleanup.
 }
-strictEqual(batchCount, 1);
+assert.strictEqual(batchCount, 1);
 
 // After break, the stream should still be closable.
 // End the writable side (it was already ended by the body).

--- a/test/parallel/test-quic-stream-iteration-destroyed.mjs
+++ b/test/parallel/test-quic-stream-iteration-destroyed.mjs
@@ -5,8 +5,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -32,7 +30,7 @@ stream.destroy();
 // Iterating a destroyed stream should immediately finish.
 const iter = stream[Symbol.asyncIterator]();
 const { done } = await iter.next();
-strictEqual(done, true);
+assert.strictEqual(done, true);
 
 await stream.closed;
 await clientSession.close();

--- a/test/parallel/test-quic-stream-iteration-double.mjs
+++ b/test/parallel/test-quic-stream-iteration-double.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -26,12 +24,12 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     const iter1 = stream[Symbol.asyncIterator]();
     // Advance the first iterator so the lock is set.
     const first = await iter1.next();
-    strictEqual(first.done, false);
+    assert.strictEqual(first.done, false);
 
     // A second iterator can be created (generator object), but
     // advancing it should reject because the lock is held.
     const iter2 = stream[Symbol.asyncIterator]();
-    await rejects(iter2.next(), {
+    await assert.rejects(iter2.next(), {
       code: 'ERR_INVALID_STATE',
     });
 

--- a/test/parallel/test-quic-stream-iteration-nonreadable.mjs
+++ b/test/parallel/test-quic-stream-iteration-nonreadable.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -39,7 +37,7 @@ const stream = await clientSession.createUnidirectionalStream({
 // The sender side of a uni stream is not readable.
 const iter = stream[Symbol.asyncIterator]();
 const { done } = await iter.next();
-strictEqual(done, true);
+assert.strictEqual(done, true);
 
 await Promise.all([serverDone.promise, stream.closed]);
 await clientSession.close();

--- a/test/parallel/test-quic-stream-iteration-pull.mjs
+++ b/test/parallel/test-quic-stream-iteration-pull.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,7 +28,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
       return chunk;
     });
     const result = await bytes(transformed);
-    deepStrictEqual(result, expected);
+    assert.deepStrictEqual(result, expected);
 
     stream.writer.endSync();
     await stream.closed;

--- a/test/parallel/test-quic-stream-iteration-reset.mjs
+++ b/test/parallel/test-quic-stream-iteration-reset.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { ok, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,7 +21,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     // Reset the stream from the server side.
     stream.resetStream(42n);
-    await rejects(stream.closed, mustCall((err) => {
+    await assert.rejects(stream.closed, mustCall((err) => {
       assert.ok(err);
       return true;
     }));
@@ -42,7 +40,7 @@ const stream = await clientSession.createBidirectionalStream({
 });
 
 // Set up the closed handler before the reset to avoid unhandled rejection.
-const closedPromise = rejects(stream.closed, mustCall((err) => {
+const closedPromise = assert.rejects(stream.closed, mustCall((err) => {
   assert.ok(err);
   return true;
 }));
@@ -54,7 +52,7 @@ await serverReady.promise;
 try {
   for await (const batch of stream) {
     // May receive some data before the reset arrives.
-    ok(Array.isArray(batch));
+    assert.ok(Array.isArray(batch));
   }
 } catch {
   // The iterator may throw when the reset arrives mid-iteration.

--- a/test/parallel/test-quic-stream-iteration.mjs
+++ b/test/parallel/test-quic-stream-iteration.mjs
@@ -10,8 +10,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual, deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -35,23 +33,23 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
       // for-await yields batches.
       const chunks = [];
       for await (const batch of stream) {
-        ok(Array.isArray(batch), 'batch should be an array');
+        assert.ok(Array.isArray(batch), 'batch should be an array');
         for (const chunk of batch) {
-          ok(chunk instanceof Uint8Array, 'chunk should be Uint8Array');
+          assert.ok(chunk instanceof Uint8Array, 'chunk should be Uint8Array');
           chunks.push(chunk);
         }
       }
-      ok(chunks.length > 0);
+      assert.ok(chunks.length > 0);
     } else if (idx === 1) {
       // text() consumes as string.
       const result = await text(stream);
-      strictEqual(typeof result, 'string');
-      strictEqual(result, message);
+      assert.strictEqual(typeof result, 'string');
+      assert.strictEqual(result, message);
     } else if (idx === 2) {
       // bytes() consumes as Uint8Array.
       const result = await bytes(stream);
-      ok(result instanceof Uint8Array);
-      deepStrictEqual(result, expected);
+      assert.ok(result instanceof Uint8Array);
+      assert.deepStrictEqual(result, expected);
     }
 
     stream.writer.endSync();

--- a/test/parallel/test-quic-stream-limits-pending.mjs
+++ b/test/parallel/test-quic-stream-limits-pending.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -53,7 +51,7 @@ const s2 = await clientSession.createBidirectionalStream({
 
 // s2 should be pending until s1 closes and the server grants
 // more stream credits.
-strictEqual(s2.pending, true);
+assert.strictEqual(s2.pending, true);
 
 // Drain and close the first stream.
 for await (const _ of s1) { /* drain */ } // eslint-disable-line no-unused-vars

--- a/test/parallel/test-quic-stream-limits-uni.mjs
+++ b/test/parallel/test-quic-stream-limits-uni.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -45,7 +43,7 @@ const s1 = await clientSession.createUnidirectionalStream({
 const s2 = await clientSession.createUnidirectionalStream({
   body: encoder.encode('uni 2'),
 });
-strictEqual(s2.pending, true);
+assert.strictEqual(s2.pending, true);
 
 // Wait for both to complete.
 await s1.closed;

--- a/test/parallel/test-quic-stream-many-rapid.mjs
+++ b/test/parallel/test-quic-stream-many-rapid.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,7 +23,7 @@ const allReceived = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const data = await bytes(stream);
-    strictEqual(data.byteLength, 5);
+    assert.strictEqual(data.byteLength, 5);
     stream.writer.endSync();
     await stream.closed;
     if (++serverReceived === streamCount) {

--- a/test/parallel/test-quic-stream-onblocked.mjs
+++ b/test/parallel/test-quic-stream-onblocked.mjs
@@ -13,8 +13,6 @@ import { hasQuic, skip, mustCall, mustCallAtLeast } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,8 +22,8 @@ const { bytes } = await import('stream/iter');
 
 // quic.stream.blocked fires when a stream is flow-control blocked.
 dc.subscribe('quic.stream.blocked', mustCallAtLeast((msg) => {
-  ok(msg.stream, 'stream.blocked should include stream');
-  ok(msg.session, 'stream.blocked should include session');
+  assert.ok(msg.stream, 'stream.blocked should include stream');
+  assert.ok(msg.session, 'stream.blocked should include session');
 }, 1));
 
 const totalSize = 4096;
@@ -37,7 +35,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(received.byteLength, totalSize);
+    assert.strictEqual(received.byteLength, totalSize);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();
@@ -67,7 +65,7 @@ for await (const _ of stream) { /* drain readable side */ } // eslint-disable-li
 await stream.closed;
 await serverDone.promise;
 
-ok(blockedCount > 0, `Expected onblocked to fire, got ${blockedCount} calls`);
+assert.ok(blockedCount > 0, `Expected onblocked to fire, got ${blockedCount} calls`);
 
 await clientSession.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-pending.mjs
+++ b/test/parallel/test-quic-stream-pending.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,7 +21,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(new TextDecoder().decode(received), 'pending stream');
+    assert.strictEqual(new TextDecoder().decode(received), 'pending stream');
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();
@@ -41,7 +39,7 @@ const stream = await clientSession.createBidirectionalStream({
 
 // The stream should initially be pending (no ID assigned yet).
 // On fast machines the handshake might already be done.
-strictEqual(typeof stream.pending, 'boolean');
+assert.strictEqual(typeof stream.pending, 'boolean');
 
 // The server's onstream fires only after the handshake completes AND
 // the pending stream opens. By the time we get data on the server,

--- a/test/parallel/test-quic-stream-priority.mjs
+++ b/test/parallel/test-quic-stream-priority.mjs
@@ -3,9 +3,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
-const { readKey } = fixtures;
-
-const { rejects, strictEqual, throws } = assert;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -14,8 +11,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   await serverSession.opened;
@@ -42,9 +39,9 @@ const streamClosedPromises = [];
 {
   const stream = await clientSession.createBidirectionalStream();
   streamClosedPromises.push(stream.closed);
-  strictEqual(stream.priority, null);
+  assert.strictEqual(stream.priority, null);
 
-  throws(
+  assert.throws(
     () => stream.setPriority({ level: 'high', incremental: true }),
     { code: 'ERR_INVALID_STATE' },
   );
@@ -52,19 +49,19 @@ const streamClosedPromises = [];
 
 // Test 2: Validation of createStream priority/incremental options
 {
-  await rejects(
+  await assert.rejects(
     clientSession.createBidirectionalStream({ priority: 'urgent' }),
     { code: 'ERR_INVALID_ARG_VALUE' },
   );
-  await rejects(
+  await assert.rejects(
     clientSession.createBidirectionalStream({ priority: 42 }),
     { code: 'ERR_INVALID_ARG_VALUE' },
   );
-  await rejects(
+  await assert.rejects(
     clientSession.createBidirectionalStream({ incremental: 'yes' }),
     { code: 'ERR_INVALID_ARG_TYPE' },
   );
-  await rejects(
+  await assert.rejects(
     clientSession.createBidirectionalStream({ incremental: 1 }),
     { code: 'ERR_INVALID_ARG_TYPE' },
   );
@@ -75,15 +72,15 @@ const streamClosedPromises = [];
   const stream = await clientSession.createBidirectionalStream();
   streamClosedPromises.push(stream.closed);
 
-  throws(
+  assert.throws(
     () => stream.setPriority({ level: 'high' }),
     { code: 'ERR_INVALID_STATE' },
   );
-  throws(
+  assert.throws(
     () => stream.setPriority({ level: 'low', incremental: true }),
     { code: 'ERR_INVALID_STATE' },
   );
-  throws(
+  assert.throws(
     () => stream.setPriority(),
     { code: 'ERR_INVALID_STATE' },
   );

--- a/test/parallel/test-quic-stream-read-after-blocked.mjs
+++ b/test/parallel/test-quic-stream-read-after-blocked.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall, mustCallAtLeast } from '../common/index.mjs';
 import { setTimeout as delay } from 'node:timers/promises';
 import assert from 'node:assert';
 
-const { strictEqual, deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -50,8 +48,8 @@ while (serverStream.stats.maxOffsetAcknowledged !== serverStream.stats.bytesSent
 
 // Try to read:
 const received = await bytes(stream);
-strictEqual(received.byteLength, expected.byteLength);
-deepStrictEqual(received, expected);
+assert.strictEqual(received.byteLength, expected.byteLength);
+assert.deepStrictEqual(received, expected);
 
 stream.writer.endSync();
 await stream.closed;

--- a/test/parallel/test-quic-stream-read-after-fin.mjs
+++ b/test/parallel/test-quic-stream-read-after-fin.mjs
@@ -7,8 +7,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import { setTimeout as delay } from 'node:timers/promises';
 import assert from 'node:assert';
 
-const { deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -45,7 +43,7 @@ await serverSent.promise;
 await delay(10);
 
 const received = await bytes(stream);
-deepStrictEqual(received, expected);
+assert.deepStrictEqual(received, expected);
 
 writer.endSync();
 await stream.closed;

--- a/test/parallel/test-quic-stream-recv-coalescing.mjs
+++ b/test/parallel/test-quic-stream-recv-coalescing.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -74,8 +72,8 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     }
 
     // Data integrity.
-    strictEqual(receivedBytes, totalBytes);
-    strictEqual(receivedChecksum, expectedChecksum);
+    assert.strictEqual(receivedBytes, totalBytes);
+    assert.strictEqual(receivedChecksum, expectedChecksum);
 
     // Coalescing effectiveness: verify that at least some chunks are larger
     // than the ~1154-byte QUIC frame payload, showing that the accumulator
@@ -84,18 +82,18 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     // multiple packets arrive in the same event loop iteration. Under
     // real network conditions the effect is much more pronounced.
     const maxChunkSize = Math.max(...receivedChunkSizes);
-    ok(
+    assert.ok(
       maxChunkSize > 1154,
       `Expected at least one chunk larger than a single QUIC frame ` +
       `(1154 bytes), but max was ${maxChunkSize}`
     );
 
     // Stats: after full drain, bytes_accumulated should be 0.
-    strictEqual(stream.stats.bytesAccumulated, 0n);
+    assert.strictEqual(stream.stats.bytesAccumulated, 0n);
 
     // max_bytes_accumulated should be nonzero — data passed through
     // the accumulator.
-    ok(
+    assert.ok(
       stream.stats.maxBytesAccumulated > 0n,
       'maxBytesAccumulated should be nonzero'
     );

--- a/test/parallel/test-quic-stream-reset-after-data.mjs
+++ b/test/parallel/test-quic-stream-reset-after-data.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,14 +21,14 @@ const serverReady = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall((stream) => {
-    rejects(stream.closed, (error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+    assert.rejects(stream.closed, (error) => {
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
       return true;
     }).then(mustCall());
 
     stream.onreset = mustCall((error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-      ok(error.message.includes('44'));
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.ok(error.message.includes('44'));
       serverSession.close();
       serverDone.resolve();
     });
@@ -56,9 +54,9 @@ await serverReady.promise;
 // but may not be fully acknowledged yet.
 stream.resetStream(44n);
 
-await rejects(stream.closed, (error) => {
-  strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-  ok(error.message.includes('44'));
+await assert.rejects(stream.closed, (error) => {
+  assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+  assert.ok(error.message.includes('44'));
   return true;
 });
 

--- a/test/parallel/test-quic-stream-reset-before-data.mjs
+++ b/test/parallel/test-quic-stream-reset-before-data.mjs
@@ -14,8 +14,6 @@ import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok, deepStrictEqual, strictEqual, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,9 +23,9 @@ const { bytes } = await import('stream/iter');
 
 // quic.stream.reset fires when a stream receives RESET_STREAM from the peer.
 dc.subscribe('quic.stream.reset', mustCall((msg) => {
-  ok(msg.stream, 'stream.reset should include stream');
-  ok(msg.session, 'stream.reset should include session');
-  ok(msg.error, 'stream.reset should include error');
+  assert.ok(msg.stream, 'stream.reset should include stream');
+  assert.ok(msg.session, 'stream.reset should include session');
+  assert.ok(msg.error, 'stream.reset should include error');
 }));
 
 const encoder = new TextEncoder();
@@ -36,8 +34,8 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     stream.onreset = mustCall((error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-      ok(error.message.includes('42'));
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.ok(error.message.includes('42'));
 
       // The client reset its send side, but the server can still
       // send data on its side of the bidi stream.
@@ -46,7 +44,7 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
 
     // The stream's closed promise may reject because the client's
     // send side was reset. Either way, clean up.
-    await rejects(stream.closed, {
+    await assert.rejects(stream.closed, {
       code: 'ERR_QUIC_APPLICATION_ERROR',
     });
     serverSession.close();
@@ -70,13 +68,13 @@ stream.resetStream(42n);
 // The client should still be able to receive data from the server
 // on the readable side of this bidi stream.
 const received = await bytes(stream);
-deepStrictEqual(Buffer.from(received), Buffer.from('response'));
+assert.deepStrictEqual(Buffer.from(received), Buffer.from('response'));
 
 // stream.closed rejects with the reset error (the client's send
 // side was reset). Verify the error and consume the rejection.
-await stream.closed.catch((error) => {
-  strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-  ok(error.message.includes('42'));
+await assert.rejects(stream.closed, {
+  code: 'ERR_QUIC_APPLICATION_ERROR',
+  message: /42/,
 });
 await serverDone.promise;
 await clientSession.close();

--- a/test/parallel/test-quic-stream-reset-mid-transfer.mjs
+++ b/test/parallel/test-quic-stream-reset-mid-transfer.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -22,14 +20,14 @@ const serverReady = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall((stream) => {
-    rejects(stream.closed, (error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+    assert.rejects(stream.closed, (error) => {
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
       return true;
     }).then(mustCall());
 
     stream.onreset = mustCall((error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-      ok(error.message.includes('43'));
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.ok(error.message.includes('43'));
       serverSession.close();
       serverDone.resolve();
     });
@@ -55,9 +53,9 @@ await serverReady.promise;
 // Reset mid-transfer.
 stream.resetStream(43n);
 
-await rejects(stream.closed, (error) => {
-  strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-  ok(error.message.includes('43'));
+await assert.rejects(stream.closed, (error) => {
+  assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+  assert.ok(error.message.includes('43'));
   return true;
 });
 

--- a/test/parallel/test-quic-stream-reset-stop.mjs
+++ b/test/parallel/test-quic-stream-reset-stop.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,15 +23,15 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall((stream) => {
     // The server's stream.closed will reject when the session is
     // gracefully closed after the peer's reset.
-    rejects(stream.closed, (error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+    assert.rejects(stream.closed, (error) => {
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
       return true;
     }).then(mustCall());
 
     stream.onreset = mustCall((error) => {
       // The error is the raw close tuple: [type, code, reason].
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-      ok(error.message.includes('42'));
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.ok(error.message.includes('42'));
       serverSession.close();
       serverDone.resolve();
     });
@@ -56,9 +54,9 @@ await serverDone.promise;
 // After the server closes (sending CONNECTION_CLOSE), the client
 // session enters draining and all streams are destroyed. The client's
 // stream.closed rejects with the reset code.
-await rejects(stream.closed, (error) => {
-  strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-  ok(error.message.includes('42'));
+await assert.rejects(stream.closed, (error) => {
+  assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+  assert.ok(error.message.includes('42'));
   return true;
 });
 await clientSession.closed;

--- a/test/parallel/test-quic-stream-setbody-errors.mjs
+++ b/test/parallel/test-quic-stream-setbody-errors.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { throws } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -34,7 +32,7 @@ await clientSession.opened;
   const stream = await clientSession.createBidirectionalStream();
   stream.setBody(encoder.encode('first'));
 
-  throws(() => stream.setBody(encoder.encode('second')), {
+  assert.throws(() => stream.setBody(encoder.encode('second')), {
     code: 'ERR_INVALID_STATE',
     message: /outbound already configured/,
   });
@@ -50,7 +48,7 @@ await clientSession.opened;
   const w = stream.writer;
   w.endSync();
 
-  throws(() => stream.setBody(encoder.encode('data')), {
+  assert.throws(() => stream.setBody(encoder.encode('data')), {
     code: 'ERR_INVALID_STATE',
     message: /writer already accessed/,
   });

--- a/test/parallel/test-quic-stream-slow-consumer.mjs
+++ b/test/parallel/test-quic-stream-slow-consumer.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall, mustCallAtLeast } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -23,7 +21,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(received.byteLength, dataLength);
+    assert.strictEqual(received.byteLength, dataLength);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();
@@ -52,7 +50,7 @@ for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-v
 await Promise.all([stream.closed, serverDone.promise]);
 
 // The sender should have been blocked multiple times.
-ok(blockedCount > 0, `Expected blocking, got ${blockedCount}`);
+assert.ok(blockedCount > 0, `Expected blocking, got ${blockedCount}`);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-stats.mjs
+++ b/test/parallel/test-quic-stream-stats.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -24,19 +22,19 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const data = await bytes(stream);
-    strictEqual(data.byteLength, payloadLength);
+    assert.strictEqual(data.byteLength, payloadLength);
 
     // Stream stats should reflect received bytes.
-    strictEqual(stream.stats.bytesReceived, BigInt(payloadLength));
-    strictEqual(typeof stream.stats.createdAt, 'bigint');
-    strictEqual(typeof stream.stats.receivedAt, 'bigint');
+    assert.strictEqual(stream.stats.bytesReceived, BigInt(payloadLength));
+    assert.strictEqual(typeof stream.stats.createdAt, 'bigint');
+    assert.strictEqual(typeof stream.stats.receivedAt, 'bigint');
 
     // Send response.
     stream.setBody(encoder.encode('response'));
     await stream.closed;
 
     // After close, bytesSent should reflect response.
-    strictEqual(stream.stats.bytesSent, BigInt('response'.length));
+    assert.strictEqual(stream.stats.bytesSent, BigInt('response'.length));
 
     serverSession.close();
     serverDone.resolve();
@@ -51,23 +49,23 @@ const stream = await clientSession.createBidirectionalStream({
 });
 
 // Stats should have correct types before transfer completes.
-strictEqual(typeof stream.stats.createdAt, 'bigint');
-strictEqual(typeof stream.stats.bytesReceived, 'bigint');
-strictEqual(typeof stream.stats.bytesSent, 'bigint');
-strictEqual(typeof stream.stats.maxOffset, 'bigint');
+assert.strictEqual(typeof stream.stats.createdAt, 'bigint');
+assert.strictEqual(typeof stream.stats.bytesReceived, 'bigint');
+assert.strictEqual(typeof stream.stats.bytesSent, 'bigint');
+assert.strictEqual(typeof stream.stats.maxOffset, 'bigint');
 
 // Verify toJSON works.
 const json = stream.stats.toJSON();
-ok(json);
-strictEqual(typeof json.createdAt, 'string');
+assert.ok(json);
+assert.strictEqual(typeof json.createdAt, 'string');
 
 for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
 await stream.closed;
 await serverDone.promise;
 
 // After transfer, bytesSent should reflect the payload.
-strictEqual(stream.stats.bytesSent, BigInt(payloadLength));
-ok(stream.stats.bytesReceived > 0n);
+assert.strictEqual(stream.stats.bytesSent, BigInt(payloadLength));
+assert.ok(stream.stats.bytesReceived > 0n);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-stop-sending-interaction.mjs
+++ b/test/parallel/test-quic-stream-stop-sending-interaction.mjs
@@ -13,8 +13,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual, rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -44,9 +42,9 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     // The server's stream.closed rejects because
     // the client automatically sends RESET_STREAM in response to
     // STOP_SENDING. The error code matches the STOP_SENDING code.
-    await rejects(stream.closed, (error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-      ok(error.message.includes(String(stopCode)));
+    await assert.rejects(stream.closed, (error) => {
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.ok(error.message.includes(String(stopCode)));
       return true;
     });
 
@@ -66,7 +64,7 @@ clientStreamReady.resolve();
 // Read the server's data. The server→client direction is unaffected
 // by STOP_SENDING on the client→server direction.
 const received = await bytes(stream);
-strictEqual(new TextDecoder().decode(received), 'server data');
+assert.strictEqual(new TextDecoder().decode(received), 'server data');
 
 // The client's stream.closed resolves. The STOP_SENDING caused
 // the client's write side to end (ngtcp2 sends RESET_STREAM

--- a/test/parallel/test-quic-stream-stop-sending.mjs
+++ b/test/parallel/test-quic-stream-stop-sending.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -29,9 +27,9 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
 
     // The server's stream.closed rejects with the stop-sending code
     // because the inbound side was reset by the peer in response.
-    await rejects(stream.closed, (error) => {
-      strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
-      ok(error.message.includes('99'));
+    await assert.rejects(stream.closed, (error) => {
+      assert.strictEqual(error.code, 'ERR_QUIC_APPLICATION_ERROR');
+      assert.ok(error.message.includes('99'));
       return true;
     });
     serverSession.close();

--- a/test/parallel/test-quic-stream-uni-basic.mjs
+++ b/test/parallel/test-quic-stream-uni-basic.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { deepStrictEqual, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,17 +25,17 @@ const done = Promise.withResolvers();
 
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
-    strictEqual(stream.direction, 'uni');
+    assert.strictEqual(stream.direction, 'uni');
 
     const received = await bytes(stream);
-    deepStrictEqual(received, expected);
-    strictEqual(decoder.decode(received), message);
+    assert.deepStrictEqual(received, expected);
+    assert.strictEqual(decoder.decode(received), message);
 
     // The server side of a remote unidirectional stream is not writable.
     // The writer should be pre-closed (canWrite returns null).
     const w = stream.writer;
-    strictEqual(w.canWrite, null);
-    strictEqual(w.endSync(), 0);
+    assert.strictEqual(w.canWrite, null);
+    assert.strictEqual(w.endSync(), 0);
 
     await stream.closed;
     serverSession.close();
@@ -49,12 +47,12 @@ const clientSession = await connect(serverEndpoint.address);
 await clientSession.opened;
 
 const stream = await clientSession.createUnidirectionalStream({ body });
-strictEqual(stream.direction, 'uni');
+assert.strictEqual(stream.direction, 'uni');
 
 // The client-side uni stream is write-only — async iteration yields nothing.
 const iter = stream[Symbol.asyncIterator]();
 const { done: iterDone } = await iter.next();
-strictEqual(iterDone, true);
+assert.strictEqual(iterDone, true);
 
 await done.promise;
 // The server closed its session, delivering CONNECTION_CLOSE to the client.

--- a/test/parallel/test-quic-stream-uni-no-onstream.mjs
+++ b/test/parallel/test-quic-stream-uni-no-onstream.mjs
@@ -6,8 +6,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -15,8 +13,8 @@ if (!hasQuic) {
 const { createPrivateKey } = await import('node:crypto');
 const { listen, connect } = await import('../common/quic.mjs');
 
-const serverKey = createPrivateKey(readKey('agent1-key.pem'));
-const serverCert = readKey('agent1-cert.pem');
+const serverKey = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const serverCert = fixtures.readKey('agent1-cert.pem');
 
 const done = Promise.withResolvers();
 

--- a/test/parallel/test-quic-stream-uni-server-initiated.mjs
+++ b/test/parallel/test-quic-stream-uni-server-initiated.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { deepStrictEqual, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -41,13 +39,13 @@ await clientSession.opened;
 clientSession.onstream = mustCall(async (stream) => {
   const received = await bytes(stream);
 
-  deepStrictEqual(received, expected);
-  strictEqual(decoder.decode(received), message);
+  assert.deepStrictEqual(received, expected);
+  assert.strictEqual(decoder.decode(received), message);
 
   // The receiving side of a uni stream should not be writable.
   // The writer should be pre-closed.
   const w = stream.writer;
-  strictEqual(w.canWrite, null);
+  assert.strictEqual(w.canWrite, null);
 
   await stream.closed;
   clientSession.close();

--- a/test/parallel/test-quic-stream-write-partial-view.mjs
+++ b/test/parallel/test-quic-stream-write-partial-view.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -29,10 +27,10 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
     const received = await bytes(stream);
     // Server receives the original 8 bytes in order, regardless of
     // any caller-side mutation that happens after writeSync returns.
-    strictEqual(received.length, sourceCopy.length);
+    assert.strictEqual(received.length, sourceCopy.length);
     for (let i = 0; i < sourceCopy.length; i++) {
-      strictEqual(received[i], sourceCopy[i],
-                  `byte ${i} mismatch: got ${received[i]}, ` +
+      assert.strictEqual(received[i], sourceCopy[i],
+                         `byte ${i} mismatch: got ${received[i]}, ` +
                   `expected ${sourceCopy[i]}`);
     }
     stream.writer.endSync();
@@ -51,21 +49,18 @@ const writer = stream.writer;
 // First half. The underlying ArrayBuffer must stay live after the
 // write so that the caller can build the next view from it.
 writer.writeSync(source.subarray(0, 4));
-strictEqual(source.buffer.detached, false,
-            'source ArrayBuffer must not be detached after writeSync');
-strictEqual(source.byteLength, 8,
-            'source view must remain usable after writeSync');
+assert.strictEqual(source.buffer.detached, false); // source ArrayBuffer must not be detached after writeSync
+assert.strictEqual(source.byteLength, 8); // Source view must remain usable after writeSync
 
 // Second half — slicing into the same backing buffer must succeed.
 writer.writeSync(source.subarray(4, 8));
-strictEqual(source.buffer.detached, false,
-            'source ArrayBuffer must remain live after second writeSync');
+assert.strictEqual(source.buffer.detached, false); // source ArrayBuffer must remain live after second writeSync
 
 // The C++ layer has already copied the bytes by the time writeSync
 // returned. Mutating the source here must not affect the data the
 // peer ultimately observes.
 for (let i = 0; i < source.length; i++) source[i] = 0;
-ok(source.every((b) => b === 0), 'source mutation should succeed');
+assert.ok(source.every((b) => b === 0), 'source mutation should succeed');
 
 writer.endSync();
 

--- a/test/parallel/test-quic-stream-writer-api.mjs
+++ b/test/parallel/test-quic-stream-writer-api.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { ok, rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -45,7 +43,7 @@ await clientSession.opened;
   const w = stream.writer;
   await w.write(encoder.encode('async write'));
   const n = w.endSync();
-  strictEqual(n, 11);
+  assert.strictEqual(n, 11);
   for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
   await stream.closed;
 }
@@ -58,9 +56,9 @@ await clientSession.opened;
     encoder.encode('hello '),
     encoder.encode('writev'),
   ]);
-  strictEqual(result, true);
+  assert.strictEqual(result, true);
   const n = w.endSync();
-  strictEqual(n, 12);
+  assert.strictEqual(n, 12);
   for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
   await stream.closed;
 }
@@ -74,7 +72,7 @@ await clientSession.opened;
     encoder.encode('writev'),
   ]);
   const n = w.endSync();
-  strictEqual(n, 12);
+  assert.strictEqual(n, 12);
   for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
   await stream.closed;
 }
@@ -85,7 +83,7 @@ await clientSession.opened;
   const w = stream.writer;
   w.writeSync(encoder.encode('end async'));
   const n = await w.end();
-  strictEqual(n, 9);
+  assert.strictEqual(n, 9);
   for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
   await stream.closed;
 }
@@ -95,14 +93,14 @@ await clientSession.opened;
   const w = stream.writer;
   // canWrite should be a boolean (false initially before flow
   // control window opens, or true if the window is already open).
-  strictEqual(typeof w.canWrite, 'boolean');
-  ok(w.canWrite !== null, `canWrite should not be null, got ${w.canWrite}`);
+  assert.strictEqual(typeof w.canWrite, 'boolean');
+  assert.ok(w.canWrite !== null, `canWrite should not be null, got ${w.canWrite}`);
   // drainableProtocol should return null when canWrite is true (has capacity),
   // or a promise when canWrite is false (backpressured). Either way, it
   // should not throw.
   const { drainableProtocol: dp } = await import('stream/iter');
   const drain = w[dp]();
-  ok(drain === null || drain instanceof Promise);
+  assert.ok(drain === null || drain instanceof Promise);
   w.writeSync(encoder.encode('capacity'));
   w.endSync();
   for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
@@ -116,16 +114,16 @@ await clientSession.opened;
   const testError = new Error('writer fail test');
   w.fail(testError);
   // After fail, canWrite is null.
-  strictEqual(w.canWrite, null);
+  assert.strictEqual(w.canWrite, null);
   // drainableProtocol returns null when errored.
   const { drainableProtocol: dp } = await import('stream/iter');
-  strictEqual(w[dp](), null);
+  assert.strictEqual(w[dp](), null);
   // endSync after fail returns -1 (errored).
-  strictEqual(w.endSync(), -1);
+  assert.strictEqual(w.endSync(), -1);
   // WriteSync after fail returns false.
-  strictEqual(w.writeSync(encoder.encode('x')), false);
+  assert.strictEqual(w.writeSync(encoder.encode('x')), false);
   // Write after fail throws with the original error.
-  await rejects(w.write(encoder.encode('x')), testError);
+  await assert.rejects(w.write(encoder.encode('x')), testError);
   // Don't await stream.closed here — the reset stream may not trigger
   // server onstream (no data was sent before fail), so the server
   // won't count it. The stream is cleaned up when the session closes.
@@ -137,8 +135,8 @@ await serverEndpoint.close();
 
 // Verify server received the right data.
 const decoder = new TextDecoder();
-strictEqual(decoder.decode(serverResults[0]), 'async write');
-strictEqual(decoder.decode(serverResults[1]), 'hello writev');
-strictEqual(decoder.decode(serverResults[2]), 'async writev');
-strictEqual(decoder.decode(serverResults[3]), 'end async');
-strictEqual(decoder.decode(serverResults[4]), 'capacity');
+assert.strictEqual(decoder.decode(serverResults[0]), 'async write');
+assert.strictEqual(decoder.decode(serverResults[1]), 'hello writev');
+assert.strictEqual(decoder.decode(serverResults[2]), 'async writev');
+assert.strictEqual(decoder.decode(serverResults[3]), 'end async');
+assert.strictEqual(decoder.decode(serverResults[4]), 'capacity');

--- a/test/parallel/test-quic-stream-writer-dispose.mjs
+++ b/test/parallel/test-quic-stream-writer-dispose.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -34,14 +32,14 @@ const stream = await clientSession.createBidirectionalStream();
 const w = stream.writer;
 
 // Writer is active — canWrite should be a boolean (not null).
-strictEqual(typeof w.canWrite, 'boolean');
+assert.strictEqual(typeof w.canWrite, 'boolean');
 
 // Symbol.dispose calls fail() if not already closed/errored.
 w[Symbol.dispose]();
 
 // After dispose, writer should be errored.
-strictEqual(w.canWrite, null);
-strictEqual(w.writeSync(encoder.encode('x')), false);
+assert.strictEqual(w.canWrite, null);
+assert.strictEqual(w.writeSync(encoder.encode('x')), false);
 
 // stream.closed resolves because fail() with default code 0
 // is treated as a clean close (no error).

--- a/test/parallel/test-quic-stream-writer-fail-error-code.mjs
+++ b/test/parallel/test-quic-stream-writer-fail-error-code.mjs
@@ -23,8 +23,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -33,7 +31,7 @@ const { listen, connect } = await import('../common/quic.mjs');
 const { QuicError } = await import('node:quic');
 
 function wireCodeOf(err) {
-  strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
+  assert.strictEqual(err.code, 'ERR_QUIC_APPLICATION_ERROR');
   return err.errorCode;
 }
 
@@ -89,8 +87,8 @@ await clientSession.opened;
 
 await allDone.promise;
 
-strictEqual(observed[0], expectedCodes[0]);
-strictEqual(observed[1], expectedCodes[1]);
+assert.strictEqual(observed[0], expectedCodes[0]);
+assert.strictEqual(observed[1], expectedCodes[1]);
 
 await clientSession.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-stream-zero-length.mjs
+++ b/test/parallel/test-quic-stream-zero-length.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -21,7 +19,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(received.byteLength, 0);
+    assert.strictEqual(received.byteLength, 0);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();

--- a/test/parallel/test-quic-tls-ca.mjs
+++ b/test/parallel/test-quic-tls-ca.mjs
@@ -8,9 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -18,13 +15,13 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
-const ca = readKey('ca1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
+const ca = fixtures.readKey('ca1-cert.pem');
 
 const serverEndpoint = await listen(mustCall(async (serverSession) => {
   const info = await serverSession.opened;
-  strictEqual(info.protocol, 'quic-test');
+  assert.strictEqual(info.protocol, 'quic-test');
   serverSession.close();
 }), {
   sni: { '*': { keys: [key], certs: [cert] } },
@@ -41,7 +38,7 @@ const clientSession = await connect(serverEndpoint.address, {
 });
 
 const info = await clientSession.opened;
-strictEqual(info.protocol, 'quic-test');
+assert.strictEqual(info.protocol, 'quic-test');
 // The CA option is accepted. Validation may or may not succeed
 // depending on the cert chain. The important thing is the
 // handshake completed and the option was used.

--- a/test/parallel/test-quic-tls-crl.mjs
+++ b/test/parallel/test-quic-tls-crl.mjs
@@ -10,9 +10,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,11 +17,11 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const ca2Cert = readKey('ca2-cert.pem');
-const ca2Crl = readKey('ca2-crl.pem');
-const ca2CrlAgent3 = readKey('ca2-crl-agent3.pem');
-const agent3Key = createPrivateKey(readKey('agent3-key.pem'));
-const agent3Cert = readKey('agent3-cert.pem');
+const ca2Cert = fixtures.readKey('ca2-cert.pem');
+const ca2Crl = fixtures.readKey('ca2-crl.pem');
+const ca2CrlAgent3 = fixtures.readKey('ca2-crl-agent3.pem');
+const agent3Key = createPrivateKey(fixtures.readKey('agent3-key.pem'));
+const agent3Cert = fixtures.readKey('agent3-cert.pem');
 
 // --- Non-revoked: agent3 with original CRL (doesn't list agent3) ---
 {
@@ -45,9 +42,9 @@ const agent3Cert = readKey('agent3-cert.pem');
 
   // Should succeed — agent3 is NOT in the original CRL.
   const info = await clientSession.opened;
-  strictEqual(clientSession.destroyed, false);
+  assert.strictEqual(clientSession.destroyed, false);
   // No revocation error.
-  ok(!info.validationErrorReason ||
+  assert.ok(!info.validationErrorReason ||
      !info.validationErrorReason.includes('revoked'));
   await clientSession.close();
   await serverEndpoint.close();
@@ -74,7 +71,7 @@ const agent3Cert = readKey('agent3-cert.pem');
   // reports "certificate revoked". This verifies the CRL is loaded
   // and checked.
   const info = await clientSession.opened;
-  strictEqual(info.validationErrorReason, 'certificate revoked');
+  assert.strictEqual(info.validationErrorReason, 'certificate revoked');
   await clientSession.close();
   await serverEndpoint.close();
 }

--- a/test/parallel/test-quic-tls-keylog.mjs
+++ b/test/parallel/test-quic-tls-keylog.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,17 +25,17 @@ const expectedLabels = [
 ];
 
 function assertKeylogLines(lines, side) {
-  ok(lines.length > 0, `Expected ${side} keylog lines, got ${lines.length}`);
+  assert.ok(lines.length > 0, `Expected ${side} keylog lines, got ${lines.length}`);
 
   for (const line of lines) {
-    strictEqual(typeof line, 'string',
-                `Each ${side} keylog line should be a string`);
+    assert.strictEqual(typeof line, 'string',
+                       `Each ${side} keylog line should be a string`);
   }
 
   const joined = lines.join('');
   for (const label of expectedLabels) {
-    ok(joined.includes(label),
-       `Expected ${side} keylog to contain ${label}`);
+    assert.ok(joined.includes(label),
+              `Expected ${side} keylog to contain ${label}`);
   }
 }
 

--- a/test/parallel/test-quic-tls-options.mjs
+++ b/test/parallel/test-quic-tls-options.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, ok } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,15 +16,15 @@ if (!hasQuic) {
 const { listen, connect, constants } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 
 // Custom ciphers. Use a specific TLS 1.3 cipher suite.
 {
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     const info = await serverSession.opened;
-    strictEqual(typeof info.cipher, 'string');
-    ok(info.cipher.includes('AES_256_GCM'));
+    assert.strictEqual(typeof info.cipher, 'string');
+    assert.ok(info.cipher.includes('AES_256_GCM'));
     serverSession.close();
   }), {
     sni: { '*': { keys: [key], certs: [cert] } },
@@ -43,8 +40,8 @@ const cert = readKey('agent1-cert.pem');
   });
 
   const info = await clientSession.opened;
-  ok(info.cipher.includes('AES_256_GCM'));
-  strictEqual(info.cipherVersion, 'TLSv1.3');
+  assert.ok(info.cipher.includes('AES_256_GCM'));
+  assert.strictEqual(info.cipherVersion, 'TLSv1.3');
 
   await clientSession.closed;
   await serverEndpoint.close();
@@ -78,8 +75,8 @@ const cert = readKey('agent1-cert.pem');
 
 // Default ciphers/groups are non-empty strings from constants.
 {
-  strictEqual(typeof constants.DEFAULT_CIPHERS, 'string');
-  ok(constants.DEFAULT_CIPHERS.length > 0);
-  strictEqual(typeof constants.DEFAULT_GROUPS, 'string');
-  ok(constants.DEFAULT_GROUPS.length > 0);
+  assert.strictEqual(typeof constants.DEFAULT_CIPHERS, 'string');
+  assert.ok(constants.DEFAULT_CIPHERS.length > 0);
+  assert.strictEqual(typeof constants.DEFAULT_GROUPS, 'string');
+  assert.ok(constants.DEFAULT_GROUPS.length > 0);
 }

--- a/test/parallel/test-quic-tls-trace.mjs
+++ b/test/parallel/test-quic-tls-trace.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,7 +25,7 @@ const clientSession = await connect(serverEndpoint.address, {
   tlsTrace: true,
 });
 await clientSession.opened;
-strictEqual(clientSession.destroyed, false);
+assert.strictEqual(clientSession.destroyed, false);
 
 await clientSession.closed;
 await serverEndpoint.close();

--- a/test/parallel/test-quic-tls-verify-client.mjs
+++ b/test/parallel/test-quic-tls-verify-client.mjs
@@ -10,9 +10,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, ok, rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,17 +17,17 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const serverKey = createPrivateKey(readKey('agent1-key.pem'));
-const serverCert = readKey('agent1-cert.pem');
-const clientKey = createPrivateKey(readKey('agent2-key.pem'));
-const clientCert = readKey('agent2-cert.pem');
+const serverKey = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const serverCert = fixtures.readKey('agent1-cert.pem');
+const clientKey = createPrivateKey(fixtures.readKey('agent2-key.pem'));
+const clientCert = fixtures.readKey('agent2-cert.pem');
 
 // --- TLS-03: Client provides a certificate — handshake succeeds ---
 {
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
     await serverSession.opened;
     // The server should see the client's certificate.
-    ok(serverSession.peerCertificate);
+    assert.ok(serverSession.peerCertificate);
     await serverSession.close();
   }), {
     sni: { '*': { keys: [serverKey], certs: [serverCert] } },
@@ -58,7 +55,7 @@ const clientCert = readKey('agent2-cert.pem');
 // closes both sides with a transport error.
 {
   const serverEndpoint = await listen(mustCall(async (serverSession) => {
-    await rejects(serverSession.closed, {
+    await assert.rejects(serverSession.closed, {
       code: 'ERR_QUIC_TRANSPORT_ERROR',
     });
   }), {
@@ -66,7 +63,7 @@ const clientCert = readKey('agent2-cert.pem');
     alpn: ['quic-test'],
     verifyClient: true,
     onerror: mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+      assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
     }),
   });
 
@@ -75,13 +72,13 @@ const clientCert = readKey('agent2-cert.pem');
     alpn: 'quic-test',
     verifyPeer: 'manual',
     onerror: mustCall((err) => {
-      strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
+      assert.strictEqual(err.code, 'ERR_QUIC_TRANSPORT_ERROR');
     }),
   });
 
   // The client's closed promise rejects with the transport error
   // from the server's certificate_required alert.
-  await rejects(clientSession.closed, {
+  await assert.rejects(clientSession.closed, {
     code: 'ERR_QUIC_TRANSPORT_ERROR',
   });
 

--- a/test/parallel/test-quic-token-distinct.mjs
+++ b/test/parallel/test-quic-token-distinct.mjs
@@ -5,8 +5,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, notDeepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -30,7 +28,7 @@ const cs1 = await connect(serverEndpoint.address, {
   }),
 });
 await Promise.all([cs1.opened, gotToken1.promise]);
-ok(token1.length > 0);
+assert.ok(token1.length > 0);
 
 // Client 2.
 const cs2 = await connect(serverEndpoint.address, {
@@ -40,10 +38,10 @@ const cs2 = await connect(serverEndpoint.address, {
   }),
 });
 await Promise.all([cs2.opened, gotToken2.promise]);
-ok(token2.length > 0);
+assert.ok(token2.length > 0);
 
 // Tokens should be distinct.
-notDeepStrictEqual(token1, token2);
+assert.notDeepStrictEqual(token1, token2);
 
 await cs1.close();
 await cs2.close();

--- a/test/parallel/test-quic-token-expired.mjs
+++ b/test/parallel/test-quic-token-expired.mjs
@@ -11,9 +11,6 @@ import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 import { setTimeout } from 'node:timers/promises';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -21,8 +18,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const alpn = ['quic-test'];
 
@@ -48,7 +45,7 @@ const cs1 = await connect(serverEndpoint.address, {
   }),
 });
 await Promise.all([cs1.opened, gotToken.promise]);
-ok(savedToken.length > 0);
+assert.ok(savedToken.length > 0);
 await cs1.close();
 
 // Wait for the token to expire.
@@ -64,7 +61,7 @@ const cs2 = await connect(serverEndpoint.address, {
 });
 await cs2.opened;
 // The connection succeeded despite the expired token.
-strictEqual(cs2.destroyed, false);
+assert.strictEqual(cs2.destroyed, false);
 await cs2.close();
 
 await serverEndpoint.close();

--- a/test/parallel/test-quic-token-reuse.mjs
+++ b/test/parallel/test-quic-token-reuse.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -31,8 +29,8 @@ const serverEndpoint = await listen(mustCall((serverSession) => {
 // First connection: receive the token.
 const cs1 = await connect(serverEndpoint.address, {
   onnewtoken: mustCall((token) => {
-    ok(Buffer.isBuffer(token));
-    ok(token.length > 0);
+    assert.ok(Buffer.isBuffer(token));
+    assert.ok(token.length > 0);
     savedToken = token;
     gotToken.resolve();
   }),

--- a/test/parallel/test-quic-token-secret.mjs
+++ b/test/parallel/test-quic-token-secret.mjs
@@ -9,9 +9,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -19,8 +16,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey, randomBytes } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const alpn = ['quic-test'];
 
@@ -48,7 +45,7 @@ const cs1 = await connect(ep1.address, {
   }),
 });
 await Promise.all([cs1.opened, gotToken.promise]);
-ok(savedToken.length > 0);
+assert.ok(savedToken.length > 0);
 await cs1.close();
 await ep1.close();
 
@@ -68,7 +65,7 @@ const cs2 = await connect(ep2.address, {
   token: savedToken,
 });
 await cs2.opened;
-strictEqual(cs2.destroyed, false);
+assert.strictEqual(cs2.destroyed, false);
 await cs2.close();
 await ep2.close();
 
@@ -88,6 +85,6 @@ const cs3 = await connect(ep3.address, {
   token: savedToken,
 });
 await cs3.opened;
-strictEqual(cs3.destroyed, false);
+assert.strictEqual(cs3.destroyed, false);
 await cs3.close();
 await ep3.close();

--- a/test/parallel/test-quic-transport-params-validation.mjs
+++ b/test/parallel/test-quic-transport-params-validation.mjs
@@ -10,10 +10,6 @@ import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { readKey } = fixtures;
-
-const { rejects, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -21,8 +17,8 @@ if (!hasQuic) {
 const { listen } = await import('node:quic');
 const { createPrivateKey } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const alpn = ['quic-test'];
 
@@ -43,13 +39,13 @@ for (const param of [
   'ackDelayExponent',
   'maxAckDelay',
 ]) {
-  await rejects(tryListen({
+  await assert.rejects(tryListen({
     transportParams: { [param]: 'invalid' },
   }), {
     code: 'ERR_INVALID_ARG_VALUE',
   }, `${param} should reject string value`);
 
-  await rejects(tryListen({
+  await assert.rejects(tryListen({
     transportParams: { [param]: -1 },
   }), {
     code: 'ERR_INVALID_ARG_VALUE',
@@ -72,5 +68,5 @@ const ep = await tryListen({
     maxDatagramFrameSize: 1200,
   },
 });
-ok(ep);
+assert.ok(ep);
 await ep.close();

--- a/test/parallel/test-quic-version-negotiation-oversized-cid.mjs
+++ b/test/parallel/test-quic-version-negotiation-oversized-cid.mjs
@@ -18,8 +18,6 @@
 import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -83,7 +81,7 @@ while (serverEndpoint.stats.versionNegotiationCount === 0n) {
 
 // Exactly one VN response: the oversized packet was dropped (not crashed, not
 // negotiated), the valid packet was negotiated.
-strictEqual(serverEndpoint.stats.versionNegotiationCount, 1n);
+assert.strictEqual(serverEndpoint.stats.versionNegotiationCount, 1n);
 
 socket.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-version-negotiation.mjs
+++ b/test/parallel/test-quic-version-negotiation.mjs
@@ -12,8 +12,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -25,14 +23,14 @@ const bogusVersion = 0x1a1a1a1a;
 // Subscribe to the version negotiation diagnostics channel.
 const channelFired = Promise.withResolvers();
 dc.subscribe('quic.session.version.negotiation', mustCall((msg) => {
-  ok(msg.session, 'message should have session');
-  strictEqual(msg.version, bogusVersion);
-  ok(Array.isArray(msg.requestedVersions),
-     'requestedVersions should be an array');
-  ok(msg.requestedVersions.length > 0,
-     'server should advertise at least one version');
-  ok(Array.isArray(msg.supportedVersions),
-     'supportedVersions should be an array');
+  assert.ok(msg.session, 'message should have session');
+  assert.strictEqual(msg.version, bogusVersion);
+  assert.ok(Array.isArray(msg.requestedVersions),
+            'requestedVersions should be an array');
+  assert.ok(msg.requestedVersions.length > 0,
+            'server should advertise at least one version');
+  assert.ok(Array.isArray(msg.supportedVersions),
+            'supportedVersions should be an array');
   channelFired.resolve();
 }));
 
@@ -49,22 +47,21 @@ const clientSession = await connect(serverEndpoint.address, {
   onversionnegotiation: mustCall((version, requestedVersions,
                                   supportedVersions) => {
     // The version is the bogus version we configured.
-    strictEqual(version, bogusVersion);
+    assert.strictEqual(version, bogusVersion);
     // requestedVersions are the versions the server advertised in
     // the Version Negotiation packet.
-    ok(Array.isArray(requestedVersions),
-       'requestedVersions should be an array');
-    ok(requestedVersions.length > 0,
-       'server should advertise at least one supported version');
+    assert.ok(Array.isArray(requestedVersions),
+              'requestedVersions should be an array');
+    assert.ok(requestedVersions.length > 0,
+              'server should advertise at least one supported version');
     // supportedVersions is our local supported range [min, max].
-    ok(Array.isArray(supportedVersions),
-       'supportedVersions should be an array');
-    strictEqual(supportedVersions.length, 2,
-                'supportedVersions should have [min, max]');
+    assert.ok(Array.isArray(supportedVersions),
+              'supportedVersions should be an array');
+    assert.strictEqual(supportedVersions.length, 2);
   }),
   // The onerror callback fires with the version negotiation error.
   onerror: mustCall((err) => {
-    strictEqual(err.code, 'ERR_QUIC_VERSION_NEGOTIATION_ERROR');
+    assert.strictEqual(err.code, 'ERR_QUIC_VERSION_NEGOTIATION_ERROR');
   }),
 });
 

--- a/test/parallel/test-quic-version.mjs
+++ b/test/parallel/test-quic-version.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -31,9 +29,9 @@ const cs = await connect(serverEndpoint.address);
 const info = await cs.opened;
 
 // The cipher and protocol should be negotiated.
-strictEqual(typeof info.cipher, 'string');
-strictEqual(info.cipherVersion, 'TLSv1.3');
-strictEqual(info.protocol, 'quic-test');
+assert.strictEqual(typeof info.cipher, 'string');
+assert.strictEqual(info.cipherVersion, 'TLSv1.3');
+assert.strictEqual(info.protocol, 'quic-test');
 
 // Both V1 and V2 are in preferred/available versions
 // (configured in Session::Config). The compatible version negotiation

--- a/test/parallel/test-quic-writer-abort-signal.mjs
+++ b/test/parallel/test-quic-writer-abort-signal.mjs
@@ -5,8 +5,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 
-const { rejects } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -36,7 +34,7 @@ const w = stream.writer;
 const signal = AbortSignal.abort(new Error('already aborted'));
 
 // write() with an already-aborted signal should reject immediately.
-await rejects(
+await assert.rejects(
   w.write(encoder.encode('data'), { signal }),
   { message: 'already aborted' },
 );

--- a/test/parallel/test-quic-writer-backpressure.mjs
+++ b/test/parallel/test-quic-writer-backpressure.mjs
@@ -9,8 +9,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -28,7 +26,7 @@ const serverDone = Promise.withResolvers();
 const serverEndpoint = await listen(mustCall((serverSession) => {
   serverSession.onstream = mustCall(async (stream) => {
     const received = await bytes(stream);
-    strictEqual(received.byteLength, totalSize);
+    assert.strictEqual(received.byteLength, totalSize);
     stream.writer.endSync();
     await stream.closed;
     serverSession.close();
@@ -45,8 +43,8 @@ const stream = await clientSession.createBidirectionalStream({
 const w = stream.writer;
 
 // Initial canWrite should be true.
-strictEqual(w.canWrite, true);
-strictEqual(stream.budget, 2048);
+assert.strictEqual(w.canWrite, true);
+assert.strictEqual(stream.budget, 2048);
 
 let backpressureCount = 0;
 
@@ -59,13 +57,13 @@ for (let i = 0; i < numChunks; i++) {
 
     // drainableProtocol returns a promise when backpressured.
     const drain = w[dp]();
-    ok(drain instanceof Promise, 'drainableProtocol should return a Promise');
+    assert.ok(drain instanceof Promise, 'drainableProtocol should return a Promise');
 
     // The promise resolves when drain fires.
     await drain;
 
     // After drain, canWrite should be true.
-    ok(w.canWrite === true, `canWrite after drain should be true, got ${w.canWrite}`);
+    assert.ok(w.canWrite === true, `canWrite after drain should be true, got ${w.canWrite}`);
   }
 }
 
@@ -73,7 +71,7 @@ w.endSync();
 
 // Backpressure should have been hit with a 2KB budget
 // and 1KB chunks (every 2 chunks fills the buffer).
-ok(backpressureCount > 0, 'backpressure should have been hit');
+assert.ok(backpressureCount > 0, 'backpressure should have been hit');
 
 for await (const _ of stream) { /* drain */ } // eslint-disable-line no-unused-vars
 await Promise.all([stream.closed, serverDone.promise]);

--- a/test/parallel/test-quic-writer-stop-sending.mjs
+++ b/test/parallel/test-quic-writer-stop-sending.mjs
@@ -8,8 +8,6 @@ import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import * as assert from 'node:assert';
 import { setTimeout } from 'node:timers/promises';
 
-const { rejects, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -27,7 +25,7 @@ const serverEndpoint = await listen(mustCall(async (serverSession) => {
     stream.stopSending(1n);
     serverReady.resolve();
     stream.writer.endSync();
-    await rejects(stream.closed, mustCall((err) => {
+    await assert.rejects(stream.closed, mustCall((err) => {
       assert.ok(err);
       return true;
     }));
@@ -51,7 +49,7 @@ await setTimeout(100);
 
 // After STOP_SENDING, the writer should be in an errored state.
 // writeSync returns false (refuses to accept data).
-strictEqual(w.writeSync(encoder.encode('rejected')), false);
+assert.strictEqual(w.writeSync(encoder.encode('rejected')), false);
 
 // The stream closes after the server sends FIN.
 await Promise.all([serverDone.promise, stream.closed]);

--- a/test/parallel/test-quic-writer-write-rejects.mjs
+++ b/test/parallel/test-quic-writer-write-rejects.mjs
@@ -7,8 +7,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { rejects, strictEqual, ok } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -38,22 +36,22 @@ const stream = await clientSession.createBidirectionalStream({
 const w = stream.writer;
 
 // Fill the buffer.
-strictEqual(w.writeSync(new Uint8Array(1024)), true);
+assert.strictEqual(w.writeSync(new Uint8Array(1024)), true);
 
 // canWrite should now be false.
-strictEqual(w.canWrite, false);
+assert.strictEqual(w.canWrite, false);
 
 // Async write() should reject when buffer is full.
-await rejects(
+await assert.rejects(
   w.write(new Uint8Array(512)),
   { code: 'ERR_INVALID_STATE' },
 );
 
 // Wait for drain, then write should succeed.
 const drain = w[dp]();
-ok(drain instanceof Promise);
+assert.ok(drain instanceof Promise);
 await drain;
-ok(w.canWrite === true);
+assert.ok(w.canWrite === true);
 
 // Now write succeeds.
 await w.write(new Uint8Array(100));

--- a/test/parallel/test-quic-zero-rtt-datagram.mjs
+++ b/test/parallel/test-quic-zero-rtt-datagram.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual, deepStrictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -43,12 +41,12 @@ const serverEndpoint = await listen((serverSession) => {
 const cs1 = await connect(serverEndpoint.address, {
   transportParams: { maxDatagramFrameSize: 1200 },
   onsessionticket: mustCall((ticket) => {
-    ok(Buffer.isBuffer(ticket));
+    assert.ok(Buffer.isBuffer(ticket));
     savedTicket = ticket;
     gotTicket.resolve();
   }),
   onnewtoken: mustCall((token) => {
-    ok(Buffer.isBuffer(token));
+    assert.ok(Buffer.isBuffer(token));
     savedToken = token;
     gotToken.resolve();
   }),
@@ -69,13 +67,13 @@ const cs2 = await connect(serverEndpoint.address, {
 await cs2.sendDatagram(new Uint8Array([0xCA, 0xFE]));
 
 const info2 = await cs2.opened;
-strictEqual(info2.earlyDataAttempted, true);
-strictEqual(info2.earlyDataAccepted, true);
+assert.strictEqual(info2.earlyDataAttempted, true);
+assert.strictEqual(info2.earlyDataAccepted, true);
 
 // Verify the server received the datagram as early data.
 await serverGotDatagram.promise;
-deepStrictEqual(receivedDatagramData, Buffer.from([0xCA, 0xFE]));
-strictEqual(earlyDatagramReceived, true);
+assert.deepStrictEqual(receivedDatagramData, Buffer.from([0xCA, 0xFE]));
+assert.strictEqual(earlyDatagramReceived, true);
 
 await cs2.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-zero-rtt-disabled-client.mjs
+++ b/test/parallel/test-quic-zero-rtt-disabled-client.mjs
@@ -8,8 +8,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -53,8 +51,8 @@ const cs2 = await connect(serverEndpoint.address, {
 
 const info2 = await cs2.opened;
 // 0-RTT should NOT be attempted.
-strictEqual(info2.earlyDataAttempted, false);
-strictEqual(info2.earlyDataAccepted, false);
+assert.strictEqual(info2.earlyDataAttempted, false);
+assert.strictEqual(info2.earlyDataAccepted, false);
 
 await cs2.close();
 await serverEndpoint.close();

--- a/test/parallel/test-quic-zero-rtt-disabled-server.mjs
+++ b/test/parallel/test-quic-zero-rtt-disabled-server.mjs
@@ -10,9 +10,6 @@ import { hasQuic, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -20,8 +17,8 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey, randomBytes } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const alpn = ['quic-test'];
 
@@ -88,8 +85,8 @@ const cs2 = await connect(serverEndpoint2.address, {
 await cs2.sendDatagram(new Uint8Array([1]));
 
 const info2 = await cs2.opened;
-strictEqual(info2.earlyDataAttempted, true);
-strictEqual(info2.earlyDataAccepted, false);
+assert.strictEqual(info2.earlyDataAttempted, true);
+assert.strictEqual(info2.earlyDataAccepted, false);
 
 await cs2.closed;
 await serverEndpoint2.close();

--- a/test/parallel/test-quic-zero-rtt-rejected-settings.mjs
+++ b/test/parallel/test-quic-zero-rtt-rejected-settings.mjs
@@ -7,13 +7,10 @@
 // because the stored transport params are more permissive than
 // the current ones. The connection falls back to 1-RTT.
 
-import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import { hasQuic, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import dc from 'node:diagnostics_channel';
 import * as fixtures from '../common/fixtures.mjs';
-
-const { ok, strictEqual } = assert;
-const { readKey } = fixtures;
 
 if (!hasQuic) {
   skip('QUIC is not enabled');
@@ -22,15 +19,15 @@ if (!hasQuic) {
 const { listen, connect } = await import('node:quic');
 const { createPrivateKey, randomBytes } = await import('node:crypto');
 
-const key = createPrivateKey(readKey('agent1-key.pem'));
-const cert = readKey('agent1-cert.pem');
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
 const sni = { '*': { keys: [key], certs: [cert] } };
 const alpn = ['quic-test'];
 const tokenSecret = randomBytes(16);
 
 // quic.session.early.rejected fires when 0-RTT is rejected.
 dc.subscribe('quic.session.early.rejected', mustCall((msg) => {
-  ok(msg.session, 'early.rejected should include session');
+  assert.ok(msg.session, 'early.rejected should include session');
 }));
 
 let savedTicket;
@@ -84,7 +81,7 @@ const ep2 = await listen((serverSession) => {
     initialMaxStreamsBidi: 10,
     initialMaxData: 1048576,
   },
-  onerror(err) { ok(err); },
+  onerror: mustNotCall(),
 });
 
 const cs2 = await connect(ep2.address, {
@@ -92,7 +89,7 @@ const cs2 = await connect(ep2.address, {
   verifyPeer: 'manual',
   sessionTicket: savedTicket,
   token: savedToken,
-  onerror(err) { ok(err); },
+  onerror: mustNotCall(),
   onearlyrejected() {},
 });
 
@@ -104,8 +101,8 @@ await cs2.createBidirectionalStream({
 
 const info2 = await cs2.opened;
 // 0-RTT was attempted but rejected due to changed transport params.
-strictEqual(info2.earlyDataAttempted, true);
-strictEqual(info2.earlyDataAccepted, false);
+assert.strictEqual(info2.earlyDataAttempted, true);
+assert.strictEqual(info2.earlyDataAccepted, false);
 
 // The 0-RTT stream may have been destroyed by EarlyDataRejected.
 // Close from the client side.

--- a/test/parallel/test-quic-zero-rtt.mjs
+++ b/test/parallel/test-quic-zero-rtt.mjs
@@ -11,8 +11,6 @@
 import { hasQuic, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 
-const { ok, strictEqual } = assert;
-
 if (!hasQuic) {
   skip('QUIC is not enabled');
 }
@@ -32,44 +30,45 @@ let secondStreamEarly;
 const secondStreamDone = Promise.withResolvers();
 
 let serverSessionCount = 0;
-const serverEndpoint = await listen((serverSession) => {
+const serverEndpoint = await listen(mustCall((serverSession) => {
   const sessionNum = ++serverSessionCount;
-  serverSession.onstream = async (stream) => {
-    const data = await bytes(stream);
-    ok(data.byteLength > 0);
+  serverSession.onstream = mustCall((stream) =>
+    bytes(stream).then((data) => {
+      assert.ok(data.byteLength > 0);
 
-    if (sessionNum === 1) {
-      firstStreamEarly = stream.early;
-    } else {
-      secondStreamEarly = stream.early;
-      secondStreamDone.resolve();
-    }
+      if (sessionNum === 1) {
+        firstStreamEarly = stream.early;
+      } else {
+        secondStreamEarly = stream.early;
+        secondStreamDone.resolve();
+      }
 
-    stream.writer.endSync();
-    await stream.closed;
-    serverSession.close();
-  };
-});
+      stream.writer.endSync();
+      return stream.closed;
+
+    }).then(mustCall(() => serverSession.close()))
+  );
+}, 2));
 
 // --- ZRTT-01: First connection — receive the session ticket and token ---
 const cs1 = await connect(serverEndpoint.address, {
   onsessionticket: mustCall((ticket) => {
-    ok(Buffer.isBuffer(ticket));
-    ok(ticket.length > 0);
+    assert.ok(Buffer.isBuffer(ticket));
+    assert.ok(ticket.length > 0);
     savedTicket = ticket;
     gotTicket.resolve();
   }, 2),
   onnewtoken: mustCall((token) => {
-    ok(Buffer.isBuffer(token));
-    ok(token.length > 0);
+    assert.ok(Buffer.isBuffer(token));
+    assert.ok(token.length > 0);
     savedToken = token;
     gotToken.resolve();
   }),
 });
 
 const info1 = await cs1.opened;
-strictEqual(info1.earlyDataAttempted, false);
-strictEqual(info1.earlyDataAccepted, false);
+assert.strictEqual(info1.earlyDataAttempted, false);
+assert.strictEqual(info1.earlyDataAccepted, false);
 
 await Promise.all([gotTicket.promise, gotToken.promise]);
 
@@ -95,8 +94,8 @@ await s2.writer.write(encoder.encode('early data'));
 
 // Now wait for handshake completion.
 const info2 = await cs2.opened;
-strictEqual(info2.earlyDataAttempted, true);
-strictEqual(info2.earlyDataAccepted, true);
+assert.strictEqual(info2.earlyDataAttempted, true);
+assert.strictEqual(info2.earlyDataAccepted, true);
 
 await s2.writer.end();
 for await (const _ of s2) { /* drain */ } // eslint-disable-line no-unused-vars
@@ -104,8 +103,8 @@ await s2.closed;
 
 // Verify the server saw the early data flag.
 await secondStreamDone.promise;
-strictEqual(firstStreamEarly, false);
-strictEqual(secondStreamEarly, true);
+assert.strictEqual(firstStreamEarly, false);
+assert.strictEqual(secondStreamEarly, true);
 
 await cs2.closed;
 await serverEndpoint.close();


### PR DESCRIPTION
A number of tests are escaping the linter rules added in 0457bfee2c25987570e3dca2ebe07332de7d0795 and 634dc26605ada74c9e44492e97a247e867da1abf by destructuring `assert` and/or `fixtures`. 