### PR TITLE
perf_hooks: add missing resource timing attributes

### DIFF
--- a/lib/internal/perf/resource_timing.js
+++ b/lib/internal/perf/resource_timing.js
@@ -17,6 +17,7 @@ const { enqueue, bufferResourceTiming } = require('internal/perf/observe');
 const { validateThisInternalField } = require('internal/validators');
 const { kEnumerableProperty } = require('internal/util');
 
+const kBodyInfo = Symbol('kBodyInfo');
 const kCacheMode = Symbol('kCacheMode');
 const kRequestedUrl = Symbol('kRequestedUrl');
 const kTimingInfo = Symbol('kTimingInfo');
@@ -110,6 +111,16 @@ class PerformanceResourceTiming extends PerformanceEntry {
     return this[kTimingInfo].finalNetworkRequestStartTime;
   }
 
+  get finalResponseHeadersStart() {
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    return this[kTimingInfo].finalNetworkResponseStartTime;
+  }
+
+  get firstInterimResponseStart() {
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    return this[kTimingInfo].firstInterimNetworkResponseStartTime ?? 0;
+  }
+
   get responseStart() {
     validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
     return this[kTimingInfo].finalNetworkResponseStartTime;
@@ -148,6 +159,22 @@ class PerformanceResourceTiming extends PerformanceEntry {
     return this[kResponseStatus];
   }
 
+  get renderBlockingStatus() {
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    return this[kTimingInfo].renderBlocking === true ?
+      'blocking' : 'non-blocking';
+  }
+
+  get contentType() {
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    return this[kBodyInfo]?.contentType ?? '';
+  }
+
+  get contentEncoding() {
+    validateThisInternalField(this, kTimingInfo, 'PerformanceResourceTiming');
+    return this[kBodyInfo]?.contentEncoding ?? '';
+  }
+
   toJSON() {
     validateThisInternalField(this, kInitiatorType, 'PerformanceResourceTiming');
     return {
@@ -167,6 +194,8 @@ class PerformanceResourceTiming extends PerformanceEntry {
       connectEnd: this.connectEnd,
       secureConnectionStart: this.secureConnectionStart,
       requestStart: this.requestStart,
+      finalResponseHeadersStart: this.finalResponseHeadersStart,
+      firstInterimResponseStart: this.firstInterimResponseStart,
       responseStart: this.responseStart,
       responseEnd: this.responseEnd,
       transferSize: this.transferSize,
@@ -174,6 +203,9 @@ class PerformanceResourceTiming extends PerformanceEntry {
       decodedBodySize: this.decodedBodySize,
       deliveryType: this.deliveryType,
       responseStatus: this.responseStatus,
+      renderBlockingStatus: this.renderBlockingStatus,
+      contentType: this.contentType,
+      contentEncoding: this.contentEncoding,
     };
   }
 }
@@ -191,6 +223,8 @@ ObjectDefineProperties(PerformanceResourceTiming.prototype, {
   connectEnd: kEnumerableProperty,
   secureConnectionStart: kEnumerableProperty,
   requestStart: kEnumerableProperty,
+  finalResponseHeadersStart: kEnumerableProperty,
+  firstInterimResponseStart: kEnumerableProperty,
   responseStart: kEnumerableProperty,
   responseEnd: kEnumerableProperty,
   transferSize: kEnumerableProperty,
@@ -198,6 +232,9 @@ ObjectDefineProperties(PerformanceResourceTiming.prototype, {
   decodedBodySize: kEnumerableProperty,
   deliveryType: kEnumerableProperty,
   responseStatus: kEnumerableProperty,
+  renderBlockingStatus: kEnumerableProperty,
+  contentType: kEnumerableProperty,
+  contentEncoding: kEnumerableProperty,
   toJSON: kEnumerableProperty,
   [SymbolToStringTag]: {
     __proto__: null,
@@ -224,6 +261,7 @@ function createPerformanceResourceTiming(
   // The spec doesn't say to validate it in the class construction.
   resourceTiming[kTimingInfo] = timingInfo;
   resourceTiming[kCacheMode] = cacheMode;
+  resourceTiming[kBodyInfo] = bodyInfo;
   resourceTiming[kDeliveryType] = deliveryType;
   resourceTiming[kResponseStatus] = responseStatus;
 

--- a/test/parallel/test-perf-hooks-resourcetiming-attributes.js
+++ b/test/parallel/test-perf-hooks-resourcetiming-attributes.js
@@ -1,0 +1,100 @@
+'use strict';
+
+require('../common');
+const assert = require('assert');
+const {
+  PerformanceResourceTiming,
+  performance,
+} = require('perf_hooks');
+
+// Covers the IDL attributes finalResponseHeadersStart,
+// firstInterimResponseStart, renderBlockingStatus, contentType and contentEncoding.
+
+function createTimingInfo(overrides = {}) {
+  return {
+    startTime: 0,
+    redirectStartTime: 0,
+    redirectEndTime: 0,
+    postRedirectStartTime: 0,
+    finalServiceWorkerStartTime: 0,
+    finalNetworkRequestStartTime: 0,
+    finalNetworkResponseStartTime: 0,
+    endTime: 0,
+    encodedBodySize: 0,
+    decodedBodySize: 0,
+    finalConnectionTimingInfo: null,
+    ...overrides,
+  };
+}
+
+function markResourceTiming(timingInfo, bodyInfo) {
+  return performance.markResourceTiming(
+    timingInfo,
+    'http://localhost:8080',
+    'fetch',
+    {},
+    '',
+    bodyInfo,
+    200,
+    '',
+  );
+}
+
+// Default values with an empty body info, mirroring what the fetch
+// implementation passes for a response with no body metadata.
+{
+  const resource = markResourceTiming(createTimingInfo(), {});
+
+  assert.strictEqual(resource.finalResponseHeadersStart, 0);
+  assert.strictEqual(resource.firstInterimResponseStart, 0);
+  assert.strictEqual(resource.renderBlockingStatus, 'non-blocking');
+  assert.strictEqual(resource.contentType, '');
+  assert.strictEqual(resource.contentEncoding, '');
+}
+
+// Values reflected from timing info and body info.
+{
+  const timingInfo = createTimingInfo({
+    finalNetworkResponseStartTime: 123,
+    firstInterimNetworkResponseStartTime: 45,
+    renderBlocking: true,
+  });
+  const bodyInfo = {
+    contentType: 'text/html',
+    contentEncoding: 'gzip',
+  };
+  const resource = markResourceTiming(timingInfo, bodyInfo);
+
+  assert.strictEqual(resource.finalResponseHeadersStart, 123);
+  assert.strictEqual(resource.firstInterimResponseStart, 45);
+  assert.strictEqual(resource.renderBlockingStatus, 'blocking');
+  assert.strictEqual(resource.contentType, 'text/html');
+  assert.strictEqual(resource.contentEncoding, 'gzip');
+
+  const json = resource.toJSON();
+  assert.strictEqual(json.finalResponseHeadersStart, 123);
+  assert.strictEqual(json.firstInterimResponseStart, 45);
+  assert.strictEqual(json.renderBlockingStatus, 'blocking');
+  assert.strictEqual(json.contentType, 'text/html');
+  assert.strictEqual(json.contentEncoding, 'gzip');
+}
+
+// The attributes are enumerable getters on the prototype and perform a
+// brand check like the other PerformanceResourceTiming attributes.
+for (const name of [
+  'finalResponseHeadersStart',
+  'firstInterimResponseStart',
+  'renderBlockingStatus',
+  'contentType',
+  'contentEncoding',
+]) {
+  const desc = Object.getOwnPropertyDescriptor(
+    PerformanceResourceTiming.prototype, name);
+  assert.strictEqual(desc.enumerable, true, name);
+  assert.strictEqual(typeof desc.get, 'function', name);
+  assert.throws(() => desc.get.call({}), {
+    code: 'ERR_INVALID_THIS',
+  }, name);
+}
+
+performance.clearResourceTimings();

--- a/test/parallel/test-perf-hooks-resourcetiming.js
+++ b/test/parallel/test-perf-hooks-resourcetiming.js
@@ -174,6 +174,8 @@ function createTimingInfo({
     connectEnd: 0,
     secureConnectionStart: 0,
     requestStart: 0,
+    finalResponseHeadersStart: 0,
+    firstInterimResponseStart: 0,
     responseStart: 0,
     responseEnd: 0,
     transferSize: 0,
@@ -181,6 +183,9 @@ function createTimingInfo({
     decodedBodySize: 0,
     responseStatus: 200,
     deliveryType: '',
+    renderBlockingStatus: 'non-blocking',
+    contentType: '',
+    contentEncoding: '',
   });
   assert.strictEqual(util.inspect(performance.getEntries()), `[
   PerformanceResourceTiming {
@@ -200,13 +205,18 @@ function createTimingInfo({
     connectEnd: 0,
     secureConnectionStart: 0,
     requestStart: 0,
+    finalResponseHeadersStart: 0,
+    firstInterimResponseStart: 0,
     responseStart: 0,
     responseEnd: 0,
     transferSize: 0,
     encodedBodySize: 0,
     decodedBodySize: 0,
     deliveryType: '',
-    responseStatus: 200
+    responseStatus: 200,
+    renderBlockingStatus: 'non-blocking',
+    contentType: '',
+    contentEncoding: ''
   }
 ]`);
   assert.strictEqual(util.inspect(resource), `PerformanceResourceTiming {
@@ -226,13 +236,18 @@ function createTimingInfo({
   connectEnd: 0,
   secureConnectionStart: 0,
   requestStart: 0,
+  finalResponseHeadersStart: 0,
+  firstInterimResponseStart: 0,
   responseStart: 0,
   responseEnd: 0,
   transferSize: 0,
   encodedBodySize: 0,
   decodedBodySize: 0,
   deliveryType: '',
-  responseStatus: 200
+  responseStatus: 200,
+  renderBlockingStatus: 'non-blocking',
+  contentType: '',
+  contentEncoding: ''
 }`);
 
   assert(resource instanceof PerformanceEntry);

--- a/test/wpt/status/resource-timing.json
+++ b/test/wpt/status/resource-timing.json
@@ -23,25 +23,15 @@
   "idlharness.any.js": {
     "fail": {
       "expected": [
-        "PerformanceResourceTiming interface: attribute firstInterimResponseStart",
-        "PerformanceResourceTiming interface: attribute finalResponseHeadersStart",
-        "PerformanceResourceTiming interface: resource must inherit property \"finalResponseHeadersStart\" with the proper type",
-        "PerformanceResourceTiming interface: attribute renderBlockingStatus",
-        "PerformanceResourceTiming interface: attribute contentType",
-        "PerformanceResourceTiming interface: resource must inherit property \"firstInterimResponseStart\" with the proper type",
-        "PerformanceResourceTiming interface: resource must inherit property \"renderBlockingStatus\" with the proper type",
-        "PerformanceResourceTiming interface: resource must inherit property \"contentType\" with the proper type",
         "PerformanceResourceTiming interface: default toJSON operation on resource",
         "PerformanceResourceTiming interface: attribute workerRouterEvaluationStart",
         "PerformanceResourceTiming interface: attribute workerCacheLookupStart",
         "PerformanceResourceTiming interface: attribute workerMatchedRouterSource",
         "PerformanceResourceTiming interface: attribute workerFinalRouterSource",
-        "PerformanceResourceTiming interface: attribute contentEncoding",
         "PerformanceResourceTiming interface: resource must inherit property \"workerRouterEvaluationStart\" with the proper type",
         "PerformanceResourceTiming interface: resource must inherit property \"workerCacheLookupStart\" with the proper type",
         "PerformanceResourceTiming interface: resource must inherit property \"workerMatchedRouterSource\" with the proper type",
-        "PerformanceResourceTiming interface: resource must inherit property \"workerFinalRouterSource\" with the proper type",
-        "PerformanceResourceTiming interface: resource must inherit property \"contentEncoding\" with the proper type"
+        "PerformanceResourceTiming interface: resource must inherit property \"workerFinalRouterSource\" with the proper type"
       ]
     }
   }


### PR DESCRIPTION
Add the PerformanceResourceTiming attributes still missing from the Resource Timing spec: `finalResponseHeadersStart`, `firstInterimResponseStart`, `renderBlockingStatus`, `contentType` and `contentEncoding`. The getters follow the existing pattern in the file, and the WPT status file drops the ten idlharness subtests this makes pass.

Current values:

- **`finalResponseHeadersStart`**: same timing info field as `responseStart`
- **`contentType`**: real value, undici already provides it via the response body info
- **`contentEncoding`**: `''` (spec default, not populated by the fetch side yet)
- **`firstInterimResponseStart`**: `0` (same)
- **`renderBlockingStatus`**: `'non-blocking'` (same)

The getters pick up real values automatically once the producer side fills them in. Precedent: #51589 added `deliveryType` and `responseStatus` the same way.
