### PR TITLE
src: treat signal-terminated tasks as failures

### DIFF
--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -197,7 +197,7 @@ void ProcessRunner::ExitCallback(uv_process_t* handle,
 }
 
 void ProcessRunner::OnExit(int64_t exit_status, int term_signal) {
-  if (exit_status > 0) {
+  if (exit_status != 0 || term_signal != 0) {
     init_result_->exit_code_ = ExitCode::kGenericUserError;
   } else {
     init_result_->exit_code_ = ExitCode::kNoFailure;

--- a/test/fixtures/run-script/package.json
+++ b/test/fixtures/run-script/package.json
@@ -11,6 +11,7 @@
     "path-env-windows": "path-env.bat",
     "special-env-variables": "special-env-variables",
     "special-env-variables-windows": "special-env-variables.bat",
+    "signal-termination": "kill -TERM $$",
     "pwd": "pwd",
     "pwd-windows": "cd"
   }

--- a/test/message/node_run_non_existent.out
+++ b/test/message/node_run_non_existent.out
@@ -12,5 +12,6 @@ Available scripts are:
   path-env-windows: path-env.bat
   special-env-variables: special-env-variables
   special-env-variables-windows: special-env-variables.bat
+  signal-termination: kill -TERM $$
   pwd: pwd
   pwd-windows: cd

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -34,6 +34,17 @@ describe('node --run [command]', () => {
     assert.strictEqual(child.code, 1);
   });
 
+  it('reports signal-terminated scripts as failures', {
+    skip: common.isWindows,
+  }, async () => {
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run', 'signal-termination'],
+      { cwd: fixtures.path('run-script') },
+    );
+    assert.strictEqual(child.code, 1);
+  });
+
   it('adds node_modules/.bin to path', async () => {
     const child = await common.spawnPromisified(
       process.execPath,


### PR DESCRIPTION
Check term_signal when handling task runner process exits so scripts terminated by a signal do not incorrectly report success.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
