### PR TITLE
fs: fix recursive readdir with buffer encoding

### DIFF
--- a/lib/fs.js
+++ b/lib/fs.js
@@ -109,7 +109,10 @@ const {
   getValidatedFd,
   getValidatedPath,
   handleErrorFromBinding,
+  isDirectoryPath,
+  join: joinPath,
   preprocessSymlinkDestination,
+  relativeToBasePath,
   Stats,
   getReadFileBuffer,
   getReadFileBufferByteLengthName,
@@ -1732,11 +1735,11 @@ function handleDirents({ result, currentPath, context }) {
   for (let i = 0; i < length; i++) {
     // Avoid excluding symlinks, as they are not directories.
     // Refs: https://github.com/nodejs/node/issues/52663
-    const fullPath = pathModule.join(currentPath, names[i]);
+    const fullPath = joinPath(currentPath, names[i]);
     const dirent = getDirent(currentPath, names[i], types[i]);
     ArrayPrototypePush(context.readdirResults, dirent);
 
-    if (dirent.isDirectory() || binding.internalModuleStat(fullPath) === 1) {
+    if (dirent.isDirectory() || isDirectoryPath(fullPath)) {
       ArrayPrototypePush(context.pathsQueue, fullPath);
     }
   }
@@ -1744,12 +1747,12 @@ function handleDirents({ result, currentPath, context }) {
 
 function handleFilePaths({ result, currentPath, context }) {
   for (let i = 0; i < result.length; i++) {
-    const resultPath = pathModule.join(currentPath, result[i]);
-    const relativeResultPath = pathModule.relative(context.basePath, resultPath);
-    const stat = binding.internalModuleStat(resultPath);
+    const resultPath = joinPath(currentPath, result[i]);
+    const relativeResultPath = relativeToBasePath(context.basePath, resultPath);
+    const stat = isDirectoryPath(resultPath);
     ArrayPrototypePush(context.readdirResults, relativeResultPath);
 
-    if (stat === 1) {
+    if (stat) {
       ArrayPrototypePush(context.pathsQueue, resultPath);
     }
   }

--- a/lib/internal/fs/promises.js
+++ b/lib/internal/fs/promises.js
@@ -68,7 +68,10 @@ const {
   getValidatedPath,
   getReadFileBuffer,
   getReadFileBufferByteLengthName,
+  isDirectoryPath,
+  join: joinPath,
   preprocessSymlinkDestination,
+  relativeToBasePath,
   stringToFlags,
   stringToSymlinkType,
   toUnixTimestamp,
@@ -1640,7 +1643,7 @@ async function readdirRecursive(originalPath, options) {
       for (const dirent of getDirents(path, readdir)) {
         ArrayPrototypePush(result, dirent);
         if (dirent.isDirectory()) {
-          const direntPath = pathModule.join(path, dirent.name);
+          const direntPath = joinPath(path, dirent.name);
           ArrayPrototypePush(queue, [
             direntPath,
             await PromisePrototypeThen(
@@ -1661,13 +1664,13 @@ async function readdirRecursive(originalPath, options) {
     while (queue.length > 0) {
       const { 0: path, 1: readdir } = ArrayPrototypePop(queue);
       for (const ent of readdir) {
-        const direntPath = pathModule.join(path, ent);
-        const stat = binding.internalModuleStat(direntPath);
+        const direntPath = joinPath(path, ent);
+        const isDir = isDirectoryPath(direntPath);
         ArrayPrototypePush(
           result,
-          pathModule.relative(originalPath, direntPath),
+          relativeToBasePath(originalPath, direntPath),
         );
-        if (stat === 1) {
+        if (isDir) {
           ArrayPrototypePush(queue, [
             direntPath,
             await PromisePrototypeThen(

--- a/lib/internal/fs/utils.js
+++ b/lib/internal/fs/utils.js
@@ -65,6 +65,7 @@ const {
   validateUint32,
 } = require('internal/validators');
 const pathModule = require('path');
+const binding = internalBinding('fs');
 const kType = Symbol('type');
 const kStats = Symbol('stats');
 const kPartialAtimeNs = Symbol('partialAtimeNs');
@@ -247,6 +248,37 @@ function join(path, name) {
 
   throw new ERR_INVALID_ARG_TYPE(
     'path', ['string', 'Buffer'], path);
+}
+
+// Computes the equivalent of `path.relative(basePath, fullPath)` when
+// either argument may be a Buffer (as with `readdir(..., { recursive: true,
+// encoding: 'buffer' })`). `fullPath` is always built by repeatedly calling
+// `join()` (above) starting from `basePath`, so stripping the `basePath`
+// prefix - and the separator `join()` would have inserted - gives the same
+// result as `path.relative()` without needing its general Buffer support.
+function relativeToBasePath(basePath, fullPath) {
+  if (typeof basePath === 'string' && typeof fullPath === 'string') {
+    return pathModule.relative(basePath, fullPath);
+  }
+  const baseBuffer = isUint8Array(basePath) ? basePath : Buffer.from(basePath);
+  let offset = baseBuffer.length;
+  if (offset !== 0 && baseBuffer[offset - 1] !== bufferSep[0]) {
+    offset += bufferSep.length;
+  }
+  return fullPath.subarray(offset);
+}
+
+// `internalModuleStat` is a CommonJS-module-resolution-specific binding
+// (see lib/internal/modules/cjs/loader.js) that only accepts strings. For
+// Buffer paths, fall back to the general-purpose `stat` binding used by
+// `fs.statSync()`, which handles Buffers correctly at the native layer
+// without a lossy string round-trip.
+function isDirectoryPath(path) {
+  if (typeof path === 'string') {
+    return binding.internalModuleStat(path) === 1;
+  }
+  const stats = binding.stat(path, false, undefined, false);
+  return stats !== undefined && getStatsFromBinding(stats).isDirectory();
 }
 
 function getDirents(path, { 0: names, 1: types }, callback) {
@@ -1128,6 +1160,9 @@ module.exports = {
   getDirent,
   getDirents,
   getOptions,
+  isDirectoryPath,
+  join,
+  relativeToBasePath,
   getValidatedFd,
   getValidatedPath,
   handleErrorFromBinding,

--- a/test/parallel/test-fs-readdir-recursive-buffer.js
+++ b/test/parallel/test-fs-readdir-recursive-buffer.js
@@ -1,0 +1,49 @@
+'use strict';
+
+// Regression test for https://github.com/nodejs/node/issues/58892
+// `readdir`/`readdirSync` with `{ recursive: true }` throw
+// ERR_INVALID_ARG_TYPE when `encoding: 'buffer'` is used, because the
+// internal recursive walk joins path segments with `path.join()`, which
+// does not accept Buffer arguments.
+
+const common = require('../common');
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const tmpdir = require('../common/tmpdir');
+
+tmpdir.refresh();
+
+const nested = path.join(tmpdir.path, 'a', 'b');
+fs.mkdirSync(nested, { recursive: true });
+fs.writeFileSync(path.join(nested, 'file.txt'), 'hello');
+
+// readdirSync
+const syncResult = fs.readdirSync(tmpdir.path, { recursive: true, encoding: 'buffer' });
+assert.ok(syncResult.every((entry) => Buffer.isBuffer(entry)));
+assert.ok(syncResult.some((entry) => entry.toString().includes('file.txt')));
+
+// readdirSync with withFileTypes
+const syncDirents = fs.readdirSync(
+  tmpdir.path,
+  { recursive: true, encoding: 'buffer', withFileTypes: true }
+);
+assert.ok(syncDirents.some((dirent) => dirent.name.toString() === 'file.txt'));
+
+// readdir (callback)
+fs.readdir(
+  tmpdir.path,
+  { recursive: true, encoding: 'buffer' },
+  common.mustSucceed((entries) => {
+    assert.ok(entries.every((entry) => Buffer.isBuffer(entry)));
+    assert.ok(entries.some((entry) => entry.toString().includes('file.txt')));
+  })
+);
+
+// fs.promises.readdir
+fs.promises
+  .readdir(tmpdir.path, { recursive: true, encoding: 'buffer' })
+  .then(common.mustCall((entries) => {
+    assert.ok(entries.every((entry) => Buffer.isBuffer(entry)));
+    assert.ok(entries.some((entry) => entry.toString().includes('file.txt')));
+  }));


### PR DESCRIPTION
### Description

`fs.readdir()`, `fs.readdirSync()`, and `fs.promises.readdir()` throw
`ERR_INVALID_ARG_TYPE` (or crash the process outright in the callback
case) when called with both `{ recursive: true }` and
`{ encoding: 'buffer' }`. The internal recursive walk builds paths with
`path.join()`/`path.relative()`, and checks whether an entry is a
directory via a CommonJS-module-resolution-specific native stat
binding (`internalModuleStat`) - none of these accept `Buffer`
arguments, which is what entry names become once `encoding: 'buffer'`
is set.

```js
const fs = require('fs');
fs.readdirSync('.', { recursive: true, encoding: 'buffer' });
// Uncaught TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument
// must be of type string. Received an instance of Buffer
```

### Fix

- `internal/fs/utils` already had an unexported `join()` helper that
  correctly handles string/Buffer combinations; this exports it and
  adds two more helpers alongside it: `relativeToBasePath()` (avoids
  needing `path.relative()`'s Buffer support, since the full path is
  always built by repeatedly joining onto the base path) and
  `isDirectoryPath()`.
- `isDirectoryPath()` keeps using `internalModuleStat` for the string
  fast path (unchanged behavior/performance for the common case), but
  falls back to the general-purpose `stat` binding - the same one
  `fs.statSync()` uses - for Buffer paths. That binding handles
  Buffers correctly at the native layer, so this also avoids a lossy
  string round-trip for non-UTF8 file names, rather than just papering
  over the reported crash.
- `lib/fs.js` (`handleDirents`/`handleFilePaths`) and
  `lib/internal/fs/promises.js` (`readdirRecursive`) both had their
  own copy of this bug and are updated to use the shared helpers.

### Testing

Added `test/parallel/test-fs-readdir-recursive-buffer.js`, covering
`readdirSync`, `readdirSync` with `withFileTypes`, the `readdir`
callback form, and `fs.promises.readdir`, all with
`{ recursive: true, encoding: 'buffer' }`.

Ran the full `test/parallel/test-fs-readdir*.js` suite plus a broader
`test/parallel/test-fs-*.js` sweep (257 files) locally on Windows
(clang-cl build) - all pass except 7 pre-existing failures unrelated
to this change (`EPERM` on `symlinkSync` due to this environment not
running elevated/without Developer Mode, verified individually).

Fixes: https://github.com/nodejs/node/issues/58892