### PR TITLE
perf_hooks: add PerformanceEntry id and navigationId

### DIFF
--- a/lib/internal/perf/observe.js
+++ b/lib/internal/perf/observe.js
@@ -38,6 +38,7 @@ const {
 const {
   isPerformanceEntry,
   createPerformanceNodeEntry,
+  markPerformanceEntryQueued,
 } = require('internal/perf/performance_entry');
 
 const {
@@ -387,6 +388,8 @@ ObjectDefineProperties(PerformanceObserver.prototype, {
 function enqueue(entry) {
   if (!isPerformanceEntry(entry))
     throw new ERR_INVALID_ARG_TYPE('entry', 'PerformanceEntry', entry);
+
+  markPerformanceEntryQueued(entry);
 
   for (const obs of kObservers) {
     obs[kMaybeBuffer](entry);

--- a/lib/internal/perf/performance_entry.js
+++ b/lib/internal/perf/performance_entry.js
@@ -1,6 +1,8 @@
 'use strict';
 
 const {
+  MathFloor,
+  MathRandom,
   ObjectDefineProperties,
   Symbol,
 } = primordials;
@@ -20,11 +22,26 @@ const { validateThisInternalField } = require('internal/validators');
 const { inspect } = require('util');
 
 const kName = Symbol('PerformanceEntry.Name');
+const kId = Symbol('PerformanceEntry.Id');
 const kEntryType = Symbol('PerformanceEntry.EntryType');
 const kStartTime = Symbol('PerformanceEntry.StartTime');
 const kDuration = Symbol('PerformanceEntry.Duration');
+const kNavigationId = Symbol('PerformanceEntry.NavigationId');
 const kDetail = Symbol('NodePerformanceEntry.Detail');
 const kSkipThrow = Symbol('kSkipThrow');
+
+let lastPerformanceEntryId = MathFloor(MathRandom() * 9901) + 100;
+
+function nextPerformanceEntryId() {
+  return ++lastPerformanceEntryId;
+}
+
+function markPerformanceEntryQueued(entry) {
+  validateThisInternalField(entry, kName, 'PerformanceEntry');
+  if (entry[kId] === 0) {
+    entry[kId] = nextPerformanceEntryId();
+  }
+}
 
 function isPerformanceEntry(obj) {
   return obj?.[kName] !== undefined;
@@ -43,9 +60,16 @@ class PerformanceEntry {
     }
 
     this[kName] = name;
+    this[kId] = 0;
     this[kEntryType] = type;
     this[kStartTime] = start;
     this[kDuration] = duration;
+    this[kNavigationId] = 0;
+  }
+
+  get id() {
+    validateThisInternalField(this, kName, 'PerformanceEntry');
+    return this[kId];
   }
 
   get name() {
@@ -66,6 +90,11 @@ class PerformanceEntry {
   get duration() {
     validateThisInternalField(this, kDuration, 'PerformanceEntry');
     return this[kDuration];
+  }
+
+  get navigationId() {
+    validateThisInternalField(this, kName, 'PerformanceEntry');
+    return this[kNavigationId];
   }
 
   [kInspect](depth, options) {
@@ -90,10 +119,12 @@ class PerformanceEntry {
   }
 }
 ObjectDefineProperties(PerformanceEntry.prototype, {
+  id: kEnumerableProperty,
   name: kEnumerableProperty,
   entryType: kEnumerableProperty,
   startTime: kEnumerableProperty,
   duration: kEnumerableProperty,
+  navigationId: kEnumerableProperty,
   toJSON: kEnumerableProperty,
 });
 
@@ -134,6 +165,7 @@ module.exports = {
   createPerformanceEntry,
   PerformanceEntry,
   isPerformanceEntry,
+  markPerformanceEntryQueued,
   PerformanceNodeEntry,
   createPerformanceNodeEntry,
   kSkipThrow,

--- a/test/wpt/status/performance-timeline.json
+++ b/test/wpt/status/performance-timeline.json
@@ -7,15 +7,6 @@
       ]
     }
   },
-  "idlharness.any.js": {
-    "fail": {
-      "note": "not implemented",
-      "expected": [
-        "PerformanceEntry interface: attribute id",
-        "PerformanceEntry interface: attribute navigationId"
-      ]
-    }
-  },
   "navigation-id.helper.js": {
     "skip": "This is not a test file."
   },


### PR DESCRIPTION
This adds `PerformanceEntry.prototype.id` and `PerformanceEntry.prototype.navigationId` to match the Performance Timeline IDL.

Entries are assigned an id when they are queued, following the Performance Timeline `Queue a PerformanceEntry` algorithm. `navigationId` is initialized to `0`; Node.js does not currently track a Document-associated most recent navigation for `perf_hooks` entries.

This also updates the `performance-timeline` WPT status now that `idlharness.any.js` passes for these attributes.

Refs:
- https://w3c.github.io/performance-timeline/#performanceentry
- https://w3c.github.io/performance-timeline/#queue-a-performanceentry
- https://w3c.github.io/performance-timeline/#generate-a-performance-entry-id

## Tests

```bash
out/Release/node test/wpt/test-performance-timeline.js idlharness.any.js
out/Release/node test/parallel/test-perf-hooks-usertiming.js
out/Release/node test/parallel/test-perf-hooks-resourcetiming.js
```

```
Files: 1/1 ran, 1 passed, 0 skipped, 0 expected failures, 0 unexpected failures, 0 unexpected passes
Subtests: 58 passed, 0 skipped, 0 expected failures, 0 unexpected failures, 0 unexpected passes
```