### PR TITLE
util: fix inspect crash when getter returns a function

### DIFF
--- a/lib/internal/util/inspect.js
+++ b/lib/internal/util/inspect.js
@@ -2576,7 +2576,7 @@ function formatProperty(ctx, value, recurseTimes, key, type, desc,
         const tmp = FunctionPrototypeCall(desc.get, original);
         if (tmp === null) {
           str = `${s(`[${label}:`, sp)} ${s('null', 'null')}${s(']', sp)}`;
-        } else if (typeof tmp === 'object') {
+        } else if (typeof tmp === 'object' || typeof tmp === 'function') {
           str = `${s(`[${label}]`, sp)} ${formatValue(ctx, tmp, recurseTimes)}`;
         } else {
           const primitive = formatPrimitive(s, tmp, ctx);

--- a/test/parallel/test-util-inspect.js
+++ b/test/parallel/test-util-inspect.js
@@ -2596,6 +2596,26 @@ assert.strictEqual(
       "'foobar', { x: 1 } },\n  inc: [Getter: NaN]\n}");
 }
 
+// Property getter returning a function.
+{
+  const getterFn = {
+    get getString() { return 'foo'; },
+    string: 'foo',
+    get getObject() { return { nested: true }; },
+    object: { nested: true },
+    get getFunction() { return function fn() {}; },
+    function: function fn() {},
+  };
+  assert.strictEqual(
+    inspect(getterFn, { getters: true }),
+    "{ getString: [Getter: 'foo'],\n" +
+    "  string: 'foo',\n" +
+    '  getObject: [Getter] { nested: true },\n' +
+    "  object: { nested: true },\n" +
+    '  getFunction: [Getter] [Function: fn],\n' +
+    '  function: [Function: fn] }');
+}
+
 // Property getter throwing an error.
 {
   const error = new Error('Oops');


### PR DESCRIPTION
When a property getter returns a function, `formatProperty` incorrectly
routes the function value to `formatPrimitive`, which does not handle
functions and falls through to `Symbol.prototype.toString()`, causing a
TypeError.

Fix by treating getter-returned functions the same as getter-returned
objects in `formatProperty`, routing them through `formatValue` which
properly formats functions.

**Before (broken):**
```
getFunction: [Getter: <Inspection threw (TypeError: ...)>]
```

**After (fixed):**
```
getFunction: [Getter] [Function: fn]
```

**Changes:**
- `lib/internal/util/inspect.js`: +1/-1 — added `|| typeof tmp === 'function'` to the object-branch condition
- `test/parallel/test-util-inspect.js`: +20 — regression test reproducing the scenario

Fixes: https://github.com/nodejs/node/issues/64838