### PR TITLE
ffi: support SharedArrayBuffer in getRawPointer

### DIFF
--- a/doc/api/ffi.md
+++ b/doc/api/ffi.md
@@ -706,7 +706,7 @@ available storage. This function does not allocate memory on its own.
 added: v26.1.0
 -->
 
-* `source` {Buffer|ArrayBuffer|ArrayBufferView}
+* `source` {Buffer|ArrayBuffer|SharedArrayBuffer|ArrayBufferView}
 * Returns: {bigint}
 
 Returns the raw memory address of JavaScript-managed byte storage.

--- a/src/ffi/data.cc
+++ b/src/ffi/data.cc
@@ -739,7 +739,8 @@ void GetRawPointer(const FunctionCallbackInfo<Value>& args) {
   if (args.Length() < 1) {
     THROW_ERR_INVALID_ARG_TYPE(
         env,
-        "The first argument must be a Buffer, ArrayBuffer, or ArrayBufferView");
+        "The first argument must be a Buffer, ArrayBuffer, SharedArrayBuffer, "
+        "or ArrayBufferView");
     return;
   }
 
@@ -758,9 +759,10 @@ void GetRawPointer(const FunctionCallbackInfo<Value>& args) {
     store = args[0].As<ArrayBufferView>()->Buffer()->GetBackingStore();
     offset = args[0].As<ArrayBufferView>()->ByteOffset();
   } else {
-    THROW_ERR_INVALID_ARG_TYPE(env,
-                               "The first argument must be a Buffer, "
-                               "ArrayBuffer, or ArrayBufferView");
+    THROW_ERR_INVALID_ARG_TYPE(
+        env,
+        "The first argument must be a Buffer, "
+        "ArrayBuffer, SharedArrayBuffer, or ArrayBufferView");
     return;
   }
 

--- a/test/ffi/test-ffi-memory.js
+++ b/test/ffi/test-ffi-memory.js
@@ -125,18 +125,25 @@ test('ffi getRawPointer returns raw addresses for byte sources', () => {
   const buffer = Buffer.from([1, 2, 3]);
   const arrayBuffer = new Uint8Array([4, 5, 6, 7]).buffer;
   const view = new Uint8Array(arrayBuffer, 2);
+  const sharedArrayBuffer = new SharedArrayBuffer(4);
+  const sharedView = new Uint8Array(sharedArrayBuffer, 2);
 
   const bufferPointer = ffi.getRawPointer(buffer);
   const arrayBufferPointer = ffi.getRawPointer(arrayBuffer);
   const viewPointer = ffi.getRawPointer(view);
+  const sharedArrayBufferPointer = ffi.getRawPointer(sharedArrayBuffer);
+  const sharedViewPointer = ffi.getRawPointer(sharedView);
 
   assert.strictEqual(typeof bufferPointer, 'bigint');
   assert.strictEqual(typeof arrayBufferPointer, 'bigint');
   assert.strictEqual(typeof viewPointer, 'bigint');
+  assert.strictEqual(typeof sharedArrayBufferPointer, 'bigint');
+  assert.strictEqual(typeof sharedViewPointer, 'bigint');
 
   assert.strictEqual(bufferPointer, symbols.pointer_to_usize(buffer));
   assert.strictEqual(arrayBufferPointer, symbols.pointer_to_usize(arrayBuffer));
   assert.strictEqual(viewPointer, arrayBufferPointer + 2n);
+  assert.strictEqual(sharedViewPointer, sharedArrayBufferPointer + 2n);
 });
 
 test('ffi exportString and exportBuffer copy data into native memory', () => {


### PR DESCRIPTION
Add test coverage and documentation for `ffi.getRawPointer()` support for `SharedArrayBuffer`.

`getRawPointer()` already supported `SharedArrayBuffer` sources, but this behavior was not covered by tests or documented.

Note:

`symbols.pointer_to_usize(sharedArrayBuffer)` is not used in this test because it goes through the FFI pointer argument conversion path. The current implementation in `src/ffi/types.cc` only handles `ArrayBuffer` for pointer arguments and does not support `SharedArrayBuffer`.