### PR TITLE
stream: use validateString for consumer encoding

### DIFF
--- a/lib/internal/streams/iter/consumers.js
+++ b/lib/internal/streams/iter/consumers.js
@@ -28,7 +28,6 @@ const {
 
 const {
   codes: {
-    ERR_INVALID_ARG_TYPE,
     ERR_INVALID_ARG_VALUE,
     ERR_OUT_OF_RANGE,
   },
@@ -39,6 +38,7 @@ const {
   validateFunction,
   validateInteger,
   validateObject,
+  validateString,
 } = require('internal/validators');
 
 const {
@@ -196,10 +196,7 @@ function validateBaseConsumerOptions(options) {
     validateInteger(options.limit, 'options.limit', 0);
   }
   if (options.encoding !== undefined) {
-    if (typeof options.encoding !== 'string') {
-      throw new ERR_INVALID_ARG_TYPE('options.encoding', 'string',
-                                     options.encoding);
-    }
+    validateString(options.encoding, 'options.encoding');
     try {
       new TextDecoder(options.encoding);
     } catch {

--- a/test/parallel/test-stream-iter-consumers-text.js
+++ b/test/parallel/test-stream-iter-consumers-text.js
@@ -143,6 +143,20 @@ function testTextSyncUnsupportedEncodingThrowsRangeError() {
   );
 }
 
+async function testTextNonStringEncodingThrowsTypeError() {
+  await assert.rejects(
+    () => text(from('hello'), { encoding: 1 }),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+}
+
+function testTextSyncNonStringEncodingThrowsTypeError() {
+  assert.throws(
+    () => textSync(fromSync('hello'), { encoding: 1 }),
+    { code: 'ERR_INVALID_ARG_TYPE' },
+  );
+}
+
 Promise.all([
   testTextSyncBasic(),
   testTextAsync(),
@@ -159,4 +173,6 @@ Promise.all([
   testTextSyncBOMStripped(),
   testTextUnsupportedEncodingThrowsRangeError(),
   testTextSyncUnsupportedEncodingThrowsRangeError(),
+  testTextNonStringEncodingThrowsTypeError(),
+  testTextSyncNonStringEncodingThrowsTypeError(),
 ]).then(common.mustCall());


### PR DESCRIPTION
This replaces the manual `options.encoding` type check in stream iterator
consumers with the shared `validateString()` validator.

```diff
- if (typeof options.encoding !== 'string') {
-   throw new ERR_INVALID_ARG_TYPE('options.encoding', 'string',
-                                  options.encoding);
- }
+ validateString(options.encoding, 'options.encoding');
```

This preserves the existing error behavior while using the common validation
helper. It also adds coverage for non-string `encoding` values in both the
async `text()` and sync `textSync()` consumers.
