### PR TITLE
stream: use validateNumber for BYOB reader options.min

### DIFF
--- a/lib/internal/webstreams/readablestream.js
+++ b/lib/internal/webstreams/readablestream.js
@@ -62,6 +62,7 @@ const {
 const {
   validateAbortSignal,
   validateBuffer,
+  validateNumber,
   validateObject,
   kValidateObjectAllowObjects,
   kValidateObjectAllowObjectsAndNull,
@@ -1095,8 +1096,7 @@ class ReadableStreamBYOBReader {
     // detached, but there's no API available to use to check that.
 
     const min = options?.min ?? 1;
-    if (typeof min !== 'number')
-      throw new ERR_INVALID_ARG_TYPE('options.min', 'number', min);
+    validateNumber(min, 'options.min');
     if (!NumberIsInteger(min))
       throw new ERR_INVALID_ARG_VALUE('options.min', min, 'must be an integer');
     if (min <= 0)

--- a/test/parallel/test-whatwg-readablestream-byob-read-min.js
+++ b/test/parallel/test-whatwg-readablestream-byob-read-min.js
@@ -1,0 +1,41 @@
+'use strict';
+const common = require('../common');
+const assert = require('node:assert');
+
+const {
+  ReadableStream,
+} = require('node:stream/web');
+
+// Validation of the options.min argument of ReadableStreamBYOBReader.read()
+// must reject with the same errors regardless of how the checks are implemented internally.
+
+const reader = new ReadableStream({ type: 'bytes' })
+  .getReader({ mode: 'byob' });
+
+(async () => {
+  // A null min is not covered here: `options?.min ?? 1` turns it into
+  // the default before validation, so it never reaches the type check.
+  for (const min of ['1', true, {}, [], 1n]) {
+    await assert.rejects(
+      reader.read(new Uint8Array(8), { min }),
+      { code: 'ERR_INVALID_ARG_TYPE' },
+    );
+  }
+
+  for (const min of [NaN, 1.5, 0, -1]) {
+    await assert.rejects(
+      reader.read(new Uint8Array(8), { min }),
+      { code: 'ERR_INVALID_ARG_VALUE' },
+    );
+  }
+
+  await assert.rejects(
+    reader.read(new Uint8Array(8), { min: 9 }),
+    { code: 'ERR_OUT_OF_RANGE' },
+  );
+
+  await assert.rejects(
+    reader.read(new DataView(new ArrayBuffer(8)), { min: 9 }),
+    { code: 'ERR_OUT_OF_RANGE' },
+  );
+})().then(common.mustCall());


### PR DESCRIPTION
Replace the open-coded typeof check for `options.min` in `ReadableStreamBYOBReader.prototype.read()` with `validateNumber`. Called without min/max bounds it performs the same check and constructs `ERR_INVALID_ARG_TYPE` with the same arguments, so the rejection type, code, and message are unchanged.

The added test covers all three validation branches (type, integer/positive, out-of-range), which no existing test pinned, and passes with and without the lib change.
