### PR TITLE
lib: use validateArray for array arguments

### DIFF
--- a/lib/internal/streams/iter/broadcast.js
+++ b/lib/internal/streams/iter/broadcast.js
@@ -33,6 +33,7 @@ const {
 } = require('internal/errors');
 const {
   validateAbortSignal,
+  validateArray,
   validateInteger,
   validateObject,
 } = require('internal/validators');
@@ -554,9 +555,7 @@ class BroadcastWriter {
   }
 
   writev(chunks, options) {
-    if (!ArrayIsArray(chunks)) {
-      throw new ERR_INVALID_ARG_TYPE('chunks', 'Array', chunks);
-    }
+    validateArray(chunks, 'chunks');
     const signal = getWriterSignal(options);
     // Fast path: no signal, writer open, buffer has space
     if (this.#canUseWriteFastPath(signal)) {
@@ -615,9 +614,7 @@ class BroadcastWriter {
   }
 
   writevSync(chunks) {
-    if (!ArrayIsArray(chunks)) {
-      throw new ERR_INVALID_ARG_TYPE('chunks', 'Array', chunks);
-    }
+    validateArray(chunks, 'chunks');
     if (this.#isClosedOrAborted()) return false;
     if (!this.#broadcast[kCanWrite]()) return false;
     const converted = convertChunks(chunks);

--- a/lib/internal/streams/iter/classic.js
+++ b/lib/internal/streams/iter/classic.js
@@ -12,7 +12,6 @@
 //   toWritable(writer)           -- stream/iter Writer -> classic Writable
 
 const {
-  ArrayIsArray,
   ArrayPrototypePush,
   NumberMAX_SAFE_INTEGER,
   Promise,
@@ -41,6 +40,7 @@ const {
 } = require('internal/errors');
 
 const {
+  validateArray,
   validateInteger,
   validateObject,
 } = require('internal/validators');
@@ -619,9 +619,7 @@ function fromWritable(writable, options = kNullPrototype) {
     },
 
     writev(chunks, options) {
-      if (!ArrayIsArray(chunks)) {
-        throw new ERR_INVALID_ARG_TYPE('chunks', 'Array', chunks);
-      }
+      validateArray(chunks, 'chunks');
       getWriterSignal(options);
       if (!isWritable()) {
         return PromiseReject(new ERR_STREAM_WRITE_AFTER_END());

--- a/lib/internal/streams/iter/push.js
+++ b/lib/internal/streams/iter/push.js
@@ -6,7 +6,6 @@
 // with built-in backpressure.
 
 const {
-  ArrayIsArray,
   ArrayPrototypePush,
   PromisePrototypeThen,
   PromiseReject,
@@ -21,13 +20,13 @@ const {
 
 const {
   codes: {
-    ERR_INVALID_ARG_TYPE,
     ERR_INVALID_STATE,
   },
 } = require('internal/errors');
 const { isError, lazyDOMException } = require('internal/util');
 const {
   validateAbortSignal,
+  validateArray,
   validateInteger,
 } = require('internal/validators');
 
@@ -631,9 +630,7 @@ class PushWriter {
   }
 
   writev(chunks, options) {
-    if (!ArrayIsArray(chunks)) {
-      throw new ERR_INVALID_ARG_TYPE('chunks', 'Array', chunks);
-    }
+    validateArray(chunks, 'chunks');
     const signal = getWriterSignal(options);
     if (!signal && this.#queue.canWriteSync()) {
       const bytes = convertChunks(chunks);
@@ -650,9 +647,7 @@ class PushWriter {
   }
 
   writevSync(chunks) {
-    if (!ArrayIsArray(chunks)) {
-      throw new ERR_INVALID_ARG_TYPE('chunks', 'Array', chunks);
-    }
+    validateArray(chunks, 'chunks');
     const bytes = convertChunks(chunks);
     return this.#queue.writeSync(bytes);
   }

--- a/lib/internal/tls/secure-context.js
+++ b/lib/internal/tls/secure-context.js
@@ -26,6 +26,7 @@ const {
 } = require('internal/util/types');
 
 const {
+  validateArray,
   validateBuffer,
   validateInt32,
   validateObject,
@@ -213,10 +214,7 @@ function configSecureContext(context, options = kEmptyObject, name = 'options') 
   }
 
   if (certificateCompression != null) {
-    if (!ArrayIsArray(certificateCompression)) {
-      throw new ERR_INVALID_ARG_TYPE(
-        `${name}.certificateCompression`, 'Array', certificateCompression);
-    }
+    validateArray(certificateCompression, `${name}.certificateCompression`);
 
     if (certificateCompression.length > 0) {
       // Pack length + algorithm IDs into a single Uint32 for a cheap

--- a/lib/tls.js
+++ b/lib/tls.js
@@ -70,7 +70,7 @@ const { canonicalizeIP } = internalBinding('cares_wrap');
 const tlsCommon = require('internal/tls/common');
 const tlsWrap = require('internal/tls/wrap');
 const { domainToASCII } = require('internal/url');
-const { validateString } = require('internal/validators');
+const { validateArray, validateString } = require('internal/validators');
 
 const {
   namespace: {
@@ -206,9 +206,7 @@ function getCACertificates(type = 'default') {
 exports.getCACertificates = getCACertificates;
 
 function setDefaultCACertificates(certs) {
-  if (!ArrayIsArray(certs)) {
-    throw new ERR_INVALID_ARG_TYPE('certs', 'Array', certs);
-  }
+  validateArray(certs, 'certs');
 
   // Verify that all elements in the array are strings
   for (let i = 0; i < certs.length; i++) {


### PR DESCRIPTION
Replaces manual `ArrayIsArray` checks that throw `ERR_INVALID_ARG_TYPE` with the shared `validateArray` helper, following #39774.

The thrown error is unchanged in all seven spots: `validateArray` throws `ERR_INVALID_ARG_TYPE(name, 'Array', value)` under the same `!ArrayIsArray(value)` condition, and the default `minLength = 0` makes its length check a no-op. Existing tests already pin the message, e.g. `test-tls-set-default-ca-certificates-error.js` asserts `The "certs" argument must be an instance of Array`.

In `lib/internal/streams/iter/{push,broadcast}.js` the checks stay synchronous: `writev`/`writevSync` threw before reaching any async path, and `validateArray` throws synchronously too.
