### PR TITLE
v8: serialize heap profile script IDs as strings

### DIFF
--- a/src/node_profiling.cc
+++ b/src/node_profiling.cc
@@ -4,6 +4,7 @@
 #include "util.h"
 
 #include <memory>
+#include <string>
 
 namespace node {
 
@@ -23,7 +24,7 @@ static void BuildHeapProfileNode(Isolate* isolate,
   writer->json_keyvalue("selfSize", selfSize);
   writer->json_keyvalue("id", node->node_id);
   writer->json_objectstart("callFrame");
-  writer->json_keyvalue("scriptId", node->script_id);
+  writer->json_keyvalue("scriptId", std::to_string(node->script_id));
   writer->json_keyvalue("lineNumber", node->line_number - 1);
   writer->json_keyvalue("columnNumber", node->column_number - 1);
   Utf8Value name(isolate, node->name);

--- a/test/parallel/test-v8-heap-profile.js
+++ b/test/parallel/test-v8-heap-profile.js
@@ -4,6 +4,11 @@ require('../common');
 const assert = require('assert');
 const v8 = require('v8');
 
+function validateScriptIds(node) {
+  assert.strictEqual(typeof node.callFrame.scriptId, 'string');
+  node.children.forEach(validateScriptIds);
+}
+
 assert.throws(() => v8.startHeapProfile('bad'), {
   code: 'ERR_INVALID_ARG_TYPE',
 });
@@ -48,7 +53,7 @@ assert.throws(
 {
   const handle = v8.startHeapProfile();
   const profile = handle.stop();
-  JSON.parse(profile);
+  validateScriptIds(JSON.parse(profile).head);
 }
 
 // Custom params with all flags.


### PR DESCRIPTION
Serialize callFrame.scriptId values as decimal strings to match the CDP SamplingHeapProfile schema.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
