### PR TITLE
url: bounds-check short Windows file URL paths

### DIFF
--- a/src/node_url.cc
+++ b/src/node_url.cc
@@ -661,6 +661,12 @@ std::optional<std::string> FileURLToPath(Environment* env,
     return "\\\\" + ada::idna::to_unicode(hostname) + decoded_pathname;
   }
 
+  if (decoded_pathname.size() < 3) {
+    THROW_ERR_INVALID_FILE_URL_PATH(env->isolate(),
+                                    "File URL path must be absolute");
+    return std::nullopt;
+  }
+
   char letter = decoded_pathname[1] | 0x20;
   char sep = decoded_pathname[2];
 

--- a/test/cctest/test_path.cc
+++ b/test/cctest/test_path.cc
@@ -8,6 +8,7 @@
 #include "v8.h"
 
 using node::BufferValue;
+using node::NormalizeFileURLOrPath;
 using node::PathResolve;
 using node::ToNamespacedPath;
 
@@ -93,3 +94,26 @@ TEST_F(PathTest, ToNamespacedPath) {
   EXPECT_EQ(data.ToStringView(), "hello world");  // Input should not be mutated
 #endif
 }
+
+#ifdef _WIN32
+TEST_F(PathTest, NormalizeShortFileURLPath) {
+  const v8::HandleScope handle_scope(isolate_);
+  Argv argv;
+  Env env{handle_scope, argv, node::EnvironmentFlags::kNoBrowserGlobals};
+  v8::TryCatch try_catch(isolate_);
+
+  EXPECT_EQ(NormalizeFileURLOrPath(*env, "file:///"), "");
+  ASSERT_TRUE(try_catch.HasCaught());
+
+  v8::Local<v8::Value> exception = try_catch.Exception();
+  ASSERT_TRUE(exception->IsObject());
+  v8::Local<v8::Value> code;
+  ASSERT_TRUE(exception.As<v8::Object>()
+                  ->Get((*env)->context(),
+                        v8::String::NewFromUtf8Literal(isolate_, "code"))
+                  .ToLocal(&code));
+  ASSERT_TRUE(code->IsString());
+  node::Utf8Value code_value(isolate_, code);
+  EXPECT_EQ(code_value.ToStringView(), "ERR_INVALID_FILE_URL_PATH");
+}
+#endif


### PR DESCRIPTION
Check the decoded pathname length before reading the drive letter and colon. This prevents an out-of-bounds read for short URLs such as file:/// and reports ERR_INVALID_FILE_URL_PATH instead.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
