### PR TITLE
doc: fix permission documentation examples

### DIFF
--- a/doc/api/permissions.md
+++ b/doc/api/permissions.md
@@ -131,7 +131,7 @@ const config = fs.readFileSync('/etc/myapp/config.json', 'utf8');
 // Drop read access to /etc/myapp after initialization
 process.permission.drop('fs.read', '/etc/myapp');
 
-// This will now throw ERR_ACCESS_DENIED
+// This will now return false
 process.permission.has('fs.read', '/etc/myapp/config.json'); // false
 
 // Drop child process permission entirely
@@ -212,7 +212,7 @@ $ node --permission index.js
 * `index.js` will be included in the allowed file system read list
 
 ```console
-$ node -r /path/to/custom-require.js --permission index.js.
+$ node -r /path/to/custom-require.js --permission index.js
 ```
 
 * `/path/to/custom-require.js` will be included in the allowed file system read


### PR DESCRIPTION
Corrects two Permission Model documentation examples:

- `process.permission.has()` returns `false` after a permission is dropped.
- The command-line entrypoint is `index.js`, without a trailing period.