### PR TITLE
dns: fix crash on setServers with port 0

### DIFF
--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2251,13 +2251,13 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
     if (!elm->Get(env->context(), 1).ToLocal(&ipValue)) return;
     if (!elm->Get(env->context(), 2).ToLocal(&portValue)) return;
 
+    CHECK(familyValue->IsInt32());
     CHECK(ipValue->IsString());
+    CHECK(portValue->IsInt32());
 
-    int32_t fam;
-    if (!familyValue->Int32Value(env->context()).To(&fam)) return;
+    int32_t fam = familyValue.As<Int32>()->Value();
     node::Utf8Value ip(env->isolate(), ipValue);
-    int32_t port;
-    if (!portValue->Int32Value(env->context()).To(&port)) return;
+    int32_t port = portValue.As<Int32>()->Value();
 
     if (!csv.empty()) csv += ',';
 

--- a/src/cares_wrap.cc
+++ b/src/cares_wrap.cc
@@ -2251,13 +2251,13 @@ void SetServers(const FunctionCallbackInfo<Value>& args) {
     if (!elm->Get(env->context(), 1).ToLocal(&ipValue)) return;
     if (!elm->Get(env->context(), 2).ToLocal(&portValue)) return;
 
-    CHECK(familyValue->Int32Value(env->context()).FromJust());
     CHECK(ipValue->IsString());
-    CHECK(portValue->Int32Value(env->context()).FromJust());
 
-    int fam = familyValue->Int32Value(env->context()).FromJust();
+    int32_t fam;
+    if (!familyValue->Int32Value(env->context()).To(&fam)) return;
     node::Utf8Value ip(env->isolate(), ipValue);
-    int port = portValue->Int32Value(env->context()).FromJust();
+    int32_t port;
+    if (!portValue->Int32Value(env->context()).To(&port)) return;
 
     if (!csv.empty()) csv += ',';
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -134,6 +134,10 @@ const portsExpected = [
 dns.setServers(ports);
 assert.deepStrictEqual(dns.getServers(), portsExpected);
 
+// Port 0 means "use the default port" for c-ares.
+dns.setServers(['4.4.4.4:0', '[2001:4860:4860::8888]:0']);
+assert.deepStrictEqual(dns.getServers(), ['4.4.4.4', '2001:4860:4860::8888']);
+
 // Link-local IPv6 addresses require a zone index (scope id) to be usable;
 // c-ares drops link-local servers configured without one.
 dns.setServers(['[fe80::483a:5aff:fee6:1f04]%eth0']);


### PR DESCRIPTION
`dns.setServers(['1.1.1.1:0'])` aborts the process:

```
Assertion failed: portValue->Int32Value(env->context()).FromJust()
```

`SetServers()` in `src/cares_wrap.cc` checked the port with `CHECK(portValue->Int32Value(env->context()).FromJust())`. That asserts the port value is non-zero, not that the conversion succeeded, so a port of `0` trips it. The family value had the same problem. Both now use `Maybe::To()`, like the rest of the file.

c-ares already treats port 0 as "use the default port", so `1.1.1.1:0` becomes `1.1.1.1:53`. `[::1]:0` behaved that way already, since the bracketed-IPv6 branch in `lib/internal/dns/utils.js` coerces 0 to 53 before it ever reaches C++.

Fixes: https://github.com/nodejs/node/issues/65006