### PR TITLE
async_hooks: use validateBoolean for trackPromises

### DIFF
--- a/lib/async_hooks.js
+++ b/lib/async_hooks.js
@@ -19,13 +19,13 @@ const {
   ERR_ASYNC_RESOURCE_DOMAIN_REMOVED,
   ERR_ASYNC_TYPE,
   ERR_INVALID_ASYNC_ID,
-  ERR_INVALID_ARG_TYPE,
   ERR_INVALID_ARG_VALUE,
 } = require('internal/errors').codes;
 const {
   kEmptyObject,
 } = require('internal/util');
 const {
+  validateBoolean,
   validateFunction,
   validateString,
 } = require('internal/validators');
@@ -85,8 +85,8 @@ class AsyncHook {
       throw new ERR_ASYNC_CALLBACK('hook.destroy');
     if (promiseResolve !== undefined && typeof promiseResolve !== 'function')
       throw new ERR_ASYNC_CALLBACK('hook.promiseResolve');
-    if (trackPromises !== undefined && typeof trackPromises !== 'boolean') {
-      throw new ERR_INVALID_ARG_TYPE('trackPromises', 'boolean', trackPromises);
+    if (trackPromises !== undefined) {
+      validateBoolean(trackPromises, 'trackPromises');
     }
 
     this[init_symbol] = init;


### PR DESCRIPTION
The `trackPromises` validation added in #61415 hand-rolls a check that `validateBoolean()` already performs — same error code, same expected type string, same argument order. This replaces it with the validator.

`lib/async_hooks.js` already imports `validateString()` and `validateFunction()` and uses them for `type` and `fn`, so this also makes the file internally consistent. With the last manual check gone, the `ERR_INVALID_ARG_TYPE` import is dropped as well.

No behavior change: `validateBoolean()` is wrapped in `hideStackFrames()`, so the thrown error is identical from a caller's perspective, including the top stack frame. The existing coverage in `test/async-hooks/test-track-promises-validation.js` already asserts this, so no new tests are added.

Refs: https://github.com/nodejs/node/pull/61415
