### PR TITLE
sea: handle NUL bytes in asset keys

### DIFF
--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -829,7 +829,7 @@ void GetAsset(const FunctionCallbackInfo<Value>& args) {
   if (sea_resource.assets.empty()) {
     return;
   }
-  auto it = sea_resource.assets.find(*key);
+  auto it = sea_resource.assets.find(std::string_view(*key, key.length()));
   if (it == sea_resource.assets.end()) {
     return;
   }

--- a/test/fixtures/sea/assets/sea-config.json
+++ b/test/fixtures/sea/assets/sea-config.json
@@ -2,6 +2,8 @@
   "main": "sea.js",
   "output": "sea-prep.blob",
   "assets": {
+    "a": "utf8_test_text.txt",
+    "a\u0000b": "person.jpg",
     "utf8_test_text.txt": "utf8_test_text.txt",
     "person.jpg": "person.jpg"
   }

--- a/test/fixtures/sea/assets/sea.js
+++ b/test/fixtures/sea/assets/sea.js
@@ -54,6 +54,12 @@ assert(isSea());
 const textAssetOnDisk = readFileSync(process.env.__TEST_UTF8_TEXT_PATH, 'utf8');
 const binaryAssetOnDisk = readFileSync(process.env.__TEST_PERSON_JPG);
 
+// Check asset keys containing NUL.
+{
+  assert.strictEqual(getAsset('a', 'utf8'), textAssetOnDisk);
+  assert.deepStrictEqual(Buffer.from(getAsset('a\0b')), binaryAssetOnDisk);
+}
+
 // Check getAsset() buffer copies.
 {
   // Check that the asset embedded is the same as the original.


### PR DESCRIPTION
Construct the asset lookup string_view with the explicit Utf8Value length so embedded NUL bytes do not truncate keys.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
