### PR TITLE
child_process: fix fatal error in ParseStdioOptions

### DIFF
--- a/lib/internal/main/test_runner.js
+++ b/lib/internal/main/test_runner.js
@@ -31,6 +31,8 @@ if (isUsingInspector() && options.isolation === 'process') {
 }
 
 options.globPatterns = ArrayPrototypeSlice(process.argv, 1);
+options.cwd = process.cwd();
+options.execArgv = process.execArgv;
 
 debug('test runner configuration:', options);
 run(options).on('test:summary', (data) => {

--- a/lib/internal/test_runner/runner.js
+++ b/lib/internal/test_runner/runner.js
@@ -207,7 +207,7 @@ function getRunArgs(path, { forceExit,
    */
   const nodeOptionsSet = new SafeSet(processNodeOptions);
   const unknownProcessExecArgv = ArrayPrototypeFilter(
-    process.execArgv,
+    execArgv,
     (arg, i, arr) => !nodeOptionsSet.has(arg) && filterExecArgv(arg, i, arr),
   );
   ArrayPrototypePushApply(runArgs, unknownProcessExecArgv);
@@ -730,7 +730,7 @@ function run(options = kEmptyObject) {
     randomSeed: suppliedRandomSeed,
     execArgv = [],
     argv = [],
-    cwd = process.cwd(),
+    cwd = '.',
     rerunFailuresFilePath,
     env,
   } = options;

--- a/src/process_wrap.cc
+++ b/src/process_wrap.cc
@@ -149,6 +149,10 @@ class ProcessWrap : public HandleWrap {
       if (!stdios->Get(context, i).ToLocal(&val)) {
         return Nothing<void>();
       }
+      if (!val->IsObject()) {
+        env->ThrowTypeError("stdio must be an object");
+        return Nothing<void>();
+      }
       Local<Object> stdio = val.As<Object>();
       Local<Value> type;
       if (!stdio->Get(context, env->type_string()).ToLocal(&type)) {


### PR DESCRIPTION
Fixes #56531. Prevents a v8::ToLocalChecked Empty MaybeLocal crash caused by prototype pollution of Arrays.