### PR TITLE
tools: use 'readonly' for EventSource global

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -128,7 +128,7 @@ export default [
         CryptoKey: 'readonly',
         DecompressionStream: 'readonly',
         DisposableStack: 'readonly',
-        EventSource: 'readable',
+        EventSource: 'readonly',
         fetch: 'readonly',
         Float16Array: 'readonly',
         FormData: 'readonly',


### PR DESCRIPTION
The `EventSource` entry in `eslint.config.mjs` was the only global still using the deprecated `readable` value, while the other 40+ entries in the same block use `readonly`.

ESLint keeps `readable` and `writeable` working only for historical reasons and documents them as deprecated in favour of `readonly` and `writable`, so behavior is unchanged. This is a consistency and future-proofing fix.

The inconsistency dates back to the flat config migration in 7e6d92c ("tools: update ESLint to v9 and use flat config"), which converted the other globals from the old `.eslintrc.js` spelling but missed this single entry.

Verified locally: `eslint.config.mjs`, `lib`, `benchmark`, `tools`, and the two tests that reference the global (`test/parallel/test-eventsource.js` and `test-eventsource-disabled.js`) all lint clean, so `no-undef` still resolves `EventSource` as expected.

Fixes: https://github.com/nodejs/node/issues/64757
