### PR TITLE
repl: pass objectGroup to Runtime.awaitPromise to prevent GC collection

### DIFF
--- a/lib/internal/repl/inspector.js
+++ b/lib/internal/repl/inspector.js
@@ -179,13 +179,16 @@ class ReplInspectorChannel {
       return response;
     }
 
-    // Hold the promise open until it resolves or rejects,
-    // so we can return the final value.
+    // Hold the promise open until it resolves or rejects.
+    // Pass objectGroup so the promise remote object stays retained for the
+    // duration of the await and cannot be collected by a GC cycle between
+    // the two inspector calls.
     return this.postInterruptible('Runtime.awaitPromise', {
       __proto__: null,
       promiseObjectId: response.result.objectId,
       returnByValue: params.returnByValue,
       generatePreview: params.generatePreview,
+      objectGroup: this.objectGroup,
     }, breakOnSigint);
   }
 


### PR DESCRIPTION
## Summary

Fixes #64762.

When `ReplInspectorChannel.evaluate()` evaluates an expression that returns a promise, it issues two inspector commands in sequence:

- `Runtime.evaluate`
- `Runtime.awaitPromise`

`Runtime.evaluate` already passes `objectGroup`, placing the remote promise object into the REPL's named object group. However, `Runtime.awaitPromise` does not pass `objectGroup`.

Under GC pressure, the remote promise object can be collected before `Runtime.awaitPromise` completes, causing the inspector to return:

```text
Inspector error -32000: Promise was collected
```

Instead of reporting the user's original exception, the REPL surfaces `ERR_INSPECTOR_COMMAND`.

## Change

Pass `objectGroup` to `Runtime.awaitPromise` so the remote promise object remains retained for the duration of the await.

```diff
return this.postInterruptible('Runtime.awaitPromise', {
  __proto__: null,
  promiseObjectId: response.result.objectId,
  returnByValue: params.returnByValue,
  generatePreview: params.generatePreview,
+ objectGroup: this.objectGroup,
}, breakOnSigint);
```

## Why

The Inspector protocol allows `Runtime.awaitPromise` to receive an `objectGroup`. Passing the same object group used during `Runtime.evaluate` keeps the remote promise object alive until the await operation completes, preventing it from being collected while the inspector request is in progress.

## Testing

The existing test, `test/parallel/test-repl-pretty-stack-custom-writer.mjs`, already exercises this code path. This change makes that test reliable under GC pressure, so no additional test is required.

## Related

- Fixes #64762
- Follow-up to #64034