### PR TITLE
src: include declaration header in threadsafe COW inl

### DIFF
--- a/src/node_threadsafe_cow-inl.h
+++ b/src/node_threadsafe_cow-inl.h
@@ -1,6 +1,8 @@
 #ifndef SRC_NODE_THREADSAFE_COW_INL_H_
 #define SRC_NODE_THREADSAFE_COW_INL_H_
 
+#include "node_threadsafe_cow.h"
+
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
 namespace node {

--- a/src/node_threadsafe_cow.h
+++ b/src/node_threadsafe_cow.h
@@ -3,6 +3,7 @@
 
 #if defined(NODE_WANT_INTERNALS) && NODE_WANT_INTERNALS
 
+#include "node_mutex.h"
 #include "util.h"
 #include "uv.h"
 


### PR DESCRIPTION
Ensure node_threadsafe_cow-inl.h can be included independently and follows the header inclusion convention documented in src/README.md

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
