### PR TITLE
buffer: simplify Buffer.concat

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -616,66 +616,51 @@ Buffer.concat = function concat(list, length) {
   if (list.length === 0)
     return new FastBuffer();
 
-  if (length === undefined) {
+  const autoLength = length === undefined;
+  if (autoLength) {
     length = 0;
-    for (let i = 0; i < list.length; i++) {
-      const buf = list[i];
-      if (!isUint8Array(buf)) {
-        // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
-        // Instead, find the proper error code for this.
-        throw new ERR_INVALID_ARG_TYPE(
-          `list[${i}]`, ['Buffer', 'Uint8Array'], buf);
-      }
-      length += TypedArrayPrototypeGetByteLength(buf);
-    }
-
-    const buffer = allocate(length);
-    let pos = 0;
-    for (let i = 0; i < list.length; i++) {
-      const buf = list[i];
-      const bufLength = TypedArrayPrototypeGetByteLength(buf);
-      TypedArrayPrototypeSet(buffer, buf, pos);
-      pos += bufLength;
-    }
-
-    if (pos < length) {
-      TypedArrayPrototypeFill(buffer, 0, pos, length);
-    }
-    return buffer;
+  } else {
+    validateOffset(length, 'length');
   }
 
-  validateOffset(length, 'length');
-  for (let i = 0; i < list.length; i++) {
-    if (!isUint8Array(list[i])) {
-      // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
-      // Instead, find the proper error code for this.
-      throw new ERR_INVALID_ARG_TYPE(
-        `list[${i}]`, ['Buffer', 'Uint8Array'], list[i]);
+  let i = 0;
+  let j = 0;
+  let pos = 0;
+  const postPositions = new Array(list.length);
+  try {
+    for (; i < list.length; i++) {
+      pos += TypedArrayPrototypeGetByteLength(list[i]);
+      postPositions[i] = pos;
+      j += pos <= length;
     }
+  } catch {
+    // TODO(BridgeAR): This should not be of type ERR_INVALID_ARG_TYPE.
+    // Instead, find the proper error code for this.
+    throw new ERR_INVALID_ARG_TYPE(
+      `list[${i}]`, ['Buffer', 'Uint8Array'], list[i]);
+  }
+  if (autoLength) {
+    length = pos;
+    j = list.length;
   }
 
   const buffer = allocate(length);
-  let pos = 0;
-  for (let i = 0; i < list.length; i++) {
-    const buf = list[i];
-    const bufLength = TypedArrayPrototypeGetByteLength(buf);
-    if (pos + bufLength > length) {
-      TypedArrayPrototypeSet(buffer,
-                             TypedArrayPrototypeSubarray(buf, 0, length - pos),
-                             pos);
-      pos = length;
-      break;
-    }
-    TypedArrayPrototypeSet(buffer, buf, pos);
-    pos += bufLength;
+  // Copy from every input that fits completely.
+  for (pos = i = 0; i < j; i++) {
+    TypedArrayPrototypeSet(buffer, list[i], pos);
+    pos = postPositions[i];
   }
 
-  // Note: `length` is always equal to `buffer.length` at this point
   if (pos < length) {
-    // Zero-fill the remaining bytes if the specified `length` was more than
-    // the actual total length, i.e. if we have some remaining allocated bytes
-    // there were not initialized.
-    TypedArrayPrototypeFill(buffer, 0, pos, length);
+    // Populate the remaining bytes, either by partially consuming the next
+    // input or by zero-filling.
+    if (j < list.length) {
+      TypedArrayPrototypeSet(buffer,
+                             TypedArrayPrototypeSubarray(list[j], 0, length - pos),
+                             pos);
+    } else {
+      TypedArrayPrototypeFill(buffer, 0, pos, length);
+    }
   }
 
   return buffer;


### PR DESCRIPTION
Merge the auto-length and explicit-length paths of Buffer.concat while maintaining the branch-free status of the copy loop body from #61721 by discovering the the index of the first not-fully-copyable input inside the validation loop.

Also improve efficiency by relying upon TypedArrayPrototypeGetByteLength for input validation and capturing positions from it.

The end result is more unified code whose performance seems to be roughly equivalent and perhaps slightly skewed in favor of unspecified length:
```console
$ node-benchmark-compare <(
  node benchmark/compare.js --old ./node-upstream --new ./out/Release/node --filter buffer-concat buffers
)
                                                                            confidence improvement accuracy (*)   (**)  (***)
buffers/buffer-concat-fill.js n=800000 extraSize=1                                         -2.84 %       ±2.91% ±3.87% ±5.03%
buffers/buffer-concat-fill.js n=800000 extraSize=1024                                *      3.27 %       ±3.06% ±4.08%  ±5.31%
buffers/buffer-concat-fill.js n=800000 extraSize=256                                       -1.75 %       ±1.94% ±2.59% ±3.37%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=16          ***      7.32 %       ±1.51% ±2.03% ±2.69%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=1 pieces=4                    1.71 %       ±3.48% ±4.68% ±6.18%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=16         ***      6.54 %       ±0.56% ±0.75% ±0.98%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=16 pieces=4          ***      6.03 %       ±1.11% ±1.48% ±1.95%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=16                -2.18 %       ±2.93% ±3.90% ±5.08%
buffers/buffer-concat.js n=800000 withTotalLength=0 pieceSize=256 pieces=4         ***     11.32 %       ±3.71% ±4.98% ±6.58%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=16          ***     -5.06 %       ±0.65% ±0.87% ±1.14%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=1 pieces=4           ***     -7.62 %       ±1.33% ±1.77%  ±2.31%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=16         ***     -5.84 %       ±0.70% ±0.93% ±1.22%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=16 pieces=4          ***     -5.99 %       ±0.94% ±1.26% ±1.64%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=16        ***     -8.78 %       ±2.66% ±3.55% ±4.64%
buffers/buffer-concat.js n=800000 withTotalLength=1 pieceSize=256 pieces=4         ***     -4.70 %       ±1.67% ±2.22% ±2.90%

Be aware that when doing many comparisons the risk of a false-positive result increases.
In this case, there are 15 comparisons, you can thus expect the following amount of false-positive results:
  0.75 false positives, when considering a   5% risk acceptance (*, **, ***),
  0.15 false positives, when considering a   1% risk acceptance (**, ***),
  0.01 false positives, when considering a 0.1% risk acceptance (***)
```