### PR TITLE
test: reuse ffi.suffix instead of reimplementing it

### DIFF
--- a/test/ffi/ffi-test-common.js
+++ b/test/ffi/ffi-test-common.js
@@ -6,18 +6,15 @@ const path = require('node:path');
 
 common.skipIfFFIMissing();
 
+const { suffix } = require('node:ffi');
+
 const fixtureBuildDir = path.join(
   __dirname,
   'fixture_library',
   'build',
   common.buildType,
 );
-const libraryPath = path.join(
-  fixtureBuildDir,
-  process.platform === 'win32' ? 'ffi_test_library.dll' :
-    process.platform === 'darwin' ? 'ffi_test_library.dylib' :
-      'ffi_test_library.so',
-);
+const libraryPath = path.join(fixtureBuildDir, `ffi_test_library.${suffix}`);
 
 function ensureFixtureLibrary() {
   if (!fs.existsSync(libraryPath)) {

--- a/test/ffi/test-ffi-module.js
+++ b/test/ffi/test-ffi-module.js
@@ -154,6 +154,14 @@ test('ffi exports expected API surface', () => {
   assert.strictEqual(typeof ffi.types, 'object');
 });
 
+test('ffi.suffix matches the current platform', () => {
+  const ffi = require('node:ffi');
+  const expected = process.platform === 'win32' ? 'dll' :
+    process.platform === 'darwin' ? 'dylib' : 'so';
+
+  assert.strictEqual(ffi.suffix, expected);
+});
+
 test('ffi.types exports canonical type constants', () => {
   const ffi = require('node:ffi');
   const expected = {


### PR DESCRIPTION
`ffi-test-common.js` re-implemented the same branch that `ffi.suffix`
already exposes, risking drift from `lib/ffi.js`. `test-ffi-module.js`
only checked the key exists, not its value.

- Use `ffi.suffix` in `ffi-test-common.js` instead of re-implementing it
- Assert `ffi.suffix` matches the expected value per platform 

Related to #64805 (same fix for the docs)

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
