### PR TITLE
doc: add missing float32/float64 FFI type names

### DIFF
--- a/doc/api/ffi.md
+++ b/doc/api/ffi.md
@@ -62,16 +62,17 @@ FFI signatures use string type names.
 Supported type names:
 
 * `void`
+* `char`
 * `i8`, `int8`
-* `u8`, `uint8`, `bool`, `char`
+* `u8`, `uint8`, `bool`
 * `i16`, `int16`
 * `u16`, `uint16`
 * `i32`, `int32`
 * `u32`, `uint32`
 * `i64`, `int64`
 * `u64`, `uint64`
-* `f32`, `float`
-* `f64`, `double`
+* `f32`, `float`, `float32`
+* `f64`, `double`, `float64`
 * `pointer`, `ptr`
 * `string`, `str`
 * `buffer`


### PR DESCRIPTION
`ToFFIType()` accepts `float32` and `float64` as aliases for `float` and `double`, but the supported type names list never included them. They were added to the parser in #62892, which only touched `src/ffi/types.cc`, so the same section lists both as `ffi.types` constant values a few lines below a list that omits them.

Also splits `char` onto its own line. `u8`, `uint8` and `bool` always map to `ffi_type_uint8`, whereas `char` maps to `ffi_type_sint8` or `ffi_type_uint8` depending on the platform, as the paragraph below the list already documents.

#64848 proposes removing these aliases entirely; this only makes the list match what `ToFFIType()` accepts today, and those lines can go away with the aliases if that lands.


Refs: https://github.com/nodejs/node/pull/62892
Refs: https://github.com/nodejs/node/issues/64848