### PR TITLE
esm: only register text format when enabled

### DIFF
--- a/lib/internal/modules/esm/assert.js
+++ b/lib/internal/modules/esm/assert.js
@@ -50,9 +50,9 @@ const supportedTypeAttributes = ArrayPrototypeFilter(
 
 function initializeImportAttributes() {
   if (getOptionValue('--experimental-import-text') &&
-    formatTypeMap['text'] === undefined
+    formatTypeMap.text === undefined
   ) {
-    formatTypeMap['text'] = 'text';
+    formatTypeMap.text = 'text';
     ArrayPrototypePush(supportedTypeAttributes, 'text');
   }
 }

--- a/lib/internal/modules/esm/assert.js
+++ b/lib/internal/modules/esm/assert.js
@@ -3,6 +3,7 @@
 const {
   ArrayPrototypeFilter,
   ArrayPrototypeIncludes,
+  ArrayPrototypePush,
   ObjectKeys,
   ObjectPrototypeHasOwnProperty,
   ObjectValues,
@@ -30,7 +31,6 @@ const formatTypeMap = {
   'commonjs': kImplicitTypeAttribute,
   'json': 'json',
   'module': kImplicitTypeAttribute,
-  'text': 'text',
   'wasm': kImplicitTypeAttribute, // It's unclear whether the HTML spec will require an type attribute or not for Wasm; see https://github.com/WebAssembly/esm-integration/issues/42
 };
 // NOTE: Don't add bytes support yet as it requires Uint8Arrays backed by immutable ArrayBuffers,
@@ -47,6 +47,15 @@ const formatTypeMap = {
 const supportedTypeAttributes = ArrayPrototypeFilter(
   ObjectValues(formatTypeMap),
   (type) => type !== kImplicitTypeAttribute);
+
+function initializeImportAttributes() {
+  if (getOptionValue('--experimental-import-text') &&
+    formatTypeMap['text'] === undefined
+  ) {
+    formatTypeMap['text'] = 'text';
+    ArrayPrototypePush(supportedTypeAttributes, 'text');
+  }
+}
 
 /**
  * Test a module's import attributes.
@@ -66,12 +75,6 @@ function validateAttributes(url, format,
     }
   }
   const validType = formatTypeMap[format];
-
-  if (validType !== undefined &&
-    importAttributes.type === 'text' &&
-    !getOptionValue('--experimental-import-text')) {
-    throw new ERR_IMPORT_ATTRIBUTE_UNSUPPORTED('type', importAttributes.type, url);
-  }
 
   switch (validType) {
     case undefined:
@@ -122,6 +125,7 @@ function handleInvalidType(url, type) {
 
 
 module.exports = {
+  initializeImportAttributes,
   kImplicitTypeAttribute,
   validateAttributes,
 };

--- a/lib/internal/process/pre_execution.js
+++ b/lib/internal/process/pre_execution.js
@@ -169,6 +169,8 @@ function prepareExecution(options) {
 
   const { initializeExtensionFormatMap } = require('internal/modules/esm/get_format');
   initializeExtensionFormatMap();
+  const { initializeImportAttributes } = require('internal/modules/esm/assert');
+  initializeImportAttributes();
 
   setupVmModules();
   if (initializeModules) {

--- a/test/es-module/test-esm-loader-text-format.mjs
+++ b/test/es-module/test-esm-loader-text-format.mjs
@@ -1,0 +1,23 @@
+import '../common/index.mjs';
+import assert from 'node:assert';
+import { registerHooks } from 'node:module';
+
+// A user loader can use `text` with and without import attributes without the feature flag.
+
+registerHooks({
+  load(url, context, nextLoad) {
+    if (url.endsWith('.txt')) {
+      return nextLoad(url, { ...context, format: 'text' });
+    }
+    return nextLoad(url, context);
+  },
+});
+
+const { default: text } = await import('../fixtures/file-to-read-without-bom.txt');
+const { default: empty } = await import(
+  '../fixtures/empty.txt',
+  { with: { type: 'text' } }
+);
+
+assert.strictEqual(text, 'abc\ndef\nghi\n');
+assert.strictEqual(empty, '');


### PR DESCRIPTION
#62300 broke userland text loaders (more details [1](https://github.com/nodejs/node/pull/62300#issuecomment-5170959091), [2](https://openjs-foundation.slack.com/archives/C019Y2T6STH/p1785784543660069))

This PR aims to fix this by only conditionally adding text import if the feature flag is enabled (similarly to [initializeExtensionFormatMap](https://github.com/nodejs/node/blob/54296cb6f08c4fa37eb75e4156d396280c85309d/lib/internal/modules/esm/get_format.js#L25)) and adds a regression test