### PR TITLE
doc: stabilize --disable-warning

### DIFF
--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -733,7 +733,7 @@ added:
   - v20.11.0
 -->
 
-> Stability: 1.1 - Active development
+> Stability: 2 - Stable
 
 Disable specific process warnings by `code` or `type`.
 

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -734,7 +734,7 @@ added:
   changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/64742
-    description: The `--disable-warning` flags are now stable.
+    description: The `--disable-warning` flag is now stable.
 -->
 
 > Stability: 2 - Stable

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -731,7 +731,7 @@ Disable the ability of starting a debugging session by sending a
 added:
   - v21.3.0
   - v20.11.0
-  changes:
+changes:
   - version: REPLACEME
     pr-url: https://github.com/nodejs/node/pull/64742
     description: The `--disable-warning` flag is now stable.

--- a/doc/api/cli.md
+++ b/doc/api/cli.md
@@ -731,6 +731,10 @@ Disable the ability of starting a debugging session by sending a
 added:
   - v21.3.0
   - v20.11.0
+  changes:
+  - version: REPLACEME
+    pr-url: https://github.com/nodejs/node/pull/64742
+    description: The `--disable-warning` flags are now stable.
 -->
 
 > Stability: 2 - Stable


### PR DESCRIPTION
Mark `--disable-warning=code-or-type` as `Stability: 2 - Stable`

This supports https://github.com/fastify/fastify/pull/6871, we would like to inform Fastify users that they can silence specific warnings. Before recommending that option, I would prefer its documented behavior to be considered stable.

The option has been available since [Node.js 21.3.0](https://github.com/nodejs/node/releases/tag/v21.3.0) and was backported in https://github.com/nodejs/node/pull/51124. Its behavior is covered by [existing tests](https://github.com/nodejs/node/blob/6af3ddaf5c09544d3804e7f41fd6e14cefa8295c/test/parallel/test-process-warnings.mjs#L61).

If further work is needed, I’m happy to add it in another commit.