### PR TITLE
sqlite: isolate applyChangeset filter errors

### DIFF
--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -2277,6 +2277,7 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
 
   Local<Function> conflictFunc;
   Local<Function> filterFunc;
+  bool filterCallbackFailed = false;
   if (args.Length() > 1 && !args[1]->IsUndefined()) {
     if (!args[1]->IsObject()) {
       THROW_ERR_INVALID_ARG_TYPE(env->isolate(),
@@ -2338,25 +2339,25 @@ void DatabaseSync::ApplyChangeset(const FunctionCallbackInfo<Value>& args) {
 
       filterFunc = filterValue.As<Function>();
 
-      context.filterCallback =
-          [env, db, &filterFunc](std::string_view item) -> bool {
+      context.filterCallback = [env, &filterFunc, &filterCallbackFailed](
+                                   std::string_view item) -> bool {
         // If there was an error in the previous call to the filter's
         // callback, we skip calling it again.
-        if (db->ignore_next_sqlite_error_) {
+        if (filterCallbackFailed) {
           return false;
         }
 
         Local<Value> argv[1];
         if (!ToV8Value(env->context(), item, env->isolate())
                  .ToLocal(&argv[0])) {
-          db->SetIgnoreNextSQLiteError(true);
+          filterCallbackFailed = true;
           return false;
         }
 
         Local<Value> result;
         if (!filterFunc->Call(env->context(), Null(env->isolate()), 1, argv)
                  .ToLocal(&result)) {
-          db->SetIgnoreNextSQLiteError(true);
+          filterCallbackFailed = true;
           return false;
         }
 

--- a/test/parallel/test-sqlite-session.js
+++ b/test/parallel/test-sqlite-session.js
@@ -388,6 +388,13 @@ test('filter handler throws', (t) => {
     name: 'Error',
     message: 'Error filtering table data1'
   });
+
+  t.assert.throws(() => {
+    database2.exec('CREATE TABLEEEE');
+  }, {
+    code: 'ERR_SQLITE_ERROR',
+    message: /syntax error/,
+  });
 });
 
 test('database.createSession() - filter changes', (t) => {


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64822

When an `applyChangeset()` filter callback throws,
`ignore_next_sqlite_error_` is set. Returning false from `xFilter` is not
itself a SQLite error, so `sqlite3changeset_apply()` can return `SQLITE_OK`
without consuming the flag. The next unrelated SQLite error is then
silently suppressed.

This change keeps filter callback failure state local to the
`applyChangeset()` invocation.

---

Assisted-by: codex:gpt-5.6-sol
