### PR TITLE
test,doc: cover and document multi-byte offset/size in randomFill

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5574,9 +5574,12 @@ changes:
 
 * `buffer` {ArrayBuffer|Buffer|TypedArray|DataView} Must be supplied. The
   size of the provided `buffer` must not be larger than `2**31 - 1`.
-* `offset` {number} **Default:** `0`
-* `size` {number} **Default:** `buffer.length - offset`. The `size` must
-  not be larger than `2**31 - 1`.
+* `offset` {number} The start position, in elements for a `TypedArray` and in
+  bytes for an `ArrayBuffer` or `DataView`. **Default:** `0`
+* `size` {number} The amount to fill, in the same units as `offset`.
+  **Default:** `buffer.length - offset` for a `TypedArray`, or
+  `buffer.byteLength - offset` for an `ArrayBuffer` or `DataView`. The `size`
+  must not be larger than `2**31 - 1`.
 * `callback` {Function} `function(err, buf) {}`.
 
 This function is similar to [`crypto.randomBytes()`][] but requires the first
@@ -5711,9 +5714,12 @@ changes:
 
 * `buffer` {ArrayBuffer|Buffer|TypedArray|DataView} Must be supplied. The
   size of the provided `buffer` must not be larger than `2**31 - 1`.
-* `offset` {number} **Default:** `0`
-* `size` {number} **Default:** `buffer.length - offset`. The `size` must
-  not be larger than `2**31 - 1`.
+* `offset` {number} The start position, in elements for a `TypedArray` and in
+  bytes for an `ArrayBuffer` or `DataView`. **Default:** `0`
+* `size` {number} The amount to fill, in the same units as `offset`.
+  **Default:** `buffer.length - offset` for a `TypedArray`, or
+  `buffer.byteLength - offset` for an `ArrayBuffer` or `DataView`. The `size`
+  must not be larger than `2**31 - 1`.
 * Returns: {ArrayBuffer|Buffer|TypedArray|DataView} The object passed as
   `buffer` argument.
 

