### PR TITLE
doc: document stream.isDestroyed()

### DIFF
--- a/doc/api/stream.md
+++ b/doc/api/stream.md
@@ -3120,6 +3120,19 @@ console.log(res); // prints 'HELLOWORLD'
 For convenience, the [`readable.compose(stream)`][] method is available on
 {Readable} and {Duplex} streams as a wrapper for this function.
 
+### `stream.isDestroyed(stream)`
+
+<!-- YAML
+added:
+  - v19.9.0
+  - v18.17.0
+-->
+
+* `stream` {Readable|Writable|Duplex}
+* Returns: {boolean|null} - Only returns `null` if `stream` is not a valid `Readable`, `Writable` or `Duplex`.
+
+Returns whether the stream has been destroyed.
+
 ### `stream.isErrored(stream)`
 
 <!-- YAML


### PR DESCRIPTION
`stream.isDestroyed()` has been exported from `lib/stream.js` since v19.9.0 ([#45671](https://github.com/nodejs/node/pull/45671)) but has never been documented, while the sibling helpers exported alongside it — `isErrored()`, `isReadable()` and `isWritable()` — all have entries.

`added:` was determined by checking `lib/stream.js` at each release tag rather than from the landing date, since the commit predates the releases that carry it:

| tag | released | `Stream.isDestroyed` present |
| --- | --- | --- |
| v19.8.1 | 2023-03-15 | no |
| v19.9.0 | 2023-04-05 | **yes** |
| v18.16.0 | 2023-04-10 | no |
| v18.17.0 | 2023-07-10 | **yes** (backport) |

v20.0.0 inherited it from `main` rather than adding it, so it is not listed — matching how `isErrored()` lists only v17.3.0 and its v16.14.0 backport.

One difference is worth calling out, because it affects the documented types: unlike `isErrored()` and `isReadable()`, `isDestroyed()` bails out on anything that is not a Node.js stream (`if (!isNodeStream(stream)) return null`), so Web streams are not accepted:

```js
isDestroyed(new Readable({ read() {} }));  // false
isDestroyed(destroyedReadable);            // true
isDestroyed(new ReadableStream());         // null
isDestroyed({});                           // null
```

The entry therefore lists `Readable|Writable|Duplex` and reuses the `{boolean|null}` wording already established by `isReadable()` and `isWritable()`.

`make lint-md` and `make doc-only` both pass locally.
