### PR TITLE
fs: apply nocase to literal glob exclude patterns

### DIFF
--- a/lib/internal/fs/glob.js
+++ b/lib/internal/fs/glob.js
@@ -354,7 +354,10 @@ class Glob {
         // consistent comparison before instantiating matchers.
         const matchers = exclude
           .map((pattern) => resolve(this.#root, pattern))
-          .map((pattern) => createMatcher(pattern));
+          // Exclude matching is a pure string comparison with no filesystem
+          // lookups, so unlike include patterns, literal patterns must also
+          // match case-insensitively on case-insensitive platforms.
+          .map((pattern) => createMatcher(pattern, { nocaseMagicOnly: false }));
         this.#isExcluded = (value) =>
           matchers.some((matcher) => matcher.match(value));
         this.#results.setup(this.#root, this.#isExcluded);

--- a/test/parallel/test-fs-glob.mjs
+++ b/test/parallel/test-fs-glob.mjs
@@ -669,3 +669,31 @@ describe('globSync - ENOTDIR', function() {
     }
   });
 });
+
+// gh-58991: exclude patterns must apply the same case-sensitivity as include
+// patterns. On case-insensitive filesystems include patterns match entries
+// regardless of case, so literal exclude patterns must match that behavior.
+const skipCaseTests = { skip: !common.isWindows && !common.isMacOS };
+describe('glob - exclude case-insensitive consistency', skipCaseTests, function() {
+  test('literal exclude ignores case (sync)', () => {
+    assert.deepStrictEqual(
+      globSync('a/b', { cwd: fixtureDir, exclude: ['A/B'] }), []);
+  });
+  test('literal exclude matches differently-cased results (sync)', () => {
+    assert.deepStrictEqual(
+      globSync('A/b', { cwd: fixtureDir, exclude: ['a/b'] }), []);
+  });
+  test('literal exclude ignores case (async)', async () => {
+    const promisified = promisify(glob);
+    assert.deepStrictEqual(
+      await promisified('a/b', { cwd: fixtureDir, exclude: ['A/B'] }), []);
+  });
+  test('literal exclude ignores case (promise)', async () => {
+    const actual = [];
+    for await (const entry of asyncGlob(
+      'a/b', { cwd: fixtureDir, exclude: ['A/B'] })) {
+      actual.push(entry);
+    }
+    assert.deepStrictEqual(actual, []);
+  });
+});


### PR DESCRIPTION
On Windows and macOS, include matching resolves literal segments through the
filesystem, while array `exclude` patterns are matched only against result path
strings. Because exclude matchers inherited `nocaseMagicOnly: true`, literal
exclude patterns remained case-sensitive while patterns containing magic were
case-insensitive.

Pass `nocaseMagicOnly: false` only when creating array exclude matchers. This is
narrower than #63446: include matcher construction and result casing remain
unchanged. Configurable case sensitivity is also left out of scope.

The new tests fail with v24.18.0 and pass with this change.

AI-assisted. Verified locally on Windows 11.

Fixes: https://github.com/nodejs/node/issues/58991
Refs: https://github.com/nodejs/node/pull/63446
