### PR TITLE
test: allow half-open CONNECT tunnel sockets

### DIFF
--- a/test/client-proxy/test-https-proxy-request-invalid-char-in-url.mjs
+++ b/test/client-proxy/test-https-proxy-request-invalid-char-in-url.mjs
@@ -82,19 +82,10 @@ for (const testCase of testCases) {
           proxy.close();
           server.close();
           assert.deepStrictEqual(requests, expectedUrls);
-          const logSet = new Set(logs);
-          for (const log of logSet) {
-            if (log.source === 'proxy connect' && log.error?.code === 'EPIPE') {
-              // There can be a race from eagerly shutting down the servers and severing
-              // two pipes at the same time but for the purpose of this test, we only
-              // care about whether the requests are initiated from the client as expected,
-              // not how the upstream/proxy servers behave. Ignore EPIPE errors from them..
-              // Refs: https://github.com/nodejs/node/issues/59741
-              console.log('Ignoring EPIPE error from proxy connect', log.error);
-              logSet.delete(log);
-            }
-          }
-          assert.deepStrictEqual(logSet, expectedProxyLogs);
+          const requestLogs = logs.filter((log) => !('error' in log));
+          const errors = logs.filter((log) => 'error' in log);
+          assert.deepStrictEqual(new Set(requestLogs), expectedProxyLogs);
+          assert.deepStrictEqual(errors, []);
         }));
       }
     }));

--- a/test/common/proxy-server.js
+++ b/test/common/proxy-server.js
@@ -80,7 +80,14 @@ function createProxyServer(options = {}) {
 
     const normalizedHostname = hostname.startsWith('[') && hostname.endsWith(']') ?
       hostname.slice(1, -1) : hostname;
-    const proxyReq = net.connect(port, normalizedHostname, () => {
+    // A CONNECT tunnel is full-duplex. Keep the upstream socket writable after
+    // receiving a FIN so that the client-to-upstream pipe can finish draining.
+    // The reverse pipe will end `res`, and `res` will in turn end `proxyReq`.
+    const proxyReq = net.connect({
+      port,
+      host: normalizedHostname,
+      allowHalfOpen: true,
+    }, () => {
       res.write(
         'HTTP/1.1 200 Connection Established\r\n' +
         'Proxy-agent: Node.js-Proxy\r\n' +


### PR DESCRIPTION
Refs: https://github.com/nodejs/reliability/issues?q=%22test-https-proxy-request-invalid-char-in-url%22

CONNECT tunnels are full-duplex. When the upstream socket receives a FIN while the client-to-upstream pipe is still draining, the default socket behavior can produce EPIPE or ECONNRESET errors.

Keep the upstream socket half-open so both directions can drain. Separate request logs from transport errors to verify that teardown completes without errors.

---

Assisted-by: codex:gpt-5.6-sol