### PR TITLE
embedder: return empty pointer without builtin snapshot

### DIFF
--- a/src/api/embed_helpers.cc
+++ b/src/api/embed_helpers.cc
@@ -317,8 +317,13 @@ void EmbedderSnapshotData::DeleteSnapshotData::operator()(
 }
 
 EmbedderSnapshotData::Pointer EmbedderSnapshotData::BuiltinSnapshotData() {
-  return EmbedderSnapshotData::Pointer{new EmbedderSnapshotData(
-      SnapshotBuilder::GetEmbeddedSnapshotData(), false)};
+  const SnapshotData* snapshot_data =
+      SnapshotBuilder::GetEmbeddedSnapshotData();
+  if (snapshot_data == nullptr) {
+    return {};
+  }
+  return EmbedderSnapshotData::Pointer{
+      new EmbedderSnapshotData(snapshot_data, false)};
 }
 
 EmbedderSnapshotData::Pointer EmbedderSnapshotData::FromBlob(

--- a/src/node.h
+++ b/src/node.h
@@ -492,7 +492,8 @@ class EmbedderSnapshotData {
 
   // Return an EmbedderSnapshotData object that refers to the built-in
   // snapshot of Node.js. This can have been configured through e.g.
-  // --node-snapshot-main=entry.js.
+  // --node-snapshot-main=entry.js. If Node.js was built without a built-in
+  // snapshot, this returns an empty pointer.
   static Pointer BuiltinSnapshotData();
 
   // Return an EmbedderSnapshotData object that is based on an input file.


### PR DESCRIPTION
Avoid creating an EmbedderSnapshotData wrapper with null implementation when Node.js is built without a builtin snapshot. This ensures callers can reliably detect the unavailable snapshot through the public API.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
