### PR TITLE
permission: support v8.setHeapSnapshotNearHeapLimit

### DIFF
--- a/src/node_v8.cc
+++ b/src/node_v8.cc
@@ -27,6 +27,7 @@
 #include "node.h"
 #include "node_external_reference.h"
 #include "node_profiling.h"
+#include "permission/permission.h"
 #include "util-inl.h"
 #include "v8-profiler.h"
 #include "v8.h"
@@ -200,6 +201,14 @@ void SetHeapSnapshotNearHeapLimit(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   uint32_t limit = args[0].As<v8::Uint32>()->Value();
   CHECK_GT(limit, 0);
+
+  std::string dir = env->options()->diagnostic_dir;
+  if (dir.empty()) {
+    dir = Environment::GetCwd(env->exec_path());
+  }
+  THROW_IF_INSUFFICIENT_PERMISSIONS(
+      env, permission::PermissionScope::kFileSystemWrite, dir);
+
   env->AddHeapSnapshotNearHeapLimitCallback();
   env->set_heap_snapshot_near_heap_limit(limit);
 }

--- a/test/parallel/test-permission-fs-write-v8.js
+++ b/test/parallel/test-permission-fs-write-v8.js
@@ -34,3 +34,12 @@ const path = require('path');
     permission: 'FileSystemWrite',
   }));
 }
+
+{
+  assert.throws(() => {
+    v8.setHeapSnapshotNearHeapLimit(1);
+  }, common.expectsError({
+    code: 'ERR_ACCESS_DENIED',
+    permission: 'FileSystemWrite',
+  }));
+}


### PR DESCRIPTION
This adds a file permission check before registering the near-heap-limit callback when using `v8.setHeapSnapshotNearHeapLimit()` to avoid writing a heap snapshot without permission.