### PR TITLE
tools: add fallback cleanup job for CQ

### DIFF
--- a/.github/workflows/commit-queue.yml
+++ b/.github/workflows/commit-queue.yml
@@ -97,3 +97,23 @@ jobs:
         run: ./tools/actions/commit-queue.sh "${GITHUB_REPOSITORY_OWNER}" "${REPOSITORY}" ${{ needs.get_mergeable_prs.outputs.numbers }}
         env:
           GITHUB_TOKEN: ${{ secrets.GH_USER_TOKEN }}
+  cleanup:
+    needs: [get_mergeable_prs, commitQueue]
+    if: cancelled() && needs.get_mergeable_prs.outputs.numbers != ''
+    runs-on: ubuntu-slim
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Re-add labels if needed
+        # If a PR was in the queue, is still open and has neither `commit-queue`
+        # nor `commit-queue-failed`, we assume it needs to get back into the queue.
+        run: |
+          for pr in $PRs; do
+            gh pr view --repo "$GITHUB_REPOSITORY" "$pr" \
+              --json state,labels \
+              --jq 'if .state == "OPEN" and all(.labels[]; .name != "commit-queue" and .name != "commit-queue-failed") then halt_error end' \
+            || gh pr edit --repo "$GITHUB_REPOSITORY" "$pr" --add-label commit-queue
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRs: ${{ needs.get_mergeable_prs.outputs.numbers }}


### PR DESCRIPTION
In case of cancellation (e.g. timeout) occuring while the CQ was dealing with a PR, we likely want the PR back into the queue.

Refs: https://github.com/nodejs/node/issues/64972

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
