### PR TITLE
test: increase timeout in probe-failure-hang-during-evaluate

### DIFF
--- a/test/parallel/test-debugger-probe-failure-hang-during-evaluate.js
+++ b/test/parallel/test-debugger-probe-failure-hang-during-evaluate.js
@@ -12,7 +12,7 @@ const { assertProbeJson } = require('../common/debugger-probe');
 const cwd = fixtures.path('debugger');
 const fixture = 'probe-inspector-close-two-probes.js';
 const marker = 'probe-inspector-close-marker';
-const timeoutMs = common.platformTimeout(1000);
+const timeoutMs = common.platformTimeout(3000);
 const probes = [
   { expr: 'closeInspector()', target: { suffix: fixture, line: 10 } },
   { expr: 'firstProbeLine', target: { suffix: fixture, line: 11 } },


### PR DESCRIPTION
On slower CI machines, the probed process may take longer time to bootstrap and establish connection to. Increase the timeout so it's more likely to finish testing before timing out.

Refs: https://github.com/nodejs/reliability/blob/main/reports/2026-07-24.md

Also see the logs of https://ci.nodejs.org/job/node-test-commit-smartos/nodes=smartos23-x64/66791/consoleFull where other probe tests take ~1s to finish end to end, and the logs of flaked probe-failure-hang-during-evaluate showed that it timing out before finishing testing.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
