### PR TITLE
doc: document REPL DEP0185 throws and uncaught-exception behavior

### DIFF
--- a/doc/api/repl.md
+++ b/doc/api/repl.md
@@ -232,6 +232,15 @@ undefined
 undefined
 ```
 
+### Error handling
+
+By default, uncaught exceptions in the REPL are printed to the output stream
+(as with `Uncaught Error: REPL await` above). `uncaughtException` listeners
+can be added freely in both standalone and nested REPLs. The `handleError`
+option of [`repl.start()`][] can customize this behavior, including
+forwarding exceptions to [`'uncaughtException'`][] by returning
+`'unhandled'`.
+
 ### Reverse-i-search
 
 <!-- YAML
@@ -424,6 +433,9 @@ const options = { useColors: true };
 const firstInstance = repl.start(options);
 const secondInstance = new repl.REPLServer(options);
 ```
+
+Calling `repl.REPLServer()` without the `new` keyword throws a `TypeError`
+(see [DEP0185][]).
 
 ### Event: `'exit'`
 
@@ -1127,6 +1139,7 @@ avoiding open network interfaces.
 
 Original code from <https://gist.github.com/TooTallNate/2053342>.
 
+[DEP0185]: deprecations.md#dep0185-instantiating-noderepl-classes-without-new
 [TTY keybindings]: readline.md#tty-keybindings
 [ZSH]: https://en.wikipedia.org/wiki/Z_shell
 [`'uncaughtException'`]: process.md#event-uncaughtexception


### PR DESCRIPTION
Two doc-only improvements to `doc/api/repl.md`, both filling gaps left by recent semver-major REPL changes:

1. `repl.REPLServer` is an ES class. Calling it without `new` is End-of-Life (DEP0185) and throws a native V8 `TypeError` at runtime. The "Class: REPLServer" section showed examples that use `new` but did not tell users that the `new`-less form throws. A short prose note is added after the construction examples pointing to the DEP0185 entry in `doc/api/deprecations.md`.

2. PR #64034 ("repl: use inspector over vm") removed the old "Global uncaught exceptions" subsection because the `domain`-based restrictions it documented no longer exist. The removal was correct, but the current uncaught-exception model was only partially documented via the `'unhandled'` description on the `handleError` option. A top-level `Error handling` section is added. The prose is anchored to the existing `Uncaught Error: REPL await` example in the preceding `await keyword` section and documents the current behavior: uncaught exceptions are printed by default, `uncaughtException` listeners work freely in standalone and nested REPLs, and the `handleError` option can forward exceptions to `'uncaughtException'` by returning `'unhandled'`.