### PR TITLE
http: fix writableFinished and 'finish' after write errors

### DIFF
--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -85,6 +85,9 @@ const kChunkedLength = Symbol('kChunkedLength');
 const kUniqueHeaders = Symbol('kUniqueHeaders');
 const kBytesWritten = Symbol('kBytesWritten');
 const kErrored = Symbol('errored');
+const kWritableFinished = Symbol('kWritableFinished');
+const kEndCallbacks = Symbol('kEndCallbacks');
+const kFlushError = Symbol('kFlushError');
 const kHighWaterMark = Symbol('kHighWaterMark');
 const kRejectNonStandardBodyWrites = Symbol('kRejectNonStandardBodyWrites');
 
@@ -153,6 +156,9 @@ function OutgoingMessage(options) {
   this._onPendingData = nop;
 
   this[kErrored] = null;
+  this[kWritableFinished] = false;
+  this[kEndCallbacks] = null;
+  this[kFlushError] = null;
   this[kHighWaterMark] = options?.highWaterMark ?? getDefaultHighWaterMark();
   this[kRejectNonStandardBodyWrites] = options?.rejectNonStandardBodyWrites ?? false;
 }
@@ -203,11 +209,7 @@ ObjectDefineProperty(OutgoingMessage.prototype, 'closed', {
 ObjectDefineProperty(OutgoingMessage.prototype, 'writableFinished', {
   __proto__: null,
   get() {
-    return (
-      this.finished &&
-      this.outputSize === 0 &&
-      (!this[kSocket] || this[kSocket].writableLength === 0)
-    );
+    return this[kWritableFinished];
   },
 });
 
@@ -1078,8 +1080,48 @@ OutgoingMessage.prototype.addTrailers = function addTrailers(headers) {
   }
 };
 
-function onFinish(outmsg) {
-  if (outmsg?.socket?._hadError) return;
+// Deliver end() callbacks, mirroring Writable: null on successful finish,
+// otherwise the error that prevented all data from being flushed.
+function flushEndCallbacks(msg, err) {
+  const callbacks = msg[kEndCallbacks];
+  if (callbacks === null)
+    return;
+  msg[kEndCallbacks] = null;
+  for (let i = 0; i < callbacks.length; i++)
+    callbacks[i](err);
+}
+
+function getEndCallbackError(msg) {
+  return msg[kErrored] ??
+    msg[kSocket]?.errored ??
+    new ERR_STREAM_DESTROYED('end');
+}
+
+function queueEndCallback(msg, callback) {
+  if (msg[kWritableFinished]) {
+    callback(new ERR_STREAM_ALREADY_FINISHED('end'));
+    return;
+  }
+  if (msg[kFlushError] !== null) {
+    process.nextTick(callback, msg[kFlushError]);
+    return;
+  }
+  msg[kEndCallbacks] ??= [];
+  msg[kEndCallbacks].push(callback);
+}
+
+function onFinish(outmsg, err) {
+  if (err ||
+      outmsg[kErrored] ||
+      outmsg[kSocket]?.errored ||
+      outmsg[kSocket]?._hadError) {
+    outmsg[kFlushError] = err ?? getEndCallbackError(outmsg);
+    flushEndCallbacks(outmsg, outmsg[kFlushError]);
+    return;
+  }
+
+  outmsg[kWritableFinished] = true;
+  flushEndCallbacks(outmsg, null);
   outmsg.emit('finish');
 }
 
@@ -1108,11 +1150,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     write_(this, chunk, encoding, null, true);
   } else if (this.finished) {
     if (typeof callback === 'function') {
-      if (!this.writableFinished) {
-        this.on('finish', callback);
-      } else {
-        callback(new ERR_STREAM_ALREADY_FINISHED('end'));
-      }
+      queueEndCallback(this, callback);
     }
     return this;
   } else if (!this._header) {
@@ -1125,7 +1163,7 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   }
 
   if (typeof callback === 'function')
-    this.once('finish', callback);
+    queueEndCallback(this, callback);
 
   if (strictContentLength(this) && this[kBytesWritten] !== this._contentLength) {
     throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(this[kBytesWritten], this._contentLength);

--- a/test/parallel/test-http-outgoing-end-multiple.js
+++ b/test/parallel/test-http-outgoing-end-multiple.js
@@ -10,8 +10,10 @@ const onWriteAfterEndError = common.mustCall((err) => {
 const server = http.createServer(common.mustCall(function(req, res) {
   res.end('testing ended state', common.mustCall());
   assert.strictEqual(res.writableCorked, 0);
+  // end() before 'finish' has been emitted queues the callback, which then
+  // reports the outcome of the flush, matching stream.Writable.
   res.end(common.mustCall((err) => {
-    assert.strictEqual(err.code, 'ERR_STREAM_ALREADY_FINISHED');
+    assert.strictEqual(err, null);
   }));
   assert.strictEqual(res.writableCorked, 0);
   res.end('end', onWriteAfterEndError);

--- a/test/parallel/test-http-outgoing-writableFinished.js
+++ b/test/parallel/test-http-outgoing-writableFinished.js
@@ -2,31 +2,130 @@
 const common = require('../common');
 const assert = require('assert');
 const http = require('http');
+const { Duplex } = require('stream');
 
-const server = http.createServer(common.mustCall(function(req, res) {
-  assert.strictEqual(res.writableFinished, false);
-  res
-    .on('finish', common.mustCall(() => {
-      assert.strictEqual(res.writableFinished, true);
-      server.close();
-    }))
-    .end();
-}));
+// writableFinished becomes true once all data has been flushed, immediately
+// before 'finish' is emitted.
+{
+  const server = http.createServer(common.mustCall(function(req, res) {
+    assert.strictEqual(res.writableFinished, false);
+    res
+      .on('finish', common.mustCall(() => {
+        assert.strictEqual(res.writableFinished, true);
+        server.close();
+      }))
+      .end();
+  }));
 
-server.listen(0);
+  server.listen(0);
 
-server.on('listening', common.mustCall(function() {
-  const clientRequest = http.request({
-    port: server.address().port,
-    method: 'GET',
-    path: '/'
+  server.on('listening', common.mustCall(function() {
+    const clientRequest = http.request({
+      port: server.address().port,
+      method: 'GET',
+      path: '/'
+    });
+
+    assert.strictEqual(clientRequest.writableFinished, false);
+    clientRequest
+      .on('finish', common.mustCall(() => {
+        assert.strictEqual(clientRequest.writableFinished, true);
+      }))
+      .end();
+    assert.strictEqual(clientRequest.writableFinished, false);
+  }));
+}
+
+// A request whose writes fail never becomes writableFinished and never emits
+// 'finish'; the end() callback receives the write error instead.
+{
+  const writeError = new Error('forced write failure');
+  const socket = new Duplex({
+    read() {},
+    write(chunk, encoding, callback) {
+      callback(writeError);
+    },
+  });
+  const failedRequest = http.request({
+    createConnection: common.mustCall(() => socket),
+    method: 'POST',
   });
 
-  assert.strictEqual(clientRequest.writableFinished, false);
-  clientRequest
-    .on('finish', common.mustCall(() => {
-      assert.strictEqual(clientRequest.writableFinished, true);
-    }))
-    .end();
-  assert.strictEqual(clientRequest.writableFinished, false);
-}));
+  failedRequest.on('finish', common.mustNotCall());
+  failedRequest.on('error', common.mustCall((err) => {
+    assert.strictEqual(err, writeError);
+  }));
+  failedRequest.on('close', common.mustCall(() => {
+    assert.strictEqual(failedRequest.writableFinished, false);
+  }));
+
+  failedRequest.write('body', common.mustCall((err) => {
+    assert.strictEqual(err, writeError);
+  }));
+  failedRequest.end(common.mustCall((err) => {
+    assert.ok(err instanceof Error);
+    assert.strictEqual(failedRequest.writableFinished, false);
+
+    // Ending again after the flush has failed still reports the failure.
+    failedRequest.end(common.mustCall((endAgainErr) => {
+      assert.strictEqual(endAgainErr, err);
+    }));
+  }));
+}
+
+// The same for a server response whose flush fails (e.g. the connection is
+// reset mid-flush). Unlike the client case, the error here only ever
+// surfaces through the socket write callbacks.
+{
+  const writeError = new Error('forced write failure');
+  const socket = new Duplex({
+    read() {},
+    write(chunk, encoding, callback) {
+      callback(writeError);
+    },
+  });
+
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('finish', common.mustNotCall());
+    res.on('close', common.mustCall(() => {
+      assert.strictEqual(res.writableFinished, false);
+    }));
+    res.end('hello', common.mustCall((err) => {
+      assert.strictEqual(err, writeError);
+      assert.strictEqual(res.writableFinished, false);
+    }));
+  }));
+
+  server.emit('connection', socket);
+  socket.push('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n');
+}
+
+// The same when end() happens after the failed write, with no data left to
+// flush: the write failure must still be detected even though end() itself
+// has nothing to send.
+{
+  const writeError = new Error('forced write failure');
+  const socket = new Duplex({
+    read() {},
+    write(chunk, encoding, callback) {
+      callback(writeError);
+    },
+  });
+
+  const server = http.createServer(common.mustCall((req, res) => {
+    res.on('finish', common.mustNotCall());
+    res.setHeader('Content-Length', '5');
+    res.write('hello', common.mustCall((err) => {
+      assert.strictEqual(err, writeError);
+    }));
+    setImmediate(common.mustCall(() => {
+      res.end(common.mustCall((err) => {
+        assert.strictEqual(err, writeError);
+        assert.strictEqual(res.writableFinished, false);
+      }));
+    }));
+  }));
+
+  server.emit('connection', socket);
+  socket.push('GET / HTTP/1.1\r\nHost: example.com\r\n\r\n');
+}

--- a/test/parallel/test-stream-pipeline.js
+++ b/test/parallel/test-stream-pipeline.js
@@ -270,7 +270,11 @@ tmpdir.refresh();
 
 {
   const server = http.createServer(common.mustCallAtLeast((req, res) => {
-    pipeline(req, res, common.mustSucceed());
+    pipeline(req, res, common.mustCall((err) => {
+      // The client destroys the request body source before EOF below, so the
+      // echoed response cannot finish successfully either.
+      assert.strictEqual(err?.code, 'ERR_STREAM_PREMATURE_CLOSE');
+    }));
   }));
 
   server.listen(0, common.mustCall(() => {


### PR DESCRIPTION
On HTTP OutgoingMessages, only emit 'finish' and set writableFinished once all data has actually been flushed successfully, and make end() callbacks report the correct outcome like stream.Writable: called with null on finish, or with the error that prevented the flush.

This changes visible behaviour in some subtle ways, but I think exclusively in a more correct direction, which matches `Writable` everywhere else and matches the existing docs. Now, if an HTTP write calls end() but fails to actually flush the data, it will fail to finish, and the `end()` callback behaviour correctly matches. See the 2 tests that need changing here due to subtle changes in ordering & finish behaviour.

It's on the line, but I'd really rather not make this semver major because it's a prerequisite for https://github.com/nodejs/node/pull/64566 fixing https://github.com/nodejs/node/issues/64272. That's a regression on v24 & v26 today, due to changes in how libuv exposes ECONNRESET. To work around that change, we need an accurate signal for writableFinished, and we currently don't have one.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
