### PR TITLE
doc: document quic stopSending() and resetStream()

### DIFF
--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1923,9 +1923,14 @@ True if `stream.destroy()` has been called.
 
 ### Aborting a stream
 
-A QuicStream can be aborted in three ways, each producing different
+A QuicStream can be aborted in several ways, each producing different
 wire-frame side effects:
 
+* [`stream.stopSending()`][] — Aborts only the readable side. Sends
+  `STOP_SENDING` to the peer. The writable side is unaffected.
+* [`stream.resetStream()`][] — Aborts only the writable side. Sends
+  `RESET_STREAM` to the peer. Unlike [`writer.fail(reason)`][], the wire
+  code is given directly rather than derived from an error.
 * [`writer.fail(reason)`][] — Aborts only the writable side. Sends
   `RESET_STREAM` to the peer. The readable side is unaffected; any data
   already buffered for read remains available.
@@ -1942,6 +1947,41 @@ When `error` is a [`QuicError`][], its [`error.errorCode`][] is used as
 the wire code for both `writer.fail()` and `stream.destroy()`. Otherwise
 the implementation falls back to the negotiated application protocol's
 "internal error" code (see [`QuicError`][]).
+
+[`stream.stopSending()`][] and [`stream.resetStream()`][] do
+not perform this derivation: they send `code` as given.
+
+### `stream.resetStream([code])`
+
+<!-- YAML
+added: v23.8.0
+-->
+
+* `code` {number|bigint} The application error code to send to the peer.
+  **Default:** `0n`.
+
+Tells the peer that this end will not send any more data on this stream,
+sending a `RESET_STREAM` frame carrying `code`. The readable side is left
+open, so data already sent by the peer remains available to read.
+
+No acknowledgement of this action is provided. Has no effect if the stream
+has been destroyed.
+
+### `stream.stopSending([code])`
+
+<!-- YAML
+added: v23.8.0
+-->
+
+* `code` {number|bigint} The application error code to send to the peer.
+  **Default:** `0n`.
+
+Asks the peer to stop sending data on this stream, sending a `STOP_SENDING`
+frame carrying `code`. The writable side is left open, so this end can
+still send data.
+
+No acknowledgement of this action is provided. Has no effect if the stream
+has been destroyed.
 
 ### `stream.early`
 
@@ -4576,11 +4616,13 @@ throughput issues caused by flow control.
 [`stream.onwanttrailers`]: #streamonwanttrailers
 [`stream.pendingTrailers`]: #streampendingtrailers
 [`stream.priority`]: #streampriority
+[`stream.resetStream()`]: #streamresetstreamcode
 [`stream.sendHeaders()`]: #streamsendheadersheaders-options
 [`stream.sendInformationalHeaders()`]: #streamsendinformationalheadersheaders
 [`stream.sendTrailers()`]: #streamsendtrailersheaders
 [`stream.setBody()`]: #streamsetbodybody
 [`stream.setPriority()`]: #streamsetpriorityoptions
+[`stream.stopSending()`]: #streamstopsendingcode
 [`stream.writer`]: #streamwriter
 [`writer.fail()`]: #streamwriter
 [`writer.fail(reason)`]: #streamwriter

--- a/doc/api/quic.md
+++ b/doc/api/quic.md
@@ -1964,8 +1964,12 @@ Tells the peer that this end will not send any more data on this stream,
 sending a `RESET_STREAM` frame carrying `code`. The readable side is left
 open, so data already sent by the peer remains available to read.
 
-No acknowledgement of this action is provided. Has no effect if the stream
-has been destroyed.
+Any data still queued for sending is discarded. A reset stream is never
+acknowledged by the peer, so the outbound queue can no longer drain.
+
+No acknowledgement of this action is provided. The call does nothing if the
+stream has been destroyed, if it has already been reset, or if it is a
+remote-initiated unidirectional stream, which has no writable side to abort.
 
 ### `stream.stopSending([code])`
 
@@ -1980,8 +1984,9 @@ Asks the peer to stop sending data on this stream, sending a `STOP_SENDING`
 frame carrying `code`. The writable side is left open, so this end can
 still send data.
 
-No acknowledgement of this action is provided. Has no effect if the stream
-has been destroyed.
+No acknowledgement of this action is provided. The call does nothing if the
+stream has been destroyed, or if it is a locally-initiated unidirectional
+stream, which has no readable side to abort.
 
 ### `stream.early`
 


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/63680

`QuicStream.prototype.stopSending()` and `QuicStream.prototype.resetStream()`
are part of the public surface but were missing from the QuicStream reference.

The wording follows the JSDoc already on the implementation:

https://github.com/nodejs/node/blob/8a1ca0f4ddc14f2901fe8fe76fa9681a3ceabbb6/lib/internal/quic/quic.js#L2411-L2435

I also added both to the **Aborting a stream** section, which listed only
`writer.fail()` and `stream.destroy()`. The distinction seemed worth calling
out: those two derive the wire code from an error (falling back to the
protocol's "internal error" code), while `stopSending()` and `resetStream()`
send the given `code` as-is.

`added:` is set to `v23.8.0`, matching the rest of the file — both methods were
introduced in 062ae6f3cb5, the same commit that created `doc/api/quic.md`, and
were simply omitted from it. Happy to change this if a different version is
more accurate.

### Verification

`doc/api/quic.md` is in `skip_apidoc_files` (Makefile), so it is not part of the
HTML/JSON doc build and `make doc-only` does not exercise it. Validation was
therefore limited to:

- `node tools/lint-md/lint-md.mjs doc/api/quic.md` — clean
- `python3 tools/test.py doctool` — 3/3 passing
- Anchors follow the file's existing convention (`stream.setPriority([options])`
  → `#streamsetpriorityoptions`)

### Note

This supersedes #63681, which covered the same issue but was closed without
landing.


### Update

Added a second commit covering behaviour the first one missed:

- `resetStream()` discards any data still queued for sending, and is a no-op
  once the stream has already been reset.
- Neither method sends a frame on the unidirectional stream that lacks the side
  it aborts — `stopSending()` on a locally-initiated one, `resetStream()` on a
  remote-initiated one. Both fail silently there.

Verified against `Stream::DoStreamReset` and `Stream::SendStopSending` in
`src/quic/streams.cc`. The directionality wording follows `stream.destroy()`,
which already frames the readable side as existing on bidirectional and
remote-initiated unidirectional streams.

I left the valid range of `code` undocumented on purpose: the binding reads it
with `Uint64Value()` and discards the lossless flag, so out-of-range values are
silently truncated rather than rejected. Documenting a 62-bit limit would state
a contract the implementation does not currently enforce. Happy to open that
separately if it's worth tracking.
