### PR TITLE
ffi: preserve link register in ppc64 trampoline

### DIFF
--- a/src/ffi/platforms/ppc64.cc
+++ b/src/ffi/platforms/ppc64.cc
@@ -134,13 +134,21 @@ extern "C" bool node_ffi_create_fast_trampoline(
   }
 
   // Load the target address from the literal pool into r12, then branch through
-  // CTR. ELFv2 functions can use r12 to establish their TOC on global entry.
-  Emit32(&cursor, Bl(1));              // bl .+4
-  Emit32(&cursor, Mfspr(12, 8));       // mflr r12
-  Emit32(&cursor, Ld(12, 12, 20));     // ld r12, literal-mflr(r12)
-  Emit32(&cursor, Mtspr(9, 12));       // mtctr r12
-  Emit32(&cursor, 0x4e800420);         // bctr
-  Emit32(&cursor, 0x60000000);         // nop; align literal to 8 bytes
+  // CTR. Save the caller's link register before using `bl` to obtain the
+  // trampoline's address, and restore it before the tail branch so the native
+  // target returns to V8 rather than back into the trampoline. ELFv2 functions
+  // can use r12 to establish their TOC on global entry.
+  Emit32(&cursor, Mfspr(0, 8));   // mflr r0
+  Emit32(&cursor, Bl(1));         // bl .+4
+  Emit32(&cursor, Mfspr(12, 8));  // mflr r12
+  Emit32(&cursor, Mtspr(8, 0));   // mtlr r0
+  const unsigned literal_offset = gp_count % 2 == 0 ? 24 : 20;
+  Emit32(&cursor, Ld(12, 12, literal_offset));
+  Emit32(&cursor, Mtspr(9, 12));  // mtctr r12
+  Emit32(&cursor, 0x4e800420);    // bctr
+  if (gp_count % 2 == 0) {
+    Emit32(&cursor, 0x60000000);  // nop; align literal to 8 bytes
+  }
   Emit64(&cursor, reinterpret_cast<uintptr_t>(target));
 
   const size_t written = reinterpret_cast<uint8_t*>(cursor) -


### PR DESCRIPTION
Refs: https://github.com/nodejs/node/pull/64639#issuecomment-5095412282

The PPC64LE fast FFI trampoline uses `bl .+4` to obtain the address
needed to load its target literal. The `bl` instruction overwrites the
caller's link register, but the trampoline did not restore it before
tail-branching to the native target.

As a result, optimized FFI calls could return into the trampoline
instead of returning to V8, causing an infinite loop. This manifested
as 120-second timeouts on `rhel8-power9le` and `rhel9-ppc64le`.

Preserve the caller's link register in `r0` and restore it before the
tail branch. The target literal padding is also selected according to
the GP argument count so that the literal remains 8-byte aligned.

---

Assisted-by: codex:gpt-5.6-sol