### PR TITLE
typings: add heap_utils internalBinding types

### DIFF
--- a/typings/globals.d.ts
+++ b/typings/globals.d.ts
@@ -8,14 +8,16 @@ import { ConstantsBinding } from './internalBinding/constants';
 import { CryptoBinding } from './internalBinding/crypto';
 import { DebugBinding } from './internalBinding/debug';
 import { EncodingBinding } from './internalBinding/encoding_binding';
-import { HttpParserBinding } from './internalBinding/http_parser';
-import { InspectorBinding } from './internalBinding/inspector';
-import { IPCSerdesBinding } from './internalBinding/ipc_serdes';
 import { FsBinding } from './internalBinding/fs';
 import { FsDirBinding } from './internalBinding/fs_dir';
+import { HeapUtilsBinding } from './internalBinding/heap_utils';
+import { HttpParserBinding } from './internalBinding/http_parser';
 import { ICUBinding } from './internalBinding/icu';
+import { InspectorBinding } from './internalBinding/inspector';
+import { IPCSerdesBinding } from './internalBinding/ipc_serdes';
 import { LocksBinding } from './internalBinding/locks';
 import { MessagingBinding } from './internalBinding/messaging';
+import { ModulesBinding } from './internalBinding/modules';
 import { OptionsBinding } from './internalBinding/options';
 import { OSBinding } from './internalBinding/os';
 import { ProcessBinding } from './internalBinding/process';
@@ -32,7 +34,6 @@ import { UtilBinding } from './internalBinding/util';
 import { UVBinding } from './internalBinding/uv';
 import { WASIBinding } from './internalBinding/wasi';
 import { WorkerBinding } from './internalBinding/worker';
-import { ModulesBinding } from './internalBinding/modules';
 import { ZlibBinding } from './internalBinding/zlib';
 
 interface InternalBindingMap {
@@ -48,6 +49,7 @@ interface InternalBindingMap {
   encoding_binding: EncodingBinding;
   fs: FsBinding;
   fs_dir: FsDirBinding;
+  heap_utils: HeapUtilsBinding;
   http_parser: HttpParserBinding;
   icu: ICUBinding;
   inspector: InspectorBinding;

--- a/typings/internalBinding/heap_utils.d.ts
+++ b/typings/internalBinding/heap_utils.d.ts
@@ -1,0 +1,17 @@
+import { owner_symbol } from './symbols';
+
+declare namespace InternalHeapUtilsBinding {
+  interface HeapSnapshotStreamHandle {
+    [owner_symbol]?: object;
+    onread?: (arrayBuffer: ArrayBuffer | undefined) => void;
+    readStart(): number;
+  }
+}
+
+export interface HeapUtilsBinding {
+  buildEmbedderGraph(): object[];
+  triggerHeapSnapshot(filename: string | undefined, options: Uint8Array): string;
+  createHeapSnapshotStream(
+    options: Uint8Array,
+  ): InternalHeapUtilsBinding.HeapSnapshotStreamHandle;
+}


### PR DESCRIPTION
Add typings for the `heap_utils` internal binding.

Changes:
- Added `typings/internalBinding/heap_utils.d.ts`
- Added `heap_utils` to `InternalBindingMap`
- Typed `buildEmbedderGraph()`, `triggerHeapSnapshot()`, and `createHeapSnapshotStream()`
- Sorted `typings/globals.d.ts` imports alphabetically