### PR TITLE
test_runner: flush report stream before force exit

### DIFF
--- a/lib/internal/test_runner/test.js
+++ b/lib/internal/test_runner/test.js
@@ -85,6 +85,7 @@ const {
 } = require('internal/validators');
 const {
   clearTimeout,
+  setImmediate,
   setTimeout,
 } = require('timers');
 const { TIMEOUT_MAX } = require('internal/timers');
@@ -1476,7 +1477,19 @@ class Test extends AsyncResource {
             if (!destination.closed && typeof destination.close === 'function') {
               destination.close(resolve);
             } else {
-              resolve();
+              // The destination has no close() to await - for example a child
+              // process's stdout, which is a pipe to the test runner's parent
+              // process. Writes to a pipe are asynchronous, so the process.exit()
+              // below can truncate buffered output and silently drop test
+              // results (https://github.com/nodejs/node/issues/64833). Switch the
+              // underlying handle to blocking so any queued bytes are flushed to
+              // the OS, then end the stream and wait for it to finish before
+              // exiting.
+              if (destination._handle &&
+                  typeof destination._handle.setBlocking === 'function') {
+                destination._handle.setBlocking(true);
+              }
+              destination.end(resolve);
             }
           });
         }));
@@ -1484,6 +1497,11 @@ class Test extends AsyncResource {
 
       this.harness.teardown();
       await SafePromiseAllReturnVoid(promises);
+      // Yield once more so the event loop can drain any report events that are
+      // still in flight from child processes (their stdout is piped into this
+      // process) before we force the exit. The blocking flush above guarantees
+      // the writable side; this covers the readable side on the parent.
+      await new Promise((resolve) => setImmediate(resolve));
       process.exit();
     }
   }

--- a/test/parallel/test-runner-force-exit-no-verdict-loss.js
+++ b/test/parallel/test-runner-force-exit-no-verdict-loss.js
@@ -1,0 +1,71 @@
+'use strict';
+require('../common');
+const tmpdir = require('../common/tmpdir');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const { writeFileSync, mkdirSync, readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+// Regression test for https://github.com/nodejs/node/issues/64833.
+//
+// When --test-force-exit is combined with process isolation and concurrency,
+// each test file runs in a child process that streams its results back to the
+// parent over a pipe. Writes to a pipe are asynchronous, so a forced
+// process.exit() could truncate the still-flushing report stream, silently
+// dropping test verdicts while the process still exited with code 0.
+//
+// Generate several test files, each of which keeps itself alive with a ref'd
+// handle (so --test-force-exit is required to finish), then assert that every
+// single verdict survives the forced exit.
+
+const FILES = 12;
+const TESTS_PER_FILE = 1000;
+const EXPECTED = FILES * TESTS_PER_FILE;
+
+tmpdir.refresh();
+const testsDir = tmpdir.resolve('tests');
+mkdirSync(testsDir);
+
+for (let f = 0; f < FILES; f++) {
+  let body = "'use strict';\n";
+  body += "const { test } = require('node:test');\n";
+  // A ref'd handle keeps the child alive so it never exits on its own; only
+  // --test-force-exit ends it, forcing a process.exit() while the child's
+  // stdout may still be flushing verdicts to the parent.
+  body += 'setInterval(() => {}, 1_000_000);\n';
+  for (let t = 0; t < TESTS_PER_FILE; t++) {
+    body += `test('f${f}_t${t}', () => {});\n`;
+  }
+  writeFileSync(join(testsDir, `f${f}.test.js`), body);
+}
+
+// Write the aggregated report to a file rather than piping it through
+// spawnSync (12k TAP lines would exceed the default maxBuffer). Running from
+// within testsDir lets the runner auto-discover the *.test.js files.
+const destination = tmpdir.resolve('out.tap');
+const args = [
+  '--test',
+  '--test-force-exit',
+  '--test-concurrency=16',
+  '--test-reporter=tap',
+  `--test-reporter-destination=${destination}`,
+];
+const child = spawnSync(process.execPath, args, { encoding: 'utf8', cwd: testsDir });
+
+assert.strictEqual(
+  child.status,
+  0,
+  `unexpected exit code ${child.status} (signal ${child.signal})\n${child.stderr}`,
+);
+
+const output = readFileSync(destination, 'utf8');
+const pass = output.match(/# pass (\d+)/);
+const fail = output.match(/# fail (\d+)/);
+assert.notStrictEqual(pass, null, `missing pass summary in output:\n${output}`);
+assert.strictEqual(
+  Number(pass[1]),
+  EXPECTED,
+  `expected ${EXPECTED} passing verdicts but only ${pass[1]} reached the reporter ` +
+  `(force-exit truncated the child -> parent report stream)`,
+);
+assert.strictEqual(Number(fail?.[1]), 0, `unexpected failures:\n${output}`);


### PR DESCRIPTION
## Summary

Fixes: https://github.com/nodejs/node/issues/64833

When `--test-force-exit` is used together with process isolation, each test file runs in a child process that streams its results back to the test runner's parent process over its `stdout`, which is a pipe. Writes to a pipe are asynchronous, so the `process.exit()` issued on force exit could quit the process while report frames were still buffered in the pipe. The trailing `test:pass` / `test:fail` events were silently dropped, yet the process still exited with code `0` — so verdicts disappeared with no error and no failing exit status.

The flush loop added in #55099 only drains reporter destinations that expose a `close()` method (for example file destinations). A pipe has no `close()`, so that branch resolved immediately without flushing anything, leaving the async pipe writes to be truncated by the exit. This is why the loss only reproduces where the pipe is non-blocking (Linux); on Windows named pipes, TTYs, and file destinations the writes are effectively blocking, so the output looked clean.

## Fix

In the force-exit path, for a destination that has no `close()` (the child-process pipe case), switch the underlying handle to blocking with `_handle.setBlocking(true)` — the same idiom Node already uses before exit in `lib/net.js` and `lib/tty.js` — then `end()` the stream and await it, so any queued bytes are flushed to the OS before the process exits. Existing file destinations continue to use the `close()` path unchanged.

Additionally, yield once via `setImmediate` after tearing down the harness and before `process.exit()`, so report events that have already arrived on the parent's readable side get dispatched to the reporters before exit. This part follows the approach proposed in #64857 by @NeverBetterEnough; on its own a single tick is probabilistic under concurrency and did not fully eliminate the loss in my testing, but combined with the blocking flush the result is deterministic.

## Test

Adds `test/parallel/test-runner-force-exit-no-verdict-loss.js`, which generates 12 files of 1000 tests each and runs them with `--test-force-exit` at `--test-concurrency=16`, then asserts that all 12000 verdicts are present in the reporter output and the process exits `0`. The test fails on `main` (e.g. `11532 !== 12000`) and passes with this change. Existing `test-runner-force-exit*` tests, including the one from #55099, continue to pass.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
