### PR TITLE
stream: reduce per-chunk work in WHATWG tee and BYOB reads

### DIFF
--- a/benchmark/webstreams/tee.js
+++ b/benchmark/webstreams/tee.js
@@ -1,0 +1,44 @@
+'use strict';
+const common = require('../common.js');
+const { ReadableStream } = require('node:stream/web');
+
+const bench = common.createBenchmark(main, {
+  n: [1e5],
+  type: ['normal', 'bytes'],
+});
+
+async function main({ n, type }) {
+  let i = 0;
+  const source = type === 'bytes' ?
+    {
+      type: 'bytes',
+      pull(controller) {
+        if (i++ < n) controller.enqueue(new Uint8Array(16));
+        else controller.close();
+      },
+    } :
+    {
+      pull(controller) {
+        if (i++ < n) controller.enqueue('a');
+        else controller.close();
+      },
+    };
+
+  const rs = new ReadableStream(source);
+  const [branch1, branch2] = rs.tee();
+  const reader1 = branch1.getReader();
+  const reader2 = branch2.getReader();
+  let reads = 0;
+
+  bench.start();
+  for (;;) {
+    const [result1, result2] = await Promise.all([
+      reader1.read(),
+      reader2.read(),
+    ]);
+    if (result1.done || result2.done) break;
+    reads++;
+  }
+  bench.end(reads);
+  console.assert(reads === n);
+}

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -7,7 +7,6 @@ const {
   ArrayBufferPrototypeSlice,
   ArrayBufferPrototypeTransfer,
   ArrayPrototypePush,
-  ArrayPrototypeShift,
   DataView,
   FunctionPrototypeBind,
   FunctionPrototypeCall,
@@ -1258,7 +1257,7 @@ class ReadableByteStreamController {
         byteOffset,
         bytesFilled,
         byteLength,
-      } = this[kState].pendingPullIntos[0];
+      } = this[kState].pendingPullIntos.peek();
       const view =
         new Uint8Array(
           buffer,
@@ -1341,9 +1340,11 @@ class ReadableByteStreamController {
       pendingPullIntos,
     } = this[kState];
     if (pendingPullIntos.length > 0) {
-      const firstPendingPullInto = pendingPullIntos[0];
+      const firstPendingPullInto = pendingPullIntos.peek();
       firstPendingPullInto.type = 'none';
-      this[kState].pendingPullIntos = [firstPendingPullInto];
+      const queue = new Queue();
+      queue.push(firstPendingPullInto);
+      this[kState].pendingPullIntos = queue;
     }
   }
 
