### PR TITLE
src,dns: reserve vector capacity to avoid unnecessary reallocations

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -627,6 +627,7 @@ Maybe<int> ParseTxtReply(Environment* env,
     // Each TXT record is a chunk consisting of one or more character-strings.
     LocalVector<Value> chunks(env->isolate());
     size_t str_count = ares_dns_rr_get_abin_cnt(rr, ARES_RR_TXT_DATA);
+    chunks.reserve(str_count);
     for (size_t j = 0; j < str_count; j++) {
       size_t str_len = 0;
       const unsigned char* str =

--- a/src/node_messaging.cc
+++ b/src/node_messaging.cc
@@ -486,6 +486,7 @@ Maybe<bool> Message::Serialize(Environment* env,
   delegate.serializer = &serializer;
 
   LocalVector<ArrayBuffer> array_buffers(env->isolate());
+  array_buffers.reserve(transfer_list_v.length());
   for (uint32_t i = 0; i < transfer_list_v.length(); ++i) {
     Local<Value> entry_val = transfer_list_v[i];
     if (!entry_val->IsObject()) {


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
`Message::Serialize()` and `ParseTxtReply()` both grow a `LocalVector`
via repeated `push_back()` without reserving capacity first, even
though the upper bound on the number of elements is known before the
loop starts. This adds `reserve()` in both places, following the
usual idiom of reserving upfront when the size (or a bound on it) is
already known, to avoid the repeated allocate/copy/free cycle that
happens each time capacity is exceeded.

Note: in `Message::Serialize`, `transfer_list_v.length()` is an upper
bound rather than an exact count (only `ArrayBuffer` entries get
pushed into `array_buffers`), so a transfer list with few or no
ArrayBuffers reserves capacity that ends up unused. No functional
change either way.
