### PR TITLE
fs: avoid crash after tolerated watch ENOENT

### DIFF
--- a/lib/internal/fs/watchers.js
+++ b/lib/internal/fs/watchers.js
@@ -317,6 +317,8 @@ FSWatcher.prototype[kFSWatchStart] = function(filename,
                                  encoding);
   if (err) {
     if (!throwIfNoEntry && err === UV_ENOENT) {
+      // FSEventWrap::Start() already started closing the native handle.
+      this._handle = null;
       return;
     }
 

--- a/test/parallel/test-fs-watch-enoent.js
+++ b/test/parallel/test-fs-watch-enoent.js
@@ -62,7 +62,11 @@ tmpdir.refresh();
     );
   } else {
     const watcher = fs.watch(nonexistentFile, { throwIfNoEntry: false }, common.mustNotCall());
-    watcher.close();
+    if (common.isLinux) {
+      setTimeout(common.mustCall(() => watcher.close()), common.platformTimeout(10));
+    } else {
+      watcher.close();
+    }
   }
 }
 

--- a/test/parallel/test-watch-mode-missing-env-file-signal.mjs
+++ b/test/parallel/test-watch-mode-missing-env-file-signal.mjs
@@ -1,0 +1,91 @@
+import * as common from '../common/index.mjs';
+import assert from 'node:assert';
+import { spawn } from 'node:child_process';
+import { once } from 'node:events';
+import { writeFileSync } from 'node:fs';
+import { clearTimeout, setTimeout } from 'node:timers';
+import tmpdir from '../common/tmpdir.js';
+
+if (!common.isLinux)
+  common.skip('This test verifies Linux fs.watch() behavior');
+
+tmpdir.refresh();
+const entry = tmpdir.resolve('entry.js');
+const missingEnvFile = tmpdir.resolve('missing.env');
+writeFileSync(entry, '');
+
+async function withTimeout(promise, message) {
+  let timeout;
+  const timedOut = new Promise((_, reject) => {
+    timeout = setTimeout(
+      () => reject(new Error(message)),
+      common.platformTimeout(10_000),
+    );
+  });
+
+  try {
+    return await Promise.race([promise, timedOut]);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function testSignal(signal) {
+  const child = spawn(process.execPath, [
+    '--watch',
+    `--env-file-if-exists=${missingEnvFile}`,
+    entry,
+  ], {
+    cwd: tmpdir.path,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const closed = once(child, 'close');
+  const ready = Promise.withResolvers();
+  let stdout = '';
+  let stderr = '';
+
+  child.stdout.setEncoding('utf8');
+  child.stdout.on('data', (data) => {
+    stdout += data;
+    if (stdout.includes('Completed running')) {
+      ready.resolve();
+    }
+  });
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (data) => {
+    stderr += data;
+  });
+  child.once('error', ready.reject);
+  child.once('exit', (code, exitSignal) => {
+    ready.reject(new Error(
+      `Watch mode exited before becoming ready: code=${code}, signal=${exitSignal}`,
+    ));
+  });
+
+  try {
+    await withTimeout(
+      ready.promise,
+      'Timed out waiting for watch mode readiness',
+    );
+    assert.strictEqual(child.kill(signal), true);
+    const [code, exitSignal] = await withTimeout(
+      closed,
+      `Timed out waiting for watch mode to exit after ${signal}`,
+    );
+
+    assert.strictEqual(code, 0);
+    assert.strictEqual(exitSignal, null);
+    assert.doesNotMatch(
+      `${stdout}\n${stderr}`,
+      /Assertion failed|FSEventWrap::GetInitialized/,
+    );
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+    }
+    await closed.catch(() => {});
+  }
+}
+
+await testSignal('SIGINT');
+await testSignal('SIGTERM');


### PR DESCRIPTION
## Summary

- Clear the JavaScript `FSEvent` wrapper from `FSWatcher._handle` when a
  missing path is tolerated with `throwIfNoEntry: false`.
- Update `test/parallel/test-fs-watch-enoent.js` to exercise
  `FSWatcher.close()` after giving the native close callback an opportunity
  to run on Linux.
- Add `test/parallel/test-watch-mode-missing-env-file-signal.mjs` to verify
  clean SIGINT and SIGTERM exits when an optional env file is missing.

## Details

On Linux, `uv_fs_event_start()` returns `UV_ENOENT` for a missing path.
`FSEventWrap::Start()` starts closing the native handle before returning that
error. When `throwIfNoEntry` is false, `FSWatcher._handle` previously kept a
reference to the JavaScript `FSEvent` wrapper. A later `FSWatcher.close()`
accessed that wrapper's `initialized` getter after the native `FSEventWrap`
had been detached, causing the `FSEventWrap::GetInitialized()` null-wrapper
assertion.

Set `FSWatcher._handle` to `null` in the tolerated `UV_ENOENT` branch. This is
only a JavaScript lifecycle-state transition; it does not close the native
handle a second time or emit a `close` event.

The Linux regression test uses `common.platformTimeout(10)`, a non-zero
delayed timer, before calling `close()`. A next tick or immediate can run
before the native close callback and therefore would not reliably exercise
the detached-wrapper state.

The watch-mode regression test starts separate processes for SIGINT and
SIGTERM, waits for watch-mode readiness, and checks for a zero exit code, no
terminating signal, and no native assertion output. It also has readiness and
shutdown timeouts and always cleans up a child on failure.

## Testing

- Official Docker baselines reproduced the native assertion with
  `node:24.16.0-slim`, `node:24.18.0-slim`, and `node:26.5.0-slim`.
- The pre-fix baseline was also reproduced locally at `upstream/HEAD`
  [`41525ab9fcb92d6f487047b024be29a1a96d639c`](https://github.com/nodejs/node/commit/41525ab9fcb92d6f487047b024be29a1a96d639c)
  with exit code 134.
- The patch was rebased onto `upstream/HEAD`
  [`012ecf51d39d784f1c217f941122717688c31add`](https://github.com/nodejs/node/commit/012ecf51d39d784f1c217f941122717688c31add).
- `test/parallel/test-fs-watch-enoent.js` and
  `test/parallel/test-watch-mode-missing-env-file-signal.mjs` passed
  individually and for 20 repetitions each.
- The watch-mode regression test passed for 20 repetitions in an Ubuntu 26.04
  container using the patched build.
- Existing-path, default `throwIfNoEntry`, immediate-close, repeated-close,
  `ref()`/`unref()`, AbortSignal, and standalone watch-mode controls passed.
- A 2,000-watcher stress check observed 2,000 `FSEVENTWRAP` initializations and
  2,000 destroys.
- `make lint` passed.
- `git diff --check` passed.
- `make -j4 test` passed on `012ecf51d39d784f1c217f941122717688c31add`
  in a clean test environment: 5,790 passed, 0 failed.

Fixes: https://github.com/nodejs/node/issues/64819
Refs: https://github.com/nodejs/node/pull/61870
Refs: https://github.com/nodejs/node/pull/20985
