### PR TITLE
buffer: use Clamp conversion in Blob slice

### DIFF
--- a/lib/internal/blob.js
+++ b/lib/internal/blob.js
@@ -261,11 +261,11 @@ class Blob {
 
     start = converters['long long'](
       start,
-      { __proto__: null, context: 'start' },
+      { __proto__: null, context: 'start', clamp: true },
     );
     end = converters['long long'](
       end,
-      { __proto__: null, context: 'end' },
+      { __proto__: null, context: 'end', clamp: true },
     );
 
     if (start < 0) {

--- a/test/wpt/status/FileAPI/blob.cjs
+++ b/test/wpt/status/FileAPI/blob.cjs
@@ -36,16 +36,4 @@ module.exports = {
   'Blob-in-worker.worker.js': {
     skip: 'Depends on Web Workers API',
   },
-  'Blob-slice.any.js': {
-    fail: {
-      expected: [
-        'Slicing test: slice (1,1).',
-        'Slicing test: slice (1,3).',
-        'Slicing test: slice (1,5).',
-        'Slicing test: slice (1,7).',
-        'Slicing test: slice (1,8).',
-        'Slicing test: slice (1,9).',
-      ],
-    },
-  },
 };


### PR DESCRIPTION
This aligns `Blob.prototype.slice()` with the File API Web IDL definition:

```webidl
Blob slice(optional [Clamp] long long start,
           optional [Clamp] long long end,
           optional DOMString contentType);
```

The `start` and `end` arguments should use Web IDL `[Clamp]` conversion. 

This fixes the expected failures in `Blob-slice.any.js` for fractional start/end values.

Refs: https://www.w3.org/TR/FileAPI/#dfn-Blob

#### Testing

```console
$ ./node test/wpt/test-blob.js Blob-slice.any.js

Files: 1/1 ran, 1 passed, 0 skipped, 0 expected failures, 0 unexpected failures, 0 unexpected passes
Subtests: 150 passed, 0 skipped, 0 expected failures, 0 unexpected failures, 0 unexpected passes
```

```console
$ tools/test.py wpt/test-blob

[00:00|% 100|+   1|-   0]: Done
```