### PR TITLE
doc: fix grammar and wording in assert documentation

### DIFF
--- a/doc/api/assert.md
+++ b/doc/api/assert.md
@@ -317,7 +317,7 @@ const assert2 = new Assert({ skipPrototype: true });
 assert2.deepStrictEqual(foo, bar); // OK
 ```
 
-When destructured, methods lose access to the instance's `this` context and revert to default assertion behavior
+When destructured, methods lose access to the instance's `this` context and revert to the default assertion behavior
 (diff: 'simple', non-strict mode).
 To maintain custom options when using destructured methods, avoid
 destructuring and call methods directly on the instance.
@@ -423,8 +423,8 @@ are also recursively evaluated by the following rules.
 ### Comparison details
 
 * Primitive values are compared with the [`==` operator][],
-  with the exception of {NaN}. It is treated as being identical in case
-  both sides are {NaN}.
+  except for {NaN}, which is treated as identical when both
+  sides are {NaN}.
 * [Type tags][Object.prototype.toString()] of objects should be the same.
 * Only [enumerable "own" properties][] are considered.
 * Object constructors are compared when available.
@@ -938,7 +938,7 @@ error messages as expressive as possible.
 If specified, `error` can be a [`Class`][], {RegExp} or a validation
 function. See [`assert.throws()`][] for more details.
 
-Besides the async nature to await the completion behaves identically to
+Aside from asynchronously awaiting completion, it behaves identically to
 [`assert.doesNotThrow()`][].
 
 ```mjs


### PR DESCRIPTION
## Summary

This pull request fixes several minor grammar and punctuation issues in the assert.md documentation.

The changes are documentation-only.