### PR TITLE
sea: reject malformed --node-options values

### DIFF
--- a/src/node.cc
+++ b/src/node.cc
@@ -1633,7 +1633,14 @@ static ExitCode StartInternal(int argc, char** argv) {
 
 int Start(int argc, char** argv) {
 #ifndef DISABLE_SINGLE_EXECUTABLE_APPLICATION
-  std::tie(argc, argv) = sea::FixupArgsForSEA(argc, argv);
+  std::vector<std::string> errors;
+  std::tie(argc, argv) = sea::FixupArgsForSEA(argc, argv, &errors);
+  if (!errors.empty()) {
+    for (const std::string& error : errors) {
+      FPrintF(stderr, "%s: %s\n", argv[0], error);
+    }
+    return static_cast<int>(ExitCode::kInvalidCommandLineArgument);
+  }
 #endif
   return static_cast<int>(StartInternal(argc, argv));
 }

--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -283,7 +283,9 @@ void IsExperimentalSeaWarningNeeded(const FunctionCallbackInfo<Value>& args) {
       sea_resource.flags & SeaFlags::kDisableExperimentalSeaWarning));
 }
 
-std::tuple<int, char**> FixupArgsForSEA(int argc, char** argv) {
+std::tuple<int, char**> FixupArgsForSEA(int argc,
+                                        char** argv,
+                                        std::vector<std::string>* errors) {
   // Repeats argv[0] at position 1 on argv as a replacement for the missing
   // entry point file path.
   if (IsSingleExecutable()) {
@@ -303,8 +305,10 @@ std::tuple<int, char**> FixupArgsForSEA(int argc, char** argv) {
       for (int i = 1; i < argc; ++i) {
         if (strncmp(argv[i], "--node-options=", 15) == 0) {
           std::string node_options = argv[i] + 15;
-          std::vector<std::string> errors;
-          cli_extension_args = ParseNodeOptionsEnvVar(node_options, &errors);
+          cli_extension_args = ParseNodeOptionsEnvVar(node_options, errors);
+          if (!errors->empty()) {
+            return {argc, argv};
+          }
           // Remove this argument by shifting the rest
           for (int j = i; j < argc - 1; ++j) {
             argv[j] = argv[j + 1];

--- a/src/node_sea.h
+++ b/src/node_sea.h
@@ -70,7 +70,9 @@ struct SeaResource {
 bool IsSingleExecutable();
 std::string_view FindSingleExecutableBlob();
 SeaResource FindSingleExecutableResource();
-std::tuple<int, char**> FixupArgsForSEA(int argc, char** argv);
+std::tuple<int, char**> FixupArgsForSEA(int argc,
+                                        char** argv,
+                                        std::vector<std::string>* errors);
 node::ExitCode WriteSingleExecutableBlob(
     const std::string& config_path,
     const std::vector<std::string>& args,

--- a/test/sea/test-single-executable-application-exec-argv-extension-cli.js
+++ b/test/sea/test-single-executable-application-exec-argv-extension-cli.js
@@ -20,18 +20,36 @@ tmpdir.refresh();
 
 const outputFile = buildSEA(fixtures.path('sea', 'exec-argv-extension-cli'));
 
+const env = {
+  ...process.env,
+  NODE_OPTIONS: '--max-old-space-size=2048', // Should be ignored
+  COMMON_DIRECTORY: join(__dirname, '..', 'common'),
+  NODE_DEBUG_NATIVE: 'SEA',
+};
+
 // Test that --node-options works with execArgvExtension: "cli"
 spawnSyncAndAssert(
   outputFile,
   ['--node-options=--max-old-space-size=1024', 'user-arg1', 'user-arg2'],
   {
-    env: {
-      ...process.env,
-      NODE_OPTIONS: '--max-old-space-size=2048', // Should be ignored
-      COMMON_DIRECTORY: join(__dirname, '..', 'common'),
-      NODE_DEBUG_NATIVE: 'SEA',
-    },
+    env,
   },
   {
     stdout: /execArgvExtension cli test passed/,
   });
+
+// Test that malformed --node-options values are rejected.
+[
+  ['--no-warnings "', /unterminated string/],
+  ['"--no-warnings\\', /invalid escape/],
+].forEach(([nodeOptions, stderr]) => {
+  spawnSyncAndAssert(
+    outputFile,
+    [`--node-options=${nodeOptions}`],
+    { env },
+    {
+      status: 9,
+      stdout: '',
+      stderr,
+    });
+});


### PR DESCRIPTION
Propagate tokenization errors from ParseNodeOptionsEnvVar through FixupArgsForSEA and abort startup with an invalid command-line status instead of applying partially parsed options.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
