### PR TITLE
src: match cmd.exe case-insensitively in task runner

### DIFF
--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -60,7 +60,11 @@ ProcessRunner::ProcessRunner(std::shared_ptr<InitializationResultImpl> result,
   }
 
 #ifdef _WIN32
-  if (file_.ends_with("cmd.exe")) {
+  static constexpr std::string_view cmd_exe = "cmd.exe";
+  if (file_.size() >= cmd_exe.size() &&
+      StringEqualNoCaseN(file_.data() + file_.size() - cmd_exe.size(),
+                         cmd_exe.data(),
+                         cmd_exe.size())) {
     // If the file is cmd.exe, use the following command line arguments:
     // "/c" Carries out the command and exit.
     // "/d" Disables execution of AutoRun commands.

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -34,6 +34,28 @@ describe('node --run [command]', () => {
     assert.strictEqual(child.code, 1);
   });
 
+  it('recognizes cmd.exe case-insensitively', {
+    skip: !common.isWindows,
+  }, async () => {
+    const env = { ...process.env };
+    const comspecKey = Object.keys(env)
+      .find((key) => key.toLowerCase() === 'comspec');
+    assert.notStrictEqual(comspecKey, undefined);
+    const comspec = env[comspecKey];
+    assert.match(comspec, /cmd\.exe$/i);
+    delete env[comspecKey];
+    env.ComSpec = comspec.replace(/cmd\.exe$/i, 'CMD.EXE');
+
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run', 'pwd-windows'],
+      { cwd: fixtures.path('run-script'), env },
+    );
+    assert.strictEqual(child.stdout.trim(), fixtures.path('run-script'));
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
   it('adds node_modules/.bin to path', async () => {
     const child = await common.spawnPromisified(
       process.execPath,


### PR DESCRIPTION
Use a case-insensitive suffix comparison for ComSpec so uppercase and mixed-case CMD.EXE paths use the correct /c invocation.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
