### PR TITLE
esm: fix wasm import name in error message

### DIFF
--- a/lib/internal/modules/esm/translators.js
+++ b/lib/internal/modules/esm/translators.js
@@ -581,7 +581,7 @@ translators.set('wasm', function(url, translateContext) {
       throw new WebAssembly.LinkError(`Invalid Wasm import "${impt.module}" in ${url}`);
     }
     if (impt.name.startsWith('wasm:') || impt.name.startsWith('wasm-js:')) {
-      throw new WebAssembly.LinkError(`Invalid Wasm import name "${impt.module}" in ${url}`);
+      throw new WebAssembly.LinkError(`Invalid Wasm import name "${impt.name}" in ${url}`);
     }
     importsList.add(impt.module);
   }


### PR DESCRIPTION

Fix the error message for reserved Wasm import names.

The loader checks `impt.name` when rejecting import names that start with `wasm:` or `wasm-js:`, but the thrown error message reported `impt.module` instead. 
This made the message point at the wrong part of the Wasm import.

This changes the message to report the rejected import name.