### PR TITLE
dns: validate address type in lookupService

### DIFF
--- a/lib/dns.js
+++ b/lib/dns.js
@@ -83,6 +83,7 @@ const {
   validateNumber,
   validateOneOf,
   validatePort,
+  validateString,
   validateStringWithoutNullBytes,
 } = require('internal/validators');
 
@@ -268,6 +269,8 @@ function onlookupservice(err, hostname, service) {
 function lookupService(address, port, callback) {
   if (arguments.length !== 3)
     throw new ERR_MISSING_ARGS('address', 'port', 'callback');
+
+  validateString(address, 'address');
 
   if (isIP(address) === 0)
     throw new ERR_INVALID_ARG_VALUE('address', address);

--- a/lib/internal/dns/promises.js
+++ b/lib/internal/dns/promises.js
@@ -282,6 +282,8 @@ function lookupService(address, port) {
   if (arguments.length !== 2)
     throw new ERR_MISSING_ARGS('address', 'port');
 
+  validateString(address, 'address');
+
   if (isIP(address) === 0)
     throw new ERR_INVALID_ARG_VALUE('address', address);
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -377,6 +377,24 @@ assert.throws(() => {
   }, err);
 }
 
+{
+  const invalidAddress = Buffer.from('127.0.0.1');
+  const err = {
+    code: 'ERR_INVALID_ARG_TYPE',
+    name: 'TypeError',
+    message: 'The "address" argument must be of type string. ' +
+    'Received an instance of Buffer'
+  };
+
+  assert.throws(() => {
+    dnsPromises.lookupService(invalidAddress, 0);
+  }, err);
+
+  assert.throws(() => {
+    dns.lookupService(invalidAddress, 0, common.mustNotCall());
+  }, err);
+}
+
 [null, undefined, 65538, 'test', NaN, Infinity, Symbol(), 0n, true, false, '', () => {}, {}].forEach((port) => {
   const err = {
     code: 'ERR_SOCKET_BAD_PORT',


### PR DESCRIPTION
`dns.lookupService()` and `dns.promises.lookupService()` abort the process with a native assertion when `address` is a non-string that still coerces to a valid IP, like a `Buffer`. `isIP()` stringifies its argument, so the existing guard passes and the raw value reaches the C++ binding, where it trips `CHECK(args[1]->IsString())`. Validating that `address` is a string first, as `dgram` already does, makes a bad type throw `ERR_INVALID_ARG_TYPE` instead of crashing.

Fixes: https://github.com/nodejs/node/issues/64877
