### PR TITLE
Create parent directories for test reporter destinations

### DIFF
--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -201,7 +201,7 @@ async function getReportersMap(reporters, destinations) {
   return SafePromiseAllReturnArrayLike(reporters, async (name, i) => {
     const destinationPath = destinations[i];
     const destination = kBuiltinDestinations.get(destinationPath) ?? (
-      mkdirSync(dirname(destinationPath), { recursive: true }),
+      mkdirSync(dirname(destinationPath), { __proto__: null, recursive: true }),
       createWriteStream(destinationPath, { __proto__: null, flush: true })
     );
 

--- a/lib/internal/test_runner/utils.js
+++ b/lib/internal/test_runner/utils.js
@@ -35,8 +35,8 @@ const {
 
 const { AsyncResource } = require('async_hooks');
 const { tracingChannel } = require('diagnostics_channel');
-const { relative, sep, resolve } = require('path');
-const { createWriteStream, readFileSync } = require('fs');
+const { dirname, relative, sep, resolve } = require('path');
+const { createWriteStream, mkdirSync, readFileSync } = require('fs');
 const { pathToFileURL } = require('internal/url');
 const { getOptionValue } = require('internal/options');
 const { green, yellow, red, white, shouldColorize } = require('internal/util/colors');
@@ -199,8 +199,11 @@ function parsePreviousRuns(rerunFailuresFilePath) {
 
 async function getReportersMap(reporters, destinations) {
   return SafePromiseAllReturnArrayLike(reporters, async (name, i) => {
-    const destination = kBuiltinDestinations.get(destinations[i]) ??
-      createWriteStream(destinations[i], { __proto__: null, flush: true });
+    const destinationPath = destinations[i];
+    const destination = kBuiltinDestinations.get(destinationPath) ?? (
+      mkdirSync(dirname(destinationPath), { recursive: true }),
+      createWriteStream(destinationPath, { __proto__: null, flush: true })
+    );
 
     // Load the test reporter passed to --test-reporter
     let reporter = tryBuiltinReporter(name);

--- a/test/parallel/test-runner-reporters.js
+++ b/test/parallel/test-runner-reporters.js
@@ -76,6 +76,19 @@ describe('node:test reporters', { concurrency: true }, () => {
     assert.match(fileContents, /✖ nested/);
   });
 
+  it('should create parent directories for a file destination', async () => {
+    const file = tmpdir.resolve(`${tmpFiles++}/nested/report.out`);
+    const child = spawnSync(process.execPath,
+                            ['--test', '--test-reporter', 'dot', '--test-reporter-destination', file, testFile]);
+    assert.strictEqual(child.stderr.toString(), '');
+    assert.strictEqual(child.stdout.toString(), '');
+    const fileContents = fs.readFileSync(file, 'utf8');
+    assert.match(fileContents, /\.XX\.\n/);
+    assert.match(fileContents, /Failed tests:/);
+    assert.match(fileContents, /✖ failing/);
+    assert.match(fileContents, /✖ nested/);
+  });
+
   it('should disallow using v8-serializer as reporter', async () => {
     const child = spawnSync(process.execPath, ['--test', '--test-reporter', 'v8-serializer', testFile]);
     assert.strictEqual(child.stdout.toString(), '');


### PR DESCRIPTION
This creates missing parent directories before opening file-backed `--test-reporter-destination` outputs, so paths like `coverage/lcov.info` no longer fail with ENOENT when the parent directory does not exist.

It also adds a regression test for a nested reporter destination path.

Fixes #64994