### PR TITLE
test: fix flaky HTTP/2 reset callback check

### DIFF
--- a/test/parallel/test-http2-reset-happy-close.js
+++ b/test/parallel/test-http2-reset-happy-close.js
@@ -43,8 +43,17 @@ function runScenario(rstCode, expectedErrorCode, next) {
       stream.respond({ ':status': 200 });
 
       let writeCbCount = 0;
+      let streamClosed = false;
+      const maybeCloseServer = () => {
+        if (streamClosed && writeCbCount === N_WRITES)
+          server.close(next);
+      };
+      const onWrite = common.mustCall(() => {
+        writeCbCount++;
+        maybeCloseServer();
+      }, N_WRITES);
       for (let i = 0; i < N_WRITES; i++) {
-        stream.write(Buffer.alloc(CHUNK_BYTES), () => { writeCbCount++; });
+        stream.write(Buffer.alloc(CHUNK_BYTES), onWrite);
       }
 
       stream.on('aborted', common.mustCall(() => {
@@ -69,16 +78,11 @@ function runScenario(rstCode, expectedErrorCode, next) {
         // 'finish' must not have been emitted (writes were aborted).
         assert.strictEqual(stream.writableFinished, false);
         assert.strictEqual(stream.destroyed, true);
-        // The C++ Http2Stream::Destroy SetImmediate flushes any
-        // still-queued WriteWraps with UV_ECANCELED, which fires the
-        // remaining `_write` callbacks. Those land *after* 'close';
-        // verify the full set has fired by the next two immediates.
-        setImmediate(common.mustCall(() => setImmediate(common.mustCall(() => {
-          assert.strictEqual(writeCbCount, N_WRITES,
-                             `all ${N_WRITES} write callbacks must fire ` +
-                             `(got ${writeCbCount})`);
-          server.close(next);
-        }))));
+        // Write callbacks for data already handed to the socket can land
+        // after 'close'. Wait for all of them rather than assuming a fixed
+        // number of event loop iterations is sufficient.
+        streamClosed = true;
+        maybeCloseServer();
       }));
     }));
   }));


### PR DESCRIPTION
Refs: https://github.com/nodejs/reliability/issues?q=sort%3Aupdated-desc%20test-http2-reset-happy-close

The test previously expected all pending write callbacks to run within two
`setImmediate()` turns after the HTTP/2 stream emitted `'close'`. Write
callbacks can run later when data has already been handed to the socket,
making that timing assumption unreliable under CI load.

Track stream closure and write callback completion independently, and close
the server only after both conditions are satisfied. Use `common.mustCall()`
to continue verifying that all 16 callbacks run. If a callback is genuinely
lost, the test harness will time out or report the callback count mismatch.

---

Assisted-by: codex:gpt-5.6-sol

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
