### PR TITLE
stream: use validateObject for zlib/iter params

### DIFF
--- a/lib/internal/streams/iter/transform.js
+++ b/lib/internal/streams/iter/transform.js
@@ -40,6 +40,7 @@ const { isArrayBufferView, isAnyArrayBuffer } = require('internal/util/types');
 const { kValidatedTransform } = require('internal/streams/iter/types');
 const {
   checkRangesOrGetDefault,
+  kValidateObjectAllowArray,
   validateFiniteNumber,
   validateObject,
 } = require('internal/validators');
@@ -106,9 +107,7 @@ function validateDictionary(dictionary) {
 
 function validateParams(params, maxParam, errClass) {
   if (params === undefined) return;
-  if (typeof params !== 'object' || params === null) {
-    throw new ERR_INVALID_ARG_TYPE('options.params', 'Object', params);
-  }
+  validateObject(params, 'options.params', kValidateObjectAllowArray);
   const keys = ObjectKeys(params);
   for (let i = 0; i < keys.length; i++) {
     const origKey = keys[i];

--- a/test/parallel/test-stream-iter-transform-params.js
+++ b/test/parallel/test-stream-iter-transform-params.js
@@ -1,0 +1,30 @@
+// Flags: --experimental-stream-iter
+'use strict';
+
+const common = require('../common');
+const assert = require('assert');
+const { from, pull, bytes } = require('stream/iter');
+const { compressBrotli, compressZstd } = require('zlib/iter');
+
+// Type validation of options.params in zlib/iter transforms: plain
+// objects and arrays pass the check, any other value rejects with
+// ERR_INVALID_ARG_TYPE. Arrays have always passed the typeof-based
+// check, so this behavior must be preserved by any refactor.
+
+const consume = (transform) => bytes(pull(from('test'), transform));
+
+(async () => {
+  for (const compress of [compressBrotli, compressZstd]) {
+    for (const params of [42, 'bad', true, Symbol(), () => {}, null]) {
+      await assert.rejects(
+        consume(compress({ params })),
+        { code: 'ERR_INVALID_ARG_TYPE' },
+      );
+    }
+
+    // An empty array has no own keys, so it passes both the type check
+    // and the per-key validation and compression succeeds.
+    const out = await consume(compress({ params: [] }));
+    assert.ok(out.byteLength > 0);
+  }
+})().then(common.mustCall());


### PR DESCRIPTION
Replace the open-coded object check in `validateParams()` with `validateObject` using the `kValidateObjectAllowArray` flag. The flag matches the previous `typeof params !== 'object' || params === null` semantics case by case: arrays keep passing, null and other primitives keep rejecting. Both paths construct `ERR_INVALID_ARG_TYPE` with identical arguments, so the error type, code, and message are unchanged.

The added test locks the array-accepting boundary, which was not covered by the existing validation tests, and passes with and without the lib change.
