### PR TITLE
src: create task runner PATH when missing

### DIFF
--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -93,6 +93,8 @@ void ProcessRunner::SetEnvironmentVariables() {
   int env_count;
   CHECK_EQ(0, uv_os_environ(&env_items, &env_count));
 
+  bool has_path_env_var = false;
+
   // Iterate over environment variables once to store them in the current
   // ProcessRunner instance.
   for (int i = 0; i < env_count; i++) {
@@ -110,11 +112,16 @@ void ProcessRunner::SetEnvironmentVariables() {
 
     if (StringEqualNoCase(name.c_str(), "path")) {
       // Add path env variable to the beginning of the PATH
+      has_path_env_var = true;
       value = path_env_var_ + value;
     }
     env_vars_.push_back(name + "=" + value);
   }
   uv_os_free_environ(env_items, env_count);
+
+  if (!has_path_env_var) {
+    env_vars_.push_back("PATH=" + path_env_var_);
+  }
 
   // Add NODE_RUN_SCRIPT_NAME environment variable to the environment
   // to indicate which script is being run.

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -45,6 +45,21 @@ describe('node --run [command]', () => {
     assert.strictEqual(child.code, 0);
   });
 
+  it('creates PATH when it is missing from the environment', async () => {
+    const env = Object.fromEntries(
+      Object.entries(process.env)
+        .filter(([key]) => key.toLowerCase() !== 'path'),
+    );
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run', `ada${envSuffix}`],
+      { cwd: fixtures.path('run-script'), env },
+    );
+    assert.match(child.stdout, /06062023/);
+    assert.strictEqual(child.stderr, '');
+    assert.strictEqual(child.code, 0);
+  });
+
   it('chdirs into package directory', async () => {
     const child = await common.spawnPromisified(
       process.execPath,


### PR DESCRIPTION
Track whether the inherited environment contains PATH and create it from the discovered node_modules/.bin paths when absent.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