@@ -2820,7 +2821,7 @@ function readableByteStreamControllerClose(controller) {
   }
 
   if (pendingPullIntos.length) {
-    const firstPendingPullInto = pendingPullIntos[0];
+    const firstPendingPullInto = pendingPullIntos.peek();
     if (firstPendingPullInto.bytesFilled % firstPendingPullInto.elementSize !== 0) {
       const error = new ERR_INVALID_STATE.TypeError('Partial read');
       readableByteStreamControllerError(controller, error);
@@ -2877,7 +2878,7 @@ function readableByteStreamControllerClearAlgorithms(controller) {
 
 function readableByteStreamControllerClearPendingPullIntos(controller) {
   readableByteStreamControllerInvalidateBYOBRequest(controller);
-  controller[kState].pendingPullIntos = [];
+  controller[kState].pendingPullIntos = kEmptyQueue;
 }
 
 function readableByteStreamControllerGetDesiredSize(controller) {
@@ -2979,7 +2980,7 @@ function readableByteStreamControllerPullInto(
     type: 'byob',
   };
   if (pendingPullIntos.length) {
-    ArrayPrototypePush(pendingPullIntos, desc);
+    pendingPullIntos.push(desc);
     readableStreamAddReadIntoRequest(stream, readIntoRequest);
     return;
   }
@@ -3005,9 +3006,20 @@ function readableByteStreamControllerPullInto(
       return;
     }
   }
-  ArrayPrototypePush(pendingPullIntos, desc);
+  materializePendingPullIntos(controller[kState]).push(desc);
   readableStreamAddReadIntoRequest(stream, readIntoRequest);
   readableByteStreamControllerCallPullIfNeeded(controller);
+}
+
+// Pending pull-into descriptor queues start out as (and are reset to)
+// the shared immutable empty queue so that constructing a byte stream
+// never allocates descriptor storage; the two push sites that can
+// observe an empty queue materialize a real Queue on first use.
+function materializePendingPullIntos(state) {
+  const pendingPullIntos = state.pendingPullIntos;
+  if (pendingPullIntos === kEmptyQueue)
+    return state.pendingPullIntos = new Queue();
+  return pendingPullIntos;
 }
 
 function readableByteStreamControllerRespondInternal(controller, bytesWritten) {
@@ -3015,7 +3027,7 @@ function readableByteStreamControllerRespondInternal(controller, bytesWritten) {
     stream,
     pendingPullIntos,
   } = controller[kState];
-  const desc = pendingPullIntos[0];
+  const desc = pendingPullIntos.peek();
   readableByteStreamControllerInvalidateBYOBRequest(controller);
   if (stream[kState].state === 'closed') {
     if (bytesWritten)
@@ -3040,7 +3052,7 @@ function readableByteStreamControllerRespond(controller, bytesWritten) {
     stream,
   } = controller[kState];
   assert(pendingPullIntos.length);
-  const desc = pendingPullIntos[0];
+  const desc = pendingPullIntos.peek();
 
   if (stream[kState].state === 'closed') {
     if (bytesWritten !== 0)
@@ -3085,7 +3097,7 @@ function readableByteStreamControllerFillHeadPullIntoDescriptor(
     pendingPullIntos,
     byobRequest,
   } = controller[kState];
-  assert(!pendingPullIntos.length || pendingPullIntos[0] === desc);
+  assert(!pendingPullIntos.length || pendingPullIntos.peek() === desc);
   assert(byobRequest === null);
   desc.bytesFilled += size;
 }
@@ -3108,7 +3120,7 @@ function readableByteStreamControllerEnqueue(controller, chunk) {
   const transferredBuffer = ArrayBufferPrototypeTransfer(buffer);
 
   if (pendingPullIntos.length) {
-    const firstPendingPullInto = pendingPullIntos[0];
+    const firstPendingPullInto = pendingPullIntos.peek();
 
     if (ArrayBufferPrototypeGetDetached(firstPendingPullInto.buffer)) {
       throw new ERR_INVALID_STATE.TypeError(
@@ -3155,7 +3167,7 @@ function readableByteStreamControllerEnqueue(controller, chunk) {
     } else {
       assert(!queue.length);
       if (pendingPullIntos.length) {
-        assert(pendingPullIntos[0].type === 'default');
+        assert(pendingPullIntos.peek().type === 'default');
         readableByteStreamControllerShiftPendingPullInto(controller);
       }
       const transferredView =
@@ -3324,7 +3336,7 @@ function readableByteStreamControllerProcessPullIntoDescriptorsUsingQueue(
   while (pendingPullIntos.length) {
     if (!controller[kState].queueTotalSize)
       break;
-    const desc = pendingPullIntos[0];
+    const desc = pendingPullIntos.peek();
     if (readableByteStreamControllerFillPullIntoDescriptorFromQueue(
       controller,
       desc)) {
@@ -3404,7 +3416,7 @@ function readableByteStreamControllerRespondWithNewView(controller, view) {
   } = controller[kState];
   assert(pendingPullIntos.length);
 
-  const desc = pendingPullIntos[0];
+  const desc = pendingPullIntos.peek();
   assert(stream[kState].state !== 'errored');
 
   const viewByteLength = ArrayBufferViewGetByteLength(view);
@@ -3444,7 +3456,7 @@ function readableByteStreamControllerRespondWithNewView(controller, view) {
 
 function readableByteStreamControllerShiftPendingPullInto(controller) {
   assert(controller[kState].byobRequest === null);
-  return ArrayPrototypeShift(controller[kState].pendingPullIntos);
+  return controller[kState].pendingPullIntos.shift();
 }
 
 function readableByteStreamControllerCallPullIfNeeded(controller) {
@@ -3540,7 +3552,6 @@ function readableByteStreamControllerProcessReadRequestsUsingQueue(controller) {
 
 function readableByteStreamControllerPullSteps(controller, readRequest) {
   const {
-    pendingPullIntos,
     queueTotalSize,
     stream,
   } = controller[kState];
@@ -3559,8 +3570,7 @@ function readableByteStreamControllerPullSteps(controller, readRequest) {
   if (autoAllocateChunkSize !== undefined) {
     try {
       const buffer = new ArrayBuffer(autoAllocateChunkSize);
-      ArrayPrototypePush(
-        pendingPullIntos,
+      materializePendingPullIntos(controller[kState]).push(
         {
           buffer,
           bufferByteLength: autoAllocateChunkSize,
@@ -3610,7 +3620,7 @@ function setupReadableByteStreamController(
     pullAlgorithm,
     cancelAlgorithm,
     autoAllocateChunkSize,
-    pendingPullIntos: [],
+    pendingPullIntos: kEmptyQueue,
   };
   stream[kState].controller = controller;
 

--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -1805,29 +1805,42 @@ function readableStreamDefaultTee(stream, cloneForBranch2) {
   let branch2;
   const cancelPromise = PromiseWithResolvers();
 
+  // At most one read is ever in flight (`reading` guards pullAlgorithm),
+  // so one read request object and one forwarding microtask function are
+  // reused for every chunk; the chunk travels through `pendingChunk`.
+  // The request is materialized lazily on the first pull so that tee()
+  // itself stays allocation-light.
+  let pendingChunk;
+  let readRequest;
+  function forwardChunk() {
+    reading = false;
+    const value1 = pendingChunk;
+    let value2 = pendingChunk;
+    pendingChunk = undefined;
+    if (!canceled2 && cloneForBranch2) {
+      value2 = structuredClone(value2);
+    }
+    if (!canceled1) {
+      readableStreamDefaultControllerEnqueue(
+        branch1[kState].controller,
+        value1);
+    }
+    if (!canceled2) {
+      readableStreamDefaultControllerEnqueue(
+        branch2[kState].controller,
+        value2);
+    }
+  }
+
   async function pullAlgorithm() {
     if (reading) return;
     reading = true;
-    const readRequest = {
+    readRequest ??= {
       [kChunk](value) {
-        queueMicrotask(() => {
-          reading = false;
-          const value1 = value;
-          let value2 = value;
-          if (!canceled2 && cloneForBranch2) {
-            value2 = structuredClone(value2);
-          }
-          if (!canceled1) {
-            readableStreamDefaultControllerEnqueue(
-              branch1[kState].controller,
-              value1);
-          }
-          if (!canceled2) {
-            readableStreamDefaultControllerEnqueue(
-              branch2[kState].controller,
-              value2);
-          }
-        });
+        // The microtask is required by the spec (ReadableStreamTee's
+        // "chunk steps" queue one).
+        pendingChunk = value;
+        queueMicrotask(forwardChunk);
       },
       [kClose]() {
         // The `process.nextTick()` is not part of the spec.
@@ -1921,6 +1934,55 @@ function readableByteStreamTee(stream) {
     );
   }
 
+  // As in readableStreamDefaultTee, only one read is ever in flight, so
+  // the default-reader read request and its forwarding microtask are
+  // shared across all chunks.
+  let pendingChunk;
+  function forwardChunk() {
+    readAgainForBranch1 = false;
+    readAgainForBranch2 = false;
+    const chunk1 = pendingChunk;
+    let chunk2 = pendingChunk;
+    pendingChunk = undefined;
+
+    if (!canceled1 && !canceled2) {
+      try {
+        chunk2 = cloneAsUint8Array(chunk1);
+      } catch (error) {
+        readableByteStreamControllerError(
+          branch1[kState].controller,
+          error,
+        );
+        readableByteStreamControllerError(
+          branch2[kState].controller,
+          error,
+        );
+        cancelDeferred.resolve(readableStreamCancel(stream, error));
+        return;
+      }
+    }
+    if (!canceled1) {
+      readableByteStreamControllerEnqueue(
+        branch1[kState].controller,
+        chunk1,
+      );
+    }
+    if (!canceled2) {
+      readableByteStreamControllerEnqueue(
+        branch2[kState].controller,
+        chunk2,
+      );
+    }
+    reading = false;
+
+    if (readAgainForBranch1) {
+      pull1Algorithm();
+    } else if (readAgainForBranch2) {
+      pull2Algorithm();
+    }
+  }
+
+  let defaultReadRequest;
   function pullWithDefaultReader() {
     if (isReadableStreamBYOBReader(reader)) {
       readableStreamBYOBReaderRelease(reader);
@@ -1928,50 +1990,10 @@ function readableByteStreamTee(stream) {
       forwardReaderError(reader);
     }
 
-    const readRequest = {
+    defaultReadRequest ??= {
       [kChunk](chunk) {
-        queueMicrotask(() => {
-          readAgainForBranch1 = false;
-          readAgainForBranch2 = false;
-          const chunk1 = chunk;
-          let chunk2 = chunk;
-
-          if (!canceled1 && !canceled2) {
-            try {
-              chunk2 = cloneAsUint8Array(chunk);
-            } catch (error) {
-              readableByteStreamControllerError(
-                branch1[kState].controller,
-                error,
-              );
-              readableByteStreamControllerError(
-                branch2[kState].controller,
-                error,
-              );
-              cancelDeferred.resolve(readableStreamCancel(stream, error));
-              return;
-            }
-          }
-          if (!canceled1) {
-            readableByteStreamControllerEnqueue(
-              branch1[kState].controller,
-              chunk1,
-            );
-          }
-          if (!canceled2) {
-            readableByteStreamControllerEnqueue(
-              branch2[kState].controller,
-              chunk2,
-            );
-          }
-          reading = false;
-
-          if (readAgainForBranch1) {
-            pull1Algorithm();
-          } else if (readAgainForBranch2) {
-            pull2Algorithm();
-          }
-        });
+        pendingChunk = chunk;
+        queueMicrotask(forwardChunk);
       },
       [kClose]() {
         reading = false;
@@ -1996,8 +2018,7 @@ function readableByteStreamTee(stream) {
         reading = false;
       },
     };
-
-    readableStreamDefaultReaderRead(reader, readRequest);
+    readableStreamDefaultReaderRead(reader, defaultReadRequest);
   }
 
   function pullWithBYOBReader(view, forBranch2) {

--- a/test/parallel/test-whatwg-readablestream.js
+++ b/test/parallel/test-whatwg-readablestream.js
@@ -37,7 +37,8 @@ const {
 } = require('internal/webstreams/readablestream');
 
 const {
-  kState
+  kState,
+  Queue,
 } = require('internal/webstreams/util');
 
 const {
@@ -1581,7 +1582,9 @@ class Source {
     start(c) { controller = c; }
   });
 
-  controller[kState].pendingPullIntos = [{}];
+  const pendingPullIntos = new Queue();
+  pendingPullIntos.push({});
+  controller[kState].pendingPullIntos = pendingPullIntos;
   assert.throws(() => readableByteStreamControllerRespond(controller, 0), {
     code: 'ERR_INVALID_ARG_VALUE',
   });


### PR DESCRIPTION
Two per-chunk reductions in the WHATWG streams implementation, continuing the series from #64431 / #64451.

**1. Ring buffer for pending BYOB pull-into descriptors**

The byte controller's `[[pendingPullIntos]]` list was the last per-chunk queue still backed by a plain array consumed with `ArrayPrototypeShift`. BYOB reads push and shift one descriptor per read, and `Array.prototype.shift` has real per-call cost even at length 1. This backs the list with the same lazily materialized `Queue` ring buffer used for the request queues in #64431, so constructing a byte stream still allocates no descriptor storage.

**2. Reused tee read request**

Both `ReadableStreamDefaultTee` and the byte tee's default-reader pull path allocated a fresh read request object (three computed-symbol methods) plus a fresh forwarding microtask closure for every chunk. Only one read is ever in flight per tee (guarded by the `reading` flag), so a single read request and forwarding function are now shared across all chunks, with the chunk handed over through a captured slot. The request is materialized lazily on the first pull so `tee()` itself stays allocation-light.

A steady-state tee benchmark is added (`benchmark/webstreams/tee.js`); tee previously only had creation coverage.

**Benchmarks** (`benchmark/compare.js`, 12–20 runs each, quiet machine):

```
                                                            confidence improvement accuracy
webstreams/tee.js type='normal' n=100000                           ***    +79.78 %  ±11.02%
webstreams/tee.js type='bytes' n=100000                            ***    +29.38 %   ±5.05%
webstreams/readable-read.js type='byob' n=100000                    **     +2.45 %   ±3.06%
```

All other rows (readable-read normal, read-buffered, async-iterator, creation incl. `ReadableStream.tee`, js_transfer) are neutral; the eager-request version of the tee change initially regressed tee creation by 24 % which is what motivated the lazy materialization (row now +0.49 % n.s.).

Gates: WPT streams/compression/encoding plus the whatwg/webstreams parallel suites all pass. One white-box test that planted a plain array as `[[pendingPullIntos]]` was updated to build the real `Queue` representation.