### PR TITLE
http: reject responses exceeding header limit

### DIFF
--- a/doc/api/http.md
+++ b/doc/api/http.md
@@ -1127,9 +1127,11 @@ const hasContentType = request.hasHeader('content-type');
 
 ### `request.maxHeadersCount`
 
-* Type: {number} **Default:** `2000`
+* Type: {number} **Default:** `1000`
 
-Limits maximum response headers count. If set to 0, no limit will be applied.
+Limits the maximum response headers count. Responses exceeding this limit are
+rejected with an [`HPE_HEADER_OVERFLOW`][] error. If set to `0`, no limit will
+be applied.
 
 ### `request.path`
 
@@ -1914,7 +1916,7 @@ added: v5.7.0
 added: v0.7.0
 -->
 
-* Type: {number} **Default:** `2000`
+* Type: {number} **Default:** `1000`
 
 Limits maximum incoming headers count. If set to 0, no limit will be applied.
 

--- a/src/node_http_parser.cc
+++ b/src/node_http_parser.cc
@@ -1047,10 +1047,6 @@ class Parser : public AsyncWrap, public StreamListener {
   }
 
   int TrackHeaderPair() {
-    if (parser_.type != HTTP_REQUEST) {
-      return 0;
-    }
-
     header_pairs_ += 2;
 
     Local<Value> max_header_pairs_v;

--- a/test/parallel/test-http-max-headers-count-overflow.js
+++ b/test/parallel/test-http-max-headers-count-overflow.js
@@ -4,17 +4,17 @@ const assert = require('assert');
 const http = require('http');
 const net = require('net');
 
-const server = http.createServer(common.mustNotCall());
+const requestServer = http.createServer(common.mustNotCall());
 
-server.maxHeadersCount = 2;
+requestServer.maxHeadersCount = 2;
 
-server.on('clientError', common.mustCall((err, socket) => {
+requestServer.on('clientError', common.mustCall((err, socket) => {
   assert.strictEqual(err.code, 'HPE_HEADER_OVERFLOW');
   socket.end('HTTP/1.1 431 Request Header Fields Too Large\r\n\r\n');
 }));
 
-server.listen(0, common.mustCall(() => {
-  const port = server.address().port;
+requestServer.listen(0, common.mustCall(() => {
+  const port = requestServer.address().port;
   const req = 'POST / HTTP/1.1\r\n' +
               'Host: localhost\r\n' +
               'X-A: b\r\n' +
@@ -28,7 +28,47 @@ server.listen(0, common.mustCall(() => {
     this.on('data', (chunk) => response += chunk);
     this.on('end', common.mustCall(() => {
       assert.match(response, /^HTTP\/1\.1 431 /);
-      server.close();
+      requestServer.close();
     }));
   }));
+}));
+
+const responseServer = net.createServer(common.mustCall((socket) => {
+  socket.once('data', common.mustCall(() => {
+    socket.end('HTTP/1.1 200 OK\r\n' +
+               'X-A: a\r\n' +
+               'X-B: b\r\n' +
+               'Content-Length: 0\r\n\r\n');
+  }));
+}));
+
+responseServer.listen(0, common.mustCall(() => {
+  const req = http.request({
+    port: responseServer.address().port,
+  }, common.mustNotCall());
+  req.maxHeadersCount = 2;
+  req.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'HPE_HEADER_OVERFLOW');
+    responseServer.close();
+  }));
+  req.end();
+}));
+
+const defaultResponseServer = net.createServer(common.mustCall((socket) => {
+  socket.once('data', common.mustCall(() => {
+    socket.end('HTTP/1.1 200 OK\r\n' +
+               'X: a\r\n'.repeat(1000) +
+               'Content-Length: 0\r\n\r\n');
+  }));
+}));
+
+defaultResponseServer.listen(0, common.mustCall(() => {
+  const req = http.request({
+    port: defaultResponseServer.address().port,
+  }, common.mustNotCall());
+  req.on('error', common.mustCall((err) => {
+    assert.strictEqual(err.code, 'HPE_HEADER_OVERFLOW');
+    defaultResponseServer.close();
+  }));
+  req.end();
 }));

--- a/test/parallel/test-http-max-headers-count.js
+++ b/test/parallel/test-http-max-headers-count.js
@@ -67,7 +67,7 @@ server.maxHeadersCount = max;
 
 server.listen(0, common.mustCall(() => {
   const clientMaxAndExpected = [ // for client
-    [20, 20],
+    [200, 104],
     [1200, 104],
     [0, N + 4], // Host and Connection
   ];

--- a/test/parallel/test-https-max-headers-count.js
+++ b/test/parallel/test-https-max-headers-count.js
@@ -56,7 +56,7 @@ server.maxHeadersCount = max;
 
 server.listen(0, common.mustCall(() => {
   const clientMaxAndExpected = [ // for client
-    [20, 20],
+    [200, 104],
     [1200, 104],
     [0, N + 4], // Host and Connection
   ];


### PR DESCRIPTION
Previously, ClientRequest silently truncated responses that exceeded request.maxHeadersCount while llhttp continued using omitted headers.

Reject these responses with HPE_HEADER_OVERFLOW so parser state and exposed headers cannot diverge. This is a semver-major behavior change.

<!--
If you are submitting a pull request for the first time,
check out the guide for first-time contributors for tips and answers to FAQs:
https://github.com/nodejs/node/blob/HEAD/doc/contributing/first-contributions.md

Before submitting a pull request, please read:

- the CONTRIBUTING guide at https://github.com/nodejs/node/blob/HEAD/CONTRIBUTING.md
- the commit message formatting guidelines at
  https://github.com/nodejs/node/blob/HEAD/doc/contributing/pull-requests.md#commit-message-guidelines

For code changes:
1. Include tests for any bug fixes or new features.
2. Update documentation if relevant.
3. Ensure that `make -j4 test` (UNIX), or `vcbuild test` (Windows) passes.

If you believe this PR should be highlighted in the Node.js CHANGELOG
please add the `notable-change` label.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
-->
