### PR TITLE
sea: avoid dangling CLI option pointers

### DIFF
--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -321,10 +321,11 @@ std::tuple<int, char**> FixupArgsForSEA(int argc, char** argv) {
                      cli_extension_args.size() + 2);
     new_argv.emplace_back(argv[0]);
 
+    exec_argv_storage.reserve(sea_resource.exec_argv.size() +
+                              cli_extension_args.size());
+
     // Insert exec argv from SEA config
     if (!sea_resource.exec_argv.empty()) {
-      exec_argv_storage.reserve(sea_resource.exec_argv.size() +
-                                cli_extension_args.size());
       for (const auto& arg : sea_resource.exec_argv) {
         exec_argv_storage.emplace_back(arg);
         new_argv.emplace_back(exec_argv_storage.back().data());

--- a/test/fixtures/sea/exec-argv-extension-cli/sea-config.json
+++ b/test/fixtures/sea/exec-argv-extension-cli/sea-config.json
@@ -2,6 +2,5 @@
   "main": "sea.js",
   "output": "sea-prep.blob",
   "disableExperimentalSEAWarning": true,
-  "execArgv": ["--no-warnings"],
   "execArgvExtension": "cli"
 }

--- a/test/fixtures/sea/exec-argv-extension-cli/sea.js
+++ b/test/fixtures/sea/exec-argv-extension-cli/sea.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 console.log('process.argv:', JSON.stringify(process.argv));
 console.log('process.execArgv:', JSON.stringify(process.execArgv));
 
-// Should have execArgv from SEA config + CLI --node-options
+// Should have all options from CLI --node-options
 assert.deepStrictEqual(process.execArgv, ['--no-warnings', '--max-old-space-size=1024']);
 
 assert.deepStrictEqual(process.argv.slice(2), [

--- a/test/sea/test-single-executable-application-exec-argv-extension-cli.js
+++ b/test/sea/test-single-executable-application-exec-argv-extension-cli.js
@@ -23,7 +23,11 @@ const outputFile = buildSEA(fixtures.path('sea', 'exec-argv-extension-cli'));
 // Test that --node-options works with execArgvExtension: "cli"
 spawnSyncAndAssert(
   outputFile,
-  ['--node-options=--max-old-space-size=1024', 'user-arg1', 'user-arg2'],
+  [
+    '--node-options=--no-warnings --max-old-space-size=1024',
+    'user-arg1',
+    'user-arg2',
+  ],
   {
     env: {
       ...process.env,


### PR DESCRIPTION
Reserve exec argv storage before inserting configured and CLI-expanded arguments so vector reallocation cannot invalidate pointers in argv.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
