### PR TITLE
test: fix lint in dtls tests

### DIFF
--- a/test/parallel/test-dtls-accessors.mjs
+++ b/test/parallel/test-dtls-accessors.mjs
@@ -9,9 +9,6 @@ import {
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -22,9 +19,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 const gotServerSession = Promise.withResolvers();
 
@@ -34,26 +31,26 @@ const server = listen(mustCall((session) => {
 
 // --- Endpoint state after listen(): bound and listening. ---
 const es = server.state;
-strictEqual(es.bound, true);
-strictEqual(es.listening, true);
-strictEqual(es.closing, false);
-strictEqual(es.destroyed, false);
-strictEqual(es.sessionCount, 0);
+assert.strictEqual(es.bound, true);
+assert.strictEqual(es.listening, true);
+assert.strictEqual(es.closing, false);
+assert.strictEqual(es.destroyed, false);
+assert.strictEqual(es.sessionCount, 0);
 
 // The busy property is settable via the endpoint and reflected in the state view.
-strictEqual(server.busy, false);
-strictEqual(es.busy, false);
+assert.strictEqual(server.busy, false);
+assert.strictEqual(es.busy, false);
 server.busy = true;
-strictEqual(server.busy, true);
-strictEqual(es.busy, true);
+assert.strictEqual(server.busy, true);
+assert.strictEqual(es.busy, true);
 server.busy = false;
-strictEqual(es.busy, false);
+assert.strictEqual(es.busy, false);
 
 // --- Endpoint onerror accessor. ---
-strictEqual(server.onerror, undefined);
+assert.strictEqual(server.onerror, undefined);
 const onEndpointError = mustNotCall();
 server.onerror = onEndpointError;
-strictEqual(server.onerror, onEndpointError);
+assert.strictEqual(server.onerror, onEndpointError);
 
 const client = connect('127.0.0.1', server.address.port, {
   ca: [ca],
@@ -62,43 +59,43 @@ const client = connect('127.0.0.1', server.address.port, {
 
 // --- Session state during the handshake. ---
 const cs = client.state;
-strictEqual(cs.handshaking, true);
-strictEqual(cs.open, false);
-strictEqual(cs.closing, false);
-strictEqual(cs.destroyed, false);
-strictEqual(cs.hasMessageListener, false);
+assert.strictEqual(cs.handshaking, true);
+assert.strictEqual(cs.open, false);
+assert.strictEqual(cs.closing, false);
+assert.strictEqual(cs.destroyed, false);
+assert.strictEqual(cs.hasMessageListener, false);
 
 // --- Session callback accessors: unset, then set. ---
-strictEqual(client.onmessage, undefined);
-strictEqual(client.onerror, undefined);
-strictEqual(client.onhandshake, undefined);
-strictEqual(client.onkeylog, undefined);
+assert.strictEqual(client.onmessage, undefined);
+assert.strictEqual(client.onerror, undefined);
+assert.strictEqual(client.onhandshake, undefined);
+assert.strictEqual(client.onkeylog, undefined);
 // A connect() session owns its internal endpoint.
-strictEqual(client.ownsEndpoint, true);
+assert.strictEqual(client.ownsEndpoint, true);
 
 client.onmessage = mustNotCall();
-strictEqual(typeof client.onmessage, 'function');
+assert.strictEqual(typeof client.onmessage, 'function');
 // Attaching a message listener flips the shared flag.
-strictEqual(cs.hasMessageListener, true);
+assert.strictEqual(cs.hasMessageListener, true);
 
 client.onerror = mustNotCall();
-strictEqual(typeof client.onerror, 'function');
+assert.strictEqual(typeof client.onerror, 'function');
 
 client.onhandshake = mustCall();
-strictEqual(typeof client.onhandshake, 'function');
+assert.strictEqual(typeof client.onhandshake, 'function');
 
 client.onkeylog = mustCallAtLeast();
-strictEqual(typeof client.onkeylog, 'function');
+assert.strictEqual(typeof client.onkeylog, 'function');
 
 await client.opened;
 
 // --- Session state after the handshake completes. ---
-strictEqual(cs.handshaking, false);
-strictEqual(cs.open, true);
+assert.strictEqual(cs.handshaking, false);
+assert.strictEqual(cs.open, true);
 
 const serverSession = await gotServerSession.promise;
 await serverSession.opened;
-strictEqual(es.sessionCount, 1);
+assert.strictEqual(es.sessionCount, 1);
 
 await client.close();
 await server.close();

--- a/test/parallel/test-dtls-alpn.mjs
+++ b/test/parallel/test-dtls-alpn.mjs
@@ -74,8 +74,8 @@ await endpoint.close();
   const serverSession = await gotServerSession.promise;
   await serverSession.opened;
 
-  strictEqual(client.alpnProtocol, undefined);
-  strictEqual(serverSession.alpnProtocol, undefined);
+  assert.strictEqual(client.alpnProtocol, undefined);
+  assert.strictEqual(serverSession.alpnProtocol, undefined);
 
   await client.close();
   await server.close();

--- a/test/parallel/test-dtls-ciphers.mjs
+++ b/test/parallel/test-dtls-ciphers.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, throws } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 const CIPHER = 'ECDHE-RSA-AES128-GCM-SHA256';
 
@@ -43,15 +40,15 @@ const CIPHER = 'ECDHE-RSA-AES128-GCM-SHA256';
   const serverSession = await gotServerSession.promise;
   await serverSession.opened;
 
-  strictEqual(client.cipher.name, CIPHER);
-  strictEqual(serverSession.cipher.name, CIPHER);
+  assert.strictEqual(client.cipher.name, CIPHER);
+  assert.strictEqual(serverSession.cipher.name, CIPHER);
 
   await client.close();
   await server.close();
 }
 
 // Case 2: an invalid cipher list is rejected.
-throws(() => listen(mustNotCall(), {
+assert.throws(() => listen(mustNotCall(), {
   cert, key, port: 0, host: '127.0.0.1', ciphers: 'THIS-IS-NOT-A-CIPHER',
 }), { code: 'ERR_CRYPTO_OPERATION_FAILED' });
 
@@ -74,6 +71,6 @@ throws(() => listen(mustNotCall(), {
 }
 
 // Case 4: an invalid ECDH curve is rejected.
-throws(() => listen(mustNotCall(), {
+assert.throws(() => listen(mustNotCall(), {
   cert, key, port: 0, host: '127.0.0.1', ecdhCurve: 'not-a-curve',
 }), { code: 'ERR_CRYPTO_OPERATION_FAILED' });

--- a/test/parallel/test-dtls-client-cert.mjs
+++ b/test/parallel/test-dtls-client-cert.mjs
@@ -7,9 +7,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { ok, rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -20,9 +17,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 // Case 1: the client presents a certificate the server can verify.
 {
@@ -44,8 +41,8 @@ const ca = readKey('ca1-cert.pem').toString();
 
   // The server received and verified the client's certificate.
   const clientCert = serverSession.peerCertificate;
-  ok(clientCert);
-  ok(clientCert.includes('BEGIN CERTIFICATE'));
+  assert.ok(clientCert);
+  assert.ok(clientCert.includes('BEGIN CERTIFICATE'));
 
   await client.close();
   await server.close();
@@ -63,7 +60,7 @@ const ca = readKey('ca1-cert.pem').toString();
   });
 
   // The exact alert text varies, so assert only that the handshake is rejected.
-  await rejects(client.opened, {
+  await assert.rejects(client.opened, {
     message: /handshake failure/
   });
 

--- a/test/parallel/test-dtls-connect-error-cleanup.mjs
+++ b/test/parallel/test-dtls-connect-error-cleanup.mjs
@@ -8,9 +8,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -21,9 +18,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 // The client rejects the certificate mid-handshake, so this server session
 // never opens; its opened rejection is handled internally by the library.
@@ -37,7 +34,7 @@ const session = connect('127.0.0.1', server.address.port, {
   servername: 'wrong.example.com',
 });
 
-await rejects(session.opened, /certificate verify failed/i);
+await assert.rejects(session.opened, /certificate verify failed/i);
 
 // The failed connect must have closed its internally-owned endpoint. Without
 // that, this await never settles and the test times out.

--- a/test/parallel/test-dtls-destroy-in-callback.mjs
+++ b/test/parallel/test-dtls-destroy-in-callback.mjs
@@ -9,8 +9,6 @@
 import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -21,9 +19,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 // ---------------------------------------------------------------------------
 // Case 1: destroy the (server) session from inside onmessage. The datagram

--- a/test/parallel/test-dtls-errors.mjs
+++ b/test/parallel/test-dtls-errors.mjs
@@ -7,9 +7,6 @@ import { hasCrypto, skip, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { throws } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -20,22 +17,22 @@ if (!process.features.dtls) {
 
 const { listen, DTLSEndpoint } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const mismatchedKey = readKey('agent2-key.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const mismatchedKey = fixtures.readKey('agent2-key.pem').toString();
 
 // A malformed certificate PEM is rejected.
-throws(() => listen(mustNotCall(), {
+assert.throws(() => listen(mustNotCall(), {
   cert: 'not a certificate', key, port: 0,
 }), { code: 'ERR_CRYPTO_OPERATION_FAILED' });
 
 // A malformed private key PEM is rejected.
-throws(() => listen(mustNotCall(), {
+assert.throws(() => listen(mustNotCall(), {
   cert, key: 'not a key', port: 0,
 }), { code: 'ERR_CRYPTO_OPERATION_FAILED' });
 
 // A private key that does not match the certificate is rejected.
-throws(() => listen(mustNotCall(), {
+assert.throws(() => listen(mustNotCall(), {
   cert, key: mismatchedKey, port: 0,
 }), { code: 'ERR_CRYPTO_OPERATION_FAILED' });
 
@@ -43,6 +40,6 @@ throws(() => listen(mustNotCall(), {
 {
   const endpoint = new DTLSEndpoint();
   endpoint.bind('127.0.0.1', 0);
-  throws(() => endpoint.bind('127.0.0.1', 0), { code: 'ERR_INVALID_STATE' });
+  assert.throws(() => endpoint.bind('127.0.0.1', 0), { code: 'ERR_INVALID_STATE' });
   await endpoint.close();
 }

--- a/test/parallel/test-dtls-keylog.mjs
+++ b/test/parallel/test-dtls-keylog.mjs
@@ -7,9 +7,6 @@ import { hasCrypto, skip, mustCall, mustCallAtLeast } from '../common/index.mjs'
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, match } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -20,9 +17,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 const gotKeylog = Promise.withResolvers();
 
@@ -37,8 +34,8 @@ const client = connect('127.0.0.1', server.address.port, {
 
 // A keylog line is "<LABEL> <hex> <hex>" (e.g. "CLIENT_RANDOM ...").
 client.onkeylog = mustCallAtLeast((line) => {
-  strictEqual(typeof line, 'string');
-  match(line, /^\S+ [0-9a-f]+ [0-9a-f]+$/i);
+  assert.strictEqual(typeof line, 'string');
+  assert.match(line, /^\S+ [0-9a-f]+ [0-9a-f]+$/i);
   gotKeylog.resolve();
 });
 

--- a/test/parallel/test-dtls-mtu.mjs
+++ b/test/parallel/test-dtls-mtu.mjs
@@ -7,9 +7,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, throws } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -20,13 +17,13 @@ if (!process.features.dtls) {
 
 const { listen, connect, DTLSEndpoint } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 // MTU must be within [256, 65535].
-throws(() => new DTLSEndpoint({ mtu: 255 }), { code: 'ERR_OUT_OF_RANGE' });
-throws(() => new DTLSEndpoint({ mtu: 65536 }), { code: 'ERR_OUT_OF_RANGE' });
+assert.throws(() => new DTLSEndpoint({ mtu: 255 }), { code: 'ERR_OUT_OF_RANGE' });
+assert.throws(() => new DTLSEndpoint({ mtu: 65536 }), { code: 'ERR_OUT_OF_RANGE' });
 
 // A valid boundary MTU is accepted.
 {
@@ -41,7 +38,7 @@ throws(() => new DTLSEndpoint({ mtu: 65536 }), { code: 'ERR_OUT_OF_RANGE' });
 
   const server = listen(mustCall((session) => {
     session.onmessage = mustCall((data) => {
-      strictEqual(data.toString(), 'hello');
+      assert.strictEqual(data.toString(), 'hello');
       session.send('world');
     });
   }), {
@@ -55,7 +52,7 @@ throws(() => new DTLSEndpoint({ mtu: 65536 }), { code: 'ERR_OUT_OF_RANGE' });
   });
 
   client.onmessage = mustCall((data) => {
-    strictEqual(data.toString(), 'world');
+    assert.strictEqual(data.toString(), 'world');
     received.resolve();
   });
 

--- a/test/parallel/test-dtls-options.mjs
+++ b/test/parallel/test-dtls-options.mjs
@@ -51,15 +51,15 @@ assert.throws(() => {
 }, { code: 'ERR_OUT_OF_RANGE' });
 
 // Test: mtu must be an integer within [256, 65535].
-throws(() => {
+assert.throws(() => {
   connect('127.0.0.1', 4433, { mtu: 100 });
 }, { code: 'ERR_OUT_OF_RANGE' });
 
-throws(() => {
+assert.throws(() => {
   connect('127.0.0.1', 4433, { mtu: 70000 });
 }, { code: 'ERR_OUT_OF_RANGE' });
 
 // Test: alpn must be a string array or Buffer.
-throws(() => {
+assert.throws(() => {
   connect('127.0.0.1', 4433, { alpn: 123 });
 }, { code: 'ERR_INVALID_ARG_TYPE' });

--- a/test/parallel/test-dtls-reject-unauthorized.mjs
+++ b/test/parallel/test-dtls-reject-unauthorized.mjs
@@ -8,9 +8,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { match, rejects } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -21,8 +18,8 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
 
 // Case 1: with rejectUnauthorized, a certificate that does not chain to a
 // trusted CA fails verification. The servername matches the certificate, so
@@ -39,7 +36,7 @@ const key = readKey('agent1-key.pem').toString();
     servername: 'agent1',
   });
 
-  await rejects(client.opened, /certificate verify failed/i);
+  await assert.rejects(client.opened, /certificate verify failed/i);
 
   await client.endpoint.closed;
   await server.close();
@@ -56,7 +53,7 @@ const key = readKey('agent1-key.pem').toString();
   });
 
   const { protocol } = await client.opened;
-  match(protocol, /DTLS/i);
+  assert.match(protocol, /DTLS/i);
 
   await client.close();
   await server.close();

--- a/test/parallel/test-dtls-robustness.mjs
+++ b/test/parallel/test-dtls-robustness.mjs
@@ -7,8 +7,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import dgram from 'node:dgram';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +17,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 const server = listen(mustCall((session) => {
   session.onhandshake = mustCall();

--- a/test/parallel/test-dtls-send.mjs
+++ b/test/parallel/test-dtls-send.mjs
@@ -6,9 +6,6 @@ import { hasCrypto, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -19,9 +16,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 // The largest application payload that fits in a single DTLS record (2^14).
 const MAX_RECORD = 16384;
@@ -40,12 +37,12 @@ const MAX_RECORD = 16384;
     rejectUnauthorized: false,
   });
 
-  strictEqual(client.send('before handshake'), -1);
+  assert.strictEqual(client.send('before handshake'), -1);
 
   await client.opened;
 
-  strictEqual(client.send(Buffer.alloc(MAX_RECORD, 0x61)), MAX_RECORD);
-  strictEqual(await received.promise, MAX_RECORD);
+  assert.strictEqual(client.send(Buffer.alloc(MAX_RECORD, 0x61)), MAX_RECORD);
+  assert.strictEqual(await received.promise, MAX_RECORD);
 
   await client.close();
   await server.close();
@@ -63,7 +60,7 @@ const MAX_RECORD = 16384;
   });
 
   await client.opened;
-  strictEqual(client.send(Buffer.alloc(MAX_RECORD + 1, 0x61)), -1);
+  assert.strictEqual(client.send(Buffer.alloc(MAX_RECORD + 1, 0x61)), -1);
 
   await client.close();
   await server.close();

--- a/test/parallel/test-dtls-session-table-cleanup.mjs
+++ b/test/parallel/test-dtls-session-table-cleanup.mjs
@@ -8,9 +8,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -21,9 +18,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 // ---------------------------------------------------------------------------
 // Case 1: the server closes its own session -> removed from the table.
@@ -42,9 +39,9 @@ const ca = readKey('ca1-cert.pem').toString();
   await client.opened;
   const session = await gotSession.promise;
 
-  strictEqual(server.state.sessionCount, 1);
+  assert.strictEqual(server.state.sessionCount, 1);
   await session.close();
-  strictEqual(server.state.sessionCount, 0);
+  assert.strictEqual(server.state.sessionCount, 0);
 
   await client.close();
   await server.close();
@@ -68,10 +65,10 @@ const ca = readKey('ca1-cert.pem').toString();
   await client.opened;
   const session = await gotSession.promise;
 
-  strictEqual(server.state.sessionCount, 1);
+  assert.strictEqual(server.state.sessionCount, 1);
   await client.close();   // Sends close_notify to the server
   await session.closed;   // Server processes it, detaches, and emits its close
-  strictEqual(server.state.sessionCount, 0);
+  assert.strictEqual(server.state.sessionCount, 0);
 
   await server.close();
 }

--- a/test/parallel/test-dtls-srtp.mjs
+++ b/test/parallel/test-dtls-srtp.mjs
@@ -8,9 +8,6 @@ import { hasCrypto, skip, mustCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { strictEqual, deepStrictEqual, notDeepStrictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -21,9 +18,9 @@ if (!process.features.dtls) {
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 const SRTP_PROFILE = 'SRTP_AEAD_AES_128_GCM';
 
@@ -50,26 +47,26 @@ const serverSession = await gotServerSession.promise;
 await serverSession.opened;
 
 // Both peers negotiate the same SRTP profile.
-strictEqual(client.srtpProfile, SRTP_PROFILE);
-strictEqual(serverSession.srtpProfile, SRTP_PROFILE);
+assert.strictEqual(client.srtpProfile, SRTP_PROFILE);
+assert.strictEqual(serverSession.srtpProfile, SRTP_PROFILE);
 
 // Both peers derive identical keying material for the same label and length.
 const label = 'EXTRACTOR-dtls_srtp';
 const clientKM = client.exportKeyingMaterial(60, label);
 const serverKM = serverSession.exportKeyingMaterial(60, label);
-strictEqual(clientKM.length, 60);
-deepStrictEqual(clientKM, serverKM);
+assert.strictEqual(clientKM.length, 60);
+assert.deepStrictEqual(clientKM, serverKM);
 
 // The optional context is bound into the derivation: the same context yields
 // the same material on both peers, and a different context yields different
 // material.
 const contextA = Buffer.from('context-a');
 const contextB = Buffer.from('context-b');
-deepStrictEqual(
+assert.deepStrictEqual(
   client.exportKeyingMaterial(32, label, contextA),
   serverSession.exportKeyingMaterial(32, label, contextA),
 );
-notDeepStrictEqual(
+assert.notDeepStrictEqual(
   client.exportKeyingMaterial(32, label, contextA),
   client.exportKeyingMaterial(32, label, contextB),
 );

--- a/test/parallel/test-dtls-unhandled-rejection.mjs
+++ b/test/parallel/test-dtls-unhandled-rejection.mjs
@@ -6,8 +6,6 @@
 import { hasCrypto, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -21,9 +19,9 @@ process.on('unhandledRejection', mustNotCall());
 
 const { listen, connect } = await import('node:dtls');
 
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 const server = listen(mustCall(), {
   cert, key, port: 0, host: '127.0.0.1',

--- a/test/parallel/test-dtls-verify-identity.mjs
+++ b/test/parallel/test-dtls-verify-identity.mjs
@@ -9,9 +9,6 @@ import { hasCrypto, skip, mustCall, mustNotCall } from '../common/index.mjs';
 import assert from 'node:assert';
 import * as fixtures from '../common/fixtures.mjs';
 
-const { match, rejects, strictEqual } = assert;
-const { readKey } = fixtures;
-
 if (!hasCrypto) {
   skip('missing crypto');
 }
@@ -24,9 +21,9 @@ const { listen, connect } = await import('node:dtls');
 
 // The agent1 certificate has CN=agent1 and no subjectAltName, so OpenSSL
 // matches the identity "agent1" (via the subject CN) and rejects other names.
-const cert = readKey('agent1-cert.pem').toString();
-const key = readKey('agent1-key.pem').toString();
-const ca = readKey('ca1-cert.pem').toString();
+const cert = fixtures.readKey('agent1-cert.pem').toString();
+const key = fixtures.readKey('agent1-key.pem').toString();
+const ca = fixtures.readKey('ca1-cert.pem').toString();
 
 // ---------------------------------------------------------------------------
 // Case 1: a matching servername with rejectUnauthorized succeeds, and the
@@ -49,9 +46,9 @@ const ca = readKey('ca1-cert.pem').toString();
   });
 
   const { protocol } = await session.opened;
-  match(protocol, /DTLS/i);
+  assert.match(protocol, /DTLS/i);
 
-  strictEqual(await sawServername.promise, 'agent1');
+  assert.strictEqual(await sawServername.promise, 'agent1');
 
   await session.close();
   await server.close();
@@ -75,7 +72,7 @@ const ca = readKey('ca1-cert.pem').toString();
     servername: 'wrong.example.com',
   });
 
-  await rejects(session.opened, /certificate verify failed/i);
+  await assert.rejects(session.opened, /certificate verify failed/i);
 
   // Closing the session tears down the internally-owned client endpoint.
   await session.close();


### PR DESCRIPTION
a7d16a8cc6e introduced destructured uses of `assert` and `fixtures` in the dtls tests, which the test lint rules forbid (`no-restricted-syntax`), so `lint-js-and-md` is currently failing on main and on every open PR.

Two of the files (`test-dtls-alpn.mjs`, `test-dtls-options.mjs`) also called bare `strictEqual`/`throws` that were never imported at all — those threw `ReferenceError` at runtime when the assertions ran.

This uses the `assert` and `fixtures` namespaces directly throughout, matching the rest of the test suite.

All 25 `test-dtls-*` tests pass locally on this branch and `make lint-js` is clean.

cc @jasnell