### PR TITLE
meta: remove node_crates .gitignore

### DIFF
--- a/deps/crates/.gitignore
+++ b/deps/crates/.gitignore
@@ -1,3 +1,0 @@
-# Include everything in `vendor/` except for hidden files
-!vendor/**/*
-.DS_Store


### PR DESCRIPTION
This only existed to exclude Finder's .DS_Store metadata from manual updates, but these are now automanaged by node-core-utils (which runs `git add --force` anyway).
