### PR TITLE
src: export manually declared postmortem metadata

### DIFF
--- a/src/node_postmortem_metadata.cc
+++ b/src/node_postmortem_metadata.cc
@@ -36,12 +36,13 @@
   V(ListNode_ReqWrap, next_, uintptr_t, ListNode<ReqWrapBase>::next_)
 
 extern "C" {
-int nodedbg_const_ContextEmbedderIndex__kEnvironment__int;
-int nodedbg_const_BaseObject__kInternalFieldCount__int;
-int nodedbg_const_HandleWrap__kInternalFieldCount__int;
-int nodedbg_const_ReqWrap__kInternalFieldCount__int;
-uintptr_t nodedbg_offset_ExternalString__data__uintptr_t;
-uintptr_t nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue;
+NODE_EXTERN int nodedbg_const_ContextEmbedderIndex__kEnvironment__int;
+NODE_EXTERN int nodedbg_const_BaseObject__kInternalFieldCount__int;
+NODE_EXTERN int nodedbg_const_HandleWrap__kInternalFieldCount__int;
+NODE_EXTERN int nodedbg_const_ReqWrap__kInternalFieldCount__int;
+NODE_EXTERN uintptr_t nodedbg_offset_ExternalString__data__uintptr_t;
+NODE_EXTERN uintptr_t
+    nodedbg_offset_ReqWrap__req_wrap_queue___ListNode_ReqWrapQueue;
 
 #define V(Class, Member, Type, Accessor)                                      \
   NODE_EXTERN uintptr_t NODEDBG_OFFSET(Class, Member, Type);


### PR DESCRIPTION
Apply NODE_EXTERN to the manually declared nodedbg_* symbols, matching the macro-generated metadata. This prevents Windows LTCG from discarding symbols required by postmortem debugging tools.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
