### PR TITLE
sea: reject trailing content in config JSON

### DIFF
--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -537,6 +537,14 @@ std::optional<SeaConfig> ParseSingleExecutableConfig(
     }
   }
 
+  if (!document.at_end()) {
+    FPrintF(stderr,
+            "Cannot parse JSON from %s: %s\n",
+            config_path,
+            simdjson::error_message(simdjson::TRAILING_CONTENT));
+    return std::nullopt;
+  }
+
   if (static_cast<bool>(result.flags & SeaFlags::kUseSnapshot) &&
       static_cast<bool>(result.flags & SeaFlags::kUseCodeCache)) {
     // TODO(joyeecheung): code cache in snapshot should be configured by

--- a/test/sea/test-single-executable-blob-config-errors.js
+++ b/test/sea/test-single-executable-blob-config-errors.js
@@ -49,6 +49,24 @@ const { spawnSyncAndAssert } = require('../common/child_process');
 
 {
   tmpdir.refresh();
+  const config = tmpdir.resolve('trailing-content.json');
+  writeFileSync(
+    config,
+    '{"main":"bundle.js","output":"sea.blob"}{}',
+    'utf8',
+  );
+  spawnSyncAndAssert(
+    process.execPath,
+    ['--experimental-sea-config', config], {
+      cwd: tmpdir.path,
+    }, {
+      status: 1,
+      stderr: /TRAILING_CONTENT/,
+    });
+}
+
+{
+  tmpdir.refresh();
   const config = tmpdir.resolve('empty.json');
   writeFileSync(config, '{}', 'utf8');
   spawnSyncAndAssert(


### PR DESCRIPTION
Ensure the on-demand parser reaches the end of the document after reading the root object. Reject concatenated JSON values with TRAILING_CONTENT

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
