### PR TITLE
src: include filesystem root in package search

### DIFF
--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -221,10 +221,9 @@ FindPackageJson(const std::filesystem::path& cwd) {
   std::string raw_content;
   std::string path_env_var;
   auto root_path = cwd.root_path();
+  auto directory_path = cwd;
 
-  for (auto directory_path = cwd;
-       !std::filesystem::equivalent(root_path, directory_path);
-       directory_path = directory_path.parent_path()) {
+  while (true) {
     // Append "path/node_modules/.bin" to the env var, if it is a directory.
     auto node_modules_bin = directory_path / "node_modules" / ".bin";
     if (std::filesystem::is_directory(node_modules_bin)) {
@@ -238,10 +237,16 @@ FindPackageJson(const std::filesystem::path& cwd) {
       std::string contents = package_json_path.string();
       USE(ReadFileSync(&raw_content, contents.c_str()) > 0);
     }
+
+    // Include the root directory in the search before stopping traversal.
+    if (std::filesystem::equivalent(root_path, directory_path)) {
+      break;
+    }
+    directory_path = directory_path.parent_path();
   }
 
-  // This means that there is no package.json until the root directory.
-  // In this case, we just return nullopt, which will terminate the process..
+  // This means that there is no package.json in cwd or its parent directories.
+  // In this case, return nullopt, which will terminate the process.
   if (raw_content.empty()) {
     return std::nullopt;
   }


### PR DESCRIPTION
Move the root termination check after processing the current directory so node --run can find package.json and node_modules/.bin at the filesystem root.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
