### PR TITLE
src: override inherited task runner environment

### DIFF
--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -11,6 +11,15 @@ static constexpr const char* env_var_separator = ";";
 static constexpr const char* env_var_separator = ":";
 #endif  // _WIN32
 
+static bool IsNodeRunEnvironmentVariable(const std::string& name) {
+#ifdef _WIN32
+  return StringEqualNoCase(name.c_str(), "NODE_RUN_SCRIPT_NAME") ||
+         StringEqualNoCase(name.c_str(), "NODE_RUN_PACKAGE_JSON_PATH");
+#else
+  return name == "NODE_RUN_SCRIPT_NAME" || name == "NODE_RUN_PACKAGE_JSON_PATH";
+#endif  // _WIN32
+}
+
 ProcessRunner::ProcessRunner(std::shared_ptr<InitializationResultImpl> result,
                              const std::filesystem::path& package_json_path,
                              std::string_view script_name,
@@ -107,6 +116,12 @@ void ProcessRunner::SetEnvironmentVariables() {
       file_ = value;
     }
 #endif  // _WIN32
+
+    // These variables describe the current task and are added below. Do not
+    // retain inherited values, as that would create duplicate entries.
+    if (IsNodeRunEnvironmentVariable(name)) {
+      continue;
+    }
 
     if (StringEqualNoCase(name.c_str(), "path")) {
       // Add path env variable to the beginning of the PATH

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -189,6 +189,29 @@ describe('node --run [command]', () => {
     assert.strictEqual(child.code, 0);
   });
 
+  it('should override inherited special environment variables', async () => {
+    const scriptName = `special-env-variables${envSuffix}`;
+    const packageJsonPath = fixtures.path('run-script/package.json');
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run', scriptName],
+      {
+        cwd: fixtures.path('run-script'),
+        env: {
+          ...process.env,
+          NODE_RUN_SCRIPT_NAME: 'inherited-script-name',
+          NODE_RUN_PACKAGE_JSON_PATH: 'inherited-package-json-path',
+        },
+      },
+    );
+    assert.deepStrictEqual(child.stdout.trim().split(/\r?\n/), [
+      scriptName,
+      packageJsonPath,
+    ]);
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
   it('will search parent directories for a package.json file', async () => {
     const packageJsonPath = fixtures.path('run-script/package.json');
     const child = await common.spawnPromisified(


### PR DESCRIPTION
Filter inherited NODE_RUN_SCRIPT_NAME and NODE_RUN_PACKAGE_JSON_PATH before adding the current task values. This prevents duplicate environment entries during nested node --run invocations.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
