### PR TITLE
meta: add @nodejs/url as codeowner for node_url_pattern.*

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -206,6 +206,7 @@
 /deps/ada @nodejs/url
 /lib/internal/url.js @nodejs/url
 /lib/url.js @nodejs/url
+/src/node_url_pattern.* @nodejs/url
 /src/node_url.* @nodejs/url
 /test/fixtures/wpt/url @nodejs/url
 


### PR DESCRIPTION
As far as I can tell, `src/node_url_pattern.*` is part of the URL surface, so the team should get pinged on changes