### PR TITLE
stream: fix recursive WritableStream abort

### DIFF
--- a/lib/internal/webstreams/writablestream.js
+++ b/lib/internal/webstreams/writablestream.js
@@ -701,14 +701,17 @@ function writerReadyPromise(writer) {
 }
 
 function writableStreamAbort(stream, reason) {
-  const {
-    state,
-    controller,
-  } = stream[kState];
+  const { controller } = stream[kState];
+
+  let state = stream[kState].state;
   if (state === 'closed' || state === 'errored')
     return PromiseResolve();
 
   controller[kState].abortController.abort(reason);
+
+  state = stream[kState].state;
+  if (state === 'closed' || state === 'errored')
+    return PromiseResolve();
 
   if (stream[kState].pendingAbortRequest.abort.promise !== undefined)
     return stream[kState].pendingAbortRequest.abort.promise;
@@ -807,7 +810,7 @@ function writableStreamRejectCloseAndClosedPromiseIfNeeded(stream) {
   }
 
   const closedPromiseCache = stream[kState].closedPromise;
-  if (closedPromiseCache !== undefined) {
+  if (closedPromiseCache !== undefined && isPromisePending(closedPromiseCache.promise)) {
     setPromiseHandled(closedPromiseCache.promise);
     closedPromiseCache.reject(stream[kState].storedError);
   }
@@ -817,7 +820,7 @@ function writableStreamRejectCloseAndClosedPromiseIfNeeded(stream) {
   } = stream[kState];
   if (writer !== undefined) {
     const closeCache = writer[kState].close;
-    if (closeCache !== undefined) {
+    if (closeCache !== undefined && isPromisePending(closeCache.promise)) {
       setPromiseHandled(closeCache.promise);
       closeCache.reject(stream[kState].storedError);
     }

--- a/test/wpt/status/streams.json
+++ b/test/wpt/status/streams.json
@@ -43,13 +43,5 @@
   },
   "transform-streams/invalid-realm.tentative.window.js": {
     "skip": "Browser-specific test"
-  },
-  "writable-streams/aborting.any.js": {
-    "fail": {
-      "note": "Recursive abort() call from within an abort algorithm triggers ERR_INTERNAL_ASSERTION",
-      "expected": [
-        "recursive abort() call from abort() aborting signal"
-      ]
-    }
   }
 }


### PR DESCRIPTION

Re-check the stream state after signaling the controller's abort signal, as required by steps 3 and 4 of the `WritableStreamAbort` algorithm.

Refs: https://streams.spec.whatwg.org/#writable-stream-abort


Also, reject close promise caches only when their promises are still pending. A cache lazily materialized after the stream becomes errored may already contain a rejected promise and does not have a callable `reject` method.


Remove the expected-failure entry for the recursive abort WPT.


## Testing

```console
$ ./node test/wpt/test-streams.js writable-streams/aborting.any.js

Files: 1/1 ran, 1 passed, 0 skipped, 0 expected failures, 0 unexpected failures, 0 unexpected passes
Subtests: 65 passed, 0 skipped, 0 expected failures, 0 unexpected failures, 0 unexpected passes
```
