### PR TITLE
crypto: improve native error handling and key synchronization

### DIFF
--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -337,6 +337,10 @@ void ComputeSecret(const FunctionCallbackInfo<Value>& args) {
   }
 
   auto dp = dh.computeSecret(key);
+  if (!dp) {
+    return THROW_ERR_CRYPTO_OPERATION_FAILED(env,
+                                             "Failed to compute shared secret");
+  }
 
   Local<Value> buffer;
   if (DataPointerToBuffer(env, std::move(dp)).ToLocal(&buffer)) {
@@ -354,8 +358,9 @@ void SetPublicKey(const FunctionCallbackInfo<Value>& args) {
   if (!buf.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "buf is too big");
   BignumPointer num(buf.data(), buf.size());
-  CHECK(num);
-  CHECK(dh.setPublicKey(std::move(num)));
+  if (!num) return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid public key");
+  if (!dh.setPublicKey(std::move(num)))
+    return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid public key");
 }
 
 void SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
@@ -368,8 +373,9 @@ void SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   if (!buf.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "buf is too big");
   BignumPointer num(buf.data(), buf.size());
-  CHECK(num);
-  CHECK(dh.setPrivateKey(std::move(num)));
+  if (!num) return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid private key");
+  if (!dh.setPrivateKey(std::move(num)))
+    return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid private key");
 }
 
 void Check(const FunctionCallbackInfo<Value>& args) {

--- a/src/crypto/crypto_dh.cc
+++ b/src/crypto/crypto_dh.cc
@@ -358,8 +358,7 @@ void SetPublicKey(const FunctionCallbackInfo<Value>& args) {
   if (!buf.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "buf is too big");
   BignumPointer num(buf.data(), buf.size());
-  if (!num) return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid public key");
-  if (!dh.setPublicKey(std::move(num)))
+  if (!num || !dh.setPublicKey(std::move(num)))
     return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid public key");
 }
 
@@ -373,8 +372,7 @@ void SetPrivateKey(const FunctionCallbackInfo<Value>& args) {
   if (!buf.CheckSizeInt32()) [[unlikely]]
     return THROW_ERR_OUT_OF_RANGE(env, "buf is too big");
   BignumPointer num(buf.data(), buf.size());
-  if (!num) return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid private key");
-  if (!dh.setPrivateKey(std::move(num)))
+  if (!num || !dh.setPrivateKey(std::move(num)))
     return THROW_ERR_INVALID_ARG_VALUE(env, "Invalid private key");
 }
 

--- a/src/crypto/crypto_keys.cc
+++ b/src/crypto/crypto_keys.cc
@@ -952,10 +952,13 @@ KeyObjectData::KeyObjectData(std::nullptr_t)
 
 KeyObjectData::KeyObjectData(ByteSource symmetric_key)
     : key_type_(KeyType::kKeyTypeSecret),
+      mutex_(std::make_shared<Mutex>()),
       data_(std::make_shared<Data>(std::move(symmetric_key))) {}
 
 KeyObjectData::KeyObjectData(KeyType type, EVPKeyPointer&& pkey)
-    : key_type_(type), data_(std::make_shared<Data>(std::move(pkey))) {}
+    : key_type_(type),
+      mutex_(std::make_shared<Mutex>()),
+      data_(std::make_shared<Data>(std::move(pkey))) {}
 
 void KeyObjectData::Data::MemoryInfo(MemoryTracker* tracker) const {
   if (asymmetric_key) {

--- a/src/crypto/crypto_turboshake.cc
+++ b/src/crypto/crypto_turboshake.cc
@@ -469,7 +469,11 @@ bool TurboShakeTraits::DeriveBits(Environment* env,
                                   CryptoJobMode mode,
                                   CryptoErrorStore* errors) {
   CHECK_GT(params.output_length, 0);
-  char* buf = MallocOpenSSL<char>(params.output_length);
+  char* buf = static_cast<char*>(OPENSSL_malloc(params.output_length));
+  if (buf == nullptr) {
+    errors->Insert(NodeCryptoError::ALLOCATION_FAILED);
+    return false;
+  }
 
   const uint8_t* input = reinterpret_cast<const uint8_t*>(params.data.data());
   size_t input_len = params.data.size();
@@ -595,7 +599,11 @@ bool KangarooTwelveTraits::DeriveBits(Environment* env,
     return false;
   }
 
-  char* buf = MallocOpenSSL<char>(params.output_length);
+  char* buf = static_cast<char*>(OPENSSL_malloc(params.output_length));
+  if (buf == nullptr) {
+    errors->Insert(NodeCryptoError::ALLOCATION_FAILED);
+    return false;
+  }
 
   switch (params.variant) {
     case KangarooTwelveVariant::KT128:


### PR DESCRIPTION
3 improvements in `src/crypto`

- report DH failures instead of aborting or returning an empty secret
- create KeyObjectData mutex before sharing key data so every copy uses one lock
- return an operation error when XOF output allocation fails