### PR TITLE
url: create URLPattern result properties in WebIDL order

### DIFF
--- a/src/node_url_pattern.cc
+++ b/src/node_url_pattern.cc
@@ -446,13 +446,13 @@ MaybeLocal<Object> URLPattern::URLPatternComponentResult::ToJSObject(
   auto tmpl = env->urlpatterncomponentresult_template();
   if (tmpl.IsEmpty()) {
     static constexpr std::string_view namesVec[] = {
-        "input",
         "groups",
+        "input",
     };
     tmpl = DictionaryTemplate::New(isolate, namesVec);
     env->set_urlpatterncomponentresult_template(tmpl);
   }
-  MaybeLocal<Value> values[] = {input, parsed_group};
+  MaybeLocal<Value> values[] = {parsed_group, input};
   return NewDictionaryInstance(env->context(), tmpl, values);
 }
 
@@ -463,15 +463,15 @@ MaybeLocal<Value> URLPattern::URLPatternResult::ToJSValue(
   auto tmpl = env->urlpatternresult_template();
   if (tmpl.IsEmpty()) {
     static constexpr std::string_view namesVec[] = {
-        "inputs",
-        "protocol",
-        "username",
-        "password",
-        "hostname",
-        "port",
-        "pathname",
-        "search",
         "hash",
+        "hostname",
+        "inputs",
+        "password",
+        "pathname",
+        "port",
+        "protocol",
+        "search",
+        "username",
     };
     tmpl = DictionaryTemplate::New(isolate, namesVec);
     env->set_urlpatternresult_template(tmpl);
@@ -479,6 +479,8 @@ MaybeLocal<Value> URLPattern::URLPatternResult::ToJSValue(
 
   size_t index = 0;
   MaybeLocal<Value> vals[] = {
+      URLPatternComponentResult::ToJSObject(env, result.hash),
+      URLPatternComponentResult::ToJSObject(env, result.hostname),
       Array::New(env->context(),
                  result.inputs.size(),
                  [&index, &inputs = result.inputs, env]() {
@@ -493,14 +495,12 @@ MaybeLocal<Value> URLPattern::URLPatternResult::ToJSValue(
                      return URLPatternInit::ToJsObject(env, init);
                    }
                  }),
-      URLPatternComponentResult::ToJSObject(env, result.protocol),
-      URLPatternComponentResult::ToJSObject(env, result.username),
       URLPatternComponentResult::ToJSObject(env, result.password),
-      URLPatternComponentResult::ToJSObject(env, result.hostname),
-      URLPatternComponentResult::ToJSObject(env, result.port),
       URLPatternComponentResult::ToJSObject(env, result.pathname),
+      URLPatternComponentResult::ToJSObject(env, result.port),
+      URLPatternComponentResult::ToJSObject(env, result.protocol),
       URLPatternComponentResult::ToJSObject(env, result.search),
-      URLPatternComponentResult::ToJSObject(env, result.hash)};
+      URLPatternComponentResult::ToJSObject(env, result.username)};
   return NewDictionaryInstanceNullProto(env->context(), tmpl, vals);
 }
 

--- a/test/parallel/test-urlpattern.js
+++ b/test/parallel/test-urlpattern.js
@@ -26,3 +26,27 @@ assert.throws(() => {
 }, {
   message: 'boom'
 });
+
+{
+  const result = new URLPattern({ pathname: '/:value' })
+    .exec('https://example.com/test');
+
+  assert.deepStrictEqual(Object.keys(result), [
+    'hash',
+    'hostname',
+    'inputs',
+    'password',
+    'pathname',
+    'port',
+    'protocol',
+    'search',
+    'username',
+  ]);
+  assert.deepStrictEqual(Object.keys(result.pathname), [
+    'groups',
+    'input',
+  ]);
+  assert.strictEqual(result.hostname.input, 'example.com');
+  assert.strictEqual(result.pathname.input, '/test');
+  assert.strictEqual(result.pathname.groups.value, 'test');
+}


### PR DESCRIPTION
Fixes: #64732
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
