### PR TITLE
tools: fix man-page generation on Windows

### DIFF
--- a/tools/doc/man-page.doc-kit.config.mjs
+++ b/tools/doc/man-page.doc-kit.config.mjs
@@ -5,7 +5,14 @@ import { fileURLToPath } from 'node:url';
 
 const root = new URL('../../', import.meta.url);
 
-const fromRoot = (path) => fileURLToPath(new URL(path, root));
+// POSIX separators, because `input` is a glob pattern and a backslash reads as
+// an escape character, which would mangle Windows paths into non-matches.
+const fromRoot = (path) =>
+  fileURLToPath(new URL(path, root)).replaceAll('\\', '/');
+
+// doc-kit only treats a value as local when it parses as a `file:` URL, and a
+// Windows drive letter parses as a URL scheme, so these must stay URLs.
+const urlFromRoot = (path) => new URL(path, root).href;
 
 export default {
   target: ['man-page'],
@@ -15,7 +22,7 @@ export default {
     output: fromRoot('tools/doc/.manpagecheck'),
 
     // Point every loadable URL at its local file so no network request is made.
-    changelog: fromRoot('CHANGELOG.md'),
-    index: fromRoot('doc/api/index.md'),
+    changelog: urlFromRoot('CHANGELOG.md'),
+    index: urlFromRoot('doc/api/index.md'),
   },
 };


### PR DESCRIPTION
I hit this while working on #64606, which changes `doc/api/cli.md` and so needs `doc/node.1` regenerated. I couldn't regenerate it natively on Windows at all - I had to run the generator from WSL to get an up-to-date man page committed.

Two separate path assumptions in `tools/doc/man-page.doc-kit.config.mjs`:

- `changelog`/`index` were native paths. doc-kit only reads a value from disk when it parses as a `file:` URL, and `E:` parses as a URL scheme (which is from where I tried to run this on Windows), so it tried to fetch them over the network and died with `TypeError: fetch failed`. Now passed as `file:` URLs.
- `input` is a glob pattern, where `\` is an escape character, so the native path matched no files. The run then spun indefinitely with no log output, which is why this wasn't obvious. Now uses POSIX separators.
