### PR TITLE
test: unflake debugger and REPL tests

### DIFF
--- a/test/parallel/test-debugger-extract-function-name.mjs
+++ b/test/parallel/test-debugger-extract-function-name.mjs
@@ -7,10 +7,14 @@ import startCLI from '../common/debugger.js';
 
 import assert from 'assert';
 
-const cli = startCLI([fixtures.path('debugger', 'three-lines.js')]);
+const env = {
+  ...process.env,
+  NODE_INSPECT_RESUME_ON_START: '1',
+};
+const cli = startCLI(
+  [fixtures.path('debugger', 'alive.js')], [], { env });
 
 try {
-  await cli.waitForInitialBreak();
   await cli.waitForPrompt();
   await cli.command('exec a = function func() {}; a;');
   assert.match(cli.output, /\[Function: func\]/);

--- a/test/parallel/test-repl-user-error-handler.js
+++ b/test/parallel/test-repl-user-error-handler.js
@@ -6,8 +6,17 @@ const { PassThrough } = require('node:stream');
 const { once } = require('node:events');
 const test = require('node:test');
 const { spawn } = require('node:child_process');
+const vm = require('node:vm');
 
 common.skipIfInspectorDisabled();
+
+function evaluate(code, context, filename, callback) {
+  try {
+    callback(null, vm.runInContext(code, context, { filename }));
+  } catch (err) {
+    callback(err);
+  }
+}
 
 function* generateCases() {
   for (const async of [false, true]) {
@@ -23,13 +32,12 @@ function* generateCases() {
 
 for (const { async, handleErrorReturn } of generateCases()) {
   test(`async: ${async}, handleErrorReturn: ${handleErrorReturn}`, async () => {
-    let err;
     const options = {
       input: new PassThrough(),
       output: new PassThrough().setEncoding('utf8'),
-      handleError: common.mustCall((e) => {
-        err = e;
-        queueMicrotask(() => repl.emit('handled-error'));
+      eval: evaluate,
+      handleError: common.mustCall((err) => {
+        queueMicrotask(() => repl.emit('handled-error', err));
         return handleErrorReturn;
       })
     };
@@ -45,13 +53,16 @@ for (const { async, handleErrorReturn } of generateCases()) {
     let outputString = '';
     options.output.on('data', (chunk) => { outputString += chunk; });
 
-    const inputString = async ?
-      'setImmediate(() => { throw new Error("testerror") })\n42\n' :
-      'throw new Error("testerror")\n42\n';
-    options.input.end(inputString);
+    const errorInput = async ?
+      'setImmediate(() => { throw new Error("testerror") })\n' :
+      'throw new Error("testerror")\n';
+    const handledErrorEvent = once(repl, 'handled-error');
+    options.input.write(errorInput);
 
-    await once(repl, 'handled-error');
+    const [err] = await handledErrorEvent;
     assert.strictEqual(err.message, 'testerror');
+    const exitEvent = once(repl, 'exit');
+    options.input.end('42\n');
     while (!/42/.test(outputString)) {
       await once(options.output, 'data');
     }
@@ -66,6 +77,7 @@ for (const { async, handleErrorReturn } of generateCases()) {
       const [uncaughtErr] = await uncaughtExceptionEvent;
       assert.strictEqual(uncaughtErr, err);
     }
+    await exitEvent;
   });
 }
 

--- a/test/sequential/test-debug-prompt.js
+++ b/test/sequential/test-debug-prompt.js
@@ -2,17 +2,45 @@
 
 const common = require('../common');
 common.skipIfInspectorDisabled();
+const assert = require('assert');
+const fixtures = require('../common/fixtures');
 const spawn = require('child_process').spawn;
 
-const proc = spawn(process.execPath, ['inspect', 'foo']);
+const proc = spawn(process.execPath, [
+  'inspect', fixtures.path('debugger', 'alive.js'),
+]);
 proc.stdout.setEncoding('utf8');
 
-let needToSendExit = true;
+const TIMEOUT = common.platformTimeout(10_000);
 let output = '';
-proc.stdout.on('data', (data) => {
-  output += data;
-  if (output.includes('debug> ') && needToSendExit) {
-    proc.stdin.write('.exit\n');
-    needToSendExit = false;
-  }
-});
+let promptSeen = false;
+
+(async () => {
+  await new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      proc.kill();
+      reject(new Error(`Timed out waiting for the debugger prompt; output: ${output}`));
+    }, TIMEOUT);
+
+    proc.stdout.on('data', (data) => {
+      output += data;
+      if (output.includes('debug> ') && !promptSeen) {
+        promptSeen = true;
+        proc.stdin.end('.exit\n');
+      }
+    });
+
+    proc.once('error', reject);
+    proc.once('close', common.mustCall((code, signal) => {
+      clearTimeout(timer);
+      if (!promptSeen) {
+        reject(new Error(
+          `Debugger exited before showing the prompt (code ${code}, signal ${signal}); ` +
+          `output: ${output}`));
+        return;
+      }
+      assert.strictEqual(code, 0);
+      resolve();
+    }));
+  });
+})().then(common.mustCall());


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/actions/runs/30080039199/job/89439279468?pr=64339

The macOS job exposed three independent test races:

- `test-debugger-extract-function-name` only checks formatting from the `exec`
  command, but synchronized on an unrelated initial-break message. Run it
  against an auto-resumed, long-lived target and synchronize directly on the
  debugger prompt instead.
- `test-repl-user-error-handler` could receive an inspector
  `Promise was collected` evaluation error before the user error it intended to
  assert. Give this focused `handleError` test a synchronous VM evaluator,
  submit the throwing and follow-up expressions separately, and await clean
  REPL teardown.
- `test-debug-prompt` relied on a nonexistent target and had no assertion,
  timeout, or child-process lifecycle handling. Use a long-lived debugger
  target, assert that the prompt is received, and report startup/exit failures
  instead of hanging.

Validation:

- `python3 tools/test.py test/sequential/test-debug-prompt.js`
- `python3 tools/test.py parallel/test-debugger-extract-function-name parallel/test-repl-user-error-handler`
- targeted ESLint
- commit-message validation
