### PR TITLE
sqlite: reject non-positive backup rates

### DIFF
--- a/doc/api/sqlite.md
+++ b/doc/api/sqlite.md
@@ -1356,7 +1356,7 @@ changes:
     database that have been added with [`ATTACH DATABASE`][] **Default:** `'main'`.
   * `target` {string} Name of the target database. This can be `'main'` (the default primary database) or any other
     database that have been added with [`ATTACH DATABASE`][] **Default:** `'main'`.
-  * `rate` {number} Number of pages to be transmitted in each batch of the backup. **Default:** `100`.
+  * `rate` {integer} Positive number of pages to be transmitted in each batch of the backup. **Default:** `100`.
   * `progress` {Function} An optional callback function that will be called after each backup step. The argument passed
     to this callback is an {Object} with `remainingPages` and `totalPages` properties, describing the current progress
     of the backup operation.

--- a/src/node_sqlite.cc
+++ b/src/node_sqlite.cc
@@ -2171,6 +2171,12 @@ void Backup(const FunctionCallbackInfo<Value>& args) {
         return;
       }
       rate = rate_v.As<Int32>()->Value();
+      if (rate <= 0) {
+        THROW_ERR_OUT_OF_RANGE(
+            env->isolate(),
+            "The \"options.rate\" argument must be a positive integer.");
+        return;
+      }
     }
 
     Local<Value> source_v;

--- a/test/parallel/test-sqlite-backup.mjs
+++ b/test/parallel/test-sqlite-backup.mjs
@@ -124,6 +124,15 @@ describe('backup()', () => {
       message: 'The "options.rate" argument must be an integer.'
     });
 
+    for (const rate of [0, -1]) {
+      t.assert.throws(() => {
+        backup(database, 'hello.db', { rate });
+      }, {
+        code: 'ERR_OUT_OF_RANGE',
+        message: 'The "options.rate" argument must be a positive integer.'
+      });
+    }
+
     t.assert.throws(() => {
       backup(database, 'hello.db', {
         progress: 'invalid'


### PR DESCRIPTION
Fixes: https://github.com/nodejs/node/issues/64892

Passing a rate of `0` to `backup()` causes `sqlite3_backup_step()` to copy no pages. The backup job then continually reschedules itself and the returned promise never settles.

This change requires backup rates to be positive integers to prevent zero-work backup jobs.

---

Assisted-by: codex:gpt-5.6-sol