### PR TITLE
fs: fix out-of-bounds write in mkdtemp for long prefixes

### DIFF
--- a/src/node_file.cc
+++ b/src/node_file.cc
@@ -3364,10 +3364,11 @@ static void Mkdtemp(const FunctionCallbackInfo<Value>& args) {
   CHECK_GE(argc, 2);
 
   BufferValue tmpl(isolate, args[0]);
-  static constexpr const char* const suffix = "XXXXXX";
-  const auto length = tmpl.length();
-  tmpl.AllocateSufficientStorage(length + strlen(suffix));
-  snprintf(tmpl.out() + length, tmpl.length(), "%s", suffix);
+  const auto prefix_length = tmpl.length();
+  static constexpr std::string_view suffix = "XXXXXX";
+  tmpl.AllocateSufficientStorage(prefix_length + suffix.size() + 1);
+  memcpy(tmpl.out() + prefix_length, suffix.data(), suffix.size());
+  tmpl.SetLengthAndZeroTerminate(prefix_length + suffix.size());
 
   CHECK_NOT_NULL(*tmpl);
 


### PR DESCRIPTION
Mkdtemp() allocated the template buffer as `length + strlen("XXXXXX")`,
leaving no room for the terminating NUL byte that snprintf() writes. For
a single-byte prefix long enough to force the heap allocation path
(length + 6 > the stack-buffer threshold), snprintf() wrote the six 'X'
characters plus its NUL one byte past the end of the buffer -- a 1-byte
heap-buffer-overflow flagged by AddressSanitizer.

Allocate one extra byte for the NUL terminator, matching the `+ 1`
already used by the sibling allocations in the same file.

Signed-off-by: frandle331-yh <s1240100@gmail.com>
