### PR TITLE
quic: fix segfault after fragmented client hello

### DIFF
--- a/src/quic/session.cc
+++ b/src/quic/session.cc
@@ -2813,9 +2813,9 @@ bool Session::ReadPacket(const uint8_t* data,
       Debug(this, "Session successfully received %zu-byte packet", len);
       if (!is_destroyed()) [[likely]] {
         STAT_INCREMENT_N(Stats, bytes_received, len);
-        // Process deferred operations that couldn't run inside callback
-        // scopes (e.g., HTTP/3 GOAWAY handling that calls into JS).
-        application().PostReceive();
+        // Process deferred application operations after ALPN selection - not
+        // necessarily resolved yet as ClientHello can span multiple packets.
+        if (has_application()) application().PostReceive();
         // Surface a server session to JS once its ClientHello has been
         // processed (OnSelectAlpn fired: SNI + ALPN are known and reliable).
         // Held first-flight events - including 0-RTT request streams - replay

--- a/test/parallel/test-quic-multipacket-clienthello.mjs
+++ b/test/parallel/test-quic-multipacket-clienthello.mjs
@@ -1,0 +1,60 @@
+// Flags: --experimental-quic --experimental-stream-iter --no-warnings
+
+// A large post-quantum key share splits the ClientHello across QUIC Initial
+// packets. The server must accept the incomplete first packet before ALPN has
+// selected its application, then complete the handshake and process streams.
+
+import { hasQuic, skip, mustCall } from '../common/index.mjs';
+import assert from 'node:assert';
+import * as fixtures from '../common/fixtures.mjs';
+
+if (!hasQuic) {
+  skip('QUIC is not enabled');
+}
+
+const { createPrivateKey } = await import('node:crypto');
+const { listen, connect } = await import('node:quic');
+const { bytes } = await import('stream/iter');
+
+const key = createPrivateKey(fixtures.readKey('agent1-key.pem'));
+const cert = fixtures.readKey('agent1-cert.pem');
+const alpn = 'quic-multipacket-clienthello';
+const groups = 'X25519MLKEM768';
+const streamReceived = Promise.withResolvers();
+
+const endpoint = await listen(mustCall(async (session) => {
+  const info = await session.opened;
+  assert.strictEqual(session.alpnProtocol, alpn);
+  assert.strictEqual(info.cipherVersion, 'TLSv1.3');
+
+  session.onstream = mustCall(async (stream) => {
+    assert.strictEqual(
+      Buffer.from(await bytes(stream)).toString(),
+      'application event survived',
+    );
+    stream.writer.endSync();
+    await stream.closed;
+    streamReceived.resolve();
+  });
+}), {
+  host: '127.0.0.1',
+  port: 0,
+  alpn: [alpn],
+  groups,
+  sni: { '*': { keys: [key], certs: [cert] } },
+});
+
+const session = await connect(endpoint.address, {
+  alpn,
+  groups,
+  servername: 'localhost',
+  verifyPeer: 'manual',
+});
+
+await session.opened;
+const stream = await session.createBidirectionalStream({
+  body: 'application event survived',
+});
+await Promise.all([stream.closed, streamReceived.promise]);
+await session.close();
+await endpoint.close();


### PR DESCRIPTION
If the client hello is fragmented across packets, we start trying to initialize the application before ALPN actually selected an application, so we segfault (repro in the test here).

This changes QUIC session setup to defer processing until an application is selected (i.e. ALPN resolved). Test confirms that session handling after deferring that works fine.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
