### PR TITLE
src: constrain COW forwarding constructors

### DIFF
--- a/src/node_threadsafe_cow.h
+++ b/src/node_threadsafe_cow.h
@@ -6,7 +6,9 @@
 #include "util.h"
 #include "uv.h"
 
-#include <memory>   // std::shared_ptr<T>
+#include <concepts>
+#include <memory>  // std::shared_ptr<T>
+#include <type_traits>
 #include <utility>  // std::forward<T>
 
 namespace node {
@@ -17,6 +19,8 @@ template <typename T>
 class CopyOnWrite final {
  public:
   template <typename... Args>
+    requires(!(sizeof...(Args) == 1 &&
+               (std::same_as<CopyOnWrite, std::remove_cvref_t<Args>> || ...)))
   explicit CopyOnWrite(Args&&... args)
       : data_(std::make_shared<T>(std::forward<Args>(args)...)) {}
 
@@ -57,6 +61,10 @@ class ThreadsafeCopyOnWrite final {
 
  public:
   template <typename... Args>
+    requires(
+        !(sizeof...(Args) == 1 &&
+          (std::same_as<ThreadsafeCopyOnWrite, std::remove_cvref_t<Args>> ||
+           ...)))
   ThreadsafeCopyOnWrite(Args&&... args)
       : impl_(T(std::forward<Args>(args)...)) {}
 

--- a/test/cctest/test_per_process.cc
+++ b/test/cctest/test_per_process.cc
@@ -6,6 +6,8 @@
 
 #include <string>
 
+using node::CopyOnWrite;
+using node::ThreadsafeCopyOnWrite;
 using node::builtins::BuiltinLoader;
 using node::builtins::BuiltinSourceMap;
 
@@ -17,6 +19,26 @@ class PerProcessTest : public ::testing::Test {
 };
 
 namespace {
+
+TEST(CopyOnWriteTest, CopiesFromNonConstLvalue) {
+  CopyOnWrite<int> original(42);
+  CopyOnWrite<int> copy(original);
+
+  *copy.write() = 43;
+
+  EXPECT_EQ(*original, 42);
+  EXPECT_EQ(*copy, 43);
+}
+
+TEST(ThreadsafeCopyOnWriteTest, CopiesFromNonConstLvalue) {
+  ThreadsafeCopyOnWrite<int> original(42);
+  ThreadsafeCopyOnWrite<int> copy(original);
+
+  *copy.write() = 43;
+
+  EXPECT_EQ(*original.read(), 42);
+  EXPECT_EQ(*copy.read(), 43);
+}
 
 TEST_F(PerProcessTest, EmbeddedSources) {
   const auto& sources = PerProcessTest::get_sources_for_test();


### PR DESCRIPTION
Exclude the wrapper type from the forwarding constructors so that non-const lvalue copies select the copy constructor.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