--- a/lib/internal/crypto/random.js
+++ b/lib/internal/crypto/random.js
@@ -168,7 +168,7 @@ function randomFill(buf, offset, size, callback) {
     size = buf.length;
   } else if (typeof size === 'function') {
     callback = size;
-    size = buf.length - offset;
+    size = (buf.length ?? buf.byteLength) - offset;
   } else {
     validateFunction(callback, 'callback');
   }

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -219,45 +219,52 @@ common.expectWarning('DeprecationWarning',
 }
 
 {
-  const buf = new Uint16Array(4);
+  const buf = new Uint16Array(10);
   const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFillSync(buf, 1, 1);
+  crypto.randomFillSync(buf, 1, 8);
   const after = Buffer.from(buf.buffer).toString('hex');
   assert.notStrictEqual(before, after);
   assert.deepStrictEqual(before.slice(0, 4), after.slice(0, 4));
-  assert.deepStrictEqual(before.slice(8), after.slice(8));
+  assert.deepStrictEqual(before.slice(-4), after.slice(-4));
 }
 
 {
-  const buf = new Uint32Array(4);
+  const buf = new Uint32Array(10);
   const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFillSync(buf, 1, 1);
+  crypto.randomFillSync(buf, 1, 8);
   const after = Buffer.from(buf.buffer).toString('hex');
   assert.notStrictEqual(before, after);
   assert.deepStrictEqual(before.slice(0, 8), after.slice(0, 8));
-  assert.deepStrictEqual(before.slice(16), after.slice(16));
+  assert.deepStrictEqual(before.slice(-8), after.slice(-8));
 }
 
 {
-  const buf = new Uint16Array(4);
+  const buf = new Uint16Array(10);
   const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFill(buf, 1, 1, common.mustSucceed((buf) => {
+  crypto.randomFill(buf, 1, 8, common.mustSucceed((buf) => {
     const after = Buffer.from(buf.buffer).toString('hex');
     assert.notStrictEqual(before, after);
     assert.deepStrictEqual(before.slice(0, 4), after.slice(0, 4));
-    assert.deepStrictEqual(before.slice(8), after.slice(8));
+    assert.deepStrictEqual(before.slice(-4), after.slice(-4));
   }));
 }
 
 {
-  const buf = new Uint32Array(4);
+  const buf = new Uint32Array(10);
   const before = Buffer.from(buf.buffer).toString('hex');
-  crypto.randomFill(buf, 1, 1, common.mustSucceed((buf) => {
+  crypto.randomFill(buf, 1, 8, common.mustSucceed((buf) => {
     const after = Buffer.from(buf.buffer).toString('hex');
     assert.notStrictEqual(before, after);
     assert.deepStrictEqual(before.slice(0, 8), after.slice(0, 8));
-    assert.deepStrictEqual(before.slice(16), after.slice(16));
+    assert.deepStrictEqual(before.slice(-8), after.slice(-8));
   }));
+}
+
+{
+  // randomFill() with an offset and no size must not throw for types
+  // without a .length property, matching randomFillSync().
+  crypto.randomFill(new ArrayBuffer(10), 2, common.mustSucceed());
+  crypto.randomFill(new DataView(new ArrayBuffer(10)), 2, common.mustSucceed());
 }
 
 {

--- a/test/parallel/test-crypto-random.js
+++ b/test/parallel/test-crypto-random.js
@@ -219,6 +219,48 @@ common.expectWarning('DeprecationWarning',
 }
 
 {
+  const buf = new Uint16Array(4);
+  const before = Buffer.from(buf.buffer).toString('hex');
+  crypto.randomFillSync(buf, 1, 1);
+  const after = Buffer.from(buf.buffer).toString('hex');
+  assert.notStrictEqual(before, after);
+  assert.deepStrictEqual(before.slice(0, 4), after.slice(0, 4));
+  assert.deepStrictEqual(before.slice(8), after.slice(8));
+}
+
+{
+  const buf = new Uint32Array(4);
+  const before = Buffer.from(buf.buffer).toString('hex');
+  crypto.randomFillSync(buf, 1, 1);
+  const after = Buffer.from(buf.buffer).toString('hex');
+  assert.notStrictEqual(before, after);
+  assert.deepStrictEqual(before.slice(0, 8), after.slice(0, 8));
+  assert.deepStrictEqual(before.slice(16), after.slice(16));
+}
+
+{
+  const buf = new Uint16Array(4);
+  const before = Buffer.from(buf.buffer).toString('hex');
+  crypto.randomFill(buf, 1, 1, common.mustSucceed((buf) => {
+    const after = Buffer.from(buf.buffer).toString('hex');
+    assert.notStrictEqual(before, after);
+    assert.deepStrictEqual(before.slice(0, 4), after.slice(0, 4));
+    assert.deepStrictEqual(before.slice(8), after.slice(8));
+  }));
+}
+
+{
+  const buf = new Uint32Array(4);
+  const before = Buffer.from(buf.buffer).toString('hex');
+  crypto.randomFill(buf, 1, 1, common.mustSucceed((buf) => {
+    const after = Buffer.from(buf.buffer).toString('hex');
+    assert.notStrictEqual(before, after);
+    assert.deepStrictEqual(before.slice(0, 8), after.slice(0, 8));
+    assert.deepStrictEqual(before.slice(16), after.slice(16));
+  }));
+}
+
+{
   [
     Buffer.alloc(10),
     new Uint8Array(new Array(10).fill(0)),


### PR DESCRIPTION
<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->

* Document that `offset`/`size` are in elements for a `TypedArray` and in
  bytes for an `ArrayBuffer` / `DataView` (default given per type)
* Fix `randomFill()` throwing for `ArrayBuffer` / `DataView` with an offset,
  where `buf.length - offset` becomes `NaN`
* Add regression tests for multi-byte `offset`/`size` and the offset case