### PR TITLE
doc: fix typos in documentation

### DIFF
--- a/doc/api/crypto.md
+++ b/doc/api/crypto.md
@@ -5038,7 +5038,7 @@ HKDF is a simple key derivation function defined in RFC 5869. The given `ikm`,
 `salt` and `info` are used with the `digest` to derive a key of `keylen` bytes.
 
 The supplied `callback` function is called with two arguments: `err` and
-`derivedKey`. If an errors occurs while deriving the key, `err` will be set;
+`derivedKey`. If an error occurs while deriving the key, `err` will be set;
 otherwise `err` will be `null`. The successfully generated `derivedKey` will
 be passed to the callback as an {ArrayBuffer}. An error will be thrown if any
 of the input arguments specify invalid values or types.

--- a/doc/api/errors.md
+++ b/doc/api/errors.md
@@ -1508,7 +1508,7 @@ New HTTP/2 Streams may not be opened after the `Http2Session` has received a
 
 ### `ERR_HTTP2_HEADERS_AFTER_RESPOND`
 
-An additional headers was specified after an HTTP/2 response was initiated.
+Additional headers were specified after an HTTP/2 response was initiated.
 
 <a id="ERR_HTTP2_HEADERS_SENT"></a>
 
@@ -2817,7 +2817,7 @@ changes:
     description: Added the `requireStack` and `topLevelAwaitLocations` properties.
 -->
 
-When trying to `require()` a [ES Module][], the module turns out to be asynchronous.
+When trying to `require()` an [ES Module][], the module turns out to be asynchronous.
 That is, it contains top-level await.
 
 When uncaught, the flag `--experimental-print-required-tla` prints
@@ -2839,7 +2839,7 @@ This error has the following additional non-enumerable properties:
 
 ### `ERR_REQUIRE_CYCLE_MODULE`
 
-When trying to `require()` a [ES Module][], a CommonJS to ESM or ESM to CommonJS edge
+When trying to `require()` an [ES Module][], a CommonJS to ESM or ESM to CommonJS edge
 participates in an immediate cycle.
 This is not allowed because ES Modules cannot be evaluated while they are
 already being evaluated.

--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1189,7 +1189,7 @@ added:
  - v12.16.0
 -->
 
-* Type: {boolean} Whether the request is send through a reused socket.
+* Type: {boolean} Whether the request is sent through a reused socket.
 
 When sending request through a keep-alive enabled agent, the underlying socket
 might be reused. But if server closes connection at unfortunate time, client

--- a/doc/api/net.md
+++ b/doc/api/net.md
@@ -2141,7 +2141,7 @@ Creates a new TCP or [IPC][] server.
 If `allowHalfOpen` is set to `true`, when the other end of the socket
 signals the end of transmission, the server will only send back the end of
 transmission when [`socket.end()`][] is explicitly called. For example, in the
-context of TCP, when a FIN packed is received, a FIN packed is sent
+context of TCP, when a FIN packet is received, a FIN packet is sent
 back only when [`socket.end()`][] is explicitly called. Until then the
 connection is half-closed (non-readable but still writable). See [`'end'`][]
 event and [RFC 1122][half-closed] (section 4.2.2.13) for more information.

--- a/doc/api/process.md
+++ b/doc/api/process.md
@@ -3290,7 +3290,7 @@ const { platform } = require('node:process');
 console.log(`This platform is ${platform}`);
 ```
 
-The value `'android'` may also be returned if the Node.js is built on the
+The value `'android'` may also be returned if Node.js is built on the
 Android operating system. However, Android support in Node.js
 [is experimental][Android building].
 

--- a/doc/api/punycode.md
+++ b/doc/api/punycode.md
@@ -101,7 +101,7 @@ added: v0.6.1
 
 The `punycode.toUnicode()` method converts a string representing a domain name
 containing [Punycode][] encoded characters into Unicode. Only the [Punycode][]
-encoded parts of the domain name are be converted.
+encoded parts of the domain name are converted.
 
 ```js
 // decode domain names


### PR DESCRIPTION
Fixes several small typos and grammatical errors in the API documentation.