### PR TITLE
src: return failure when task spawning fails

### DIFF
--- a/src/node_task_runner.cc
+++ b/src/node_task_runner.cc
@@ -210,6 +210,8 @@ void ProcessRunner::Run() {
   options_.cwd = cwd_.c_str();
   if (int r = uv_spawn(loop_, &process_, &options_)) {
     fprintf(stderr, "Error: %s\n", uv_strerror(r));
+    init_result_->exit_code_ = ExitCode::kGenericUserError;
+    return;
   }
 
   uv_run(loop_, UV_RUN_DEFAULT);

--- a/test/parallel/test-node-run.js
+++ b/test/parallel/test-node-run.js
@@ -34,6 +34,26 @@ describe('node --run [command]', () => {
     assert.strictEqual(child.code, 1);
   });
 
+  it('returns an error when spawning the shell fails', {
+    skip: !common.isWindows,
+  }, async () => {
+    const env = { ...process.env };
+    for (const key of Object.keys(env)) {
+      if (key.toLowerCase() === 'comspec') {
+        delete env[key];
+      }
+    }
+    env.ComSpec = fixtures.path('run-script', 'non-existent-cmd.exe');
+
+    const child = await common.spawnPromisified(
+      process.execPath,
+      [ '--run', 'test'],
+      { cwd: fixtures.path('run-script'), env },
+    );
+    assert.match(child.stderr, /^Error: /);
+    assert.strictEqual(child.code, 1);
+  });
+
   it('adds node_modules/.bin to path', async () => {
     const child = await common.spawnPromisified(
       process.execPath,


### PR DESCRIPTION
Set a non-zero exit code and return immediately when uv_spawn() fails, since no process exit callback will be invoked.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
