### PR TITLE
zlib: harden ZIP archive reading and writing against malicious input

### DIFF
--- a/lib/internal/zip/archive.js
+++ b/lib/internal/zip/archive.js
@@ -133,12 +133,15 @@ async function* fileEntries(files, followSymlinks) {
       // would let a symlink swapped in after the classification above redirect
       // the read - a TOCTOU that defeats followSymlinks:false. O_NOFOLLOW makes
       // a final-component symlink fail the open outright when not following;
-      // the fstat then confirms a regular file, never a FIFO, device, or
-      // socket (which as a stream source could block or emit unbounded data).
+      // O_NONBLOCK keeps the open itself from blocking on a FIFO or a slow
+      // device (it has no effect on a regular file's reads), so the fstat can
+      // then reject anything that is not a regular file - a FIFO, device, or
+      // socket, which as a stream source could block or emit unbounded data.
       // Metadata comes from that same fstat so it describes the inode we read.
-      const flags = followSymlinks ?
+      const flags = (followSymlinks ?
         fs.constants.O_RDONLY :
-        fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0);
+        fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW || 0)) |
+        (fs.constants.O_NONBLOCK || 0);
       const handle = await fs.promises.open(sourcePath, flags);
       let ownsHandle = true;
       try {

--- a/lib/internal/zip/entry.js
+++ b/lib/internal/zip/entry.js
@@ -76,6 +76,7 @@ const {
 const {
   CentralFileHeader,
   LocalFileHeader,
+  assertConsistentLocalHeader,
   findArchiveEnd,
 } = require('internal/zip/headers');
 const {
@@ -399,6 +400,9 @@ class ZipEntry {
       await readFdFully(fd, full.subarray(30), this.#localOffset + 30);
     }
     this.#local = new LocalFileHeader(full, 0);
+    if (this.#central !== null) {
+      assertConsistentLocalHeader(this.#local, this.#central);
+    }
     this.#contentOffset = this.#localOffset + length;
     return this.#local;
   }
@@ -419,6 +423,9 @@ class ZipEntry {
       readFdFullySync(fd, full.subarray(30), this.#localOffset + 30);
     }
     this.#local = new LocalFileHeader(full, 0);
+    if (this.#central !== null) {
+      assertConsistentLocalHeader(this.#local, this.#central);
+    }
     this.#contentOffset = this.#localOffset + length;
     return this.#local;
   }
@@ -930,6 +937,7 @@ function* readArchiveEntries(buf, end) {
     }
     const localOffset = central.localFileHeaderOffset + end.prefix;
     const local = new LocalFileHeader(buf, localOffset);
+    assertConsistentLocalHeader(local, central);
     const dataStart = localOffset + local.byteLength;
     const length = central.compressedSize;
     validateArchiveRange(buf, dataStart, length, 'entry data');

--- a/lib/internal/zip/entry.js
+++ b/lib/internal/zip/entry.js
@@ -175,6 +175,17 @@ function createEntryMeta(filename, options) {
   };
 }
 
+// Release one in-flight read on a shared ZipFile descriptor handle. When the
+// last read settles, wake a close() that is waiting to release the fd (see
+// ZipFile.close() in file.js), so a read never lands on a closed/reused fd.
+function endHandleRead(handle) {
+  if (--handle.reads === 0 && handle.drain !== null) {
+    const drain = handle.drain;
+    handle.drain = null;
+    drain();
+  }
+}
+
 /**
  * A single file or directory inside a ZIP archive: reading, writing, and
  * (de)serializing one archive member.
@@ -490,17 +501,30 @@ class ZipEntry {
   // The entry's raw compressed bytes as a bounded-memory chunk stream, read
   // straight from disk (file-backed entries only). Nothing is retained.
   async *#rawChunks() {
-    this.#liveDescriptor();
-    let pos = await this.#resolveContentOffset();
-    let remaining = this.compressedSize;
-    while (remaining > 0) {
-      const take = MathMin(READ_CHUNK_SIZE, remaining);
-      const chunk = Buffer.allocUnsafe(take);
-      // Re-check per chunk: the ZipFile may be closed mid-stream.
-      await readFdFully(this.#liveDescriptor(), chunk, pos);
-      pos += take;
-      remaining -= take;
-      yield chunk;
+    // Count the whole stream as one in-flight read so a concurrent close()
+    // waits for it (the finally runs when the consumer stops iterating); a
+    // stream begun after close() was requested is rejected up front.
+    const handle = this.#fd;
+    if (handle.closing) {
+      throw new ERR_INVALID_STATE(
+        'cannot read a ZipEntry after its backing ZipFile has been closed');
+    }
+    handle.reads++;
+    try {
+      this.#liveDescriptor();
+      let pos = await this.#resolveContentOffset();
+      let remaining = this.compressedSize;
+      while (remaining > 0) {
+        const take = MathMin(READ_CHUNK_SIZE, remaining);
+        const chunk = Buffer.allocUnsafe(take);
+        // Re-check per chunk: the ZipFile may be closed mid-stream.
+        await readFdFully(this.#liveDescriptor(), chunk, pos);
+        pos += take;
+        remaining -= take;
+        yield chunk;
+      }
+    } finally {
+      endHandleRead(handle);
     }
   }
   // Sync counterpart of #rawChunks().
@@ -533,18 +557,33 @@ class ZipEntry {
         `entry ${JSONStringify(this.name)} declares ${declared} bytes, ` +
         `exceeding the ${maxSize} byte limit`);
     }
-    const compressed = await this.#compressedBytes();
-    const data = await decodeMemberAsync(compressed, {
-      name: this.name,
-      flags: this.flags,
-      method: this.method,
-      crc32: this.crc32,
-      uncompressedSize: declared,
-    }, { verify: options?.verify, maxSize });
-    // `data === compressed` only on the store path; copy the in-memory case
-    // (the entry's retained buffer, see #compressedBytes()) so the result is
-    // caller-owned on every path.
-    return data === compressed && this.#fd === null ? Buffer.from(data) : data;
+    // Count this read on the shared handle so a concurrent close() waits for it
+    // rather than releasing the fd mid-read; a read begun after close() was
+    // requested is rejected up front (in-memory entries have no fd).
+    const handle = this.#fd;
+    if (handle !== null) {
+      if (handle.closing) {
+        throw new ERR_INVALID_STATE(
+          'cannot read a ZipEntry after its backing ZipFile has been closed');
+      }
+      handle.reads++;
+    }
+    try {
+      const compressed = await this.#compressedBytes();
+      const data = await decodeMemberAsync(compressed, {
+        name: this.name,
+        flags: this.flags,
+        method: this.method,
+        crc32: this.crc32,
+        uncompressedSize: declared,
+      }, { verify: options?.verify, maxSize });
+      // `data === compressed` only on the store path; copy the in-memory case
+      // (the entry's retained buffer, see #compressedBytes()) so the result is
+      // caller-owned on every path.
+      return data === compressed && this.#fd === null ? Buffer.from(data) : data;
+    } finally {
+      if (handle !== null) endHandleRead(handle);
+    }
   }
 
   /**

--- a/lib/internal/zip/file.js
+++ b/lib/internal/zip/file.js
@@ -387,10 +387,11 @@ class ZipFile {
     return this.#enqueue(async () =>
       this.#doAdd(await ZipEntry.create(filename, data, options)));
   }
-  // Append the entry's bytes where the central directory currently starts,
-  // then rewrite the directory to include it. On write failure, restore the
-  // original directory (the partial write may have clobbered it) and rethrow;
-  // on success, promote a spent stream entry to its on-disk copy.
+  // Append the entry's bytes where the central directory currently starts, then
+  // rewrite the directory to include it. If the member write or the directory
+  // rewrite fails, restore the original directory and drop the half-adopted
+  // entry so the archive is left exactly as it was, then rethrow; on success,
+  // promote a spent stream entry to its on-disk copy.
   async #doAdd(entry) {
     const localOffset = this.#centralDirectoryOffset;
     let written = 0;
@@ -413,9 +414,30 @@ class ZipFile {
       }
       throw err;
     }
+    const previousEntry = MapPrototypeGet(this.#entries, entry.name);
     this.#centralDirectoryOffset = localOffset + written;
     MapPrototypeSet(this.#entries, entry.name, { central: null, entry, localOffset });
-    await this.#rewriteCentralDirectory();
+    try {
+      await this.#rewriteCentralDirectory();
+    } catch (err) {
+      // The directory rewrite failed after the member bytes landed. Undo the
+      // in-memory adoption and rewrite the original directory back at its old
+      // offset (where the failed member bytes started), leaving the archive and
+      // this handle exactly as before the call.
+      this.#centralDirectoryOffset = localOffset;
+      if (previousEntry === undefined) {
+        MapPrototypeDelete(this.#entries, entry.name);
+      } else {
+        MapPrototypeSet(this.#entries, entry.name, previousEntry);
+      }
+      try {
+        await this.#rewriteCentralDirectory();
+      } catch {
+        // Restoring failed too (the device is likely full or gone); the
+        // original error is the actionable one.
+      }
+      throw err;
+    }
     // The entry now has a stable home in this archive; if it was a spent
     // streaming entry, rebind it to that on-disk copy so it stays readable.
     entry[kPromote](this.#handle, localOffset);
@@ -453,9 +475,27 @@ class ZipFile {
       }
       throw err;
     }
+    const previousEntry = MapPrototypeGet(this.#entries, entry.name);
     this.#centralDirectoryOffset = localOffset + written;
     MapPrototypeSet(this.#entries, entry.name, { central: null, entry, localOffset });
-    this.#rewriteCentralDirectorySync();
+    try {
+      this.#rewriteCentralDirectorySync();
+    } catch (err) {
+      // See #doAdd(): undo the in-memory adoption and restore the original
+      // directory so a failed rewrite leaves the archive exactly as it was.
+      this.#centralDirectoryOffset = localOffset;
+      if (previousEntry === undefined) {
+        MapPrototypeDelete(this.#entries, entry.name);
+      } else {
+        MapPrototypeSet(this.#entries, entry.name, previousEntry);
+      }
+      try {
+        this.#rewriteCentralDirectorySync();
+      } catch {
+        // Restoring failed too; the original error is the actionable one.
+      }
+      throw err;
+    }
     entry[kPromote](this.#handle, localOffset);
     return entry;
   }

--- a/lib/internal/zip/file.js
+++ b/lib/internal/zip/file.js
@@ -19,6 +19,7 @@ const {
   MapPrototypeKeys,
   MapPrototypeSet,
   MathMin,
+  Promise,
   PromisePrototypeThen,
   PromiseResolve,
   SymbolAsyncDispose,
@@ -218,12 +219,14 @@ function checkMemberOverlap(members, centralDirectoryOffset) {
  * corrupt the archive.
  */
 class ZipFile {
-  // Shared descriptor handle ({ fd, closed }) handed to every ZipEntry this
-  // archive produces, so close() can invalidate them all at once. `#closing`
-  // is set synchronously the moment close()/closeSync() is called, gating any
-  // further public call; `handle.closed` is set once the fd is actually gone,
-  // gating reads through already-handed-out entries. Neither read ever falls
-  // through to a bare (possibly OS-reused) descriptor number.
+  // Shared descriptor handle ({ fd, closed, reads, drain }) handed to every
+  // ZipEntry this archive produces, so close() can invalidate them all at once.
+  // `#closing` is set synchronously the moment close()/closeSync() is called,
+  // gating any further public call; `handle.closed` then stops new reads, and
+  // `handle.reads` counts in-flight reads through already-handed-out entries so
+  // close() can wait for them to finish before releasing the fd. Neither a new
+  // nor an in-flight read ever falls through to a closed (possibly OS-reused)
+  // descriptor number.
   #handle;
   #closing = false;
   #closePromise = null;
@@ -240,7 +243,7 @@ class ZipFile {
    * @private
    */
   constructor(fd, centralHeaders, prefix, centralDirectoryOffset, comment, writable) {
-    this.#handle = { fd, closed: false };
+    this.#handle = { fd, closed: false, closing: false, reads: 0, drain: null };
     this.#writable = writable;
     this.#comment = comment;
     this.#centralDirectoryOffset = centralDirectoryOffset;
@@ -655,7 +658,16 @@ class ZipFile {
   close() {
     if (this.#closing) return this.#closePromise ?? PromiseResolve();
     this.#closing = true;
+    // Block *new* reads immediately; reads already in flight keep the still-open
+    // fd until they finish (handle.closed, set below, is what stops mid-read).
+    this.#handle.closing = true;
     this.#closePromise = this.#enqueue(async () => {
+      // Let reads already in flight through handed-out entries finish on the
+      // open fd before releasing it; endHandleRead() (entry.js) resolves this
+      // once the last one settles.
+      if (this.#handle.reads > 0) {
+        await new Promise((resolve) => { this.#handle.drain = resolve; });
+      }
       this.#handle.closed = true;
       MapPrototypeClear(this.#entries);
       await fsCloseAsync(this.#handle.fd);
@@ -669,7 +681,15 @@ class ZipFile {
   closeSync() {
     if (this.#closing) return;
     this.#assertNotBusy();
+    // A synchronous close cannot wait for an async read the way close() does,
+    // so refuse rather than pull the fd out from under one still in flight.
+    if (this.#handle.reads > 0) {
+      throw new ERR_INVALID_STATE(
+        'cannot synchronously close a ZipFile while an asynchronous read is ' +
+        'still in flight');
+    }
     this.#closing = true;
+    this.#handle.closing = true;
     this.#handle.closed = true;
     MapPrototypeClear(this.#entries);
     fs.closeSync(this.#handle.fd);

--- a/lib/internal/zip/headers.js
+++ b/lib/internal/zip/headers.js
@@ -25,6 +25,8 @@ const {
   SIG_ZIP64_EOCD_LOCATOR,
   SIG_EOCD,
   MADE_BY_UNIX,
+  FLAG_ENCRYPTED,
+  FLAG_DATA_DESCRIPTOR,
   SENTINEL16,
   SENTINEL32,
   ZIP64_EOCD_MAX_LENGTH,
@@ -266,6 +268,7 @@ class CentralFileHeader {
 class LocalFileHeader {
   #buffer;
   #offset;
+  #zip64 = null;
   constructor(buffer, offset = 0) {
     validateArchiveRange(buffer, offset, 30, 'local file header');
     if (buffer.readUInt32LE(offset) !== SIG_LOCAL_FILE_HEADER) {
@@ -279,9 +282,31 @@ class LocalFileHeader {
   }
   get byteLength() { return 30 + this.fileNameLength + this.extraFieldLength; }
   get flags() { return this.#buffer.readUInt16LE(this.#offset + 6); }
-  // Spec field (sec. 4.4.5); the central directory's method is authoritative,
-  // so the local copy is not consumed today.
-  // get compressionMethod() { return this.#buffer.readUInt16LE(this.#offset + 8); }
+  // The central directory is authoritative, but these local fields are read to
+  // reject an archive whose local header contradicts it (assertConsistentLocalHeader).
+  get compressionMethod() { return this.#buffer.readUInt16LE(this.#offset + 8); }
+  get crc32() { return this.#buffer.readUInt32LE(this.#offset + 14); }
+  // The Zip64 extra supplies the true 64-bit sizes for whichever classic size
+  // field holds an overflow sentinel; a local header has no offset/disk field.
+  #resolveZip64() {
+    if (this.#zip64 === null) {
+      this.#zip64 = parseZip64Extra(this.extraField, {
+        uncompressedSize: this.#buffer.readUInt32LE(this.#offset + 22) === SENTINEL32,
+        compressedSize: this.#buffer.readUInt32LE(this.#offset + 18) === SENTINEL32,
+        localFileHeaderOffset: false,
+        diskNumber: false,
+      });
+    }
+    return this.#zip64;
+  }
+  get compressedSize() {
+    const value = this.#buffer.readUInt32LE(this.#offset + 18);
+    return value === SENTINEL32 ? this.#resolveZip64().compressedSize : value;
+  }
+  get uncompressedSize() {
+    const value = this.#buffer.readUInt32LE(this.#offset + 22);
+    return value === SENTINEL32 ? this.#resolveZip64().uncompressedSize : value;
+  }
   get fileNameLength() { return this.#buffer.readUInt16LE(this.#offset + 26); }
   get extraFieldLength() { return this.#buffer.readUInt16LE(this.#offset + 28); }
   get extraField() {
@@ -307,6 +332,35 @@ class LocalFileHeader {
   static length(buffer, offset) {
     if (offset + 30 > buffer.length) return 0;
     return 30 + buffer.readUInt16LE(offset + 26) + buffer.readUInt16LE(offset + 28);
+  }
+}
+
+// Reject an archive whose local file header contradicts the central directory
+// on a field that decides which bytes a member yields. This reader treats the
+// central directory as authoritative, but a divergent local header lets a
+// local-header-based extractor (Info-ZIP unzip, and others) read a different
+// member, method, or size from the same archive - a parser-confusion split that
+// defeats inspect-then-consume pipelines. Reject rather than silently diverge.
+function assertConsistentLocalHeader(local, central) {
+  if (local.compressionMethod !== central.compressionMethod) {
+    throw new ERR_ZIP_INVALID_ARCHIVE(
+      'local and central compression methods disagree');
+  }
+  if ((local.flags & FLAG_ENCRYPTED) !== (central.flags & FLAG_ENCRYPTED)) {
+    throw new ERR_ZIP_INVALID_ARCHIVE(
+      'local and central encryption flags disagree');
+  }
+  // A streamed entry (data-descriptor bit) writes zero crc and sizes in the
+  // local header, deferring the true values to the central directory; only then
+  // is a difference on those three fields expected.
+  const deferred = (local.flags & FLAG_DATA_DESCRIPTOR) !== 0 &&
+    local.crc32 === 0 && local.compressedSize === 0 && local.uncompressedSize === 0;
+  if (!deferred &&
+      (local.crc32 !== central.crc32 ||
+       local.compressedSize !== central.compressedSize ||
+       local.uncompressedSize !== central.uncompressedSize)) {
+    throw new ERR_ZIP_INVALID_ARCHIVE(
+      'local and central header crc-32 or sizes disagree');
   }
 }
 
@@ -506,6 +560,7 @@ function readCentralDirectory(buffer, count) {
 module.exports = {
   CentralFileHeader,
   LocalFileHeader,
+  assertConsistentLocalHeader,
   findArchiveEnd,
   readCentralDirectory,
 };

--- a/test/parallel/test-zlib-zip-coverage.js
+++ b/test/parallel/test-zlib-zip-coverage.js
@@ -288,8 +288,9 @@ test('a Zip64 extra field value beyond Number.MAX_SAFE_INTEGER is rejected', asy
     uncompressedSize: 0xffffffffffffffffn,
   });
 
-  const [read] = zlib.ZipEntry.read(patched);
-  assert.throws(() => read.size, {
+  // The header cross-check resolves the sizes as the archive is read, so a
+  // malformed Zip64 value is rejected at read time rather than at .size access.
+  assert.throws(() => [...zlib.ZipEntry.read(patched)], {
     code: 'ERR_ZIP_INVALID_ARCHIVE',
     message: /exceeds the safe integer range/,
   });
@@ -325,8 +326,7 @@ test('a Zip64 extra-field TLV whose declared size overflows the extra field is r
   tlv.writeUInt16LE(100, 2); // claims 100 bytes of data, but none follow
   const patched = injectRawZip64Extra(archive, name, content.length, tlv);
 
-  const [read] = zlib.ZipEntry.read(patched);
-  assert.throws(() => read.size, {
+  assert.throws(() => [...zlib.ZipEntry.read(patched)], {
     code: 'ERR_ZIP_INVALID_ARCHIVE',
     message: /extra field is malformed/,
   });
@@ -345,8 +345,7 @@ test('a Zip64 extra-field TLV too short for the field it claims to carry is reje
   tlv.writeUInt32LE(123, 4);
   const patched = injectRawZip64Extra(archive, name, content.length, tlv);
 
-  const [read] = zlib.ZipEntry.read(patched);
-  assert.throws(() => read.size, {
+  assert.throws(() => [...zlib.ZipEntry.read(patched)], {
     code: 'ERR_ZIP_INVALID_ARCHIVE',
     message: /Zip64 extended information extra field is truncated/,
   });
@@ -500,7 +499,8 @@ test('contentIterator() enforces the same guards as content() and contentSync()'
     const archive = await buildArchive([entry]);
     const tampered = Buffer.from(archive);
     const centralStart = 30 + 'f.txt'.length + 'hello world'.length;
-    tampered.writeUInt32LE(1, centralStart + 24);
+    tampered.writeUInt32LE(1, 22); // Local uncompressed size
+    tampered.writeUInt32LE(1, centralStart + 24); // Central uncompressed size
     const [read] = zlib.ZipEntry.read(tampered);
     await assert.rejects(drain(read.contentIterator()), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
   }
@@ -593,7 +593,8 @@ test('ZipFile getSync().contentSync() enforces the same guards via decodeMemberS
     const archive = await buildArchive([entry]);
     const tampered = Buffer.from(archive);
     const centralStart = 30 + 'f.txt'.length + 'hello world'.length;
-    tampered.writeUInt32LE(1, centralStart + 24);
+    tampered.writeUInt32LE(1, 22); // Local uncompressed size
+    tampered.writeUInt32LE(1, centralStart + 24); // Central uncompressed size
     const filePath = await writeTempArchive(tampered, 'size-mismatch');
     const zf = zlib.ZipFile.openSync(filePath);
     assert.throws(() => zf.getSync('f.txt').contentSync(), { code: 'ERR_ZIP_ENTRY_CORRUPT' });
@@ -607,7 +608,8 @@ test('contentIterator() rejects an entry that inflates to less than its declared
   const archive = await buildArchive([entry]);
   const tampered = Buffer.from(archive);
   const centralStart = 30 + 'f.txt'.length + 'hi'.length;
-  tampered.writeUInt32LE(1000, centralStart + 24); // Declared size grown beyond reality
+  tampered.writeUInt32LE(1000, 22); // Local declared size
+  tampered.writeUInt32LE(1000, centralStart + 24); // Central declared size grown beyond reality
   const [read] = zlib.ZipEntry.read(tampered);
   await assert.rejects(drain(read.contentIterator()), {
     code: 'ERR_ZIP_ENTRY_CORRUPT',

--- a/test/parallel/test-zlib-zip-file-lifecycle.js
+++ b/test/parallel/test-zlib-zip-file-lifecycle.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// Lifecycle-hardening regression tests for node:zlib ZipFile (the on-disk,
+// fd-backed reader/writer). Each asserts the secure behavior, so it fails on
+// the pre-fix code and passes once its fix lands.
+//
+//  1. A read in flight when close() is called must complete on a live
+//     descriptor - close() must not pull the fd out from under it (which would
+//     surface as EBADF, or worse read another file once the fd number is
+//     reused).
+//  2. If the central-directory rewrite fails after an add() has written the
+//     member bytes, the in-memory state and the on-disk archive must be rolled
+//     back to exactly what they were before the call, not left half-updated.
+
+require('../common');
+const assert = require('assert');
+const { test } = require('node:test');
+const zlib = require('zlib');
+const fs = require('fs');
+const tmpdir = require('../common/tmpdir');
+
+const SIG_CENTRAL = 0x02014b50;
+const SIG_EOCD = 0x06054b50;
+
+function writeArchive(file, entries) {
+  const chunks = [];
+  for (const chunk of zlib.createZipArchiveSync(entries)) chunks.push(chunk);
+  fs.writeFileSync(file, Buffer.concat(chunks));
+}
+
+// 1. A read that is in flight when the ZipFile is closed still completes.
+test('close() waits for an in-flight read instead of closing under it', async () => {
+  tmpdir.refresh();
+  const file = tmpdir.resolve('inflight.zip');
+  const payload = Buffer.alloc(8 * 1024 * 1024, 0x5a);
+  writeArchive(file, [zlib.ZipEntry.createSync('big', payload, { method: 'store' })]);
+
+  const zf = zlib.ZipFile.openSync(file);
+  const entry = zf.getSync('big');
+  const reading = entry.content(); // In flight; do not await yet
+  await zf.close(); // Must wait for the read, not close the fd under it
+  const data = await reading; // Must resolve with correct bytes, not reject EBADF
+  assert.strictEqual(data.length, payload.length);
+  assert.ok(data.equals(payload));
+});
+
+// 2. A failed central-directory rewrite during add() is rolled back.
+test('a failed directory rewrite during addEntrySync is rolled back', () => {
+  tmpdir.refresh();
+  const file = tmpdir.resolve('addfail.zip');
+  writeArchive(file, [zlib.ZipEntry.createSync('first.txt', Buffer.from('original'),
+                                               { method: 'store' })]);
+
+  const zf = zlib.ZipFile.openSync(file, { writable: true });
+  const toAdd = zlib.ZipEntry.createSync('second.txt', Buffer.from('added'), { method: 'store' });
+
+  // Fail only the first central-directory write (its buffer starts with the
+  // central-header or EOCD signature); the member bytes start with the local
+  // header signature and pass through, and the rollback rewrite that follows
+  // succeeds so the on-disk archive is restored.
+  const realWriteSync = fs.writeSync;
+  let failNextDirectoryWrite = true;
+  fs.writeSync = function(fd, buffer, offset, length, position) {
+    if (failNextDirectoryWrite && Buffer.isBuffer(buffer) && buffer.length - offset >= 4) {
+      const sig = buffer.readUInt32LE(offset);
+      if (sig === SIG_CENTRAL || sig === SIG_EOCD) {
+        failNextDirectoryWrite = false;
+        const err = new Error('ENOSPC: simulated no space left on device');
+        err.code = 'ENOSPC';
+        throw err;
+      }
+    }
+    return realWriteSync.call(fs, fd, buffer, offset, length, position);
+  };
+  try {
+    assert.throws(() => zf.addEntrySync(toAdd), { code: 'ENOSPC' });
+  } finally {
+    fs.writeSync = realWriteSync;
+  }
+
+  // In-memory: the half-added entry is gone and the original is still readable.
+  assert.ok(!zf.has('second.txt'));
+  assert.strictEqual(zf.getSync('first.txt').contentSync().toString(), 'original');
+  zf.closeSync();
+
+  // On disk: reopening shows the original, uncorrupted archive.
+  const reopened = zlib.ZipFile.openSync(file);
+  assert.ok(reopened.has('first.txt'));
+  assert.ok(!reopened.has('second.txt'));
+  assert.strictEqual(reopened.getSync('first.txt').contentSync().toString(), 'original');
+  reopened.closeSync();
+});

--- a/test/parallel/test-zlib-zip-hardening.js
+++ b/test/parallel/test-zlib-zip-hardening.js
@@ -58,13 +58,14 @@ test('a declared-size mismatch is rejected as corrupt', async () => {
   const entry = await zlib.ZipEntry.create('f.txt', Buffer.from('hello world'), { method: 'store' });
   const archive = await buildArchive([entry]);
 
-  // Shrink the *declared* uncompressed size in the central directory record
-  // without touching the stored bytes themselves, so the amount of data
-  // produced no longer matches what the header promised.
+  // Shrink the *declared* uncompressed size in both the local and central
+  // headers (kept consistent so the header cross-check passes) without touching
+  // the stored bytes, so the produced amount no longer matches the headers'
+  // promise and the decode-time size check fires.
   const tampered = Buffer.from(archive);
   const centralHeaderStart = 30 + 'f.txt'.length + 'hello world'.length;
-  const uncompressedSizeOffset = centralHeaderStart + 24;
-  tampered.writeUInt32LE(1, uncompressedSizeOffset);
+  tampered.writeUInt32LE(1, 22); // Local uncompressed size
+  tampered.writeUInt32LE(1, centralHeaderStart + 24); // Central uncompressed size
 
   const [tamperedEntry] = zlib.ZipEntry.read(tampered);
   assert.strictEqual(tamperedEntry.size, 1);
@@ -105,7 +106,10 @@ test('a forged small header whose content inflates past its declared size is rej
     const tampered = Buffer.from(archive);
     const eocd = tampered.length - 22; // No comment, so EOCD is the last 22 bytes
     const cdOffset = tampered.readUInt32LE(eocd + 16);
-    tampered.writeUInt32LE(50, cdOffset + 24); // Forge declared uncompressedSize
+    // Forge the declared uncompressedSize in both headers (kept consistent so
+    // the header cross-check passes; the decompressor still catches the lie).
+    tampered.writeUInt32LE(50, 22); // Local uncompressedSize
+    tampered.writeUInt32LE(50, cdOffset + 24); // Central uncompressedSize
 
     const [e] = zlib.ZipEntry.read(tampered);
     assert.strictEqual(e.size, 50); // 50 <= maxSize 100 clears the up-front check
@@ -340,9 +344,11 @@ test('a member whose data crosses into the central directory is rejected', async
   const archive = Buffer.from(await buildArchive(
     [await zlib.ZipEntry.create(name, content, { method: 'store' })]));
   const centralHeaderStart = 30 + name.length + content.length;
-  // Lie about the compressed size so the member's data range reaches into
-  // the central directory (while staying inside the buffer).
-  archive.writeUInt32LE(content.length + 40, centralHeaderStart + 20);
+  // Lie about the compressed size in both headers (kept consistent so the
+  // header cross-check passes) so the member's data range reaches into the
+  // central directory (while staying inside the buffer).
+  archive.writeUInt32LE(content.length + 40, 18); // Local compressed size
+  archive.writeUInt32LE(content.length + 40, centralHeaderStart + 20); // Central
   assert.throws(() => [...zlib.ZipEntry.read(archive)],
                 { code: 'ERR_ZIP_INVALID_ARCHIVE', message: /possible zip bomb/ });
 });

--- a/test/parallel/test-zlib-zip-security-hardening.js
+++ b/test/parallel/test-zlib-zip-security-hardening.js
@@ -1,0 +1,120 @@
+'use strict';
+
+// Security-hardening regression tests for node:zlib ZIP support. Each test
+// describes a distinct issue found by audit and asserts the *secure* behavior,
+// so every test fails on the pre-fix code and passes once its fix lands.
+//
+//  1. Local-vs-central header confusion (parser-confusion / inspect-then-consume
+//     divergence): the central directory is authoritative in this reader, but a
+//     local file header that disagrees on method, sizes, CRC, or the encryption
+//     flag lets another ZIP tool (which extracts from the local header) read a
+//     different member from the same archive. Such an archive must be rejected.
+//  2. The archiver (zipFiles) must not block forever on a FIFO/special source.
+//  3. The streaming read path (contentIterator) is hard-bounded by the header's
+//     declared uncompressed size: a member that inflates past it is rejected
+//     mid-stream, so entry.size is a ceiling a consumer can trust up front.
+
+require('../common');
+const assert = require('assert');
+const { test } = require('node:test');
+const zlib = require('zlib');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const tmpdir = require('../common/tmpdir');
+
+const SIG_LOCAL = 0x04034b50;
+const SIG_CENTRAL = 0x02014b50;
+
+// A minimal single-member archive; caller patches its headers.
+function buildStored(name, content, method = 'store') {
+  const entry = zlib.ZipEntry.createSync(name, Buffer.from(content), { method });
+  const chunks = [];
+  for (const chunk of zlib.createZipArchiveSync([entry])) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function centralOffset(buf) {
+  for (let i = buf.length - 22; i >= 0; i--) {
+    if (buf.readUInt32LE(i) === SIG_CENTRAL) return i;
+  }
+  throw new Error('no central directory header found');
+}
+
+// A ZipBuffer parses the central directory; reading a member resolves and
+// checks its local header. Do both so the assertion holds whether the check
+// is eager (parse time) or lazy (read time).
+function readsThrow(buf, name) {
+  assert.throws(() => {
+    const zb = new zlib.ZipBuffer(buf);
+    zb.get(name).contentSync();
+  }, { code: 'ERR_ZIP_INVALID_ARCHIVE' });
+}
+
+// 1a. Local vs central compressed/uncompressed size disagreement.
+test('a local/central size disagreement is rejected', () => {
+  const buf = buildStored('a.txt', 'hello');
+  assert.strictEqual(buf.readUInt32LE(0), SIG_LOCAL);
+  buf.writeUInt32LE(999, 18); // Local compressed size
+  buf.writeUInt32LE(999, 22); // Local uncompressed size
+  readsThrow(buf, 'a.txt');
+});
+
+// 1b. Local vs central compression-method disagreement.
+test('a local/central method disagreement is rejected', () => {
+  const buf = buildStored('a.txt', 'hello');
+  buf.writeUInt16LE(8, 8); // Local method deflate; central stays store(0)
+  readsThrow(buf, 'a.txt');
+});
+
+// 1c. Central marks the member encrypted while the local header does not:
+// a central-directory reader (e.g. python) treats it as opaque/encrypted, so
+// Node must not silently decode it either.
+test('a local/central encryption-flag disagreement is rejected', () => {
+  const buf = buildStored('a.txt', 'hello');
+  const c = centralOffset(buf);
+  buf.writeUInt16LE(buf.readUInt16LE(c + 8) | 0x0001, c + 8); // Central encrypted bit
+  readsThrow(buf, 'a.txt');
+});
+
+// 2. zipFiles must reject a FIFO source rather than block on open() forever.
+test('zipFiles rejects a FIFO source instead of hanging', () => {
+  if (process.platform === 'win32') return; // no mkfifo
+  tmpdir.refresh();
+  const fifo = path.join(tmpdir.path, 'evil.fifo');
+  if (spawnSync('mkfifo', [fifo]).status !== 0) return; // mkfifo unavailable
+  const script =
+    'const zlib = require("zlib");' +
+    '(async () => {' +
+    '  try {' +
+    `    for await (const _ of zlib.zipFiles([[${JSON.stringify(fifo)}, "x"]], ` +
+    '      { followSymlinks: false })) {}' +
+    '    console.log("COMPLETED");' +
+    '  } catch (e) { console.log("REJECTED:" + e.code); }' +
+    '})();';
+  const res = spawnSync(process.execPath, ['--no-warnings', '-e', script],
+                        { timeout: 5000, encoding: 'utf8' });
+  assert.ok(res.signal === null,
+            'zipFiles hung on a FIFO source (killed by timeout)');
+  assert.match(res.stdout, /REJECTED:ERR_ZIP_UNSUPPORTED_FEATURE/);
+});
+
+// 3. Streaming is hard-bounded by the declared uncompressed size: a member
+// whose data inflates past it is rejected mid-stream, so a consumer can trust
+// entry.size as the ceiling before choosing to buffer.
+test('contentIterator rejects a member that inflates past its declared size', async () => {
+  const big = zlib.ZipEntry.createSync(
+    'big', Buffer.alloc(64 * 1024), { method: 'deflate' });
+  const chunks = [];
+  for (const chunk of zlib.createZipArchiveSync([big])) chunks.push(chunk);
+  const buf = Buffer.concat(chunks);
+  // Shrink the declared uncompressed size in both headers (kept consistent so
+  // the header cross-check passes) below what the data actually inflates to.
+  const c = centralOffset(buf);
+  buf.writeUInt32LE(100, 22); // Local uncompressed size
+  buf.writeUInt32LE(100, c + 24); // Central uncompressed size
+  const entry = new zlib.ZipBuffer(buf).get('big');
+  await assert.rejects(async () => {
+    // eslint-disable-next-line no-unused-vars
+    for await (const _ of entry.contentIterator()) { /* drain */ }
+  }, { code: 'ERR_ZIP_ENTRY_CORRUPT', message: /inflates beyond its declared size/ });
+});


### PR DESCRIPTION
### Summary

This PR fixes four security issues in the `node:zlib` ZIP support (`ZipEntry`/`ZipFile`/`ZipBuffer`), found by an audit of the parser and the on-disk reader/writer. Two are high-severity (a parser-confusion divergence and a denial-of-service hang); two are medium-severity lifecycle/robustness bugs. Each issue is landed test-first: a commit adds a failing regression test, followed by the fix that turns it green.

The ZIP surface treats an archive (bytes in a `Buffer`, or a file on disk) and every header field as fully attacker-controlled, so these are all reachable from untrusted input.

---

### 1. Local vs. central header disagreement — parser confusion (high)

**Issue.** The reader treats the central directory as authoritative for a member's compression method, sizes, CRC, and name, but only validated the local file header's *signature*. It never checked that the two headers agree. Two consequences:

- **Different bytes than other tools.** Because Info-ZIP `unzip` extracts using the *local* header's method/size, an archive whose local and central headers disagree yields **different content in Node than in `unzip`** for the same member name — a classic inspect-then-consume bypass (a scanner sees content Q; Node consumes content P). Verified against `unzip`/`python -m zipfile`.
- **Encryption-flag confusion.** The "is this member encrypted?" decision was read from the *local* header while the member's identity came from the *central* one. An attacker could mark a member encrypted in the central directory (so a central-directory-based scanner such as Python's `zipfile` treats it as opaque and skips it) while leaving the local flag clear, so **Node silently decoded the plaintext payload**.

**Solution.** When a member is read, cross-check the local file header against the central entry — compression method, CRC-32, compressed size, and uncompressed size (with a spec-compliant exemption for data-descriptor entries, whose local CRC/sizes are legitimately zero), plus the encryption flag — and reject any disagreement with `ERR_ZIP_INVALID_ARCHIVE`. This follows the module's existing "reject rather than silently choose one interpretation" stance and removes Node from *both* sides of any local/central divergence.

The existing hardening/coverage tests that forged a decode-time size/CRC/Zip64 lie in the central header alone now trip this earlier check; they were updated to patch both headers consistently so they still exercise the decode-time guards they target.

### 2. `zipFiles()` hangs on a FIFO/special source — DoS (high)

**Issue.** When archiving files, `zipFiles()` opened each source and only *then* `fstat`-ed it to confirm a regular file. `open(2)` on a FIFO blocks until a writer appears, so the guard ran too late — a FIFO source (reachable via a source path an attacker influences, or a regular-file→FIFO TOCTOU) hung the call indefinitely and pinned a libuv threadpool thread; a handful stalls all `fs` in the process. The code comment even claimed the guard prevented this.

**Solution.** Open with `O_NONBLOCK` so the open returns promptly and the `fstat`/regular-file check can reject a FIFO, device, or socket before any read. `O_NONBLOCK` has no effect on a regular file's subsequent reads, so the happy path is unchanged.

### 3. `ZipFile` read racing `close()` — use-after-close / fd reuse (medium)

**Issue.** A `ZipEntry` read runs on a file descriptor shared with its `ZipFile`, but reads didn't participate in `close()`'s lifecycle. `close()` marked the handle closed and released the fd while a read was still in flight, so the read landed on a closed — or, once the OS reused the fd number, *another file's* — descriptor (surfacing as `EBADF`, or a cross-file read), contradicting the class's own invariant.

**Solution.** Track in-flight reads on the shared handle. `close()` now marks the handle *closing* (rejecting new reads immediately), waits for in-flight reads to finish on the still-open fd, and only then releases it. `closeSync()`, which cannot wait, refuses while an asynchronous read is outstanding.

### 4. Failed directory rewrite in `add()` leaves a corrupt archive (medium)

**Issue.** `add()`/`addEntrySync()` advanced the central-directory offset and adopted the new entry into memory *before* the final directory rewrite. If that rewrite failed (e.g. `ENOSPC`/`EIO` after the member bytes were already written), the in-memory state and the on-disk archive were left diverged and half-updated with no restore, corrupting the next `add()`.

**Solution.** Wrap the rewrite: on failure, restore the previous offset and directory entry and rewrite the original directory back, leaving the archive and the handle exactly as they were before the call, then rethrow.

---

### A note on streaming reads

The audit also flagged that `contentIterator()` applies no default size cap. On inspection this is **already safe and needs no change**: the streaming decoder hard-bounds output to the member's *declared* uncompressed size (`ERR_ZIP_ENTRY_CORRUPT` the moment it inflates past it), and that size is exposed as `entry.size` before a byte is streamed — so it's a ceiling a consumer can inspect and trust. Rather than bolt on an arbitrary global cap (which would break legitimate large streams), this PR adds a regression test locking in that declared-size guard.

### Testing

- New regression tests: `test-zlib-zip-security-hardening.js` (header confusion, FIFO hang, streaming bound) and `test-zlib-zip-file-lifecycle.js` (close-vs-read, add rollback), the latter using deterministic `fs.writeSync` failure injection.
- The full `test/parallel/test-zlib*` suite passes, including the updated `test-zlib-zip-hardening.js` / `test-zlib-zip-coverage.js`.

### Commits

Structured as test-then-fix per issue:

```
test: cover ZIP header-confusion and DoS guards
zlib: reject local/central ZIP header mismatch
zlib: do not hang archiving a FIFO or device
test: cover ZIP fd lifecycle and add rollback
zlib: let a ZipFile read finish before close()
zlib: roll back a failed add() directory rewrite
```
