### PR TITLE
dns: validate port range in `setServers()`

### DIFF
--- a/lib/internal/dns/utils.js
+++ b/lib/internal/dns/utils.js
@@ -24,6 +24,7 @@ const {
   validateArray,
   validateInt32,
   validateOneOf,
+  validatePort,
   validateString,
   validateUint32,
 } = require('internal/validators');
@@ -129,6 +130,7 @@ class ResolverBase {
         if (ipVersion !== 0) {
           const port = NumberParseInt(
             RegExpPrototypeSymbolReplace(addrSplitRE, serv, '$2')) || IANA_DNS_PORT;
+          validatePort(port);
           return ArrayPrototypePush(newSet, [ipVersion, match[1], port]);
         }
       }
@@ -138,13 +140,13 @@ class ResolverBase {
 
       if (addrSplitMatch) {
         const hostIP = addrSplitMatch[1];
-        const port = addrSplitMatch[2] || IANA_DNS_PORT;
+        const port = NumberParseInt(addrSplitMatch[2]) || IANA_DNS_PORT;
 
         ipVersion = isIP(hostIP);
 
         if (ipVersion !== 0) {
-          return ArrayPrototypePush(
-            newSet, [ipVersion, hostIP, NumberParseInt(port)]);
+          validatePort(port);
+          return ArrayPrototypePush(newSet, [ipVersion, hostIP, port]);
         }
       }
 

--- a/test/parallel/test-dns.js
+++ b/test/parallel/test-dns.js
@@ -90,6 +90,22 @@ assert(existing.length > 0);
   });
 }
 
+{
+  // Out-of-range ports, which should throw a clean error.
+  const invalidPorts = [2 ** 16, 2 ** 32, 2 ** 64];
+  invalidPorts.forEach((port) => {
+    assert.throws(
+      () => {
+        dns.setServers([`1.2.3.4:${port}`]);
+      },
+      {
+        name: 'RangeError',
+        code: 'ERR_SOCKET_BAD_PORT'
+      }
+    );
+  });
+}
+
 const goog = [
   '8.8.8.8',
   '8.8.4.4',


### PR DESCRIPTION
As per https://github.com/nodejs/node/pull/65009#pullrequestreview-4855375767.

`dns.setServers()` currently has the following shenanigans with out-of-range port numbers:

- uint16 overflow (seems version-/platform-dependent)
  ```js
  dns.setServers(['1.2.3.4:65535', '1.2.3.4:65536', '1.2.3.4:65537'])
  dns.getServers()
  [ '1.2.3.4:65535', '1.2.3.4', '1.2.3.4:1' ]
  ```
- process crash if >INT\_MAX
  ```js
  dns.setServers(['1.1.1.1:99999999999999999999999999'])
  // #  node[1673753]: void node::cares_wrap::(anonymous namespace)::SetServers(const FunctionCallbackInfo<Value> &) at ../src/cares_wrap.cc:2164
  // #  Assertion failed: portValue->Int32Value(env->context()).FromJust()
  ```

(the latter of these is not addressed by #65009)