### PR TITLE
vfs: speed up recursive readdir test setup

### DIFF
--- a/test/parallel/test-vfs-readdir-symlink-recursive.js
+++ b/test/parallel/test-vfs-readdir-symlink-recursive.js
@@ -114,12 +114,8 @@ assert.ok(
   const v = vfs.create();
 
   // Build /deep/0/1/2/.../999/leaf.txt
-  let path = '/deep';
-  v.mkdirSync(path);
-  for (let i = 0; i < DEPTH; i++) {
-    path += `/${i}`;
-    v.mkdirSync(path);
-  }
+  const path = `/deep/${Array.from({ length: DEPTH }, (_, i) => i).join('/')}`;
+  v.mkdirSync(path, { recursive: true });
   v.writeFileSync(`${path}/leaf.txt`, 'deep');
 
   const entries = v.readdirSync('/deep', { recursive: true });


### PR DESCRIPTION
Refs: https://github.com/nodejs/reliability/issues?q=sort%3Aupdated-desc%20%22test-vfs-readdir-symlink-recursive%22

The deep-tree test created 1,000 directories individually using
increasingly long paths. Repeatedly resolving those paths made the test
slow enough to reach the timeout on Windows CI under load.

Construct the final path first and create the directory tree with one
recursive `mkdirSync()` call. This preserves the depth and recursive
readdir coverage while avoiding the expensive setup.

Locally, on macOS, the targeted test runtime decreased from approximately
10 seconds to less than one second.

---

Assisted-by: codex:gpt-5.6-sol