### PR TITLE
stream: preserve push signal abort reason

### DIFF
--- a/lib/internal/streams/iter/push.js
+++ b/lib/internal/streams/iter/push.js
@@ -24,7 +24,7 @@ const {
     ERR_INVALID_STATE,
   },
 } = require('internal/errors');
-const { isError, lazyDOMException } = require('internal/util');
+const { lazyDOMException } = require('internal/util');
 const {
   validateAbortSignal,
   validateInteger,
@@ -105,9 +105,7 @@ class PushQueue {
 
     if (this.#signal) {
       this.#abortHandler = () => {
-        this.fail(isError(this.#signal.reason) ?
-          this.#signal.reason :
-          lazyDOMException('Aborted', 'AbortError'));
+        this.fail(this.#signal.reason);
       };
       onSignalAbort(this.#signal, this.#abortHandler);
     }

--- a/test/parallel/test-stream-iter-push-basic.js
+++ b/test/parallel/test-stream-iter-push-basic.js
@@ -107,6 +107,16 @@ async function testAbortSignal() {
   );
 }
 
+async function testAbortSignalReason() {
+  const reason = 'test reason';
+  const ac = new AbortController();
+  const { writer } = push({ signal: ac.signal });
+
+  ac.abort(reason);
+
+  await assert.rejects(writer.write('data'), (err) => err === reason);
+}
+
 async function testPreAbortedSignal() {
   const { readable } = push({ signal: AbortSignal.abort() });
   await assert.rejects(async () => {
@@ -172,6 +182,7 @@ Promise.all([
   testWriterFail(),
   testConsumerBreak(),
   testAbortSignal(),
+  testAbortSignalReason(),
   testPreAbortedSignal(),
   testConsumerBreakWriteSyncReturnsFalse(),
   testPushWithTransforms(),


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64797

The push stream's stream-wide abort handler only forwarded the signal's
reason when it was an `Error`. Valid non-Error reasons, such as strings and
numbers, were replaced with a new `AbortError`.

Pass `signal.reason` directly to `writer.fail()` so the writer fails with the
original reason.

---

Assisted-by: codex:gpt-5.6-sol