### PR TITLE
doc: add contributing detail for git Signed-off-by trailer

### DIFF
--- a/doc/contributing/pull-requests.md
+++ b/doc/contributing/pull-requests.md
@@ -151,7 +151,7 @@ to review changes that are split across multiple commits.
 
 ```bash
 git add my/changed/files
-git commit
+git commit -s
 ```
 
 Multiple commits often get squashed when they are landed. See the
@@ -205,6 +205,9 @@ A good commit message should describe what changed and why.
    and at least one should match the author information in the commit metadata.
    This rule does not apply to dependency updates (e.g. cherry-picks), release
    commits, or backport commits.
+
+   [`git commit -s`][git commit -s] (with lowercase `s`) adds a
+   `Signed-off-by` trailer at the end of the commit log message.
 
 Sample final commit message after landing:
 
@@ -312,7 +315,7 @@ GitHub will automatically update the pull request.
 
 ```bash
 git add my/changed/files
-git commit
+git commit -s
 git push origin my-branch
 ```
 
@@ -617,6 +620,7 @@ More than one subsystem may be valid for any particular issue or pull request.
 [approved]: #getting-approvals-for-your-pull-request
 [benchmark results]: writing-and-running-benchmarks.md
 [collaborator guide]: collaborator-guide.md
+[git commit -s]: https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s
 [guide for writing tests in Node.js]: writing-tests.md
 [hiding-a-comment]: https://help.github.com/articles/managing-disruptive-comments/#hiding-a-comment
 [https://ci.nodejs.org/]: https://ci.nodejs.org/


### PR DESCRIPTION
Fixes: #64799

## Situation

The instructions under [contributing > Pull requests > Commit message guidelines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines) document section are formulated without reference to the [`git commit -s`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) option which provides for assisted addition of the required `Signed-off-by` trailer:

---

6. Your commit must contain the `Signed-off-by` line with your name and email
   address as an acknowledgement that you agree to the [Developer Certificate of Origin](https://github.com/nodejs/node/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11).
   Bot generated commits are exempt from this requirement. If a commit has
   multiple authors, the `Signed-off-by` line should be added for each author;
   and at least one should match the author information in the commit metadata.
   This rule does not apply to dependency updates (e.g. cherry-picks), release
   commits, or backport commits.

---

The examples of `git commit` also do not show the use of the `-s` option.

It is however mentioned in the [contributing > Guides and FAQs for first-time contributors > Going through the pull request review process](https://github.com/nodejs/node/blob/main/doc/contributing/first-contributions.md#going-through-the-pull-request-review-process)

## Change

Add instructions to [contributing > Pull requests > Commit message guidelines](https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines) for the [`git commit -s`](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s) option.

Add the `-s` option to the existing `git commit` examples.

[git commit -s](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--s), lower case `s` for Signed-off-by, could be confused with: 

[git commit -S](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt--Skey-id), upper case `S` for `--gpg-sign`

so there is a note emphasising that lowercase `s` should be used.
