### PR TITLE
process: add `process.entrypoint`

### DIFF
--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1519,11 +1519,11 @@ emitMyWarning();
 added: REPLACEME
 -->
 
-* Type: {URL | undefined}
+* Type: {string | undefined}
 
-The entry point that Node.js was started with. Worker threads inherit this
-value. If Node.js was started without an entry point, such as in the REPL, the
-value is {undefined}.
+The URL of the entry point that Node.js was started with, such as
+`'file:///path/to/app.js'`. Worker threads inherit this value. If Node.js was
+started without an entry point, such as in the REPL, the value is {undefined}.
 
 ## `process.env`
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1521,8 +1521,9 @@ added: REPLACEME
 
 * Type: {URL | undefined}
 
-The entrypoint that node was instantiated with, or {undefined} if node
-was instantiated without one (e.g., in the REPL).
+The entry point that Node.js was started with. Worker threads inherit this
+value. If Node.js was started without an entry point, such as in the REPL, the
+value is {undefined}.
 
 ## `process.env`
 

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -1513,6 +1513,17 @@ emitMyWarning();
 // Emits nothing
 ```
 
+## `process.entrypoint`
+
+<!-- YAML
+added: REPLACEME
+-->
+
+* Type: {URL | undefined}
+
+The entrypoint that node was instantiated with, or {undefined} if node
+was instantiated without one (e.g., in the REPL).
+
 ## `process.env`
 
 <!-- YAML

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -105,9 +105,7 @@ port.on('message', (message) => {
       mainThreadPort,
     } = message;
 
-    const { URL } = require('internal/url');
-    defineEntrypoint(entrypoint === undefined ?
-      undefined : new URL(entrypoint));
+    defineEntrypoint(() => entrypoint);
 
     if (doEval !== 'internal') {
       if (argv !== undefined) {

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -14,6 +14,7 @@ const {
 } = primordials;
 
 const {
+  defineEntrypoint,
   prepareWorkerThreadExecution,
   initializeModuleLoaders,
   markBootstrapComplete,
@@ -133,7 +134,11 @@ port.on('message', (message) => {
     workerIo.sharedCwdCounter = cwdCounter;
 
     const isLoaderHookWorker = (filename === 'internal/modules/esm/worker' && doEval === 'internal');
-    if (!isLoaderHookWorker) {
+    if (isLoaderHookWorker) {
+      const { URL } = require('internal/url');
+      defineEntrypoint(workerData.entrypoint === undefined ?
+        undefined : new URL(workerData.entrypoint));
+    } else {
       // If we are in the loader hook worker, delay the module loader initializations until
       // initializeAsyncLoaderHooksOnLoaderHookWorker() which needs to run preloads
       // after the asynchronous loader hooks are registered.

--- a/lib/internal/main/worker_thread.js
+++ b/lib/internal/main/worker_thread.js
@@ -96,6 +96,7 @@ port.on('message', (message) => {
       argv,
       cwdCounter,
       doEval,
+      entrypoint,
       environmentData,
       filename,
       hasStdin,
@@ -103,6 +104,10 @@ port.on('message', (message) => {
       workerData,
       mainThreadPort,
     } = message;
+
+    const { URL } = require('internal/url');
+    defineEntrypoint(entrypoint === undefined ?
+      undefined : new URL(entrypoint));
 
     if (doEval !== 'internal') {
       if (argv !== undefined) {
@@ -134,11 +139,7 @@ port.on('message', (message) => {
     workerIo.sharedCwdCounter = cwdCounter;
 
     const isLoaderHookWorker = (filename === 'internal/modules/esm/worker' && doEval === 'internal');
-    if (isLoaderHookWorker) {
-      const { URL } = require('internal/url');
-      defineEntrypoint(workerData.entrypoint === undefined ?
-        undefined : new URL(workerData.entrypoint));
-    } else {
+    if (!isLoaderHookWorker) {
       // If we are in the loader hook worker, delay the module loader initializations until
       // initializeAsyncLoaderHooksOnLoaderHookWorker() which needs to run preloads
       // after the asynchronous loader hooks are registered.

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -530,7 +530,6 @@ class AsyncLoaderHookWorker {
       stdout: false,
       trackUnmanagedFds: false,
       workerData: {
-        entrypoint: process.entrypoint?.href,
         lock,
       },
     });

--- a/lib/internal/modules/esm/hooks.js
+++ b/lib/internal/modules/esm/hooks.js
@@ -530,6 +530,7 @@ class AsyncLoaderHookWorker {
       stdout: false,
       trackUnmanagedFds: false,
       workerData: {
+        entrypoint: process.entrypoint?.href,
         lock,
       },
     });

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -27,6 +27,7 @@ const {
   setupCoverageHooks,
   emitExperimentalWarning,
   deprecate,
+  getCWDURL,
 } = require('internal/util');
 
 const {
@@ -254,6 +255,16 @@ function refreshRuntimeOptions() {
   refreshOptions();
 }
 
+function defineEntrypoint(entrypoint) {
+  ObjectDefineProperty(process, 'entrypoint', {
+    __proto__: null,
+    writable: false,
+    enumerable: true,
+    configurable: true,
+    value: entrypoint,
+  });
+}
+
 /**
  * Patch the process object with legacy properties and normalizations.
  * Replace `process.argv[0]` with `process.execPath`, preserving the original `argv[0]` value as `process.argv0`.
@@ -293,6 +304,16 @@ function patchProcessObject(expandArgv1) {
       // Continue regardless of error.
     }
   }
+
+  let entrypoint;
+  if (mainEntry !== undefined) {
+    const { pathToFileURL } = require('internal/url');
+    entrypoint = pathToFileURL(mainEntry);
+  } else if (getOptionValue('--entry-url') && process.argv[1]) {
+    const { URL } = require('internal/url');
+    entrypoint = new URL(process.argv[1], getCWDURL());
+  }
+  defineEntrypoint(entrypoint);
 
   // We need to initialize the global console here again with process.stdout
   // and friends for snapshot deserialization.
@@ -824,6 +845,7 @@ function getHeapSnapshotFilename(diagnosticDir) {
 }
 
 module.exports = {
+  defineEntrypoint,
   initializeModuleLoaders,
   prepareMainThreadExecution,
   prepareWorkerThreadExecution,

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -255,13 +255,22 @@ function refreshRuntimeOptions() {
   refreshOptions();
 }
 
-function defineEntrypoint(entrypoint) {
+function defineEntrypoint(computeEntrypoint) {
+  let entrypoint;
+  let computed = false;
+
   ObjectDefineProperty(process, 'entrypoint', {
     __proto__: null,
-    writable: false,
     enumerable: true,
     configurable: true,
-    value: entrypoint,
+    get() {
+      if (!computed) {
+        entrypoint = computeEntrypoint();
+        computed = true;
+      }
+      return entrypoint;
+    },
+    set: undefined,
   });
 }
 
@@ -305,15 +314,18 @@ function patchProcessObject(expandArgv1) {
     }
   }
 
-  let entrypoint;
-  if (mainEntry !== undefined) {
-    const { pathToFileURL } = require('internal/url');
-    entrypoint = pathToFileURL(mainEntry);
-  } else if (getOptionValue('--entry-url') && process.argv[1]) {
-    const { URL } = require('internal/url');
-    entrypoint = new URL(process.argv[1], getCWDURL());
-  }
-  defineEntrypoint(entrypoint);
+  const entryArg = process.argv[1];
+  defineEntrypoint(() => {
+    if (mainEntry !== undefined) {
+      const { pathToFileURL } = require('internal/url');
+      return pathToFileURL(mainEntry).href;
+    }
+    if (entryArg && getOptionValue('--entry-url')) {
+      const { URL } = require('internal/url');
+      return new URL(entryArg, getCWDURL()).href;
+    }
+    return undefined;
+  });
 
   // We need to initialize the global console here again with process.stdout
   // and friends for snapshot deserialization.

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -362,7 +362,7 @@ class Worker extends EventEmitter {
 
     this[kPort].postMessage({
       argv,
-      entrypoint: process.entrypoint?.href,
+      entrypoint: process.entrypoint,
       type: messageTypes.LOAD_SCRIPT,
       filename,
       doEval,

--- a/lib/internal/worker.js
+++ b/lib/internal/worker.js
@@ -362,6 +362,7 @@ class Worker extends EventEmitter {
 
     this[kPort].postMessage({
       argv,
+      entrypoint: process.entrypoint?.href,
       type: messageTypes.LOAD_SCRIPT,
       filename,
       doEval,

--- a/test/fixtures/entrypoint/check-commonjs.cjs
+++ b/test/fixtures/entrypoint/check-commonjs.cjs
@@ -2,4 +2,4 @@
 
 const assert = require('node:assert');
 
-assert.strictEqual(process.entrypoint.href, process.env.NODE_TEST_ENTRYPOINT);
+assert.strictEqual(process.entrypoint, process.env.NODE_TEST_ENTRYPOINT);

--- a/test/fixtures/entrypoint/check-commonjs.cjs
+++ b/test/fixtures/entrypoint/check-commonjs.cjs
@@ -1,0 +1,5 @@
+'use strict';
+
+const assert = require('node:assert');
+
+assert.strictEqual(process.entrypoint.href, process.env.NODE_TEST_ENTRYPOINT);

--- a/test/fixtures/entrypoint/check-module.mjs
+++ b/test/fixtures/entrypoint/check-module.mjs
@@ -1,4 +1,4 @@
 import assert from 'node:assert';
 import { entrypoint } from 'node:process';
 
-assert.strictEqual(entrypoint.href, process.env.NODE_TEST_ENTRYPOINT);
+assert.strictEqual(entrypoint, process.env.NODE_TEST_ENTRYPOINT);

--- a/test/fixtures/entrypoint/check-module.mjs
+++ b/test/fixtures/entrypoint/check-module.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { entrypoint } from 'node:process';
+
+assert.strictEqual(entrypoint.href, process.env.NODE_TEST_ENTRYPOINT);

--- a/test/fixtures/entrypoint/commonjs.cjs
+++ b/test/fixtures/entrypoint/commonjs.cjs
@@ -1,1 +1,1 @@
-console.log(process.entrypoint.href);
+console.log(process.entrypoint);

--- a/test/fixtures/entrypoint/commonjs.cjs
+++ b/test/fixtures/entrypoint/commonjs.cjs
@@ -1,0 +1,1 @@
+console.log(process.entrypoint.href);

--- a/test/fixtures/entrypoint/loader.mjs
+++ b/test/fixtures/entrypoint/loader.mjs
@@ -1,4 +1,4 @@
 import assert from 'node:assert';
 import { entrypoint } from 'node:process';
 
-assert.strictEqual(entrypoint.href, process.env.NODE_TEST_ENTRYPOINT);
+assert.strictEqual(entrypoint, process.env.NODE_TEST_ENTRYPOINT);

--- a/test/fixtures/entrypoint/loader.mjs
+++ b/test/fixtures/entrypoint/loader.mjs
@@ -1,0 +1,4 @@
+import assert from 'node:assert';
+import { entrypoint } from 'node:process';
+
+assert.strictEqual(entrypoint.href, process.env.NODE_TEST_ENTRYPOINT);

--- a/test/fixtures/entrypoint/module.mjs
+++ b/test/fixtures/entrypoint/module.mjs
@@ -1,1 +1,1 @@
-console.log(process.entrypoint.href);
+console.log(process.entrypoint);

--- a/test/fixtures/entrypoint/module.mjs
+++ b/test/fixtures/entrypoint/module.mjs
@@ -1,0 +1,1 @@
+console.log(process.entrypoint.href);

--- a/test/fixtures/entrypoint/worker.cjs
+++ b/test/fixtures/entrypoint/worker.cjs
@@ -1,0 +1,9 @@
+'use strict';
+
+const { isMainThread, workerData, Worker } = require('node:worker_threads');
+
+if (isMainThread || workerData === 'nested') {
+  new Worker(__filename, { workerData: isMainThread ? 'nested' : 'leaf' });
+} else {
+  console.log(process.entrypoint.href);
+}

--- a/test/fixtures/entrypoint/worker.cjs
+++ b/test/fixtures/entrypoint/worker.cjs
@@ -5,5 +5,5 @@ const { isMainThread, workerData, Worker } = require('node:worker_threads');
 if (isMainThread || workerData === 'nested') {
   new Worker(__filename, { workerData: isMainThread ? 'nested' : 'leaf' });
 } else {
-  console.log(process.entrypoint.href);
+  console.log(process.entrypoint);
 }

--- a/test/parallel/test-process-entrypoint.js
+++ b/test/parallel/test-process-entrypoint.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const { spawnPromisified } = require('../common');
+const fixtures = require('../common/fixtures');
+
+const assert = require('node:assert');
+const { execPath } = require('node:process');
+const { describe, it } = require('node:test');
+
+const cjsFixture = fixtures.path('entrypoint', 'commonjs.cjs');
+const cjsFixtureURL = fixtures.fileURL('entrypoint', 'commonjs.cjs').href;
+
+const mjsFixture = fixtures.path('entrypoint', 'module.mjs');
+const mjsFixtureURL = fixtures.fileURL('entrypoint', 'module.mjs').href;
+
+const cjsPreload = fixtures.path('entrypoint', 'check-commonjs.cjs');
+const esmPreload = fixtures.fileURL('entrypoint', 'check-module.mjs').href;
+const loader = fixtures.fileURL('entrypoint', 'loader.mjs').href;
+
+const printEntrypoint = 'console.log(process.entrypoint?.href)';
+
+async function getEntrypoint(args, options, expected) {
+  const { code, signal, stderr, stdout } = await spawnPromisified(
+    execPath,
+    args,
+    {
+      ...options,
+      env: {
+        ...process.env,
+        NODE_TEST_ENTRYPOINT: expected,
+      },
+    },
+  );
+  assert.strictEqual(code, 0, stderr);
+  assert.strictEqual(signal, null);
+
+  return stdout.trim();
+}
+
+const testCases = [
+  {
+    name: 'is the file URL of a CommonJS entry point',
+    args: [cjsFixture],
+    expected: cjsFixtureURL,
+  },
+  {
+    name: 'is the file URL of an ES module entry point',
+    args: [mjsFixture],
+    expected: mjsFixtureURL,
+  },
+  {
+    name: 'is absolute when passed a relative path',
+    args: ['./commonjs.cjs'],
+    options: { cwd: fixtures.path('entrypoint') },
+    expected: cjsFixtureURL,
+  },
+  {
+    name: 'stays correct when using --require',
+    args: ['--require', cjsPreload, cjsFixture],
+    expected: cjsFixtureURL,
+  },
+  {
+    name: 'stays correct when using --import',
+    args: ['--import', esmPreload, cjsFixture],
+    expected: cjsFixtureURL,
+  },
+  {
+    name: 'stays correct when using --loader',
+    args: ['--loader', loader, cjsFixture],
+    expected: cjsFixtureURL,
+  },
+  {
+    name: 'stays correct when combining preloads and loaders',
+    args: [
+      '--require', cjsPreload,
+      '--import', esmPreload,
+      '--loader', loader,
+      mjsFixture,
+    ],
+    expected: mjsFixtureURL,
+  },
+  {
+    name: 'supports non-file --entry-url entry points',
+    args: ['--entry-url', `data:text/javascript,${printEntrypoint}`],
+    expected: `data:text/javascript,${printEntrypoint}`,
+  },
+  {
+    name: 'is undefined when evaluating CommonJS without an entry point',
+    args: ['--eval', printEntrypoint],
+    expected: 'undefined',
+  },
+  {
+    name: 'is undefined when evaluating an ES module without an entry point',
+    args: ['--input-type=module', '--eval', printEntrypoint],
+    expected: 'undefined',
+  },
+];
+
+describe('process.entrypoint', { concurrency: true }, () => {
+  for (const { name, args, options, expected } of testCases) {
+    it(name, async () => {
+      assert.strictEqual(await getEntrypoint(args, options, expected), expected);
+    });
+  }
+});

--- a/test/parallel/test-process-entrypoint.js
+++ b/test/parallel/test-process-entrypoint.js
@@ -13,6 +13,9 @@ const cjsFixtureURL = fixtures.fileURL('entrypoint', 'commonjs.cjs').href;
 const mjsFixture = fixtures.path('entrypoint', 'module.mjs');
 const mjsFixtureURL = fixtures.fileURL('entrypoint', 'module.mjs').href;
 
+const workerFixture = fixtures.path('entrypoint', 'worker.cjs');
+const workerFixtureURL = fixtures.fileURL('entrypoint', 'worker.cjs').href;
+
 const cjsPreload = fixtures.path('entrypoint', 'check-commonjs.cjs');
 const esmPreload = fixtures.fileURL('entrypoint', 'check-module.mjs').href;
 const loader = fixtures.fileURL('entrypoint', 'loader.mjs').href;
@@ -78,6 +81,16 @@ const testCases = [
       mjsFixture,
     ],
     expected: mjsFixtureURL,
+  },
+  {
+    name: 'is inherited by worker threads and their preloads and loaders',
+    args: [
+      '--require', cjsPreload,
+      '--import', esmPreload,
+      '--loader', loader,
+      workerFixture,
+    ],
+    expected: workerFixtureURL,
   },
   {
     name: 'supports non-file --entry-url entry points',

--- a/test/parallel/test-process-entrypoint.js
+++ b/test/parallel/test-process-entrypoint.js
@@ -20,7 +20,7 @@ const cjsPreload = fixtures.path('entrypoint', 'check-commonjs.cjs');
 const esmPreload = fixtures.fileURL('entrypoint', 'check-module.mjs').href;
 const loader = fixtures.fileURL('entrypoint', 'loader.mjs').href;
 
-const printEntrypoint = 'console.log(process.entrypoint?.href)';
+const printEntrypoint = 'console.log(process.entrypoint)';
 
 async function getEntrypoint(args, options, expected) {
   const { code, signal, stderr, stdout } = await spawnPromisified(


### PR DESCRIPTION
Ref: https://github.com/nodejs/node/issues/51840

Adds a `process.entrypoint` non-configurable property to the `process` object during bootstrap. This property reflects the executable's main entrypoint (i.e. not `--require` or `--import`-ed files, the _main_ file).

Additionally, this entrypoint is passed to workers, so it reflects the entrypoint of the process that created the worker, _not_ the entrypoint of the worker itself.