### PR TITLE
doc: formalize TestOptions.fn and TestOptions.name as part of the public API

### DIFF
--- a/doc/api/test.md
+++ b/doc/api/test.md
@@ -1956,6 +1956,10 @@ changes:
     If the number of assertions run in the test does not match the number
     specified in the plan, the test will fail.
     **Default:** `undefined`.
+  * `fn` {Function|AsyncFunction} The function under test. If provided, it will take
+    precedence over the `fn` parameter.
+  * `name` {string} The name of the test. If provided, it will take precedence over the
+    `name` parameter.
 * `fn` {Function|AsyncFunction} The function under test. The first argument
   to this function is a [`TestContext`][] object. If the test uses callbacks,
   the callback function is passed as the second argument. **Default:** A no-op

--- a/test/parallel/test-runner-option-precedence.js
+++ b/test/parallel/test-runner-option-precedence.js
@@ -1,0 +1,41 @@
+'use strict';
+require('../common');
+const { test, suite } = require('node:test');
+
+suite('test runner option precedence', () => {
+  test(
+    'overridden test name',
+    { name: 'options.name overrides test name', plan: 1 },
+    (t) => {
+      t.assert.strictEqual(t.name, 'options.name overrides test name');
+    },
+  );
+
+  test(
+    'options.fn overrides test function',
+    {
+      fn: (t) => {
+        t.assert.ok(true);
+      },
+      plan: 1,
+    },
+    (t) => {
+      t.assert.fail('should not be called');
+    },
+  );
+
+  test('options.fn only', {
+    plan: 1,
+    fn: (t) => {
+      t.assert.ok(true);
+    },
+  });
+
+  test({
+    name: 'single parameter options',
+    plan: 1,
+    fn: (t) => {
+      t.assert.ok(true);
+    },
+  });
+});


### PR DESCRIPTION
`TestOptions` as provided to `node:test`'s `test`/`it` supports both `name` and `fn` as options per its implementation.

I'd like to formalize this as part of the public, documented API.

### Motivation

I have a use-case for consuming both fields.  I'd like to be able to return the result of a function to `test`/`it` without needing to spread the parameters; e.g.:

```js
const testOptionsFactory = (opts = {}) => {
  return {
    fn: () => { /* .. */ },
    name: opts.name
  };
};

test(testOptionsFactory({name: 'foo'}));
```

If I cannot rely on this behavior, then I would need to instead return an array of parameters and spread them:

```js
const testParamsFactory = (opts = {}) => {
  return opts.name !== undefined
    ? [opts.name, () => { /* .. */ }] : [() => { /* .. */ }];
};

test(...testParamsFactory({name: 'foo'}));
```

I don't think it's too terribly controversial that the former is more ergonomic than the latter.

### Next Steps

Once this lands, I plan to propose the addition of these fields to `@types/node`. Since the fields are not currently publicly documented, I can't justify such a change.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
