### PR TITLE
test_runner: fix env option validation

### DIFF
--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -908,7 +908,7 @@ function run(options = kEmptyObject) {
   }
 
   if (env != null) {
-    validateObject(env);
+    validateObject(env, 'options.env');
 
     if (isolation === 'none') {
       throw new ERR_INVALID_ARG_VALUE('options.env', env, 'is not supported with isolation=\'none\'');

--- a/test/parallel/test-runner-run.mjs
+++ b/test/parallel/test-runner-run.mjs
@@ -673,6 +673,14 @@ describe('require(\'node:test\').run', { concurrency: true }, () => {
         }));
     });
 
+    it('should only allow object in options.env', () => {
+      [Symbol(), [], () => {}, 0, 1, 0n, 1n, '', '1', true, false]
+        .forEach((env) => assert.throws(() => run({ files: [], env }), {
+          code: 'ERR_INVALID_ARG_TYPE',
+          message: /The "options\.env" property must be of type object\./
+        }));
+    });
+
     it('should not allow files and globPatterns used together', () => {
       assert.throws(() => run({ files: ['a.js'], globPatterns: ['*.js'] }), {
         code: 'ERR_INVALID_ARG_VALUE'


### PR DESCRIPTION
Invalid values passed to `run({ env })` currently throw
`ERR_INTERNAL_ASSERTION` because the option name is missing from the
`validateObject()` call.

This passes `options.env` to the validator so callers receive
`ERR_INVALID_ARG_TYPE` instead, and adds a regression test for invalid
values.

Tests: `tools/test.py test/parallel/test-runner-run.mjs`