### PR TITLE
crypto: improve argument validation and error messages

### DIFF
--- a/lib/internal/crypto/argon2.js
+++ b/lib/internal/crypto/argon2.js
@@ -169,7 +169,7 @@ function check(algorithm, parameters) {
   if (parameters.secret === undefined) {
     secret = new Uint8Array(0);
   } else {
-    secret = getArrayBufferOrView(parameters.secret);
+    secret = getArrayBufferOrView(parameters.secret, 'parameters.secret');
     validateInteger(secret.byteLength, 'parameters.secret.byteLength', 0, MAX_POSITIVE_UINT_32);
   }
 
@@ -177,7 +177,7 @@ function check(algorithm, parameters) {
   if (parameters.associatedData === undefined) {
     associatedData = new Uint8Array(0);
   } else {
-    associatedData = getArrayBufferOrView(parameters.associatedData);
+    associatedData = getArrayBufferOrView(parameters.associatedData, 'parameters.associatedData');
     validateInteger(associatedData.byteLength, 'parameters.associatedData.byteLength', 0, MAX_POSITIVE_UINT_32);
   }
 

--- a/lib/internal/crypto/keygen.js
+++ b/lib/internal/crypto/keygen.js
@@ -209,10 +209,10 @@ const nidOnlyKeyPairs = {
 function createJob(mode, type, options) {
   validateString(type, 'type');
 
-  const encoding = new SafeArrayIterator(parseKeyEncoding(type, options));
-
   if (options !== undefined)
     validateObject(options, 'options');
+
+  const encoding = new SafeArrayIterator(parseKeyEncoding(type, options));
 
   switch (type) {
     case 'rsa':

--- a/lib/internal/crypto/keys.js
+++ b/lib/internal/crypto/keys.js
@@ -470,7 +470,9 @@ function parseKeyEncoding(enc, keyType, isPublic, objName) {
             encodingNames[type], 'does not support encryption');
         }
       } else if (passphrase !== undefined) {
-        throw new ERR_INVALID_ARG_VALUE(option('cipher', objName), cipher);
+        throw new ERR_INVALID_ARG_VALUE(
+          option('cipher', objName), cipher,
+          'is required when a passphrase is specified');
       }
     }
 

--- a/lib/internal/crypto/x509.js
+++ b/lib/internal/crypto/x509.js
@@ -193,7 +193,7 @@ class X509Certificate {
     if (value === undefined) {
       const cert = this[kHandle].getIssuerCert();
       if (cert)
-        value = new InternalX509Certificate(this[kHandle].getIssuerCert());
+        value = new InternalX509Certificate(cert);
       this[kInternalState].set('issuerCertificate', value);
     }
     return value;

--- a/test/parallel/test-crypto-argon2.js
+++ b/test/parallel/test-crypto-argon2.js
@@ -140,6 +140,18 @@ for (const key of Object.keys(defaults)) {
   assert.throws(() => crypto.argon2Sync('argon2id', parameters), expected);
 }
 
+for (const key of ['secret', 'associatedData']) {
+  const expected = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    message: new RegExp(`"parameters\\.${key}"`),
+  };
+  for (const value of [123, null, true, {}, []]) {
+    const parameters = { ...defaults, [key]: value };
+    assert.throws(() => crypto.argon2('argon2id', parameters, () => {}), expected);
+    assert.throws(() => crypto.argon2Sync('argon2id', parameters), expected);
+  }
+}
+
 {
   const expected = { code: 'ERR_INVALID_ARG_TYPE' };
   assert.throws(() => crypto.argon2(), expected);

--- a/test/parallel/test-crypto-key-objects.js
+++ b/test/parallel/test-crypto-key-objects.js
@@ -1014,7 +1014,8 @@ if (!process.features.openssl_is_boringssl) {
   }, {
     name: 'TypeError',
     code: 'ERR_INVALID_ARG_VALUE',
-    message: "The property 'options.cipher' is invalid. Received undefined"
+    message: "The property 'options.cipher' is required when a " +
+      'passphrase is specified. Received undefined',
   });
 }
 

--- a/test/parallel/test-crypto-keygen.js
+++ b/test/parallel/test-crypto-keygen.js
@@ -89,6 +89,21 @@ const isBoringSSL = process.features.openssl_is_boringssl;
     message: 'The "options" argument must be of type object. ' +
       'Received type number (0)'
   });
+
+  for (const type of ['rsa', 'ed25519']) {
+    assert.throws(() => generateKeyPairSync(type, null), {
+      name: 'TypeError',
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "options" argument must be of type object. ' +
+        'Received null'
+    });
+    assert.throws(() => generateKeyPair(type, null, common.mustNotCall()), {
+      name: 'TypeError',
+      code: 'ERR_INVALID_ARG_TYPE',
+      message: 'The "options" argument must be of type object. ' +
+        'Received null'
+    });
+  }
 }
 
 {


### PR DESCRIPTION
- Report the correct parameter name for invalid optional inputs in `parseKeyEncoding`.
- Reject null options with ERR_INVALID_ARG_TYPE in `generateKeyPair(Sync)`.
- Avoid a second native call when reading the issuer certificate in `X509Certificate`.
- Explain that a cipher is required when a passphrase is provided in `parseKeyEncoding`.