### PR TITLE
lib: fix typo in comment in _http_client.js

### DIFF
--- a/lib/_http_client.js
+++ b/lib/_http_client.js
@@ -296,7 +296,7 @@ function rewriteForProxiedHttp(req, reqOptions, proxyAuthority, userHostHeader, 
     // so a rejected request doesn't leave proxy-* headers stuck on the outgoing header store.
     // XXX(joyeecheung): This validates whether the request conforms to the RFC, but here
     // we only do it for proxied requests for backward compatibility. For non-proxied requests,
-    // ensuring thst the request is well formed has been entirely left to the user.
+    // ensuring that the request is well formed has been entirely left to the user.
     const result = validateRequestAuthority(req.path, proxyAuthority, userHostHeader, headerArray);
     if (headerArray === undefined) {
       const currentHost = req.getHeader('host');


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
Fix a typo ("thst" → "that") in a comment in `lib/_http_client.js`.
