### PR TITLE
doc: narrow ReadableStreamBYOBRequest.view type to Uint8Array

### DIFF
--- a/doc/api/webstreams.md
+++ b/doc/api/webstreams.md
@@ -893,7 +893,7 @@ to a new `Buffer`, `TypedArray`, or `DataView`.
 added: v16.5.0
 -->
 
-* Type: {Buffer|TypedArray|DataView}
+* Type: {Uint8Array}
 
 ### Class: `WritableStream`
 


### PR DESCRIPTION
Fixes #62952

## What does this PR do?

Narrows the documented type of `ReadableStreamBYOBRequest.view` from `ArrayBufferView` to `Uint8Array` in the Node.js Web Streams API documentation. This matches the actual WebIDL and Chromium/Node implementation, where a BYOB request always provides a `Uint8Array` view.

## Changes

- `doc/api/webstreams.md`: one-line type change in the `ReadableStreamBYOBRequest` section.

## How did you verify your code works?

- I checked the Web Streams standard and the Node.js source; `ReadableStreamBYOBRequest.view` is created from a `Uint8Array` in the implementation.
- I built the docs locally with `make doc` and confirmed the generated HTML reflects the narrowed type without breaking surrounding anchors.
- This is a documentation-only change; no runtime behavior is affected.
