### PR TITLE
build: enable perfetto updater

### DIFF
--- a/.github/workflows/tools.yml
+++ b/.github/workflows/tools.yml
@@ -35,6 +35,7 @@ on:
           - nghttp2
           - nghttp3
           - ngtcp2
+          - perfetto
           - postject
           - root-certificates
           - simdjson
@@ -234,6 +235,14 @@ jobs:
             label: dependencies
             run: |
               ./tools/dep_updaters/update-ngtcp2.sh > temp-output
+              cat temp-output
+              tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
+              rm temp-output
+          - id: perfetto
+            subsystem: deps
+            label: dependencies
+            run: |
+              ./tools/dep_updaters/update-perfetto.sh > temp-output
               cat temp-output
               tail -n1 temp-output | grep "NEW_VERSION=" >> "$GITHUB_ENV" || true
               rm temp-output

--- a/tools/dep_updaters/update-perfetto.sh
+++ b/tools/dep_updaters/update-perfetto.sh
@@ -57,7 +57,7 @@ echo "$NEW_VERSION" > perfetto/VERSION
 curl -sL -o "perfetto/LICENSE" "https://raw.githubusercontent.com/google/perfetto/refs/tags/$PERFETTO_REF/LICENSE"
 
 # Remove C API headers. Only keep C++ API headers.
-rm perfetto/sdk/perfetto_c.h perfetto/sdk/perfetto_c.cc
+rm -f perfetto/sdk/perfetto_c.h perfetto/sdk/perfetto_c.cc
 
 echo "Copying existing gyp files"
 cp "$DEPS_DIR/perfetto/perfetto.gyp" "$WORKSPACE/perfetto"


### PR DESCRIPTION
Now that the perfetto build is enabled in GHA, the perfetto changes can be verified by CI. Enable `tools/dep_updaters/update-perfetto.sh` in the GHA deps updater workflow now.