### PR TITLE
http: optimize corked writes and header pair tracking

### DIFF
--- a/benchmark/http/bench-parser.js
+++ b/benchmark/http/bench-parser.js
@@ -31,6 +31,8 @@ function main({ len, n }) {
   function newParser(type) {
     const parser = new HTTPParser();
     parser.initialize(type, {});
+    // Direct parsers bypass cleanParser(); use its production default.
+    parser.maxHeaderPairs = 2000;
 
     parser.headers = [];
 

--- a/benchmark/http/cork.js
+++ b/benchmark/http/cork.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const common = require('../common.js');
+
+const bench = common.createBenchmark(main, {
+  type: ['bytes', 'buffer'],
+  len: [64, 1024],
+  chunks: [4, 16],
+  c: [50],
+  duration: 5,
+});
+
+function main({ type, len, chunks, c, duration }) {
+  const http = require('http');
+  const chunk = type === 'bytes' ? 'a'.repeat(len) : Buffer.alloc(len, 'a');
+
+  const server = http.createServer((req, res) => {
+    res.cork();
+    for (let i = 0; i < chunks; i++) {
+      res.write(chunk);
+    }
+    res.uncork();
+    res.end();
+  });
+
+  server.listen(0, () => {
+    bench.http({
+      connections: c,
+      duration,
+      port: server.address().port,
+    }, () => {
+      server.close();
+    });
+  });
+}

--- a/lib/_http_outgoing.js
+++ b/lib/_http_outgoing.js
@@ -290,45 +290,59 @@ OutgoingMessage.prototype.cork = function cork() {
   }
 };
 
-OutgoingMessage.prototype.uncork = function uncork() {
-  this[kCorked]--;
-  if (this[kSocket]) {
-    this[kSocket].uncork();
-  }
+function flushChunkedBuffer(msg) {
+  const buf = msg[kChunkedBuffer];
+  const len = msg[kChunkedLength];
 
-  if (this[kCorked] || this[kChunkedBuffer].length === 0) {
-    return;
-  }
-
-  const len = this[kChunkedLength];
-  const buf = this[kChunkedBuffer];
-
-  assert(this.chunkedEncoding);
+  assert(msg.chunkedEncoding);
 
   let callbacks;
-  this._send(len.toString(16), 'latin1', null);
-  this._send(crlf_buf, null, null);
+  msg._send(len.toString(16), 'latin1', null);
+  msg._send(crlf_buf, null, null);
   for (let n = 0; n < buf.length; n += 3) {
-    this._send(buf[n + 0], buf[n + 1], null);
+    msg._send(buf[n + 0], buf[n + 1], null);
     if (buf[n + 2]) {
       callbacks ??= [];
       callbacks.push(buf[n + 2]);
     }
   }
-  this._send(crlf_buf, null, callbacks.length ? (err) => {
+  msg._send(crlf_buf, null, callbacks.length ? (err) => {
     for (const callback of callbacks) {
       callback(err);
     }
   } : null);
 
-  this[kChunkedBuffer].length = 0;
-  this[kChunkedLength] = 0;
+  buf.length = 0;
+  msg[kChunkedLength] = 0;
+}
+
+function emitDrainIfNeeded(msg) {
+  if (msg[kNeedDrain] && msg.writableLength === 0) {
+    msg[kNeedDrain] = false;
+    msg.emit('drain');
+  }
+}
+
+OutgoingMessage.prototype.uncork = function uncork() {
+  this[kCorked]--;
+
+  const flushed = !this[kCorked] && this[kChunkedBuffer].length !== 0;
+  try {
+    if (flushed) {
+      flushChunkedBuffer(this);
+    }
+  } finally {
+    if (this[kSocket]) {
+      this[kSocket].uncork();
+    }
+  }
+
+  if (!flushed) {
+    return;
+  }
 
   // If we had a pending drain and flushed all data, emit the drain event.
-  if (this[kNeedDrain] && this.writableLength === 0) {
-    this[kNeedDrain] = false;
-    this.emit('drain');
-  }
+  emitDrainIfNeeded(this);
 };
 
 OutgoingMessage.prototype.setTimeout = function setTimeout(msecs, callback) {
@@ -1131,6 +1145,13 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
     throw new ERR_HTTP_CONTENT_LENGTH_MISMATCH(this[kBytesWritten], this._contentLength);
   }
 
+  // Flush message-level corked data before the terminating chunk. Keep the
+  // socket corked so all HTTP framing can be written as a single batch.
+  const flushed = this[kChunkedBuffer].length !== 0;
+  if (flushed) {
+    flushChunkedBuffer(this);
+  }
+
   const finish = onFinish.bind(undefined, this);
 
   if (this._hasBody && this.chunkedEncoding) {
@@ -1149,7 +1170,13 @@ OutgoingMessage.prototype.end = function end(chunk, encoding, callback) {
   this[kCorked] = 1;
   this.uncork();
 
+  // Mark the message as ended before emitting drain. A synchronous drain
+  // listener must not be able to write after the terminating chunk.
   this.finished = true;
+
+  if (flushed) {
+    emitDrainIfNeeded(this);
+  }
 
   // There is the first message on the outgoing queue, and we've sent
   // everything to the socket.

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -323,6 +323,7 @@ class Parser : public AsyncWrap, public StreamListener {
     allocator_.Reset();
     url_.Reset();
     status_message_.Reset();
+    max_header_pairs_cached_ = false;
 
     if (connectionsList_ != nullptr) {
       connectionsList_->Push(this);
@@ -465,6 +466,7 @@ class Parser : public AsyncWrap, public StreamListener {
     num_fields_ = 0;
     num_values_ = 0;
     header_pairs_ = 0;
+    max_header_pairs_cached_ = false;
 
     // METHOD
     if (parser_.type == HTTP_REQUEST) {
@@ -1034,6 +1036,7 @@ class Parser : public AsyncWrap, public StreamListener {
     headers_completed_ = false;
     max_http_header_size_ = max_http_header_size;
     header_pairs_ = 0;
+    max_header_pairs_cached_ = false;
   }
 
 
@@ -1053,21 +1056,23 @@ class Parser : public AsyncWrap, public StreamListener {
 
     header_pairs_ += 2;
 
-    Local<Value> max_header_pairs_v;
-    if (!object()
-             ->Get(env()->context(),
-                   FIXED_ONE_BYTE_STRING(env()->isolate(), "maxHeaderPairs"))
-             .ToLocal(&max_header_pairs_v)) {
-      got_exception_ = true;
-      return -1;
+    if (!max_header_pairs_cached_) {
+      Local<Value> max_header_pairs_v;
+      if (!object()
+               ->Get(env()->context(),
+                     FIXED_ONE_BYTE_STRING(env()->isolate(), "maxHeaderPairs"))
+               .ToLocal(&max_header_pairs_v)) {
+        got_exception_ = true;
+        return -1;
+      }
+
+      max_header_pairs_ = max_header_pairs_v->IsNumber()
+                              ? max_header_pairs_v.As<Number>()->Value()
+                              : 0;
+      max_header_pairs_cached_ = true;
     }
 
-    if (!max_header_pairs_v->IsNumber()) {
-      return 0;
-    }
-
-    const double max_header_pairs = max_header_pairs_v.As<Number>()->Value();
-    if (max_header_pairs > 0 && header_pairs_ > max_header_pairs) {
+    if (max_header_pairs_ > 0 && header_pairs_ > max_header_pairs_) {
       llhttp_set_error_reason(&parser_, "HPE_HEADER_OVERFLOW:Header overflow");
       return HPE_USER;
     }
@@ -1109,6 +1114,8 @@ class Parser : public AsyncWrap, public StreamListener {
   const char* current_buffer_data_;
   bool headers_completed_ = false;
   size_t header_pairs_ = 0;
+  double max_header_pairs_ = 0;
+  bool max_header_pairs_cached_ = false;
   bool pending_pause_ = false;
   bool received_data_ = false;
   uint64_t header_nread_ = 0;

--- a/test/parallel/test-http-outgoing-corked-end.js
+++ b/test/parallel/test-http-outgoing-corked-end.js
@@ -1,0 +1,199 @@
+/* eslint-disable node-core/crypto-check */
+
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const http = require('http');
+const net = require('net');
+
+function runRoundTrip(transport, serverOptions, requestOptions = {}) {
+  return new Promise((resolve, reject) => {
+    const server = serverOptions === undefined ?
+      transport.createServer(onRequest) :
+      transport.createServer(serverOptions, onRequest);
+
+    function onRequest(req, res) {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => body += chunk);
+      req.on('end', common.mustCall(() => {
+        assert.strictEqual(body, 'ABCD');
+
+        const callbacks = [];
+        res.setHeader('Trailer', 'x-test');
+        res.flushHeaders();
+
+        // Exercise an explicit flush while the socket remains corked.
+        res.cork();
+        res.cork();
+        res.write('E', common.mustCall(() => callbacks.push('E')));
+        res.write('F', common.mustCall(() => callbacks.push('F')));
+
+        const originalSend = res._send;
+        res._send = common.mustCall(function(...args) {
+          assert.notStrictEqual(this.socket.writableCorked, 0);
+          return originalSend.apply(this, args);
+        }, 5);
+        try {
+          res.uncork();
+          res.uncork();
+        } finally {
+          res._send = originalSend;
+        }
+
+        // end() must flush this buffer before the terminating chunk.
+        res.cork();
+        res.cork();
+        res.write('G', common.mustCall(() => callbacks.push('G')));
+        res.addTrailers({ 'x-test': 'yes' });
+        res.once('finish', common.mustCall(() => callbacks.push('finish')));
+        res.end('H', common.mustCall(() => {
+          callbacks.push('end');
+          assert.deepStrictEqual(callbacks, ['E', 'F', 'G', 'finish', 'end']);
+        }));
+        assert.strictEqual(res.writableCorked, 0);
+      }));
+    }
+
+    server.on('error', reject);
+    server.listen(0, common.localhostIPv4, common.mustCall(() => {
+      const callbacks = [];
+      const req = transport.request({
+        host: common.localhostIPv4,
+        port: server.address().port,
+        method: 'POST',
+        ...requestOptions,
+      }, common.mustCall((res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => body += chunk);
+        res.on('end', common.mustCall(() => {
+          assert.strictEqual(body, 'EFGH');
+          assert.strictEqual(res.trailers['x-test'], 'yes');
+          server.close(common.mustCall(resolve));
+        }));
+      }));
+
+      req.on('error', reject);
+      req.cork();
+      req.cork();
+      req.write('A', common.mustCall(() => callbacks.push('A')));
+      req.write('B', common.mustCall(() => callbacks.push('B')));
+      req.uncork();
+      req.uncork();
+      req.cork();
+      req.cork();
+      req.write('C', common.mustCall(() => callbacks.push('C')));
+      req.once('finish', common.mustCall(() => callbacks.push('finish')));
+      req.end('D', common.mustCall(() => {
+        callbacks.push('end');
+        assert.deepStrictEqual(callbacks, ['A', 'B', 'C', 'finish', 'end']);
+      }));
+      assert.strictEqual(req.writableCorked, 0);
+    }));
+  });
+}
+
+function runPipelined() {
+  return new Promise((resolve, reject) => {
+    let firstResponse;
+    const server = http.createServer(common.mustCall((req, res) => {
+      if (req.url === '/first') {
+        firstResponse = res;
+        return;
+      }
+
+      assert.strictEqual(req.url, '/second');
+      assert.strictEqual(res.socket, null);
+      res.cork();
+      res.cork();
+      res.write('B');
+      res.write('C');
+      res.end();
+      assert.strictEqual(res.writableCorked, 0);
+      firstResponse.end('A');
+    }, 2));
+
+    server.on('error', reject);
+    server.listen(0, common.localhostIPv4, common.mustCall(() => {
+      const socket = net.createConnection({
+        host: common.localhostIPv4,
+        port: server.address().port,
+      });
+      let response = '';
+
+      socket.setEncoding('latin1');
+      socket.on('error', reject);
+      socket.on('data', (chunk) => response += chunk);
+      socket.on('end', common.mustCall(() => {
+        assert.match(response, /\r\n\r\nAHTTP\/1\.1 200 OK\r\n/);
+        assert.match(response, /\r\n\r\n1\r\nB\r\n1\r\nC\r\n0\r\n\r\n$/);
+        server.close(common.mustCall(resolve));
+      }));
+      socket.on('connect', common.mustCall(() => {
+        socket.end(
+          'GET /first HTTP/1.1\r\nHost: localhost\r\n\r\n' +
+          'GET /second HTTP/1.1\r\nHost: localhost\r\n' +
+          'Connection: close\r\n\r\n',
+        );
+      }));
+    }));
+  });
+}
+
+function runDrainOnEnd() {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(common.mustCall((req, res) => {
+      res.cork();
+      assert.strictEqual(res.write('1'.repeat(10)), true);
+      assert.strictEqual(res.write('2'.repeat(1000)), false);
+      assert.strictEqual(res.writableNeedDrain, true);
+
+      res.once('drain', common.mustCall(() => {
+        assert.strictEqual(res.finished, true);
+        assert.strictEqual(res.writableNeedDrain, false);
+        assert.strictEqual(res.writableLength, 0);
+      }));
+      res.end();
+    }));
+
+    server.on('connection', common.mustCall((socket) => {
+      socket._writableState.highWaterMark = 1000;
+    }));
+    server.on('error', reject);
+    server.listen(0, common.localhostIPv4, common.mustCall(() => {
+      const req = http.get({
+        host: common.localhostIPv4,
+        port: server.address().port,
+      }, common.mustCall((res) => {
+        let body = '';
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => body += chunk);
+        res.on('end', common.mustCall(() => {
+          assert.strictEqual(body, '1'.repeat(10) + '2'.repeat(1000));
+          server.close(common.mustCall(resolve));
+        }));
+      }));
+      req.on('error', reject);
+    }));
+  });
+}
+
+async function main() {
+  await runRoundTrip(http);
+
+  if (common.hasCrypto) {
+    const fixtures = require('../common/fixtures');
+    const https = require('https');
+    await runRoundTrip(https, {
+      key: fixtures.readKey('agent1-key.pem'),
+      cert: fixtures.readKey('agent1-cert.pem'),
+    }, { rejectUnauthorized: false });
+  }
+
+  await runPipelined();
+  await runDrainOnEnd();
+}
+
+main().then(common.mustCall());

--- a/test/parallel/test-http-parser-max-header-pairs-cache.js
+++ b/test/parallel/test-http-parser-max-header-pairs-cache.js
@@ -1,0 +1,79 @@
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { HTTPParser } = require('_http_common');
+
+const { REQUEST } = HTTPParser;
+const kOnHeaders = HTTPParser.kOnHeaders | 0;
+const kOnHeadersComplete = HTTPParser.kOnHeadersComplete | 0;
+const kOnBody = HTTPParser.kOnBody | 0;
+const kOnMessageComplete = HTTPParser.kOnMessageComplete | 0;
+
+function createParser() {
+  const parser = new HTTPParser();
+  parser.initialize(REQUEST, {});
+  parser[kOnHeaders] = () => {};
+  parser[kOnHeadersComplete] = () => {};
+  parser[kOnBody] = common.mustNotCall();
+  parser[kOnMessageComplete] = () => {};
+  return parser;
+}
+
+// maxHeaderPairs is cached once for each independent header section. Main
+// headers, trailers, the next message, and a reinitialized parser must each
+// observe a fresh value.
+{
+  const parser = createParser();
+  const limits = [2, 4, 2, 2];
+
+  Object.defineProperty(parser, 'maxHeaderPairs', {
+    configurable: true,
+    get: common.mustCall(() => limits.shift(), limits.length),
+  });
+
+  parser[kOnHeadersComplete] = common.mustCall(undefined, 3);
+  parser[kOnMessageComplete] = common.mustCall(undefined, 3);
+
+  const pipelined = Buffer.from(
+    'POST /first HTTP/1.1\r\n' +
+    'Transfer-Encoding: chunked\r\n' +
+    '\r\n' +
+    '0\r\n' +
+    'X-A: a\r\n' +
+    'X-B: b\r\n' +
+    '\r\n' +
+    'GET /second HTTP/1.1\r\n' +
+    'X-C: c\r\n' +
+    '\r\n'
+  );
+  assert.strictEqual(parser.execute(pipelined, 0, pipelined.length),
+                     pipelined.length);
+
+  parser.initialize(REQUEST, {});
+  const reused = Buffer.from('GET /reused HTTP/1.1\r\nX-D: d\r\n\r\n');
+  assert.strictEqual(parser.execute(reused, 0, reused.length), reused.length);
+  assert.deepStrictEqual(limits, []);
+}
+
+// Preserve the existing exception behavior for the first property lookup.
+{
+  const parser = createParser();
+  const expected = new Error('maxHeaderPairs getter');
+  Object.defineProperty(parser, 'maxHeaderPairs', {
+    get: common.mustCall(() => { throw expected; }),
+  });
+  const request = Buffer.from('GET / HTTP/1.1\r\nX-A: a\r\n\r\n');
+  assert.throws(() => parser.execute(request, 0, request.length), expected);
+}
+
+// Non-positive and non-number values continue to mean unlimited.
+for (const maxHeaderPairs of [undefined, null, NaN, 0, -1, new Number(2)]) {
+  const parser = createParser();
+  parser.maxHeaderPairs = maxHeaderPairs;
+  const request = Buffer.from(
+    'GET / HTTP/1.1\r\nX-A: a\r\nX-B: b\r\nX-C: c\r\n\r\n'
+  );
+  assert.strictEqual(parser.execute(request, 0, request.length),
+                     request.length);
+}


### PR DESCRIPTION
This PR contains two focused HTTP performance improvements without adding or
changing public APIs.

### Optimize corked outgoing writes
`OutgoingMessage.uncork()` previously uncorked the underlying socket before
flushing its buffered HTTP chunk. The individual framing writes therefore
bypassed socket-level batching.

Buffered body data could also be flushed after the terminating chunk when
`end()` was called while the message was still corked.

This change:

- flushes buffered HTTP chunks before uncorking the socket;
- flushes buffered body data before writing the terminating chunk;
- preserves callback ordering, backpressure, trailers, TLS, and pipelining;
- prevents a synchronous `drain` listener from writing after the terminating
  chunk.

### Cache `maxHeaderPairs`

The HTTP parser previously read the JavaScript `maxHeaderPairs` property for
every header field.

This change caches the value once per independent header section and
invalidates it for:

- trailers;
- the next pipelined message;
- parser reinitialization.

The parser benchmark now explicitly uses the production default of 2000 header
pairs because direct benchmark parsers bypass `cleanParser()`.

## Performance

Local macOS arm64 Release results, using the median of three short runs:

| Scenario | Before | After | Improvement |
|---|---:|---:|---:|
| Core HTTP corked writes | 17.3k req/s | 59.5k req/s | 3.44x |
| Express corked writes | 16.6k req/s | 50.8k req/s | 3.06x |

Parser benchmark improvements:

| Header fields | Improvement |
|---:|---:|
| 5 | 22% |
| 17 | 54% |

End-to-end HTTP header benchmarks improved by approximately 4.8% to 7.1%.

## Tests

- Release build completed successfully.
- ESLint, cpplint, checkimports, and `git diff --check` passed.
- The focused HTTP test set passed across 80 repeated executions.
- All existing `test-http-parser-*` tests passed.
- All existing `test-http-outgoing-*` tests passed.
- Additional HTTP chunking, trailer, and pipelining tests passed.
- The new tests cover HTTP and HTTPS, client and server messages, nested
  corking, callback ordering, trailers, backpressure, and queued pipelined
  responses.

Documentation was not changed because no public API or documented behavior is
introduced.