### PR TITLE
sqlite: check database state before calling SQLite

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -2396,7 +2396,10 @@ void DatabaseSync::EnableLoadExtension(
     const FunctionCallbackInfo<Value>& args) {
   DatabaseSync* db;
   ASSIGN_OR_RETURN_UNWRAP(&db, args.This());
-  auto isolate = args.GetIsolate();
+  Environment* env = Environment::GetCurrent(args);
+  THROW_AND_RETURN_ON_BAD_STATE(env, !db->IsOpen(), "database is not open");
+
+  Isolate* isolate = env->isolate();
   if (!args[0]->IsBoolean()) {
     THROW_ERR_INVALID_ARG_TYPE(isolate,
                                "The \"allow\" argument must be a boolean.");
@@ -2424,7 +2427,7 @@ void DatabaseSync::EnableDefensive(const FunctionCallbackInfo<Value>& args) {
   Environment* env = Environment::GetCurrent(args);
   THROW_AND_RETURN_ON_BAD_STATE(env, !db->IsOpen(), "database is not open");
 
-  auto isolate = args.GetIsolate();
+  Isolate* isolate = env->isolate();
   if (!args[0]->IsBoolean()) {
     THROW_ERR_INVALID_ARG_TYPE(isolate,
                                "The \"active\" argument must be a boolean.");
@@ -2475,6 +2478,8 @@ void DatabaseSync::SetAuthorizer(const FunctionCallbackInfo<Value>& args) {
   DatabaseSync* db;
   ASSIGN_OR_RETURN_UNWRAP(&db, args.This());
   Environment* env = Environment::GetCurrent(args);
+  THROW_AND_RETURN_ON_BAD_STATE(env, !db->IsOpen(), "database is not open");
+
   Isolate* isolate = env->isolate();
 
   if (args[0]->IsNull()) {

--- a/test/parallel/test-sqlite-authz.js
+++ b/test/parallel/test-sqlite-authz.js
@@ -275,4 +275,16 @@ suite('DatabaseSync.prototype.setAuthorizer()', () => {
       message: /The "callback" argument must be a function/
     });
   });
+
+  it('throws if database is not open', () => {
+    const db = new DatabaseSync(':memory:');
+    db.close();
+
+    assert.throws(() => {
+      db.setAuthorizer(() => constants.SQLITE_OK);
+    }, {
+      code: 'ERR_INVALID_STATE',
+      message: 'database is not open',
+    });
+  });
 });

--- a/test/parallel/test-sqlite-config.js
+++ b/test/parallel/test-sqlite-config.js
@@ -61,3 +61,15 @@ test('throws if options.defensive is provided but is not a boolean', (t) => {
     message: 'The "options.defensive" argument must be a boolean.',
   });
 });
+
+test('enableLoadExtension() throws if database is not open', (t) => {
+  const db = new DatabaseSync(':memory:', { allowExtension: true });
+  db.close();
+
+  t.assert.throws(() => {
+    db.enableLoadExtension(false);
+  }, {
+    code: 'ERR_INVALID_STATE',
+    message: 'database is not open',
+  });
+});


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64811

This change checks that the database is open before calling the corresponding
SQLite APIs. Both methods now throw `ERR_INVALID_STATE`, consistent with other
`DatabaseSync` methods.

---

Assisted-by: codex:gpt-5.6-sol