### PR TITLE
[v22.x backport] fs: restore fs patchability in ESM loader

### DIFF
--- a/lib/internal/modules/esm/load.js
+++ b/lib/internal/modules/esm/load.js
@@ -10,7 +10,7 @@ const {
 const { defaultGetFormat } = require('internal/modules/esm/get_format');
 const { validateAttributes, emitImportAssertionWarning } = require('internal/modules/esm/assert');
 const { getOptionValue } = require('internal/options');
-const { readFileSync } = require('fs');
+const fs = require('fs');
 
 const defaultType =
   getOptionValue('--experimental-default-type');
@@ -38,7 +38,11 @@ function getSourceSync(url, context) {
   const responseURL = href;
   let source;
   if (protocol === 'file:') {
-    source = readFileSync(url);
+    // If you are reading this code to figure out how to patch Node.js module loading
+    // behavior - DO NOT depend on the patchability in new code: Node.js
+    // internals may stop going through the JavaScript fs module entirely.
+    // Prefer module.registerHooks() or other more formal fs hooks released in the future.
+    source = fs.readFileSync(url);
   } else if (protocol === 'data:') {
     const result = dataURLProcessor(url);
     if (result === 'failure') {

--- a/lib/internal/modules/esm/resolve.js
+++ b/lib/internal/modules/esm/resolve.js
@@ -25,7 +25,7 @@ const {
 const assert = require('internal/assert');
 const internalFS = require('internal/fs/utils');
 const { BuiltinModule } = require('internal/bootstrap/realm');
-const { realpathSync } = require('fs');
+const fs = require('fs');
 const { getOptionValue } = require('internal/options');
 // Do not eagerly grab .manifest, it may be in TDZ
 const { sep, posix: { relative: relativePosixPath }, resolve } = require('path');
@@ -277,7 +277,11 @@ function finalizeResolution(resolved, base, preserveSymlinks) {
   }
 
   if (!preserveSymlinks) {
-    const real = realpathSync(path, {
+    // If you are reading this code to figure out how to patch Node.js module loading
+    // behavior - DO NOT depend on the patchability in new code: Node.js
+    // internals may stop going through the JavaScript fs module entirely.
+    // Prefer module.registerHooks() or other more formal fs hooks released in the future.
+    const real = fs.realpathSync(path, {
       [internalFS.realpathCacheKey]: realpathCache,
     });
     const { search, hash } = resolved;

--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -24,7 +24,7 @@ const {
 
 const { BuiltinModule } = require('internal/bootstrap/realm');
 const assert = require('internal/assert');
-const { readFileSync } = require('fs');
+const fs = require('fs');
 const { dirname, extname } = require('path');
 const {
   assertBufferSource,
@@ -357,7 +357,11 @@ translators.set('commonjs', function commonjsStrategy(url, translateContext, par
 
   try {
     // We still need to read the FS to detect the exports.
-    translateContext.source ??= readFileSync(new URL(url), 'utf8');
+    // If you are reading this code to figure out how to patch Node.js module loading
+    // behavior - DO NOT depend on the patchability in new code: Node.js
+    // internals may stop going through the JavaScript fs module entirely.
+    // Prefer module.registerHooks() or other more formal fs hooks released in the future.
+    translateContext.source ??= fs.readFileSync(new URL(url), 'utf8');
   } catch {
     // Continue regardless of error.
   }


### PR DESCRIPTION
Backport of #62835 to the v22.x line.

#62835 landed on `main` in 9531947 and was backported to v26.x (v26.1.0)
and v24.x (v24.16.0), but not to v22.x. It did not cherry-pick cleanly onto
v22 — `lib/internal/modules/esm/load.js` conflicted, which is likely why it
was missed.

This fixes #64709. Under Yarn PnP on v22.22.3 through v22.23.1, the ESM
loader captures `readFileSync`/`realpathSync` before PnP patches `fs`, so
Node cannot read sources from the zip cache itself. PnP supplies the source
through its load hook instead, which routes loading through the synthetic
require in `loadCJSModule` — that one does not set `cache` or `extensions`.
Result: `rechoir`/`webpack-cli` and `import-fresh`/`postcss-loader` both
break.

Conflict resolution: v22's `load.js` also imports `getOptionValue` for
`--experimental-default-type`, which does not exist on the newer lines. That
import is preserved; only the `fs` import and call sites changed. The rest
The rest applied cleanly from 9531947.

The v22 build is still compiling locally, so I haven't yet run the
reproducer against a patched binary — I'll follow up with before/after
output. Opening now so it's visible in case someone wants to pick it up
sooner.