### PR TITLE
tools: store "default" OpenSSL version in `openssl-matrix.nix`

### DIFF
--- a/tools/dep_updaters/update-nixpkgs-pin.sh
+++ b/tools/dep_updaters/update-nixpkgs-pin.sh
@@ -42,6 +42,14 @@ COMPAT_VERSION_SHA1=$(grep 'rev =' "$NIXPKGS_COMPAT_PIN_FILE" | awk -F'"' '{ pri
 COMPAT_UPSTREAM_SHA1=$(git ls-remote "$NIXPKGS_REPO.git" nixpkgs-26.05-darwin | awk '{print $1}')
 update_pkgs_file "$NIXPKGS_COMPAT_PIN_FILE" "$COMPAT_VERSION_SHA1" "$COMPAT_UPSTREAM_SHA1"
 
+# === Update openssl-matrix.nix ===
+# When bumping the pin, we want to update the openssl-matrix.nix file to keep the list in sync nixpkgs
+# i.e. add newly added release lines, remove newly dropped release lines), and make sure the "openssl"
+# attribute still refers to the same release line as the bundled version in deps/openssl/.
+
+OPENSSL_MAJOR=$(awk -F= '/^MAJOR=[0-9]+$/ { print $2; exit }' "$BASE_DIR/deps/openssl/openssl/VERSION.dat")
+OPENSSL_MINOR=$(awk -F= '/^MINOR=[0-9]+$/ { print $2; exit }' "$BASE_DIR/deps/openssl/openssl/VERSION.dat")
+
 nix-instantiate -I "nixpkgs=$NIXPKGS_PIN_FILE" --eval --strict --json -E "
   let
     pkgs = import <nixpkgs> {};
@@ -49,15 +57,24 @@ nix-instantiate -I "nixpkgs=$NIXPKGS_PIN_FILE" --eval --strict --json -E "
       (n: builtins.match \"openssl_[0-9]+(_[0-9]+)?\" n != null)
       (builtins.attrNames pkgs);
     extraMatrixAttrs = [ \"boringssl\" ];
+    default = builtins.head (builtins.filter (n:
+      let
+        inherit (pkgs.lib) versions;
+        t = builtins.tryEval pkgs.\${n};
+        v = if t.success then builtins.tryEval t.value.version else t;
+        majorVersion = pkgs.lib.optionalString v.success (versions.major v.value);
+        minorVersion = pkgs.lib.optionalString v.success (versions.minor v.value);
+      in
+        majorVersion == ''$OPENSSL_MAJOR'' && minorVersion == ''$OPENSSL_MINOR'') opensslAttrs);
     attrs = builtins.filter
       (n:
         let t = builtins.tryEval pkgs.\${n}; in
-        t.success && (builtins.tryEval t.value.version).success
+        n != default && t.success && (builtins.tryEval t.value.version).success
       )
       (opensslAttrs ++ extraMatrixAttrs);
   in
   {
-    inherit attrs;
+    inherit attrs default;
     permittedInsecurePackages = builtins.map (attr: pkgs.\${attr}.name) (
       builtins.filter (attr: (pkgs.\${attr}.meta.insecure)) attrs
     );
@@ -69,6 +86,10 @@ nix-instantiate -I "nixpkgs=$NIXPKGS_PIN_FILE" --eval --strict --json -E "
 }:
 
 {
+  # "default" OpenSSL release line, should be kept in sync with the bundled version:
+  openssl = pkgs.\(.default);
+
+  # Other OpenSSL variants we want to test for:
   inherit (pkgs)
     \(.attrs | sort | join("\n    "))
     ;

--- a/tools/nix/openssl-matrix.nix
+++ b/tools/nix/openssl-matrix.nix
@@ -5,11 +5,14 @@
 }:
 
 {
+  # "default" OpenSSL release line, should be kept in sync with the bundled version:
+  openssl = pkgs.openssl_3_5;
+
+  # Other OpenSSL variants we want to test for:
   inherit (pkgs)
     boringssl
     openssl_1_1
     openssl_3
-    openssl_3_5
     openssl_3_6
     openssl_4_0
     ;

--- a/tools/nix/pkcs11.nix
+++ b/tools/nix/pkcs11.nix
@@ -10,7 +10,7 @@
   # pkcs11-provider is dlopen'd into the libcrypto Node.js itself links, so it
   # has to be built against that very OpenSSL. SoftHSM links OpenSSL too;
   # building it against the same one keeps a single libcrypto in the process.
-  openssl ? (import ./sharedLibDeps.nix { inherit pkgs; }).openssl,
+  openssl ? (import ./openssl-matrix.nix { inherit pkgs; }).openssl,
 
   pin ? "1234",
 }:

--- a/tools/nix/sharedLibDeps.nix
+++ b/tools/nix/sharedLibDeps.nix
@@ -48,7 +48,7 @@
   ffi = pkgs.libffiReal;
 })
 // (pkgs.lib.optionalAttrs withSSL ({
-  openssl = (import ./openssl-matrix.nix { inherit pkgs; }).openssl_3_5;
+  inherit (import ./openssl-matrix.nix { inherit pkgs; }) openssl;
 }))
 // (pkgs.lib.optionalAttrs withTemporal {
   inherit (pkgs) temporal_capi;


### PR DESCRIPTION
To help with automating keeping in sync with the bundled version.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
