### PR TITLE
test: use libuv clock for immediate queue test

### DIFF
--- a/test/parallel/test-timers-immediate-queue.js
+++ b/test/parallel/test-timers-immediate-queue.js
@@ -19,9 +19,13 @@
 // OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
 // USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+// Flags: --expose-internals --no-warnings
+
 'use strict';
 require('../common');
 const assert = require('assert');
+const { internalBinding } = require('internal/test/binding');
+const timersBinding = internalBinding('timers');
 
 // setImmediate should run clear its queued cbs once per event loop turn
 // but immediates queued while processing the current queue should happen
@@ -38,8 +42,8 @@ const QUEUE = 10;
 function run() {
   if (hit === 0) {
     setTimeout(() => { ticked = true; }, 1);
-    const now = Date.now();
-    while (Date.now() - now < 2);
+    const now = timersBinding.getLibuvNow();
+    while (timersBinding.getLibuvNow() - now < 2);
   }
 
   if (ticked) return;


### PR DESCRIPTION
Refs: https://github.com/nodejs/reliability/issues?q=sort%3Aupdated-desc%20test-timers-immediate-queue

Use `getLibuvNow()` when waiting for the timeout to expire. `Date.now()` may have different precision from libuv's clock, causing the immediate queue to run an extra iteration on platforms with coarse timers.

---

Assisted-by: codex:gpt-5.6-sol